### PR TITLE
Update docs with new cache TTLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A comprehensive Model Context Protocol (MCP) server for OmniFocus that provides 
 ## Features
 
 ### Core Capabilities
-- **Smart Caching**: TTL-based caching system for optimal performance (30s for tasks, 5m for projects, 1h for analytics)
+- **Smart Caching**: TTL-based caching system for optimal performance (1m for tasks, 10m for projects, 1h for analytics)
 - **Type Safety**: Full TypeScript support with comprehensive type definitions
 - **Official API Only**: Uses only OmniAutomation scripts via JXA (no database hacking)
 - **High Performance**: Handles 2000+ tasks efficiently with intelligent caching
@@ -22,7 +22,7 @@ A comprehensive Model Context Protocol (MCP) server for OmniFocus that provides 
   - Filter by: completion status, flags, project, tags, dates, search terms
   - Supports inbox filtering and availability checks  
   - Supports up to 1000 tasks with proper pagination metadata
-  - Results cached for 30 seconds for lightning-fast repeated queries
+  - Results cached for 1 minute for lightning-fast repeated queries
 - `get_task_count` - Get count of tasks matching filters without data
   - Same filtering options as list_tasks
   - Returns count only for performance
@@ -64,7 +64,7 @@ operations may be re-implemented for performance optimization.
 #### Project Operations
 - `list_projects` - List and filter projects with caching
   - Filter by: status (active, on hold, dropped, completed), flags, folder
-  - Results cached for 5 minutes
+  - Results cached for 10 minutes
   - Includes task counts
 - `create_project` - Create new projects with folder support
   - Automatically creates folders if they don't exist
@@ -353,10 +353,10 @@ If you see errors like `Project with ID '547' not found` followed by a Claude De
 
 The server implements intelligent caching with different TTLs for different data types:
 
-- **Tasks**: 30 seconds (frequently changing)
-- **Projects**: 5 minutes (less volatile)
+- **Tasks**: 1 minute (frequently changing)
+- **Projects**: 10 minutes (less volatile)
 - **Analytics**: 1 hour (expensive computations)
-- **Tags**: 10 minutes (relatively stable)
+- **Tags**: 20 minutes (relatively stable)
 
 Cache is automatically invalidated on write operations.
 

--- a/docs/MCP-IMPROVEMENTS.md
+++ b/docs/MCP-IMPROVEMENTS.md
@@ -121,7 +121,7 @@ Improve documentation to match MCP ecosystem standards.
  * 
  * @description
  * Retrieves tasks from OmniFocus with powerful filtering options.
- * Results are cached for 30 seconds to improve performance.
+ * Results are cached for 1 minute to improve performance.
  * 
  * @example Basic usage
  * {

--- a/docs/PERFORMANCE_ISSUE.md
+++ b/docs/PERFORMANCE_ISSUE.md
@@ -111,7 +111,7 @@ For a database with 2,000 tasks:
 
 ### Recommendations for Users
 
-1. **Use caching** - Results are cached for 30 seconds
+1. **Use caching** - Results are cached for 1 minute
 2. **Limit scope** - Use `list_tasks` with specific filters instead of `todays_agenda` when possible
 3. **Schedule updates** - Run agenda queries during natural breaks
 4. **Consider database size** - Performance scales linearly with task count

--- a/docs/USER_FEEDBACK_AND_LIMITATIONS.md
+++ b/docs/USER_FEEDBACK_AND_LIMITATIONS.md
@@ -152,6 +152,6 @@ MCP bridges operate under different constraints than traditional APIs or CLI too
 
 1. **All 24 functions are working** - The bridge is functionally complete
 2. **Performance varies by operation type** - Simple queries are fast, full scans are slow
-3. **Caching is essential** - 30-second cache makes repeated operations instant
+3. **Caching is essential** - 1-minute cache makes repeated operations instant
 4. **JXA API limitations are real** - We work around them where possible
 5. **User workflows should adapt** - Use fast operations when possible, batch slow ones

--- a/docs/prompt-cache-architecture.md
+++ b/docs/prompt-cache-architecture.md
@@ -81,10 +81,10 @@ omnifocus-mcp-pro/
 
 ```typescript
 interface CacheConfig {
-  tasks: { ttl: 30 },        // 30 seconds for task lists
-  projects: { ttl: 300 },    // 5 minutes for projects
+  tasks: { ttl: 60 },        // 1 minute for task lists
+  projects: { ttl: 600 },    // 10 minutes for projects
   analytics: { ttl: 3600 },  // 1 hour for analytics
-  tags: { ttl: 600 }         // 10 minutes for tags
+  tags: { ttl: 1200 }        // 20 minutes for tags
 }
 ```
 


### PR DESCRIPTION
## Summary
- adjust README caching TTLs
- sync docs with new 1m/10m/20m TTL settings

## Testing
- `npm run lint` *(fails: Unsafe assignment etc.)*
- `npm test` *(fails: timeout in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a8465aedc832ab1ebc5a16234600a