### PR TITLE
Fix incorrect primaryKey references

### DIFF
--- a/RELEASE_NOTES_v1.4.0.md
+++ b/RELEASE_NOTES_v1.4.0.md
@@ -25,7 +25,7 @@ All 27 tools are now working correctly, up from 85% in the previous version. Thi
 
 ### Critical Fixes
 1. **Fixed "Cannot convert undefined or null to object" errors** - Added comprehensive safe property access throughout all scripts
-2. **Fixed task ID extraction** - Now correctly uses `id.primaryKey` for all object identifiers
+2. **Fixed task ID extraction** - Now consistently retrieves identifiers using the `id()` method
 3. **Fixed tag operations** - Tag creation, renaming, merging, and deletion now work reliably
 4. **Fixed project status updates** - Projects can now be properly completed and have their status changed
 
@@ -65,7 +65,7 @@ Thanks to the user testing group for their detailed feedback and patience during
 ## Technical Details for Developers
 
 ### API Property Access Changes
-- Task properties: `task.id()` → `task.id.primaryKey`
+- Task properties continue to use `task.id()` for identifier lookup
 - Project properties: `project.name()` → `project.name`
 - Document collections: `doc.flattenedTasks()` → `doc.flattenedTasks`
 

--- a/docs/api-migration-summary.md
+++ b/docs/api-migration-summary.md
@@ -13,8 +13,8 @@ Successfully migrated the OmniFocus MCP Bridge to use the official OmniFocus 4.6
 ### 2. Property Access Pattern Updates
 
 #### Task Properties
-Changed from method calls to direct property access:
-- `task.id()` → `task.id.primaryKey`
+-Changed from method calls to direct property access (except for IDs which still
+use the `id()` method):
 - `task.name()` → `task.name`
 - `task.note()` → `task.note`
 - `task.completed()` → `task.completed`
@@ -32,7 +32,6 @@ Changed from method calls to direct property access:
 - `task.repetitionRule()` → `task.repetitionRule`
 
 #### Project Properties
-- `project.id()` → `project.id.primaryKey`
 - `project.name()` → `project.name`
 - `project.note()` → `project.note`
 - `project.status()` → `project.status`
@@ -44,7 +43,6 @@ Changed from method calls to direct property access:
 - `project.flattenedTasks()` → `project.flattenedTasks`
 
 #### Tag Properties
-- `tag.id()` → `tag.id.primaryKey`
 - `tag.name()` → `tag.name`
 - `tag.parent()` → `tag.parent`
 - `tag.tags()` → `tag.children` (note: property name change)
@@ -65,16 +63,10 @@ Changed from method calls to direct property access:
 ### 4. Key Learnings
 
 #### ObjectIdentifier
-The `id` property returns an `ObjectIdentifier` object with a `primaryKey` property:
-```typescript
-declare class ObjectIdentifier {
-    readonly objectClass: Object | null;
-    readonly primaryKey: string;
-}
-```
+Some OmniFocus objects expose an `id()` method that returns the task or project identifier as a string. The official type definitions describe an `ObjectIdentifier` type with a `primaryKey` field, but JXA scripts simply return the identifier string when calling `id()`.
 
 #### Property vs Method Access
-The official API uses property access (no parentheses) rather than method calls, which is more idiomatic for TypeScript/JavaScript.
+Most simple attributes can be accessed without parentheses (e.g. `task.name`), but identifier lookups still use the `id()` method.
 
 ### 5. Build Status
 ✅ TypeScript compilation successful - all code changes are syntactically correct.

--- a/src/omnifocus/scripts/tasks.ts
+++ b/src/omnifocus/scripts/tasks.ts
@@ -1113,8 +1113,7 @@ export const UPDATE_TASK_SCRIPT = `
       try {
         const allTasks = doc.flattenedTasks();
         for (let i = 0; i < allTasks.length; i++) {
-          if (allTasks[i].name() === task.name() && 
-              allTasks[i].primaryKey === task.primaryKey) {
+          if (allTasks[i].name() === task.name()) {
             taskIdAfterUpdate = allTasks[i].id();
             break;
           }

--- a/tests/unit/mock-id-extraction.test.ts
+++ b/tests/unit/mock-id-extraction.test.ts
@@ -82,7 +82,7 @@ describe('Mock ID Extraction Test', () => {
       updated: true
     };
     
-    // This simulates that our JXA script properly uses task.id.primaryKey()
+    // This simulates that our JXA script properly uses task.id()
     expect(mockUpdateResponse.id).toBeTruthy();
     expect(mockUpdateResponse.id).toBe('gZ0M5L3PkR8');
   });
@@ -91,16 +91,15 @@ describe('Mock ID Extraction Test', () => {
     // This tests that our script has the correct syntax
     const scriptSnippet = `
       const task = tasks[0];
-      const taskId = task.id.primaryKey();
+      const taskId = task.id();
       const project = task.containingProject();
-      const projectId = project ? project.id.primaryKey() : null;
+      const projectId = project ? project.id() : null;
     `;
     
     // Check for correct method calls with parentheses
-    expect(scriptSnippet).toContain('task.id.primaryKey()');
-    expect(scriptSnippet).toContain('project.id.primaryKey()');
+    expect(scriptSnippet).toContain('task.id()');
+    expect(scriptSnippet).toContain('project.id()');
     
-    // Ensure no instances without parentheses
-    expect(scriptSnippet).not.toMatch(/\.id\.primaryKey(?![\(\)])/);
+    expect(scriptSnippet).not.toMatch(/\.id(?!\()/);
   });
 });

--- a/tests/unit/verify-id-fix.test.ts
+++ b/tests/unit/verify-id-fix.test.ts
@@ -16,12 +16,7 @@ import {
 
 /**
  * Note: This test verifies the correct OmniFocus API usage for ID extraction.
- * In OmniFocus official API:
- * - task.id is an ObjectIdentifier with primaryKey property
- * - project.id is an ObjectIdentifier with primaryKey property
- * - All scripts should use .id.primaryKey to get the string ID
- * 
- * This test ensures we're using the correct official API patterns.
+ * IDs are retrieved using the `id()` method on tasks and projects.
  */
 describe('Verify ID Extraction Fix', () => {
   it('should use correct ID extraction patterns in task scripts', () => {


### PR DESCRIPTION
## Summary
- update documentation to state that ID retrieval uses `id()`
- correct release notes to reflect real ID usage
- remove outdated `primaryKey` comparison in `tasks.ts`
- update unit tests to match the real API

## Testing
- `node node_modules/vitest/vitest.mjs run tests/unit` *(fails: Code Changes Verification, ListTasksTool, ListProjectsTool)*

------
https://chatgpt.com/codex/tasks/task_e_688a824eee98832aa72129eff488c9d8