### PR TITLE
docs: update README to promote query_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ These prompts provide guided conversations with pre-configured questions and res
 
 ## Basic Usage
 
-### List Tasks
+### Query Tasks (List)
+The `list_tasks` tool is deprecated and retained only for backward compatibility. Use `query_tasks` with `queryType: "list"` instead:
 ```javascript
 {
-  "tool": "list_tasks",
+  "tool": "query_tasks",
   "arguments": {
+    "queryType": "list",
     "completed": false,
     "limit": 50
   }


### PR DESCRIPTION
## Summary
- Replace list_tasks example with query_tasks using queryType "list"
- Note list_tasks is deprecated and retained for backward compatibility

## Testing
- `npm test` (fails: server integration tests time out)
- `npm run lint` (fails: lint errors)

------
https://chatgpt.com/codex/tasks/task_e_689c43f0b830832aa728996d9b5c4d53