### PR TITLE
docs: add roadmap for remaining tool consolidation

### DIFF
--- a/docs/TOOL_CONSOLIDATION.md
+++ b/docs/TOOL_CONSOLIDATION.md
@@ -228,6 +228,8 @@ Potential areas for further consolidation:
 3. **Export**: Single export tool with format/type parameters
 4. **Tag Management**: Unified tag operations
 
+For detailed designs and migration steps, see [TOOL_CONSOLIDATION_ROADMAP.md](./TOOL_CONSOLIDATION_ROADMAP.md).
+
 ## Conclusion
 
 Tool consolidation represents a significant improvement in the OmniFocus MCP Server's usability, particularly for AI agents. The consolidated tools reduce cognitive load, improve consistency, and maintain full backward compatibility while providing a superior user experience.

--- a/docs/TOOL_CONSOLIDATION_ROADMAP.md
+++ b/docs/TOOL_CONSOLIDATION_ROADMAP.md
@@ -1,0 +1,84 @@
+# Remaining Tool Consolidation Roadmap
+
+## Purpose
+
+This document outlines the design for consolidating the remaining OmniFocus MCP tools into streamlined "V2" super-tools. The goal is to further reduce tool count, provide consistent interfaces, and cut context usage for LLM clients.
+
+## Design Principles
+
+- **Single entry point per domain** – each consolidated tool exposes an `operation` (or `mode`) parameter
+- **Zod schemas** – use the `schema` property from `BaseTool` for input validation
+- **Shared caching** – each operation declares its own cache keys and invalidation strategy
+- **Backward compatibility** – legacy tools remain available during migration
+
+## Consolidated Tools
+
+### 1. `tags` → `TagsToolV2`
+Combines `ListTagsTool`, `ManageTagsTool`, and `GetActiveTagsTool`.
+
+Operations:
+- `list` – return all tags
+- `manage` – create, rename, delete or merge tags
+- `active` – fetch tags attached to current selection
+
+Example:
+```javascript
+{ operation: "manage", action: "rename", tagName: "Home", newName: "House" }
+```
+
+### 2. `export` → `ExportToolV2`
+Unifies `ExportTasksTool`, `ExportProjectsTool`, and `BulkExportTool`.
+
+Operations:
+- `tasks` – export selected tasks
+- `projects` – export selected projects
+- `bulk` – export both tasks and projects with shared filters
+
+Shared parameters: `format`, `includeCompleted`, `tagFilter`.
+
+### 3. `recurring` → `RecurringTasksToolV2`
+Merges `AnalyzeRecurringTasksTool` and `GetRecurringPatternsTool`.
+
+Operations:
+- `analyze` – summarize recurring task health
+- `patterns` – list detected recurrence patterns
+
+### 4. `perspectives` → `PerspectivesToolV2`
+Replaces `ListPerspectivesTool` and `QueryPerspectiveTool`.
+
+Operations:
+- `list` – enumerate available perspectives
+- `query` – run a perspective and return tasks
+
+### 5. `system` → `SystemToolV2`
+Combines `GetVersionInfoTool` and `RunDiagnosticsTool`.
+
+Operations:
+- `version` – report server and OmniFocus versions
+- `diagnostics` – run environment checks and return results
+
+## Implementation Notes
+
+1. Each new tool extends `BaseTool` and defines a single Zod schema covering all operations.
+2. Switch logic inside `executeValidated` dispatches to operation-specific helpers.
+3. Cache invalidation mirrors existing tools (e.g., tag changes invalidate both `tags` and `tasks`).
+4. Update `src/tools/index.ts` to register these V2 tools and remove the legacy variants once validated.
+
+## Testing Strategy
+
+- Unit tests for each operation path
+- Regression tests using the manual MCP inspector script
+- Ensure `npm test` and `npm run test:integration` pass after migration
+
+## Migration Guide
+
+- LLMs should prefer the consolidated tool names: `tags`, `export`, `recurring_tasks`, `perspectives`, and `system`.
+- Legacy names remain functional but are marked deprecated in tool descriptions.
+
+## Timeline
+
+1. Implement `TagsToolV2`, `ExportToolV2`, and `RecurringTasksToolV2`
+2. Introduce `PerspectivesToolV2` and `SystemToolV2`
+3. Update documentation and examples
+4. Remove legacy tools in a subsequent major release
+


### PR DESCRIPTION
## Summary
- Add TOOL_CONSOLIDATION_ROADMAP.md detailing design for consolidating tag, export, recurring, perspective, and system tools into V2 super-tools
- Link roadmap from existing Tool Consolidation guide

## Testing
- `npm test` *(fails: cannot find legacy tool modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1438d32c832ab35427e8475363d2