### PR TITLE
docs: clarify privacy scope — server is local, LLM may not be

### DIFF
--- a/docs/user/GETTING_STARTED.md
+++ b/docs/user/GETTING_STARTED.md
@@ -255,10 +255,12 @@ See [API Reference](../api/API-COMPACT-UNIFIED.md).
 - The MCP server runs locally on your Mac and reads OmniFocus only when your assistant asks it to
 - The server itself does not send your data anywhere
 
-However, your **MCP client** (Claude Desktop, etc.) sends tool results to whatever LLM it is configured to use. If
-that LLM is cloud-hosted (e.g., Claude via Anthropic's API), then the task names, notes, projects, tags, and dates
-returned by this server are sent to that provider as part of the conversation. Only a fully local model keeps that
-data on-device.
+However, your **MCP client** (Claude Desktop, etc.) sends tool results to whatever LLM it is configured to use. If that
+LLM is cloud-hosted (e.g., Claude via Anthropic's API), then the task names, notes, projects, tags, and dates returned
+by this server are sent to that provider as part of the conversation. Only a fully local model keeps that data
+on-device.
+
+See [Privacy and Logging](PRIVACY_AND_LOGGING.md) for what the server logs and how sensitive fields are redacted.
 
 ## Getting Help
 

--- a/docs/user/GETTING_STARTED.md
+++ b/docs/user/GETTING_STARTED.md
@@ -252,9 +252,13 @@ See [API Reference](../api/API-COMPACT-UNIFIED.md).
 
 ## Privacy
 
-- All processing runs locally on your Mac
-- OmniFocus data stays in OmniFocus
-- The server accesses OmniFocus only when you ask
+- The MCP server runs locally on your Mac and reads OmniFocus only when your assistant asks it to
+- The server itself does not send your data anywhere
+
+However, your **MCP client** (Claude Desktop, etc.) sends tool results to whatever LLM it is configured to use. If
+that LLM is cloud-hosted (e.g., Claude via Anthropic's API), then the task names, notes, projects, tags, and dates
+returned by this server are sent to that provider as part of the conversation. Only a fully local model keeps that
+data on-device.
 
 ## Getting Help
 

--- a/docs/user/PRIVACY_AND_LOGGING.md
+++ b/docs/user/PRIVACY_AND_LOGGING.md
@@ -2,10 +2,20 @@
 
 ## Principles
 
-1. **Local only** - No data leaves your Mac
+1. **Server is local** - The MCP server runs on your Mac and sends your data nowhere on its own
 2. **Minimal logging** - Only what debugging requires
 3. **Automatic redaction** - Sensitive fields redacted
 4. **Debug-only content** - User data only at DEBUG level (off by default)
+
+## Scope
+
+The server itself is local. What leaves your Mac depends on the **MCP client** (Claude Desktop, ChatGPT Desktop, etc.)
+and the LLM it uses. When your assistant calls a tool, the server returns the result — task names, notes, projects,
+tags, dates — to the client, which forwards it to its LLM as part of the conversation. If that LLM is cloud-hosted, your
+data leaves the Mac at that point. Only a fully local model keeps it on-device.
+
+This document covers what the **server** logs. For what your client and LLM provider do with tool results, see their
+privacy documentation.
 
 ## What Gets Logged?
 
@@ -48,12 +58,12 @@ LOG_LEVEL=debug  # User data (redacted)
 
 ### Log Locations
 
-| Client | Path |
-|--------|------|
-| Claude Desktop | `~/Library/Logs/Claude/mcp*.log` |
-| Claude Code | `~/Library/Logs/claude-code/*.log` |
+| Client          | Path                                              |
+| --------------- | ------------------------------------------------- |
+| Claude Desktop  | `~/Library/Logs/Claude/mcp*.log`                  |
+| Claude Code     | `~/Library/Logs/claude-code/*.log`                |
 | ChatGPT Desktop | stderr/stdout (or `log stream --process ChatGPT`) |
-| Custom | stderr by default |
+| Custom          | stderr by default                                 |
 
 ### Extracting Error Metrics
 
@@ -66,6 +76,7 @@ grep ERROR_METRIC ~/Library/Logs/Claude/mcp*.log | jq -r '.errorType' | sort | u
 ```
 
 Example output (no personal data):
+
 ```
    5 SCRIPT_TIMEOUT
    2 OMNIFOCUS_NOT_RUNNING
@@ -86,10 +97,10 @@ grep ERROR_METRIC $LOG_PATH/mcp*.log | jq 'select(.recoverable == true)' | wc -l
 
 ## Implementation
 
-| Component | File | Purpose |
-|-----------|------|---------|
-| Redaction | `src/utils/logger.ts` | `redactArgs()` recursively scans objects (max depth 6) |
-| Error types | `src/utils/error-taxonomy.ts` | Categorizes errors, marks recoverability |
+| Component   | File                          | Purpose                                                |
+| ----------- | ----------------------------- | ------------------------------------------------------ |
+| Redaction   | `src/utils/logger.ts`         | `redactArgs()` recursively scans objects (max depth 6) |
+| Error types | `src/utils/error-taxonomy.ts` | Categorizes errors, marks recoverability               |
 
 ## Privacy Audit
 


### PR DESCRIPTION
The previous Privacy section implied OmniFocus data never leaves the
machine. That is only true of the MCP server itself. Tool results are
handed to the MCP client, which forwards them to whatever LLM it uses;
if that LLM is cloud-hosted, the data leaves the Mac.