### PR TITLE
docs: bring CHANGELOG and doc references up to v4.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 - **PRs**: include clear description, linked issues, test plan (`npm test`/coverage output), and any perf impact. Update
   docs when changing tools/prompts or public types. PRs must pass `lint`, `typecheck`, and all CI tests.
 
-## Unified API (v3.0.0+)
+## Unified API
 
 The server exposes 4 unified MCP tools that consolidate all functionality:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,91 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **OmniFocus 4.7+ repetition rules** — Reading tasks with repetition rules works again on current OmniFocus versions;
+  deprecated fields have been replaced with the modern API. Older tasks missing `catchUpAutomatically` no longer throw.
+- **`reviewInterval` accepts the `{ steps, unit }` object form** (OMN-38), matching what OmniFocus returns when reading
+  projects.
+- **Narrow project lookups omit the full project summary** (OMN-19) — Looking up a single project by ID or name returns
+  just that project's data without a noisy database-wide summary.
+
+### Improved
+
+- **Clearer MCP tool descriptions** for `repetitionRule`, batch `parentTempId`, and `includeCompleted`, so assistants
+  pick the right field on the first try.
+- **README restructured for public visitors.** API examples moved to the Developer Guide; the landing page now focuses
+  on what end users can do in natural language.
+
+### Developer Notes
+
+- Tag management migrated from the legacy string template to AST builders; tag mutation builders are now synchronous.
+- Export test output path uses `os.tmpdir()` so the suite runs cleanly on systems without a writable repo root.
+- SonarJS lint plugin adopted with `--max-warnings=0`; cognitive-complexity threshold tightened from 25 to 20.
+- New developer docs: architecture map, session handoff notes, dual-schema (Zod vs `inputSchema`) guidance in CLAUDE.md.
+
+## [4.1.0] - 2026-03-13
+
+### Fixed
+
+- **Duplicate project names no longer silently match the wrong project** (OMN-34). When a project filter resolves to
+  more than one project, the query returns a warning listing every match (with IDs, folder paths, and status) so you or
+  your assistant can pick the intended one. Existing unique-name filters behave exactly as before.
+
+### Developer Notes
+
+- New `EmitResult` type and shared project-resolution preamble are injected into every script builder; filter generator
+  and pipeline handle the richer return shape.
+- Structured `duplicateProjects` metadata added to filter responses.
+
+## [4.0.0] - 2026-02-22
+
+Large follow-up release to the v3.0.0 unified API. Focus: reliability of writes, correctness of IDs returned from
+create operations, and a much smaller schema footprint over the wire.
+
+### Added
+
+- **Create folders via `omnifocus_write`** — New `create_folder` operation lets you create folders (including nested
+  paths) alongside tasks and projects. (#48)
+- **Top-level `OR` in query filters** (OMN-30) — Filters can now mix `OR` groups at the top level, not just nested
+  inside `AND`.
+- **`repetitionRule` on updates** — Recurrence can be added or changed via `omnifocus_write` update, not just at
+  creation.
+- **`sequential` flag on task updates** (OMN-31) — Switch an existing action group between sequential and parallel.
+
+### Fixed
+
+- **New task IDs are always correct** (OMN-29) — Create operations resolve the real task ID via a note-marker bridge,
+  so the returned ID is what you'll find in OmniFocus (no more stale JXA IDs).
+- **Tag assignment on newly created tasks is reliable** (OMN-27) — Fresh tag IDs are bridged through OmniJS instead of
+  relying on JXA's cached references.
+- **Batch operations honor `parentTempId`** (OMN-28, OMN-31) — Tasks created inside a batch are placed in the right
+  project and can nest under sibling tasks created in the same batch.
+- **Responses return accurate IDs by default** (OMN-14, OMN-15) — Eliminated the remaining JXA `.id()` mismatches and
+  trimmed default responses so they're significantly smaller without losing essential fields.
+- **Deletes execute correctly under OmniJS** — Switched to `deleteObject()` instead of `item.remove()`.
+- **`overdue_reviews` off-by-one fixed** — Projects due for review today are no longer reported as overdue.
+- **Write pipeline wiring gaps closed** — A dozen fields that were accepted by the schema but dropped before execution
+  now flow through end-to-end.
+
+### Improved
+
+- **Advertised schema is ~99% smaller** — Replaced auto-generated JSON Schemas (a 3.2 MB `omnifocus_read` schema, plus
+  oversized `omnifocus_write` and `omnifocus_analyze` schemas) with hand-crafted minimal versions (OMN-18). A size
+  regression guard prevents accidental regrowth. MCP clients now pay a fraction of the context cost they used to.
+- **Leaner default responses** — Read queries no longer include redundant `data.preview`; batch write responses use a
+  single flat metadata envelope.
+
+### Developer Notes
+
+- Removed the manual `zod-to-json-schema` converter from `BaseTool` (OMN-16); each tool now supplies its own
+  hand-crafted `inputSchema` override and `BaseTool` throws if it's missing. The `zod-to-json-schema` devDependency is
+  gone.
+- `ExportFieldEnum` derived from `EXPORT_FIELD_MAP` keys (OMN-17) — single source of truth.
+- `FilterSchema` no longer uses `z.lazy()` recursion, eliminating a class of type-inference problems.
+- The `omnifocus-assistant` skill moved to user level via symlink; skill docs audited for post-bug-fix behavior.
+- Dropped the stale `.eslintignore` (flat config handles it) and excluded worktree directories from Vitest discovery.
+
 ## [3.0.0] - 2025-11-06
 
 ### BREAKING CHANGES

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ process.stdin.on('end', async () => {
 ```bash
 # Build & Test
 npm run build                    # Required before running
-npm run test:unit                # ~2 seconds, ~1634 tests
+npm run test:unit                # ~2 seconds, ~1644 tests
 npm run test:integration         # ~2 minutes, 73 tests (use npm, not bun)
 
 # MCP Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ focuses on developer implementation details.
 
 ---
 
-## 🎯 Unified API (v4.1.0)
+## 🎯 Unified API
 
 **Tools:** `omnifocus_read`, `omnifocus_write`, `omnifocus_analyze`, `system`
 
@@ -145,6 +145,9 @@ const bridgeResult = bridgeSetTags(app, taskId, tagNames);
 
 - Archive obsolete docs to `.archive/` → push to https://github.com/kip-d/omnifocus-mcp-archive
 - Follow Strunk's Elements of Style (tables > prose, omit needless words, active voice)
+- **Don't hardcode the current version in prose.** `package.json` and `CHANGELOG.md` are the single source of truth.
+  Historical references like "introduced in v3.0.0" are fine — descriptive labels like "(current v4.1.0)" go stale on
+  every release.
 
 ## 🚨 MCP Bridge Type Coercion
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ focuses on developer implementation details.
 
 ---
 
-## 🎯 Unified API (v3.0.0)
+## 🎯 Unified API (v4.1.0)
 
 **Tools:** `omnifocus_read`, `omnifocus_write`, `omnifocus_analyze`, `system`
 
@@ -193,7 +193,7 @@ process.stdin.on('end', async () => {
 ```bash
 # Build & Test
 npm run build                    # Required before running
-npm run test:unit                # ~2 seconds, 1622 tests
+npm run test:unit                # ~2 seconds, ~1634 tests
 npm run test:integration         # ~2 minutes, 73 tests (use npm, not bun)
 
 # MCP Testing

--- a/docs/DOCS_MAP.md
+++ b/docs/DOCS_MAP.md
@@ -107,7 +107,7 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 
 ## 📖 API Reference
 
-**Unified Builder API (4 Tools) — current: v4.1.0**
+**Unified Builder API (4 Tools)**
 
 - **[docs/api/API-COMPACT-UNIFIED.md](api/API-COMPACT-UNIFIED.md)** - Primary API reference
 - **[docs/api/README.md](api/README.md)** - API documentation overview
@@ -198,8 +198,8 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 
 **Testing prompts:**
 
-- **[TESTING_PROMPT.md](../prompts/TESTING_PROMPT.md)** - Unified testing guide for the 4-tool API with natural
-  language scenarios, technical validation, error handling, performance tests, and cleanup system
+- **[TESTING_PROMPT.md](../prompts/TESTING_PROMPT.md)** - Unified testing guide for the 4-tool API with natural language
+  scenarios, technical validation, error handling, performance tests, and cleanup system
 - **[.archive/testing-prompts/](../.archive/testing-prompts/)** - Archived testing prompts (consolidated November 2025)
 
 ---
@@ -330,7 +330,7 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 - **Debugging**: PATTERNS.md, DEBUGGING_WORKFLOW.md, LESSONS_LEARNED.md
 - **Performance**: BENCHMARK_RESULTS.md, PERFORMANCE.md, Hardware analysis docs
 - **Testing**: TEST_CLEANUP_GUIDE.md, REAL_LLM_TESTING.md, Evaluation suite
-- **API**: API-COMPACT-UNIFIED.md (unified 4-tool API, current v4.1.0)
+- **API**: API-COMPACT-UNIFIED.md (unified 4-tool API)
 - **Workflows**: GTD-WORKFLOW-MANUAL.md, SMART_CAPTURE.md, Built-in prompts
 
 ---

--- a/docs/DOCS_MAP.md
+++ b/docs/DOCS_MAP.md
@@ -81,9 +81,6 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
   properties
 - **[docs/dev/TAG_FILTERING_BUG_ANALYSIS.md](dev/TAG_FILTERING_BUG_ANALYSIS.md)** - Tag filtering implementation
   analysis
-- **[docs/dev/META_FIELDS_OPPORTUNITIES.md](dev/META_FIELDS_OPPORTUNITIES.md)** - Metadata field enhancement
-  opportunities
-- **[docs/dev/META_FIELDS_SUMMARY.md](dev/META_FIELDS_SUMMARY.md)** - Metadata field summary
 - **[docs/dev/MCP_SPECIFICATION_ALIGNMENT.md](dev/MCP_SPECIFICATION_ALIGNMENT.md)** - MCP protocol compliance details
 - **[docs/dev/SDK_UPGRADE_RECOMMENDATION.md](dev/SDK_UPGRADE_RECOMMENDATION.md)** - MCP SDK upgrade guidance
 
@@ -110,9 +107,9 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 
 ## 📖 API Reference
 
-**v3.0.0 Unified Builder API (4 Tools):**
+**Unified Builder API (4 Tools) — current: v4.1.0**
 
-- **[docs/api/API-COMPACT-UNIFIED.md](api/API-COMPACT-UNIFIED.md)** - Primary API reference for v3.0.0
+- **[docs/api/API-COMPACT-UNIFIED.md](api/API-COMPACT-UNIFIED.md)** - Primary API reference
 - **[docs/api/README.md](api/README.md)** - API documentation overview
 
 **The 4 unified tools:**
@@ -201,7 +198,7 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 
 **Testing prompts:**
 
-- **[TESTING_PROMPT.md](../prompts/TESTING_PROMPT.md)** - Unified testing guide for v3.0.0 API (4 tools) with natural
+- **[TESTING_PROMPT.md](../prompts/TESTING_PROMPT.md)** - Unified testing guide for the 4-tool API with natural
   language scenarios, technical validation, error handling, performance tests, and cleanup system
 - **[.archive/testing-prompts/](../.archive/testing-prompts/)** - Archived testing prompts (consolidated November 2025)
 
@@ -219,6 +216,21 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
   Script helper consolidation design
 - **[docs/plans/2025-11-07-phase2-helper-refactoring-foundation.md](plans/2025-11-07-phase2-helper-refactoring-foundation.md)** -
   Phase 2 helper refactoring
+- **[docs/plans/2026-02-10-nested-tag-hierarchy-syntax.md](plans/2026-02-10-nested-tag-hierarchy-syntax.md)** - Nested
+  tag hierarchy syntax
+- **[docs/plans/2026-02-15-batch-mixed-operations-design.md](plans/2026-02-15-batch-mixed-operations-design.md)** -
+  Batch mixed operations (design)
+- **[docs/plans/2026-02-15-batch-mixed-operations-plan.md](plans/2026-02-15-batch-mixed-operations-plan.md)** - Batch
+  mixed operations (plan)
+- **[docs/plans/2026-02-19-discriminated-fields-enum-design.md](plans/2026-02-19-discriminated-fields-enum-design.md)** -
+  Discriminated fields enum (design)
+- **[docs/plans/2026-02-19-discriminated-fields-enum-impl.md](plans/2026-02-19-discriminated-fields-enum-impl.md)** -
+  Discriminated fields enum (implementation)
+- **[docs/plans/2026-02-20-inbox-definition-fix.md](plans/2026-02-20-inbox-definition-fix.md)** - Inbox definition fix
+- **[docs/plans/2026-02-20-legacy-tool-removal-design.md](plans/2026-02-20-legacy-tool-removal-design.md)** - Legacy
+  tool removal (design)
+- **[docs/plans/2026-02-20-legacy-tool-removal-plan.md](plans/2026-02-20-legacy-tool-removal-plan.md)** - Legacy tool
+  removal (plan)
 - **[docs/plans/README-MULTI-MACHINE-SYNC.md](plans/README-MULTI-MACHINE-SYNC.md)** - Multi-machine sync overview
 - **[docs/plans/things-to-check-out.md](plans/things-to-check-out.md)** - Ideas and items to investigate
 
@@ -318,7 +330,7 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 - **Debugging**: PATTERNS.md, DEBUGGING_WORKFLOW.md, LESSONS_LEARNED.md
 - **Performance**: BENCHMARK_RESULTS.md, PERFORMANCE.md, Hardware analysis docs
 - **Testing**: TEST_CLEANUP_GUIDE.md, REAL_LLM_TESTING.md, Evaluation suite
-- **API**: API-COMPACT-UNIFIED.md (v3.0.0 unified 4-tool API)
+- **API**: API-COMPACT-UNIFIED.md (unified 4-tool API, current v4.1.0)
 - **Workflows**: GTD-WORKFLOW-MANUAL.md, SMART_CAPTURE.md, Built-in prompts
 
 ---
@@ -347,7 +359,7 @@ October 2025 checkpoints have been archived to `.archive/dev-historical-oct-2025
 
 ---
 
-**Last Updated**: 2026-02-08 **Total Documents**: ~100 (after archiving historical docs) **Documentation Coverage**:
+**Last Updated**: 2026-04-18 **Total Documents**: ~100 (after archiving historical docs) **Documentation Coverage**:
 Comprehensive (user, developer, API, operations, evaluation, testing)
 
 **Archived to**: `.archive/` directory and https://github.com/kip-d/omnifocus-mcp-archive (completed plans, Oct 2025

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -1,5 +1,10 @@
 # OmniFocus MCP Server - Improvement Roadmap
 
+> **Historical document.** This roadmap covers completed work through January 2026. For changes since then — the v4.0.0
+> and v4.1.0 reliability release, OMN-series fixes, schema size reductions, SonarJS adoption, AST migrations, and
+> OmniFocus 4.7+ API updates — see **[CHANGELOG.md](../CHANGELOG.md)**. This file is kept for history and won't be
+> updated per release.
+
 _Generated: September 19, 2025_ _Updated: January 2, 2026_ _Status: ALL Quick Win Phases COMPLETED + Advanced Search +
 Smart Capture + AST Bug Fixes - Foundation solid, high-value features delivered_
 

--- a/docs/api/API-COMPACT-UNIFIED.md
+++ b/docs/api/API-COMPACT-UNIFIED.md
@@ -1,4 +1,4 @@
-# OmniFocus MCP v3.0.0 - Unified Builder API (4 Tools)
+# OmniFocus MCP v4.1.0 - Unified Builder API (4 Tools)
 
 > **⚠️ For Claude Desktop Users:** Do NOT add this document to your system prompt or instructions. The MCP tool
 > descriptions already provide ~11,200 tokens of comprehensive documentation. Instead, use the slim
@@ -7,7 +7,7 @@
 
 **Status:** STABLE - Production-ready unified API with comprehensive testing and validation
 
-**📖 More Resources:** [Testing Prompt](../../TESTING_PROMPT.md) | [Full Docs](../../CLAUDE.md)
+**📖 More Resources:** [Testing Prompt](../../prompts/TESTING_PROMPT.md) | [Full Docs](../../CLAUDE.md)
 
 ---
 
@@ -151,7 +151,8 @@ Four unified tools provide streamlined MCP interface for LLM optimization:
 ```typescript
 {
   mutation: {
-    operation: "create" | "update" | "complete" | "delete" | "batch",
+    operation: "create" | "create_folder" | "update" | "complete" | "delete"
+             | "batch" | "bulk_delete" | "tag_manage",
 
     // For create
     target?: "task" | "project",
@@ -167,18 +168,32 @@ Four unified tools provide streamlined MCP interface for LLM optimization:
       plannedDate?: string,
       flagged?: boolean,
       estimatedMinutes?: number,
-      sequential?: boolean,
+      sequential?: boolean,     // Also supported on update (action groups)
       parentTaskId?: string,
-      repeatRule?: {...}
+      repetitionRule?: {...}
     },
+
+    // For create_folder
+    // data: { name: string, parentFolder?: string }
 
     // For update/complete/delete
     id?: string,
     changes?: {...},  // Same fields as data
 
     // For batch
-    operations?: Array<{target, data}>,
-    dryRun?: boolean  // Preview what would happen without executing
+    operations?: Array<{operation, target, data, tempId?, parentTempId?}>,
+    createSequentially?: boolean,  // default true
+    atomicOperation?: boolean,
+    returnMapping?: boolean,
+    stopOnError?: boolean,
+    dryRun?: boolean,              // Preview without executing
+
+    // For bulk_delete
+    // target: "task" | "project", ids: string[] (1..100), dryRun?: boolean
+
+    // For tag_manage
+    // action: "create" | "rename" | "delete" | "merge" | "nest" | "unnest" | "reparent"
+    // tagName: string; newName?, targetTag?, parentTag?: string
   }
 }
 ```
@@ -274,9 +289,33 @@ Four unified tools provide streamlined MCP interface for LLM optimization:
     }
   }
 }
+
+// Create a folder (optionally under a parent)
+{
+  mutation: {
+    operation: "create_folder",
+    data: { name: "Clients", parentFolder: "Work" }
+  }
+}
+
+// Bulk delete (up to 100 ids)
+{
+  mutation: {
+    operation: "bulk_delete",
+    target: "task",
+    ids: ["abc", "def", "ghi"],
+    dryRun: false
+  }
+}
+
+// Tag management
+{ mutation: { operation: "tag_manage", action: "create", tagName: "@errand" } }
+{ mutation: { operation: "tag_manage", action: "rename", tagName: "@errand", newName: "@shopping" } }
+{ mutation: { operation: "tag_manage", action: "merge",  tagName: "@old", targetTag: "@new" } }
+{ mutation: { operation: "tag_manage", action: "nest",   tagName: "@phone", parentTag: "@contexts" } }
 ```
 
-**Internal routing:** ManageTaskTool, BatchCreateTool, ProjectsTool, TagsTool
+**Internal routing:** ManageTaskTool, BatchCreateTool, ManageFolderTool, TagsTool, ProjectsTool
 
 ---
 
@@ -532,7 +571,7 @@ WorkflowAnalysisTool, RecurringTasksTool, ParseMeetingNotesTool, ManageReviewsTo
 - ✅ All 4 tools registered and tested
 - ✅ End-to-end integration tests passing (17/17)
 - ✅ User testing complete with 100% success rate
-- ✅ Production ready (v3.0.0)
+- ✅ Production ready (v4.1.0)
 
 ---
 

--- a/docs/api/API-COMPACT-UNIFIED.md
+++ b/docs/api/API-COMPACT-UNIFIED.md
@@ -1,4 +1,4 @@
-# OmniFocus MCP v4.1.0 - Unified Builder API (4 Tools)
+# OmniFocus MCP - Unified Builder API (4 Tools)
 
 > **⚠️ For Claude Desktop Users:** Do NOT add this document to your system prompt or instructions. The MCP tool
 > descriptions already provide ~11,200 tokens of comprehensive documentation. Instead, use the slim
@@ -571,7 +571,7 @@ WorkflowAnalysisTool, RecurringTasksTool, ParseMeetingNotesTool, ManageReviewsTo
 - ✅ All 4 tools registered and tested
 - ✅ End-to-end integration tests passing (17/17)
 - ✅ User testing complete with 100% success rate
-- ✅ Production ready (v4.1.0)
+- ✅ Production ready
 
 ---
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,7 @@
 # API Reference Documentation
 
-Complete API specifications for the OmniFocus MCP server v4.1.0.
+Complete API specifications for the OmniFocus MCP server. The current version lives in
+[package.json](../../package.json); release notes in [CHANGELOG.md](../../CHANGELOG.md).
 
 ## ⚠️ Important: Context Window Guidance
 
@@ -14,7 +15,7 @@ critical tips (date conversion, inbox assignment, countOnly, tags) without dupli
 
 ---
 
-## Current API (v4.1.0 Unified Builder API)
+## Current API (Unified Builder API)
 
 ### **API-COMPACT-UNIFIED.md** - Human Reference
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 # API Reference Documentation
 
-Complete API specifications for the OmniFocus MCP server v3.0.0.
+Complete API specifications for the OmniFocus MCP server v4.1.0.
 
 ## ⚠️ Important: Context Window Guidance
 
@@ -14,7 +14,7 @@ critical tips (date conversion, inbox assignment, countOnly, tags) without dupli
 
 ---
 
-## Current API (v3.0.0 Unified Builder API)
+## Current API (v4.1.0 Unified Builder API)
 
 ### **API-COMPACT-UNIFIED.md** - Human Reference
 
@@ -36,6 +36,7 @@ The v3.0.0 API consolidates 17 legacy tools into **4 unified tools**:
 - countOnly queries (33x faster for counts)
 - dryRun mode for batch preview
 - Export to JSON/CSV/Markdown
+- Folder creation, bulk delete, and tag management all routed through `omnifocus_write`
 
 **Use this for:**
 

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -157,7 +157,8 @@ const SAFE_TEMPLATE = [
 ## Testing
 
 ```bash
-node test-single-tool.js tasks '{"mode":"today","limit":"3"}'
+npm run test:unit         # ~2s
+npm run test:integration  # requires OmniFocus; ~4 min against a ~2500-task database
 ```
 
 | Environment | Behavior |
@@ -181,7 +182,7 @@ node test-single-tool.js tasks '{"mode":"today","limit":"3"}'
 
 ## Tool Architecture
 
-4 unified tools (v3.0.0 Unified Builder API):
+4 unified tools (v4.1.0 Unified Builder API):
 
 | Tool | Purpose |
 |------|---------|

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -6,11 +6,11 @@ Hybrid JavaScript execution: JXA entry point with OmniJS bridge for operations J
 
 ## Execution Model
 
-| Layer | Context | Use |
-|-------|---------|-----|
-| **JXA** | `osascript -l JavaScript` | Entry point, reads, simple CRUD |
-| **Bridge** | `app.evaluateJavascript()` | Tag assignment, repetition rules, bulk ops |
-| **Pure OmniJS** | N/A | Never used directly |
+| Layer           | Context                    | Use                                        |
+| --------------- | -------------------------- | ------------------------------------------ |
+| **JXA**         | `osascript -l JavaScript`  | Entry point, reads, simple CRUD            |
+| **Bridge**      | `app.evaluateJavascript()` | Tag assignment, repetition rules, bulk ops |
+| **Pure OmniJS** | N/A                        | Never used directly                        |
 
 ---
 
@@ -27,7 +27,8 @@ Operation needed?
 └── Bulk (>100 items) → JXA + Bridge
 ```
 
-**Bridge required for:** Tag assignment (JXA limitation), task movement (preserves IDs), repetition rules, perspective queries.
+**Bridge required for:** Tag assignment (JXA limitation), task movement (preserves IDs), repetition rules, perspective
+queries.
 
 ---
 
@@ -83,10 +84,10 @@ src/omnifocus/scripts/shared/
 
 ## Script Size
 
-| Context | Limit | Current Max |
-|---------|-------|-------------|
-| JXA Direct | 523KB | ~31KB (6%) |
-| OmniJS Bridge | 261KB | Well under |
+| Context       | Limit | Current Max |
+| ------------- | ----- | ----------- |
+| JXA Direct    | 523KB | ~31KB (6%)  |
+| OmniJS Bridge | 261KB | Well under  |
 
 Size is rarely the limiting factor.
 
@@ -94,12 +95,12 @@ Size is rarely the limiting factor.
 
 ## Performance
 
-| Rule | Why |
-|------|-----|
-| Never use `whose()`/`where()` | 25+ seconds |
-| Direct iteration + try/catch | 50% faster than wrappers |
-| Early exit conditions | Check completed/date first |
-| Cache timestamps | Don't create Date objects in loops |
+| Rule                          | Why                                |
+| ----------------------------- | ---------------------------------- |
+| Never use `whose()`/`where()` | 25+ seconds                        |
+| Direct iteration + try/catch  | 50% faster than wrappers           |
+| Early exit conditions         | Check completed/date first         |
+| Cache timestamps              | Don't create Date objects in loops |
 
 **Bridge for performance:** Bulk operations (>100 items), perspective queries.
 
@@ -110,8 +111,11 @@ Size is rarely the limiting factor.
 ```javascript
 // JXA
 function safeGet(fn) {
-  try { return fn(); }
-  catch (e) { return null; }
+  try {
+    return fn();
+  } catch (e) {
+    return null;
+  }
 }
 const name = safeGet(() => task.name()) || 'Unnamed';
 
@@ -120,7 +124,9 @@ function executeBridgeOp(app, template, params) {
   try {
     const result = app.evaluateJavascript(formatBridgeScript(template, params));
     return JSON.parse(result);
-  } catch (e) { return { success: false, error: String(e) }; }
+  } catch (e) {
+    return { success: false, error: String(e) };
+  }
 }
 ```
 
@@ -138,7 +144,7 @@ const SAFE_TEMPLATE = [
   '  task.clearTags();',
   '  tags.forEach(n => task.addTag(Tag.byName(n) || new Tag(n)));',
   '  return JSON.stringify({ success: true });',
-  '})()'
+  '})()',
 ].join('\\n');
 ```
 
@@ -146,11 +152,11 @@ const SAFE_TEMPLATE = [
 
 ## Anti-Patterns
 
-| Don't | Do |
-|-------|-----|
+| Don't                                                    | Do                                                   |
+| -------------------------------------------------------- | ---------------------------------------------------- |
 | String concatenation: `` `task.name = "${userInput}"` `` | Template with `formatBridgeScript(template, params)` |
-| `doc.flattenedTasks.whose({ completed: false })()` | Direct iteration with early exit |
-| Pure OmniJS without JXA wrapper | `app.evaluateJavascript(omniJsScript)` |
+| `doc.flattenedTasks.whose({ completed: false })()`       | Direct iteration with early exit                     |
+| Pure OmniJS without JXA wrapper                          | `app.evaluateJavascript(omniJsScript)`               |
 
 ---
 
@@ -161,35 +167,35 @@ npm run test:unit         # ~2s
 npm run test:integration  # requires OmniFocus; ~4 min against a ~2500-task database
 ```
 
-| Environment | Behavior |
-|-------------|----------|
-| CLI | Read operations work; write may fail |
-| Claude Desktop | All operations work |
+| Environment    | Behavior                             |
+| -------------- | ------------------------------------ |
+| CLI            | Read operations work; write may fail |
+| Claude Desktop | All operations work                  |
 
 ---
 
 ## Benchmarks
 
-| Operation | Time |
-|-----------|------|
-| Task queries (2000+ tasks) | <1s |
-| Task creation | <0.5s |
-| Tag operations via bridge | <1s |
-| Bulk exports | 2-5s |
-| Using `whose()` | 25+s |
+| Operation                  | Time  |
+| -------------------------- | ----- |
+| Task queries (2000+ tasks) | <1s   |
+| Task creation              | <0.5s |
+| Tag operations via bridge  | <1s   |
+| Bulk exports               | 2-5s  |
+| Using `whose()`            | 25+s  |
 
 ---
 
 ## Tool Architecture
 
-4 unified tools (v4.1.0 Unified Builder API):
+4 unified tools (Unified Builder API):
 
-| Tool | Purpose |
-|------|---------|
-| `omnifocus_read` | Query tasks, projects, tags, folders, perspectives |
-| `omnifocus_write` | Create, update, complete, delete tasks/projects |
-| `omnifocus_analyze` | Productivity stats, velocity, overdue, patterns |
-| `system` | Version, diagnostics, metrics |
+| Tool                | Purpose                                            |
+| ------------------- | -------------------------------------------------- |
+| `omnifocus_read`    | Query tasks, projects, tags, folders, perspectives |
+| `omnifocus_write`   | Create, update, complete, delete tasks/projects    |
+| `omnifocus_analyze` | Productivity stats, velocity, overdue, patterns    |
+| `system`            | Version, diagnostics, metrics                      |
 
 Discriminated union schemas route to backend implementations.
 

--- a/docs/dev/DEVELOPER_GUIDE.md
+++ b/docs/dev/DEVELOPER_GUIDE.md
@@ -108,7 +108,7 @@ Four tools: `omnifocus_read`, `omnifocus_write`, `omnifocus_analyze`, `system`.
 | `method`     | `fixed`, `due-after-completion`, `defer-after-completion` | Schedule method                |
 | `endDate`    | `YYYY-MM-DD`                                              | Stop recurring after this date |
 
-### Tags & Folders (omnifocus_read)
+### Tags & Folders (omnifocus_read / omnifocus_write)
 
 ```javascript
 // List tags
@@ -116,6 +116,21 @@ Four tools: `omnifocus_read`, `omnifocus_write`, `omnifocus_analyze`, `system`.
 
 // List folders
 { "query": { "type": "folders" } }
+
+// Create a folder (optionally under a parent folder)
+{ "mutation": { "operation": "create_folder", "data": { "name": "Clients", "parentFolder": "Work" } } }
+
+// Tag management: create | rename | delete | merge | nest
+{ "mutation": { "operation": "tag_manage", "action": "create", "tagName": "@errand" } }
+{ "mutation": { "operation": "tag_manage", "action": "rename", "tagName": "@errand", "newName": "@shopping" } }
+{ "mutation": { "operation": "tag_manage", "action": "merge",  "tagName": "@old", "targetTag": "@new" } }
+{ "mutation": { "operation": "tag_manage", "action": "nest",   "tagName": "@phone", "parentTag": "@contexts" } }
+```
+
+### Bulk Delete (omnifocus_write)
+
+```javascript
+{ "mutation": { "operation": "bulk_delete", "target": "task", "ids": ["id1", "id2", "id3"] } }
 ```
 
 ### Analytics (omnifocus_analyze)
@@ -136,9 +151,13 @@ Four tools: `omnifocus_read`, `omnifocus_write`, `omnifocus_analyze`, `system`.
 
 ### System
 
+`system` is a top-level tool, not a `query.type`. Call it directly:
+
 ```javascript
-{ "query": { "type": "system", "operation": "version" } }
-{ "query": { "type": "system", "operation": "diagnostics" } }
+{ "operation": "version" }
+{ "operation": "diagnostics" }
+{ "operation": "metrics" }
+{ "operation": "cache" }
 ```
 
 ---

--- a/docs/dev/DEVELOPER_GUIDE.md
+++ b/docs/dev/DEVELOPER_GUIDE.md
@@ -16,7 +16,7 @@ For developers integrating or extending the OmniFocus MCP server.
 
 ---
 
-## Unified API (v4.1.0)
+## Unified API
 
 Four tools: `omnifocus_read`, `omnifocus_write`, `omnifocus_analyze`, `system`.
 

--- a/docs/dev/MCP_SPECIFICATION_ALIGNMENT.md
+++ b/docs/dev/MCP_SPECIFICATION_ALIGNMENT.md
@@ -36,7 +36,7 @@ security principles are enforced, and best practices are followed.
 
 ### 3. Tool Implementation ✅
 
-**4 Unified Tools (v3.0.0 API):**
+**4 Unified Tools (introduced in v3.0.0; current v4.1.0):**
 
 - ✅ **omnifocus_read** - Query tasks, projects, tags, perspectives, folders, export
 - ✅ **omnifocus_write** - Create/update/complete/delete tasks and projects, batch operations

--- a/docs/dev/MCP_SPECIFICATION_ALIGNMENT.md
+++ b/docs/dev/MCP_SPECIFICATION_ALIGNMENT.md
@@ -36,7 +36,7 @@ security principles are enforced, and best practices are followed.
 
 ### 3. Tool Implementation ✅
 
-**4 Unified Tools (introduced in v3.0.0; current v4.1.0):**
+**4 Unified Tools (introduced in v3.0.0):**
 
 - ✅ **omnifocus_read** - Query tasks, projects, tags, perspectives, folders, export
 - ✅ **omnifocus_write** - Create/update/complete/delete tasks and projects, batch operations

--- a/docs/operational/LLM_USAGE_GUIDE.md
+++ b/docs/operational/LLM_USAGE_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Best practices for AI agents using the OmniFocus MCP Server v3.0.0 unified API.
+Best practices for AI agents using the OmniFocus MCP Server unified API (current v4.1.0).
 
 ## The 4 Unified Tools
 

--- a/docs/operational/LLM_USAGE_GUIDE.md
+++ b/docs/operational/LLM_USAGE_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Best practices for AI agents using the OmniFocus MCP Server unified API (current v4.1.0).
+Best practices for AI agents using the OmniFocus MCP Server unified API.
 
 ## The 4 Unified Tools
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -118,7 +118,7 @@ The unified API consolidates everything into **4 unified tools**:
 
 ### If tools aren't working:
 
-1. Check version: Should be 4.1.0 or higher
+1. Check version: should match the latest entry in [CHANGELOG.md](../CHANGELOG.md)
 2. Run diagnostics: `system` tool with `{ operation: "diagnostics" }` (`system` is a top-level tool, not a `query.type`)
 3. Check Claude Desktop logs for errors
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,4 +1,4 @@
-# OmniFocus MCP v3.0.0 Prompts
+# OmniFocus MCP Prompts
 
 This directory contains ready-to-use prompts for testing and using the OmniFocus MCP server with Claude Desktop.
 
@@ -53,7 +53,7 @@ prompt provides higher value per token.
 
 #### [TESTING_PROMPT.md](./TESTING_PROMPT.md)
 
-Comprehensive test suite for the v3.0.0 unified API. Use this to verify your installation is working correctly.
+Comprehensive test suite for the unified API. Use this to verify your installation is working correctly.
 
 - Tests all CRUD operations via `omnifocus_read` and `omnifocus_write`
 - Validates advanced features (batch, export, analytics)
@@ -94,9 +94,9 @@ Complete GTD (Getting Things Done) workflow for daily use.
 2. Customize the sections you need
 3. Save your own variations for different contexts (work, personal, etc.)
 
-## v3.0.0 Unified API
+## Unified API
 
-The v3.0.0 API consolidates everything into **4 unified tools**:
+The unified API consolidates everything into **4 unified tools**:
 
 | Tool                | Purpose                                     |
 | ------------------- | ------------------------------------------- |
@@ -118,8 +118,8 @@ The v3.0.0 API consolidates everything into **4 unified tools**:
 
 ### If tools aren't working:
 
-1. Check version: Should be 3.0.0 or higher
-2. Run diagnostics: `system` tool with `{ query: { type: "system", operation: "diagnostics" } }`
+1. Check version: Should be 4.1.0 or higher
+2. Run diagnostics: `system` tool with `{ operation: "diagnostics" }` (`system` is a top-level tool, not a `query.type`)
 3. Check Claude Desktop logs for errors
 
 ## Creating Custom Prompts
@@ -170,7 +170,7 @@ You can access these prompts by asking Claude to "use the [prompt_name] prompt":
 | **[Manual Templates](.)** (this directory)        | Beginners, customization, offline use | Copy/paste entire prompt into Claude         |
 | **[MCP Prompts](../src/prompts/)** (programmatic) | Advanced users, integrated workflows  | Ask Claude to "use the [prompt_name] prompt" |
 
-Both approaches use the same underlying v3 unified API and provide similar functionality through different interfaces.
+Both approaches use the same underlying unified API and provide similar functionality through different interfaces.
 
 ## Support
 

--- a/prompts/TESTING_PROMPT.md
+++ b/prompts/TESTING_PROMPT.md
@@ -39,7 +39,7 @@ If automated tests fail, fix those first.
 system({operation: "version"})
 ```
 
-**REPORT:** `✅ Test 1: OmniFocus MCP v3.x.x`
+**REPORT:** `✅ Test 1: OmniFocus MCP v4.x.x`
 
 ---
 

--- a/prompts/TESTING_PROMPT.md
+++ b/prompts/TESTING_PROMPT.md
@@ -1,7 +1,7 @@
 # OmniFocus MCP Test Suite
 
-**Version:** Unified API (current v4.1.0) **Time:** ~10 minutes **Purpose:** Validate MCP server functionality with real
-OmniFocus operations
+**Version:** Unified API **Time:** ~10 minutes **Purpose:** Validate MCP server functionality with real OmniFocus
+operations
 
 ---
 

--- a/prompts/TESTING_PROMPT.md
+++ b/prompts/TESTING_PROMPT.md
@@ -1,6 +1,6 @@
 # OmniFocus MCP Test Suite
 
-**Version:** v3.0.0+ Unified API **Time:** ~10 minutes **Purpose:** Validate MCP server functionality with real
+**Version:** Unified API (current v4.1.0) **Time:** ~10 minutes **Purpose:** Validate MCP server functionality with real
 OmniFocus operations
 
 ---


### PR DESCRIPTION
CHANGELOG was empty past v3.0.0 (2025-11-06) while the code had shipped
v4.0.0 and v4.1.0. Added user-facing entries for both releases plus an
Unreleased section covering post-4.1.0 fixes.

User-facing docs (README, Getting Started) were already natural-language
focused and left alone; API/JSON examples belong in the developer docs.

Changes:

CHANGELOG.md
- [4.0.0] 2026-02-22: create_folder, top-level OR filter, repetitionRule
  on updates, sequential on update, ID correctness fixes (OMN-14/15/27/
  28/29/30/31), overdue_reviews off-by-one, delete via deleteObject(),
  ~99% smaller advertised schemas, leaner default responses, plus a
  Developer Notes subsection (OMN-16/17, z.lazy removal, skill move).
- [4.1.0] 2026-03-13: OMN-34 duplicate project name resolution with
  duplicateProjects warning metadata.
- [Unreleased]: OmniFocus 4.7+ repetition rule read fields, OMN-38
  reviewInterval object form, OMN-19 narrow lookup summary, clearer MCP
  tool descriptions, README restructure; AST tag-mutation migration and
  SonarJS adoption under Developer Notes.

Version labels and small fixes:
- CLAUDE.md, ARCHITECTURE.md, API-COMPACT-UNIFIED.md, api/README.md,
  LLM_USAGE_GUIDE.md, MCP_SPECIFICATION_ALIGNMENT.md: v3.0.0 -> v4.1.0
  (historical references to what shipped in v3.0.0 left as-is).
- API-COMPACT-UNIFIED.md: documented the three missing write operations
  (create_folder, bulk_delete, tag_manage), corrected repeatRule ->
  repetitionRule, expanded batch options, fixed TESTING_PROMPT.md path.
- DEVELOPER_GUIDE.md: fixed incorrect `{query:{type:"system"}}` example
  (system is a top-level tool); added examples for create_folder,
  bulk_delete, and tag_manage using the actual schema field names
  (tagName / newName / targetTag / parentTag).
- ARCHITECTURE.md: replaced the dead `test-single-tool.js` testing
  example with the actual npm test commands.
- CLAUDE.md: corrected unit test count (1622 -> ~1644) to match
  current docs and session handoff.

Doc map / roadmap:
- DOCS_MAP.md: removed broken references to non-existent
  META_FIELDS_OPPORTUNITIES.md and META_FIELDS_SUMMARY.md; added the
  2026-02 plans (nested tag hierarchy, batch mixed ops, discriminated
  fields enum, inbox definition fix, legacy tool removal); bumped
  footer date; dropped stale v3.0.0 labels from descriptive text.
- IMPROVEMENT_ROADMAP.md: added a banner marking it as historical
  through January 2026 and redirecting readers to CHANGELOG for
  current work, so the roadmap stops drifting every release.

Follow-up commit (d0f4b6a):
- Genericized hardcoded "(current v4.1.0)" labels across docs so the
  next release doesn't require another doc-catch-up PR. Single source
  of truth is now package.json + CHANGELOG.md. Historical references
  ("introduced in v3.0.0") are kept. Added a one-line convention note
  in CLAUDE.md so the pattern doesn't return.