### PR TITLE
fix: tasks export honors outputDirectory + includeCompleted (OMN-44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   projects.
 - **Narrow project lookups omit the full project summary** (OMN-19) — Looking up a single project by ID or name returns
   just that project's data without a noisy database-wide summary.
+- **Tasks export honors `outputDirectory` and `includeCompleted`** (OMN-44) — `omnifocus_read` with
+  `type: "export", exportType: "tasks"` was silently capping the response at 1000 records and ignoring both knobs. When
+  `outputDirectory` is set, the export is written to `tasks.<format>` and the implicit cap rises to 5000;
+  `includeCompleted: false` now actually excludes completed tasks. Response-path exports emit `summary.truncated: true`
+  when the cap fires so callers can detect partial datasets.
 
 ### Improved
 
@@ -46,8 +51,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [4.0.0] - 2026-02-22
 
-Large follow-up release to the v3.0.0 unified API. Focus: reliability of writes, correctness of IDs returned from
-create operations, and a much smaller schema footprint over the wire.
+Large follow-up release to the v3.0.0 unified API. Focus: reliability of writes, correctness of IDs returned from create
+operations, and a much smaller schema footprint over the wire.
 
 ### Added
 
@@ -61,8 +66,8 @@ create operations, and a much smaller schema footprint over the wire.
 
 ### Fixed
 
-- **New task IDs are always correct** (OMN-29) — Create operations resolve the real task ID via a note-marker bridge,
-  so the returned ID is what you'll find in OmniFocus (no more stale JXA IDs).
+- **New task IDs are always correct** (OMN-29) — Create operations resolve the real task ID via a note-marker bridge, so
+  the returned ID is what you'll find in OmniFocus (no more stale JXA IDs).
 - **Tag assignment on newly created tasks is reliable** (OMN-27) — Fresh tag IDs are bridged through OmniJS instead of
   relying on JXA's cached references.
 - **Batch operations honor `parentTempId`** (OMN-28, OMN-31) — Tasks created inside a batch are placed in the right

--- a/src/tools/response-types-v2.ts
+++ b/src/tools/response-types-v2.ts
@@ -196,6 +196,7 @@ export interface ExportDataV2 {
   data: string | object;
   count: number;
   summary?: Record<string, unknown>;
+  outputPath?: string;
 }
 
 export type ExportResponseV2 = StandardResponseV2<ExportDataV2>;

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -190,7 +190,11 @@ RESPONSE CONTROL:
 
 COMPLETED TASKS:
 - Use filters: { completed: true } or filters: { status: "completed" } to query completed tasks
-- includeCompleted is for export operations only (type: "export")
+- includeCompleted is for export operations only (type: "export"); honored by exportType: "tasks" and exportType: "all"
+
+EXPORT TO DISK:
+- outputDirectory: when set with exportType: "tasks", writes tasks.<format> to disk (raises the implicit cap to 5000); required for exportType: "all"
+- A response-path export (no outputDirectory) caps at 1000 by default and emits summary.truncated when the cap fires; override with limit
 
 PERFORMANCE:
 - Use countOnly for counting questions
@@ -258,8 +262,16 @@ PERFORMANCE:
             exportType: { type: 'string', enum: ['tasks', 'projects', 'all'] },
             format: { type: 'string', enum: ['json', 'csv', 'markdown'] },
             exportFields: { type: 'array', items: { type: 'string' } },
-            outputDirectory: { type: 'string' },
-            includeCompleted: { type: 'boolean', description: 'Export only: include completed tasks in export' },
+            outputDirectory: {
+              type: 'string',
+              description:
+                'Export only: directory to write the export file to. With exportType:"tasks" writes tasks.<format> and raises the cap; required for exportType:"all".',
+            },
+            includeCompleted: {
+              type: 'boolean',
+              description:
+                'Export only: include completed tasks (default true). Honored by exportType:"tasks" and exportType:"all".',
+            },
           },
           required: ['type'],
         },
@@ -860,10 +872,14 @@ PERFORMANCE:
     format: ExportFormat,
     timer: OperationTimerV2,
   ): Promise<unknown> {
-    // Build ExportFilter from compiled query filters
+    const outputDirectory = compiled.outputDirectory;
+
+    // OMN-44: `filters.completed` (if set) takes precedence; `includeCompleted`
+    // is the higher-level convenience that the schema doc-comment promises.
+    const completedFromFlag = compiled.includeCompleted === false ? false : undefined;
     const exportFilter: ExportFilter = {
       available: compiled.filters.available,
-      completed: compiled.filters.completed,
+      completed: compiled.filters.completed ?? completedFromFlag,
       flagged: compiled.filters.flagged,
       project: undefined, // export filter uses project name, not in compiled.filters
       projectId: compiled.filters.projectId,
@@ -871,7 +887,10 @@ PERFORMANCE:
       tagsOperator: compiled.filters.tagsOperator as ExportFilter['tagsOperator'],
       search: compiled.filters.search,
     };
-    const limit = compiled.limit || 1000;
+    // OMN-44: response-size pressure does not apply when writing to disk, so
+    // raise the implicit cap; a user-supplied `limit` always wins.
+    const defaultCap = outputDirectory ? 5000 : 1000;
+    const limit = compiled.limit || defaultCap;
 
     const { script } = buildExportTasksScript(exportFilter, {
       limit,
@@ -893,7 +912,54 @@ PERFORMANCE:
     }
 
     if (isScriptSuccess(result)) {
-      const data = result.data as { format: string; data: unknown; count: number };
+      const data = result.data as {
+        format: string;
+        data: unknown;
+        count: number;
+        limited?: boolean;
+      };
+      const summary: Record<string, unknown> = {};
+      if (data.limited === true) {
+        summary.truncated = true;
+        summary.cap = limit;
+      }
+
+      // OMN-44: honor outputDirectory for tasks export. Write the payload to
+      // disk and return the path; skip embedding the full payload to keep the
+      // response small.
+      if (outputDirectory) {
+        try {
+          const fsSync = await import('fs');
+          fsSync.mkdirSync(outputDirectory, { recursive: true });
+          const outputPath = path.join(outputDirectory, `tasks.${format}`);
+          const payload = data.data;
+          const toWrite = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+          fsSync.writeFileSync(outputPath, toWrite, 'utf-8');
+          return createSuccessResponseV2(
+            'export',
+            {
+              format: data.format as ExportFormat,
+              exportType: 'tasks' as const,
+              data: { written_to: outputPath, count: data.count },
+              count: data.count,
+              outputPath,
+              ...(Object.keys(summary).length ? { summary } : {}),
+            },
+            undefined,
+            { ...timer.toMetadata(), operation: 'tasks' },
+          );
+        } catch (writeError) {
+          return createErrorResponseV2(
+            'export',
+            'WRITE_FAILED',
+            `Failed to write export file: ${String(writeError)}`,
+            undefined,
+            { outputDirectory, error: String(writeError) },
+            timer.toMetadata(),
+          );
+        }
+      }
+
       return createSuccessResponseV2(
         'export',
         {
@@ -901,6 +967,7 @@ PERFORMANCE:
           exportType: 'tasks' as const,
           data: data.data as string | object,
           count: data.count,
+          ...(Object.keys(summary).length ? { summary } : {}),
         },
         undefined,
         { ...timer.toMetadata(), operation: 'tasks' },

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -250,9 +250,19 @@ const ExportQuerySchema = BaseQuerySchema.merge(
     exportType: ExportTypeEnum.optional().describe('What to export: tasks, projects, or all'),
     format: ExportFormatEnum.optional().describe('Export format: json, csv, or markdown'),
     exportFields: z.array(ExportFieldEnum).optional().describe('Fields to include in export'),
-    outputDirectory: z.string().optional().describe('Directory for bulk export (required when exportType=all)'),
+    outputDirectory: z
+      .string()
+      .optional()
+      .describe(
+        'Directory to write the export. With exportType="tasks" writes tasks.<format> and raises the cap; required for exportType="all".',
+      ),
     includeStats: z.boolean().optional().describe('Include statistics in project export'),
-    includeCompleted: z.boolean().optional().describe('Include completed tasks in export'),
+    includeCompleted: z
+      .boolean()
+      .optional()
+      .describe(
+        'Include completed tasks in export (default true). Honored by exportType="tasks" and exportType="all".',
+      ),
   }),
 ).strict();
 

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -772,6 +772,157 @@ describe('OmniFocusReadTool', () => {
         expect(result.data.format).toBe('json');
       });
     });
+
+    // OMN-44: tasks export silently dropped records and ignored includeCompleted.
+    // Two distinct bugs in handleTaskExport: outputDirectory was never read
+    // (only handleBulkExport consumed it), and includeCompleted was never
+    // mapped onto the export filter. Sibling-handler drift.
+    describe('OMN-44 tasks export honors outputDirectory + includeCompleted', () => {
+      it('writes tasks to disk and raises the cap when outputDirectory is set', async () => {
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: { format: 'json', data: [{ id: 't1' }], count: 1 },
+        } satisfies ScriptResult);
+
+        const fsModule = await import('fs');
+        const writeSpy = vi.mocked(fsModule.writeFileSync);
+        writeSpy.mockClear();
+        const mkdirSpy = vi.mocked(fsModule.mkdirSync);
+        mkdirSpy.mockClear();
+
+        const result = (await tool.execute({
+          query: {
+            type: 'export',
+            exportType: 'tasks',
+            format: 'json',
+            outputDirectory: TEST_EXPORT_DIR,
+          },
+        })) as any;
+
+        expect(result.success).toBe(true);
+        // File was written
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        const [writtenPath] = writeSpy.mock.calls[0];
+        expect(String(writtenPath)).toContain(TEST_EXPORT_DIR);
+        expect(String(writtenPath)).toMatch(/tasks\.json$/);
+        // outputPath is reported back to the caller
+        expect(result.data.outputPath).toBe(writtenPath);
+        // The implicit cap is no longer 1000 when writing to disk; the script
+        // is generated with a substantially higher maxTasks ceiling.
+        const scriptArg = execJsonSpy.mock.calls[0][0] as string;
+        const match = scriptArg.match(/const maxTasks = (\d+);/);
+        expect(match).not.toBeNull();
+        const maxTasks = Number(match![1]);
+        expect(maxTasks).toBeGreaterThanOrEqual(5000);
+      });
+
+      it('keeps the 1000 default cap when outputDirectory is NOT set', async () => {
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: { format: 'json', data: [], count: 0 },
+        } satisfies ScriptResult);
+
+        const fsModule = await import('fs');
+        const writeSpy = vi.mocked(fsModule.writeFileSync);
+        writeSpy.mockClear();
+
+        const result = (await tool.execute({
+          query: { type: 'export', exportType: 'tasks', format: 'json' },
+        })) as any;
+
+        expect(result.success).toBe(true);
+        // No file written when outputDirectory is absent
+        expect(writeSpy).not.toHaveBeenCalled();
+        // The cap is the historical 1000 default
+        const scriptArg = execJsonSpy.mock.calls[0][0] as string;
+        const match = scriptArg.match(/const maxTasks = (\d+);/);
+        expect(match).not.toBeNull();
+        expect(Number(match![1])).toBe(1000);
+      });
+
+      it('honors includeCompleted=false for tasks export', async () => {
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: { format: 'json', data: [], count: 0 },
+        } satisfies ScriptResult);
+
+        const result = (await tool.execute({
+          query: {
+            type: 'export',
+            exportType: 'tasks',
+            format: 'json',
+            includeCompleted: false,
+          },
+        })) as any;
+
+        expect(result.success).toBe(true);
+        // The script must filter out completed tasks. The OmniJS predicate
+        // emitted by the AST builder references task.completed in the filter.
+        const scriptArg = execJsonSpy.mock.calls[0][0] as string;
+        expect(scriptArg).toContain('completed');
+        expect(scriptArg).toMatch(/!\s*task\.completed|task\.completed\s*===\s*false|completed:\s*false/);
+      });
+
+      it('treats includeCompleted=true (default) as no completed-filter', async () => {
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: { format: 'json', data: [], count: 0 },
+        } satisfies ScriptResult);
+
+        const result = (await tool.execute({
+          query: {
+            type: 'export',
+            exportType: 'tasks',
+            format: 'json',
+            includeCompleted: true,
+          },
+        })) as any;
+
+        expect(result.success).toBe(true);
+        // No completed predicate emitted into the filter
+        const scriptArg = execJsonSpy.mock.calls[0][0] as string;
+        // Filter description is emitted as a comment; check the predicate body
+        // does not constrain task.completed. The AST emits `true` for an empty
+        // filter.
+        expect(scriptArg).toContain('return true;');
+      });
+
+      it('flags truncation in summary when the script reports limited=true', async () => {
+        // Script already detects truncation via `tasksAdded >= maxTasks` and
+        // emits `limited: true` (script-builder.ts). Handler must surface it.
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: {
+            format: 'json',
+            data: new Array(1000).fill({ id: 'x' }),
+            count: 1000,
+            limited: true,
+          },
+        } satisfies ScriptResult);
+
+        const result = (await tool.execute({
+          query: { type: 'export', exportType: 'tasks', format: 'json' },
+        })) as any;
+
+        expect(result.success).toBe(true);
+        expect(result.data.summary?.truncated).toBe(true);
+        expect(result.data.summary?.cap).toBe(1000);
+      });
+
+      it('does NOT flag truncation when count is below the cap', async () => {
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: { format: 'json', data: [{ id: 't1' }], count: 1 },
+        } satisfies ScriptResult);
+
+        const result = (await tool.execute({
+          query: { type: 'export', exportType: 'tasks', format: 'json' },
+        })) as any;
+
+        expect(result.success).toBe(true);
+        expect(result.data.summary?.truncated).not.toBe(true);
+      });
+    });
   });
 
   // ─── Thin-by-default field resolution ─────────────────────────


### PR DESCRIPTION
## Summary

- `omnifocus_read` with `type: "export", exportType: "tasks"` silently capped responses at 1000 records and ignored both `outputDirectory` and `includeCompleted`. Against a 2854-task database the user lost 65% of their data on every export, and a second export with `includeCompleted: false` returned a byte-identical file.
- Root cause is sibling-handler drift: both knobs are forwarded into `CompiledQuery` by `QueryCompiler`, but only `handleBulkExport` (the `exportType: "all"` branch) read them. `handleTaskExport` never did.
- This is the same drift shape OMN-47 is auditing for — a parity test that iterates every `(CompiledQuery field × handler branch)` pair would catch it.

## Changes

- `handleTaskExport` reads `compiled.outputDirectory`; when set, writes `tasks.<format>` to that directory and raises the implicit cap from 1000 → 5000. A user-supplied `limit` always wins.
- Maps `includeCompleted: false` onto `exportFilter.completed = false`. An explicit `filters.completed` takes precedence.
- Surfaces the script's existing `limited: true` flag as `summary.{ truncated, cap }` so callers can detect partial datasets on the response path.
- `ExportDataV2.outputPath?: string` becomes a first-class response field rather than tucked inside `data`.
- Schema descriptions (Zod + `inputSchema` + top-level tool description) clarified for both knobs.

## Test plan

- [x] 6 new \`OMN-44\` unit tests in `tests/unit/tools/unified/OmniFocusReadTool.test.ts` covering: outputDirectory writes the file, cap raise, no-write when outputDirectory absent, includeCompleted=false honored, includeCompleted=true default, truncation flag fires.
- [x] Full unit suite: 1788 / 1788 passing.
- [x] Live verification against the maintainer's real OmniFocus DB (2896 tasks):
  - `outputDirectory` set → count **2896** (was 1000), file written, 2896 records on disk.
  - `includeCompleted: false` → count **2232** with 0 completed tasks in the file (664 completed correctly excluded).
  - Response path (no `outputDirectory`) → `count: 1000, summary: { truncated: true, cap: 1000 }`.
- [ ] Integration test run on the reviewer's machine (requires `VITEST_ALLOW_JXA=1`).

## Notes for reviewer

The fix deliberately does not touch caching — there is no cache on the export path, so the "byte-identical output with includeCompleted=false" symptom was a flag-dropped signal, not staleness. Confirmed by inspection of `CacheManager.ts` and the export response builders.

Closes OMN-44.