### PR TITLE
fix: warm up OmniFocus mutation path before integration tests (OMN-55)

### DIFF
--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -13,10 +13,128 @@
  */
 
 import { MCPTestClient } from './mcp-test-client.js';
+import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
 
 let sharedClient: MCPTestClient | null = null;
 let initPromise: Promise<MCPTestClient> | null = null;
 let isFirstAccess = true;
+
+/**
+ * Warm up OmniFocus + the JXA script execution path inside the spawned MCP server.
+ *
+ * Background: On the first integration-suite run of the day (or after OmniFocus has
+ * been idle, mid-sync, or freshly relaunched), the first ~5 update operations
+ * return `success: false` envelopes. Subsequent runs in the same session are clean.
+ * See Linear OMN-55 for the diagnostic data.
+ *
+ * Strategy: exercise both the read path AND the create/update/delete mutation path
+ * before any test runs, so the failing surface is warm by the time tests issue their
+ * own updates. Read-only warm-up is not enough — every failing assertion in the
+ * cold-run logs was on `updateResult.success`, not a read.
+ *
+ * Phase 1: retry a tiny inbox read until success or 15s timeout.
+ * Phase 2: create → update → delete a sandbox task; retry the update under the same
+ *          15s budget, since that's the operation that actually fails cold.
+ */
+async function warmupOmniFocus(client: MCPTestClient): Promise<void> {
+  const TIMEOUT_MS = 15000;
+  const INTERVAL_MS = 500;
+
+  // Phase 1: read path
+  const readStart = Date.now();
+  let readAttempts = 0;
+  let lastReadFailure = '(no attempts)';
+  let readOk = false;
+  while (Date.now() - readStart < TIMEOUT_MS) {
+    readAttempts++;
+    try {
+      const result = await client.callTool('omnifocus_read', {
+        query: { type: 'tasks', mode: 'inbox', limit: 1 },
+      });
+      if (result?.success) {
+        readOk = true;
+        break;
+      }
+      lastReadFailure = `success=false, error=${result?.error ?? '(none)'}`;
+    } catch (err) {
+      lastReadFailure = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((r) => setTimeout(r, INTERVAL_MS));
+  }
+  if (!readOk) {
+    throw new Error(
+      `OmniFocus warm-up (read) failed after ${readAttempts} attempts in ${TIMEOUT_MS}ms. ` +
+        `Last failure: ${lastReadFailure}. ` +
+        'Is OmniFocus running and reachable? Check for blocking dialogs.',
+    );
+  }
+
+  // Phase 2: mutation path — this is the surface that fails on cold OmniFocus
+  const warmupName = `${TEST_INBOX_PREFIX} warmup ${Date.now()}`;
+  const warmupTag = `${TEST_TAG_PREFIX}warmup`;
+
+  let taskId: string | undefined;
+  try {
+    const createResult = await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'create',
+        target: 'task',
+        data: { name: warmupName, tags: [warmupTag] },
+      },
+    });
+    taskId = createResult?.data?.task?.taskId;
+    if (!createResult?.success || !taskId) {
+      throw new Error(`OmniFocus warm-up (create) failed: ${createResult?.error ?? JSON.stringify(createResult)}`);
+    }
+
+    // Retry the update under a fresh budget — this is the exact operation
+    // that returns success: false on a cold run.
+    const updateStart = Date.now();
+    let updateAttempts = 0;
+    let lastUpdateFailure = '(no attempts)';
+    let updateOk = false;
+    while (Date.now() - updateStart < TIMEOUT_MS) {
+      updateAttempts++;
+      try {
+        const updateResult = await client.callTool('omnifocus_write', {
+          mutation: {
+            operation: 'update',
+            target: 'task',
+            id: taskId,
+            changes: { note: 'warmup' },
+          },
+        });
+        if (updateResult?.success) {
+          updateOk = true;
+          break;
+        }
+        lastUpdateFailure = `success=false, error=${updateResult?.error ?? '(none)'}`;
+      } catch (err) {
+        lastUpdateFailure = err instanceof Error ? err.message : String(err);
+      }
+      await new Promise((r) => setTimeout(r, INTERVAL_MS));
+    }
+    if (!updateOk) {
+      throw new Error(
+        `OmniFocus warm-up (update) failed after ${updateAttempts} attempts in ${TIMEOUT_MS}ms. ` +
+          `Last failure: ${lastUpdateFailure}. ` +
+          'This is the exact failure mode OMN-55 is meant to prevent; tests would fail confusingly.',
+      );
+    }
+  } finally {
+    // Best-effort cleanup of the warm-up task. Even if it fails, the sandbox
+    // sweep in setup/teardown will pick it up by the __TEST__ prefix.
+    if (taskId) {
+      try {
+        await client.callTool('omnifocus_write', {
+          mutation: { operation: 'delete', target: 'task', id: taskId },
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
 
 /**
  * Get or create the shared MCP client instance
@@ -48,7 +166,9 @@ export async function getSharedClient(): Promise<MCPTestClient> {
     console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
     sharedClient = new MCPTestClient({ enableCacheWarming: true });
     await sharedClient.startServer();
-    console.log('✅ Shared MCP server ready (cache warmed)');
+    console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
+    await warmupOmniFocus(sharedClient);
+    console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
     isFirstAccess = false; // First access complete
     return sharedClient;
   })();


### PR DESCRIPTION
## Summary

- Adds a two-phase warm-up to `tests/integration/helpers/shared-server.ts` that runs once after the spawned MCP server starts. Phase 1 retries a tiny inbox read (15s budget, 500ms interval); Phase 2 does create → update → delete on a sandbox task to exercise the exact mutation path that fails cold.
- Either phase failing throws a labelled "warm-up failed" error rather than letting the first ~5 update tests fail confusingly with `expect(updateResult.success).toBe(true)` mismatches.
- Read-only warm-up wouldn't have helped: every cold-run failure in the OMN-55 diagnostics is on the *update* path, and `ENABLE_CACHE_WARMING=true` already warms reads at server start.

## Why this location

The warm-up lives in `shared-server.ts`'s `getSharedClient`, not in `tests/support/setup-integration.ts`. Vitest `globalSetup` runs in a separate process — it can warm OmniFocus the app but not the JXA execution path of the per-run `dist/index.js` MCP server the tests actually talk to. `getSharedClient` is the first point where the test process holds a live MCP connection to warm.

## Test plan

- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 1782 passed
- [x] `VITEST_ALLOW_JXA=1 npm run test:integration` — **73 passed / 22 skipped / 0 failed** (matches healthy baseline)
- [x] Warm-up log lines visible between server-start and "ready":
  ```
  🚀 Starting shared MCP server for integration tests (with cache warming)...
  🔥 Warming up OmniFocus (read + mutation paths)...
  ✅ Shared MCP server ready (cache warmed, OmniFocus warmed)
  ```
- [x] Teardown cleanup count 9 (close to the healthy ~6, far from the cold-fail 42)
- [ ] Definitive validation = next true cold-start (first integration run of the day, after OmniFocus has been idle/relaunched). Today's runs all had OmniFocus already warm from PR validation, so the bug isn't reproducible on demand.

## Related

- Linear: OMN-55
- Sibling: OMN-56 (print `updateResult.error` on assertion failure) — once that lands, warm-up validation becomes immediate, because failing assertions will carry the underlying OmniFocus error text instead of just "expected true, got false".