### PR TITLE
Re-enable orphaned custom ESLint rules + fix metadata-snake-case V1→V2 targeting

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,168 +1,203 @@
 /**
- * Custom ESLint rules for OmniFocus MCP coding standards
+ * Custom ESLint rules for OmniFocus MCP coding standards.
+ *
+ * ESLint 9 flat-config plugin: top-level `meta` + `rules`, ESM default export.
+ * Uses ESLint 9 context properties (`context.filename`, `context.sourceCode`)
+ * rather than the deprecated `getFilename()` / `getSourceCode()` methods.
  */
 
-module.exports = {
+const FUNCTION_TYPES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']);
+
+function enclosingFunction(node) {
+  for (let n = node.parent; n; n = n.parent) {
+    if (FUNCTION_TYPES.has(n.type)) return n;
+  }
+  return null;
+}
+
+const plugin = {
+  meta: {
+    name: 'omnifocus-mcp-local',
+    version: '1.0.0',
+  },
   rules: {
-    /**
-     * Ensure all Tool classes extend BaseTool
-     */
     'extend-base-tool': {
+      meta: {
+        type: 'problem',
+        docs: { description: 'Tool classes must extend BaseTool' },
+        schema: [],
+        messages: {
+          mustExtendBaseTool: 'Tool classes must extend BaseTool',
+        },
+      },
       create(context) {
         return {
           ClassDeclaration(node) {
-            if (node.id && node.id.name.endsWith('Tool')) {
-              if (!node.superClass || node.superClass.name !== 'BaseTool') {
-                context.report({
-                  node,
-                  message: 'Tool classes must extend BaseTool',
-                });
-              }
+            if (!node.id || !node.id.name.endsWith('Tool')) return;
+            if (!node.superClass || node.superClass.type !== 'Identifier' || node.superClass.name !== 'BaseTool') {
+              context.report({ node, messageId: 'mustExtendBaseTool' });
             }
           },
         };
       },
     },
 
-    /**
-     * Ensure tools use standardized response functions
-     */
     'use-standard-response': {
+      meta: {
+        type: 'suggestion',
+        docs: {
+          description:
+            'Tool-response methods should construct results via createSuccessResponseV2 / createErrorResponseV2 / createListResponse, not plain object literals',
+        },
+        schema: [],
+        messages: {
+          useStandardResponse:
+            'Use createSuccessResponseV2, createErrorResponseV2, or createListResponse instead of returning a plain {success|data} object literal',
+        },
+      },
       create(context) {
+        const filename = context.filename;
+        if (!filename.includes('/tools/') || !filename.endsWith('Tool.ts')) return {};
+
         return {
           ReturnStatement(node) {
-            // Check if we're in a tool file
-            const filename = context.getFilename();
-            if (!filename.includes('/tools/') || !filename.endsWith('Tool.ts')) {
-              return;
-            }
+            if (!node.argument || node.argument.type !== 'ObjectExpression') return;
 
-            // Check if returning an object literal directly
-            if (node.argument && node.argument.type === 'ObjectExpression') {
-              const properties = node.argument.properties.map((p) => p.key?.name);
+            // Only enforce inside methods that are annotated as producing a
+            // StandardResponse — helpers returning internal envelopes (unknown,
+            // domain objects) are not subject to this contract.
+            const fn = enclosingFunction(node);
+            if (!fn || !fn.returnType) return;
+            const annText = context.sourceCode.getText(fn.returnType);
+            if (!annText.includes('StandardResponse')) return;
 
-              // If it looks like a response object but not using standard functions
-              if (properties.includes('success') || properties.includes('data')) {
-                context.report({
-                  node,
-                  message:
-                    'Use createSuccessResponse, createErrorResponse, or createListResponse instead of returning plain objects',
-                });
-              }
+            const keys = node.argument.properties
+              .map((p) => (p.type === 'Property' && p.key && (p.key.name || p.key.value)) || null)
+              .filter(Boolean);
+            if (keys.includes('success') || keys.includes('data')) {
+              context.report({ node, messageId: 'useStandardResponse' });
             }
           },
         };
       },
     },
 
-    /**
-     * Ensure error handling uses this.handleError
-     */
     'use-handle-error': {
+      meta: {
+        type: 'suggestion',
+        docs: {
+          description:
+            'Catch blocks that return must route through a standard error sink (this.handleError[V2] or createErrorResponse[V2]) or rethrow',
+        },
+        schema: [],
+        messages: {
+          useHandleError:
+            'Catch blocks that return should use this.handleErrorV2(error), createErrorResponseV2(...), or rethrow — not return a plain object',
+        },
+      },
       create(context) {
+        const filename = context.filename;
+        if (!filename.includes('/tools/') || !filename.endsWith('Tool.ts')) return {};
+
+        const VALID_SINK = /\bthis\.handleError(V2)?\b|\bcreateErrorResponse(V2)?\b|\bthrow\b/;
+
         return {
           CatchClause(node) {
-            const filename = context.getFilename();
-            if (!filename.includes('/tools/') || !filename.endsWith('Tool.ts')) {
-              return;
-            }
+            // Only flag catches inside methods that produce tool responses —
+            // i.e., whose return-type annotation mentions StandardResponse.
+            const fn = enclosingFunction(node);
+            if (!fn || !fn.returnType) return;
+            const annText = context.sourceCode.getText(fn.returnType);
+            if (!annText.includes('StandardResponse')) return;
 
-            // Check if catch block body contains this.handleError
-            const sourceCode = context.getSourceCode();
-            const catchBody = sourceCode.getText(node.body);
-
-            if (!catchBody.includes('this.handleError')) {
-              // Check if it's throwing (which is sometimes acceptable)
-              if (!catchBody.includes('throw')) {
-                context.report({
-                  node,
-                  message: 'Use this.handleError(error) in catch blocks for consistent error handling',
-                });
-              }
-            }
+            const text = context.sourceCode.getText(node.body);
+            // Side-effecting catch blocks (no return) record sub-task results
+            // in loops; the consistent-error-response contract doesn't apply.
+            if (!/\breturn\b/.test(text)) return;
+            if (VALID_SINK.test(text)) return;
+            context.report({ node, messageId: 'useHandleError' });
           },
         };
       },
     },
 
-    /**
-     * Ensure metadata fields use snake_case
-     */
     'metadata-snake-case': {
+      meta: {
+        type: 'suggestion',
+        docs: { description: 'Metadata fields in response builders must use snake_case' },
+        schema: [],
+        messages: {
+          snakeCaseMetadata: "Metadata field '{{key}}' should use snake_case naming",
+        },
+      },
       create(context) {
+        const RESPONSE_BUILDERS = new Set(['createSuccessResponse', 'createErrorResponse', 'createListResponse']);
         return {
           Property(node) {
-            // Look for metadata object properties
-            if (node.parent && node.parent.parent) {
-              const parentNode = node.parent.parent;
+            const objExpr = node.parent;
+            if (!objExpr || objExpr.type !== 'ObjectExpression') return;
+            const call = objExpr.parent;
+            if (!call || call.type !== 'CallExpression') return;
+            const callee = call.callee;
+            const calleeName =
+              (callee && callee.type === 'Identifier' && callee.name) ||
+              (callee && callee.type === 'MemberExpression' && callee.property && callee.property.name) ||
+              null;
+            if (!calleeName || !RESPONSE_BUILDERS.has(calleeName)) return;
+            if (call.arguments[2] !== objExpr) return;
 
-              // Check if this is likely a metadata object
-              if (parentNode.type === 'CallExpression') {
-                const callee = parentNode.callee;
-                if (
-                  callee.name === 'createSuccessResponse' ||
-                  callee.name === 'createErrorResponse' ||
-                  callee.name === 'createListResponse'
-                ) {
-                  // Check if property is in the metadata parameter (3rd argument)
-                  const args = parentNode.arguments;
-                  if (args[2] && node.parent === args[2]) {
-                    const key = node.key.name || node.key.value;
-
-                    // Check if key is camelCase (should be snake_case)
-                    if (key && /[a-z][A-Z]/.test(key)) {
-                      context.report({
-                        node,
-                        message: `Metadata field '${key}' should use snake_case naming`,
-                      });
-                    }
-                  }
-                }
-              }
+            const key = (node.key && (node.key.name || node.key.value)) || null;
+            if (typeof key === 'string' && /[a-z][A-Z]/.test(key)) {
+              context.report({ node, messageId: 'snakeCaseMetadata', data: { key } });
             }
           },
         };
       },
     },
 
-    /**
-     * Ensure schema files export Zod schemas
-     */
     'export-zod-schema': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description: 'Schema files must import zod and export at least one *Schema binding',
+        },
+        schema: [],
+        messages: {
+          missingZodImport: 'Schema files must import from zod',
+          missingSchemaExport: 'Schema files must export at least one Schema',
+        },
+      },
       create(context) {
+        const filename = context.filename;
+        if (!filename.includes('/schemas/') || !filename.endsWith('.ts')) return {};
+
+        // Files named *helper*.ts are utility modules (e.g., coerceBoolean factories)
+        // colocated with schemas — they import zod but don't define Schemas directly.
+        const isHelperModule = /helpers?\.ts$/i.test(filename);
+
         let hasZodImport = false;
         let hasSchemaExport = false;
 
         return {
           ImportDeclaration(node) {
-            if (node.source.value === 'zod') {
-              hasZodImport = true;
-            }
+            if (node.source.value === 'zod') hasZodImport = true;
           },
           ExportNamedDeclaration(node) {
-            if (node.declaration && node.declaration.declarations) {
-              node.declaration.declarations.forEach((decl) => {
-                if (decl.id.name && decl.id.name.endsWith('Schema')) {
-                  hasSchemaExport = true;
-                }
-              });
+            const decls = node.declaration && node.declaration.declarations;
+            if (!decls) return;
+            for (const d of decls) {
+              const name = d.id && d.id.name;
+              if (typeof name === 'string' && /Schema/.test(name)) {
+                hasSchemaExport = true;
+              }
             }
           },
-          'Program:exit'() {
-            const filename = context.getFilename();
-            if (filename.includes('/schemas/') && filename.endsWith('.ts')) {
-              if (!hasZodImport) {
-                context.report({
-                  node: context.getSourceCode().ast,
-                  message: 'Schema files must import from zod',
-                });
-              }
-              if (!hasSchemaExport) {
-                context.report({
-                  node: context.getSourceCode().ast,
-                  message: 'Schema files must export at least one Schema',
-                });
-              }
+          'Program:exit'(programNode) {
+            if (!hasZodImport) {
+              context.report({ node: programNode, messageId: 'missingZodImport' });
+            }
+            if (!hasSchemaExport && !isHelperModule) {
+              context.report({ node: programNode, messageId: 'missingSchemaExport' });
             }
           },
         };
@@ -170,3 +205,5 @@ module.exports = {
     },
   },
 };
+
+export default plugin;

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -131,7 +131,16 @@ const plugin = {
         },
       },
       create(context) {
-        const RESPONSE_BUILDERS = new Set(['createSuccessResponse', 'createErrorResponse', 'createListResponse']);
+        // V2 response builders and the positional index of their `metadata`
+        // argument (see src/utils/response-format.ts signatures). The index
+        // differs per builder, so a flat name set is insufficient.
+        const METADATA_ARG_INDEX = {
+          createSuccessResponseV2: 3, // (operation, data, summary?, metadata)
+          createErrorResponseV2: 5, // (operation, errorCode, message, suggestion?, details?, metadata)
+          createTaskResponseV2: 2, // (operation, tasks, metadata)
+          createListResponseV2: 3, // (operation, items, itemType, metadata)
+          createAnalyticsResponseV2: 4, // (operation, data, analysisType, keyFindings, metadata)
+        };
         return {
           Property(node) {
             const objExpr = node.parent;
@@ -143,8 +152,8 @@ const plugin = {
               (callee && callee.type === 'Identifier' && callee.name) ||
               (callee && callee.type === 'MemberExpression' && callee.property && callee.property.name) ||
               null;
-            if (!calleeName || !RESPONSE_BUILDERS.has(calleeName)) return;
-            if (call.arguments[2] !== objExpr) return;
+            if (!calleeName || !Object.prototype.hasOwnProperty.call(METADATA_ARG_INDEX, calleeName)) return;
+            if (call.arguments[METADATA_ARG_INDEX[calleeName]] !== objExpr) return;
 
             const key = (node.key && (node.key.name || node.key.value)) || null;
             if (typeof key === 'string' && /[a-z][A-Z]/.test(key)) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import tseslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import sonarjs from 'eslint-plugin-sonarjs';
 import globals from 'globals';
+import localRules from './eslint-rules/index.js';
 
 export default [
   // Base ESLint recommended rules
@@ -126,6 +127,31 @@ export default [
       '@typescript-eslint/no-unsafe-call': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
       '@typescript-eslint/no-unsafe-return': 'warn',
+    },
+  },
+
+  // Custom OmniFocus MCP rules — applied to tool implementations
+  {
+    files: ['src/tools/**/*Tool.ts'],
+    plugins: {
+      'local-rules': localRules,
+    },
+    rules: {
+      'local-rules/extend-base-tool': 'error',
+      'local-rules/use-standard-response': 'warn',
+      'local-rules/use-handle-error': 'warn',
+      'local-rules/metadata-snake-case': 'warn',
+    },
+  },
+
+  // Custom OmniFocus MCP rules — applied to schema modules
+  {
+    files: ['src/tools/**/schemas/**/*.ts', 'src/tools/schemas/**/*.ts'],
+    plugins: {
+      'local-rules': localRules,
+    },
+    rules: {
+      'local-rules/export-zod-schema': 'warn',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:dev": "./scripts/test-quick.sh",
     "test:cleanup": "npx tsx scripts/test-cleanup.ts",
     "lint": "eslint src --ext .ts",
-    "lint:strict": "eslint src --ext .ts --config .eslintrc.mcp.json",
+    "lint:strict": "eslint src --ext .ts --max-warnings=0",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "npx prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "npx prettier --check \"**/*.{ts,js,json,md}\"",

--- a/tests/unit/eslint-rules/metadata-snake-case.test.ts
+++ b/tests/unit/eslint-rules/metadata-snake-case.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import plugin from '../../../eslint-rules/index.js';
+
+// Wire ESLint's RuleTester into vitest's runner. Without this, RuleTester's
+// internal it()/describe() calls no-op when nested inside a vitest test,
+// causing assertions to silently never run.
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const rule = (plugin as { rules: Record<string, unknown> }).rules['metadata-snake-case'];
+
+if (!rule) {
+  throw new Error('metadata-snake-case rule not found on plugin export');
+}
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('metadata-snake-case', rule as never, {
+  valid: [
+    // snake_case metadata is fine
+    'createSuccessResponseV2(\'op\', {}, undefined, { total_count: 1 });',
+    'createErrorResponseV2(\'op\', \'CODE\', \'msg\', undefined, undefined, { from_cache: false });',
+    'createTaskResponseV2(\'op\', [], { returned_count: 0 });',
+    // camelCase in DATA (arg 1), not metadata — must NOT report (proves correct arg targeting)
+    'createSuccessResponseV2(\'op\', { camelCaseInData: 1 }, undefined, { snake_case: 1 });',
+    // unrelated function with camelCase object — must NOT report
+    'someOtherFn({ camelCaseKey: 1 });',
+  ],
+  invalid: [
+    {
+      // createSuccessResponseV2: metadata is arg index 3
+      code: 'createSuccessResponseV2(\'op\', {}, undefined, { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createErrorResponseV2: metadata is arg index 5
+      code: 'createErrorResponseV2(\'op\', \'CODE\', \'msg\', undefined, undefined, { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createTaskResponseV2: metadata is arg index 2
+      code: 'createTaskResponseV2(\'op\', [], { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createListResponseV2: metadata is arg index 3
+      code: 'createListResponseV2(\'op\', [], \'tasks\', { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createAnalyticsResponseV2: metadata is arg index 4
+      code: 'createAnalyticsResponseV2(\'op\', {}, \'type\', [], { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // member-expression callee form: this.createSuccessResponseV2(...)
+      code: 'this.createSuccessResponseV2(\'op\', {}, undefined, { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+  ],
+});


### PR DESCRIPTION
## What

Merges the long-unmerged `worktree-eslint9-custom-rules` work (PR #3 / commit \`3c4d55f\`) and fixes a latent bug in it.

### Background
`eslint-rules/index.js` was orphaned during the ESLint 8→9 flat-config migration — wired to nothing on `main`. The prior memory/Linear record incorrectly claimed it merged as \`d26ab52\`; verification showed it never landed (real work sat unmerged on \`origin/worktree-eslint9-custom-rules\`). This branch lands it.

### The V1→V2 fix (commit \`37d9f18\`)
Re-wiring alone was insufficient. The `metadata-snake-case` rule hardcoded **legacy V1 builder names** (`createSuccessResponse`/`createErrorResponse`/`createListResponse` — 0 call-sites in `src/`) and assumed metadata was always `arguments[2]`. The live **V2** builders place `metadata` at different positional indices each:

| Builder | metadata arg index |
|---|---|
| `createTaskResponseV2` | 2 |
| `createSuccessResponseV2` / `createListResponseV2` | 3 |
| `createAnalyticsResponseV2` | 4 |
| `createErrorResponseV2` | 5 |

A flat name-set rename would have kept the rule checking the wrong argument — silently a no-op while *looking* fixed (the exact failure mode OMN-54 exists to catch). Replaced with a per-builder index map derived from `src/utils/response-format.ts` signatures.

## Tests
- New `tests/unit/eslint-rules/metadata-snake-case.test.ts` (ESLint `RuleTester` wired into vitest). Red→green verified: pre-fix 6 invalid cases failed; post-fix 11/11 pass. Includes a valid case with camelCase in the `data` arg to prove correct arg-targeting (not just "fires somewhere").
- Full unit suite: 1655/1655 pass. `tsc` build: clean.

## Known consequence (intentionally not fixed here)
The now-*active* rule surfaces **15 pre-existing** camelCase metadata warnings (3 in `SystemTool.ts`, 12 in `OmniFocusAnalyzeTool.ts`). Left as-is: `warn` severity, and renaming response metadata keys is a client-facing contract change deserving its own ticket. Note `lint:strict` (`--max-warnings=0`) now reports these — surfacing pre-existing debt, not introducing it.

Unblocks OMN-54 (meta-check needs rules wired first) and the OMN-47 audit baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)