### PR TITLE
fix(eslint): metadata-snake-case checks createAnalyticsResponseV2 + first RuleTester coverage

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -137,6 +137,7 @@ const plugin = {
         //   createListResponseV2   (op, items, itemType, metadata?)  — 4th arg.
         //   createErrorResponseV2  (op, code, msg, suggestion?, details?, metadata?) — 6th arg.
         //   createTaskResponseV2   (op, tasks, metadata?)            — 3rd arg.
+        //   createAnalyticsResponseV2 (op, data, analysisType, keyFindings, metadata?) — 5th arg.
         const METADATA_ARG_INDEX = {
           createSuccessResponse: 2,
           createErrorResponse: 2,
@@ -145,6 +146,7 @@ const plugin = {
           createErrorResponseV2: 5,
           createListResponseV2: 3,
           createTaskResponseV2: 2,
+          createAnalyticsResponseV2: 4,
         };
         return {
           Property(node) {

--- a/tests/unit/eslint-rules/metadata-snake-case.test.ts
+++ b/tests/unit/eslint-rules/metadata-snake-case.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import plugin from '../../../eslint-rules/index.js';
+
+// Wire ESLint's RuleTester into vitest's runner. Without this, RuleTester's
+// internal it()/describe() calls no-op when nested inside a vitest test,
+// causing assertions to silently never run.
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const rule = (plugin as { rules: Record<string, unknown> }).rules['metadata-snake-case'];
+
+if (!rule) {
+  throw new Error('metadata-snake-case rule not found on plugin export');
+}
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('metadata-snake-case', rule as never, {
+  valid: [
+    // snake_case metadata is fine, for each V2 builder
+    'createSuccessResponseV2(\'op\', {}, undefined, { total_count: 1 });',
+    'createErrorResponseV2(\'op\', \'CODE\', \'msg\', undefined, undefined, { from_cache: false });',
+    'createTaskResponseV2(\'op\', [], { returned_count: 0 });',
+    'createAnalyticsResponseV2(\'op\', {}, \'type\', [], { total_items_analyzed: 1 });',
+    // camelCase in the DATA arg (not metadata) — must NOT report (proves correct arg targeting)
+    'createSuccessResponseV2(\'op\', { camelCaseInData: 1 }, undefined, { snake_case: 1 });',
+    // unrelated function — must NOT report
+    'someOtherFn({ camelCaseKey: 1 });',
+  ],
+  invalid: [
+    {
+      // createSuccessResponseV2: metadata is arg index 3
+      code: 'createSuccessResponseV2(\'op\', {}, undefined, { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createErrorResponseV2: metadata is arg index 5
+      code: 'createErrorResponseV2(\'op\', \'CODE\', \'msg\', undefined, undefined, { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createTaskResponseV2: metadata is arg index 2
+      code: 'createTaskResponseV2(\'op\', [], { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createListResponseV2: metadata is arg index 3
+      code: 'createListResponseV2(\'op\', [], \'tasks\', { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // createAnalyticsResponseV2: metadata is arg index 4
+      // Regression guard: this builder was missing from METADATA_ARG_INDEX,
+      // so the rule silently never checked its 9 call-sites' metadata.
+      code: 'createAnalyticsResponseV2(\'op\', {}, \'type\', [], { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+    {
+      // member-expression callee form: this.createSuccessResponseV2(...)
+      code: 'this.createSuccessResponseV2(\'op\', {}, undefined, { camelCaseKey: 1 });',
+      errors: [{ messageId: 'snakeCaseMetadata' }],
+    },
+  ],
+});


### PR DESCRIPTION
## What

Two small, focused changes against current `main`:

1. **Bug fix:** `metadata-snake-case`'s `METADATA_ARG_INDEX` omitted `createAnalyticsResponseV2` (9 call-sites in `src/`). Its metadata argument — index 4 in `createAnalyticsResponseV2(op, data, analysisType, keyFindings, metadata?)` — was therefore silently never snake_case-checked. Same class of latent gap the earlier V1→V2 work fixed for the other builders; this closes the last one. One-line map addition.
2. **Test coverage:** adds `tests/unit/eslint-rules/metadata-snake-case.test.ts` — the **first RuleTester test for any custom rule** (main had none). Proves the rule fires on every V2 builder at its correct per-builder metadata index, and does **not** false-fire on camelCase in the *data* argument (guards correct arg-targeting, not just "fires somewhere"). RuleTester is wired into vitest's hooks (without that, nested cases no-op silently).

## Verification (TDD red→green)

- Pre-fix (test against current `main`'s rule): only the `createAnalyticsResponseV2` invalid case failed (`Should have 1 error but had 0`) — isolating exactly the gap. 11 others passed, confirming the rule is already V2-correct elsewhere and the test is non-vacuous.
- Post-fix: 12/12 pass.
- `npm run build`: exit 0. Full unit suite: 1800/1800.

## Known consequence (intentional, not fixed here)

Activating the analytics check surfaces **12 pre-existing** camelCase metadata warnings in `src/tools/unified/OmniFocusAnalyzeTool.ts` (`includeProjectStats`, `includeTagStats`, `startDate`, `endDate`, `groupBy`, `includeWeekends`, `includeCompleted`). These are real long-standing violations that were invisible while the builder was unchecked. Left as-is: `warn` severity; CI gates on **lint errors only** (`.github/workflows/ci.yml`, threshold 50), not `lint:strict`, so CI stays green. Renaming response-metadata keys is a client-facing contract change tracked in **OMN-59**.

## Context

Salvaged from a closed redundant PR (#6) that had been built off a stale local `main`. Everything else in that PR was already on `main`; this is the only genuine residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)