### PR TITLE
fix(OMN-60): enable + persist project reviewInterval (analyze set_schedule) and expose it on omnifocus_read

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -1049,6 +1049,7 @@ const DEFAULT_PROJECT_FIELDS = [
   'sequential',
   'lastReviewDate',
   'nextReviewDate',
+  'reviewInterval', // OMN-60: emitted by the script so it can be projected when requested
 ];
 
 /**
@@ -1105,6 +1106,13 @@ function generateProjectFieldProjection(fields: string[], context?: { noteTrunca
         break;
       case 'nextReviewDate':
         projections.push('nextReviewDate: project.nextReviewDate ? project.nextReviewDate.toISOString() : null');
+        break;
+      case 'reviewInterval':
+        // OMN-60: OmniJS reviewInterval.unit is a plural string ('weeks'),
+        // .steps a number (verified via raw probe). null when unset.
+        projections.push(
+          'reviewInterval: project.reviewInterval ? { unit: project.reviewInterval.unit, steps: project.reviewInterval.steps } : null',
+        );
         break;
       case 'completedDate':
         projections.push('completedDate: project.completedDate ? project.completedDate.toISOString() : null');

--- a/src/omnifocus/scripts/reviews/set-review-schedule.ts
+++ b/src/omnifocus/scripts/reviews/set-review-schedule.ts
@@ -102,14 +102,31 @@ export const SET_REVIEW_SCHEDULE_SCRIPT = `
             try {
               const changes = [];
 
-              // Set review interval as plain object
-              // Note: OmniJS accepts { unit: "weeks", steps: N } format
+              // Set review interval. Project.reviewInterval is a strictly-typed
+              // Project.ReviewInterval — assigning a plain object, Number, or
+              // freshly-constructed instance is rejected by OmniJS (OMN-58).
+              // Working pattern: read the existing typed instance, mutate the
+              // local reference, reassign it (OMN-41 / OMN-60).
               if (reviewInterval) {
                 const unit = normalizeUnit(reviewInterval.unit);
                 const steps = reviewInterval.steps || 1;
-                // Set as plain object - OmniJS handles the conversion
-                targetProject.reviewInterval = { unit: unit, steps: steps };
-                changes.push("Review interval set to every " + steps + " " + reviewInterval.unit + "(s)");
+                const ri = targetProject.reviewInterval;
+                if (ri) {
+                  ri.steps = steps;
+                  ri.unit = unit;
+                  targetProject.reviewInterval = ri;
+                  changes.push("Review interval set to every " + steps + " " + unit);
+                } else {
+                  // No existing ReviewInterval instance to mutate, and OmniJS
+                  // cannot construct one from scratch (OMN-58). Fail loudly
+                  // rather than silently no-op.
+                  results.failed.push({
+                    projectId: projectId,
+                    projectName: targetProject.name,
+                    error: "Project has no existing reviewInterval instance to modify; OmniJS cannot construct one (OMN-41/OMN-58)"
+                  });
+                  continue;
+                }
               }
 
               // Set or calculate next review date
@@ -128,10 +145,13 @@ export const SET_REVIEW_SCHEDULE_SCRIPT = `
                 projectId: projectId,
                 projectName: targetProject.name,
                 changes: changes,
-                reviewInterval: reviewInterval ? {
-                  unit: reviewInterval.unit,
-                  steps: reviewInterval.steps
-                } : null,
+                // Echo the value actually persisted (read back), not the
+                // value requested — a setter that silently no-ops must not
+                // report success with the requested value (OMN-60).
+                reviewInterval: (function() {
+                  const ri = targetProject.reviewInterval;
+                  return ri ? { unit: ri.unit, steps: ri.steps } : null;
+                })(),
                 nextReviewDate: calculatedNextReviewDate ? calculatedNextReviewDate.toISOString() : null
               });
 

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -285,6 +285,8 @@ ANALYSIS TYPES:
 - recurring_tasks: Recurring task patterns and frequencies
 - parse_meeting_notes: Extract action items from meeting notes
 - manage_reviews: Project review operations
+  params: { operation, projectId, reviewDate, reviewInterval }
+  - set_schedule accepts reviewInterval: { unit: 'day'|'week'|'month'|'year', steps: positive int, fixed?: bool }
 
 PERFORMANCE WARNINGS:
 - pattern_analysis on 1000+ items: ~5-10 seconds
@@ -2939,7 +2941,9 @@ SCOPE FILTERING:
 
     const script = this.omniAutomation.buildScript(SET_REVIEW_SCHEDULE_SCRIPT, {
       projectIds: brandedProjectIds,
-      reviewInterval: null,
+      // OMN-60: pass the requested interval through (was hardcoded null, which
+      // made the entire reviewInterval path dead code).
+      reviewInterval: compiled.params?.reviewInterval ?? null,
       nextReviewDate: compiled.params?.reviewDate ?? null,
     });
     const result = await this.execJson(script);

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -286,7 +286,7 @@ ANALYSIS TYPES:
 - parse_meeting_notes: Extract action items from meeting notes
 - manage_reviews: Project review operations
   params: { operation, projectId, reviewDate, reviewInterval }
-  - set_schedule accepts reviewInterval: { unit: 'day'|'week'|'month'|'year', steps: positive int, fixed?: bool }
+  - set_schedule accepts reviewInterval: { unit: 'day'|'week'|'month'|'year', steps: positive int }
 
 PERFORMANCE WARNINGS:
 - pattern_analysis on 1000+ items: ~5-10 seconds

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -183,7 +183,7 @@ RESPONSE CONTROL:
 - fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true)
 - ID lookup always returns all fields with full notes
 - fields (tasks): id, name, completed, flagged, blocked, available, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox
-- fields (projects): id, name, status, flagged, note, dueDate, deferDate, completedDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, defaultSingletonActionHolder
+- fields (projects): id, name, status, flagged, note, dueDate, deferDate, completedDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder
 - sort: [{ field: "dueDate", direction: "asc" }]
 - limit/offset: Pagination (default limit: 25, max: 500)
 - countOnly: true returns only count (33x faster for "how many" questions) — tasks only

--- a/src/tools/unified/compilers/AnalysisCompiler.ts
+++ b/src/tools/unified/compilers/AnalysisCompiler.ts
@@ -68,7 +68,7 @@ export type CompiledAnalysis =
         projectId?: string;
         reviewDate?: string;
         // OMN-60: review interval for set_schedule, passed through to the script.
-        reviewInterval?: { unit: 'day' | 'week' | 'month' | 'year'; steps: number; fixed?: boolean };
+        reviewInterval?: { unit: 'day' | 'week' | 'month' | 'year'; steps: number };
       };
     };
 

--- a/src/tools/unified/compilers/AnalysisCompiler.ts
+++ b/src/tools/unified/compilers/AnalysisCompiler.ts
@@ -67,6 +67,8 @@ export type CompiledAnalysis =
         operation?: 'list_for_review' | 'mark_reviewed' | 'set_schedule' | 'clear_schedule';
         projectId?: string;
         reviewDate?: string;
+        // OMN-60: review interval for set_schedule, passed through to the script.
+        reviewInterval?: { unit: 'day' | 'week' | 'month' | 'year'; steps: number; fixed?: boolean };
       };
     };
 

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -90,6 +90,15 @@ const AnalysisSchema = z.discriminatedUnion('type', [
         operation: z.enum(['list_for_review', 'mark_reviewed', 'set_schedule', 'clear_schedule']).optional(),
         projectId: z.string().optional(),
         reviewDate: z.string().optional(),
+        // OMN-60: review interval for set_schedule. Object shape — passed
+        // through to SET_REVIEW_SCHEDULE_SCRIPT, which expects { unit, steps }.
+        reviewInterval: z
+          .object({
+            unit: z.enum(['day', 'week', 'month', 'year']),
+            steps: z.number().int().positive(),
+            fixed: z.boolean().optional(),
+          })
+          .optional(),
       })
       .optional(),
   }),

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -96,7 +96,6 @@ const AnalysisSchema = z.discriminatedUnion('type', [
           .object({
             unit: z.enum(['day', 'week', 'month', 'year']),
             steps: z.number().int().positive(),
-            fixed: z.boolean().optional(),
           })
           .optional(),
       })

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -139,6 +139,7 @@ export const ProjectFieldEnum = z.enum([
   'sequential',
   'lastReviewDate',
   'nextReviewDate',
+  'reviewInterval', // OMN-60: readable review interval { unit, steps }
   'defaultSingletonActionHolder',
 ]);
 

--- a/tests/integration/helpers/assert-field-persisted.ts
+++ b/tests/integration/helpers/assert-field-persisted.ts
@@ -1,0 +1,90 @@
+/**
+ * assertFieldPersisted — prove a mutated field actually survived the round-trip.
+ *
+ * OmniJS has a whole class of silent-no-op setter bugs: assigning a plain
+ * object / Number / freshly-constructed instance to a strictly-typed property
+ * (e.g. `project.reviewInterval = { unit, steps }`) is rejected, the mutation
+ * tool still reports success, and the value never persists. `expectOk` only
+ * proves the call returned success — it cannot catch a setter that lied.
+ *
+ * This helper closes that gap: after a mutation, it re-reads the entity and
+ * asserts the field holds the expected value, with a diagnostic-rich failure
+ * message when it does not. It is generic (caller supplies the read call and
+ * an extractor) so it covers the whole silent-setter class, not just
+ * reviewInterval.
+ *
+ * See OMN-41 / OMN-58.
+ *
+ * Usage:
+ *   import { assertFieldPersisted } from '../helpers/assert-field-persisted.js';
+ *
+ *   await client.callTool('omnifocus_analyze', { ...set_schedule... });
+ *   await assertFieldPersisted(client, {
+ *     readTool: 'omnifocus_read',
+ *     readParams: { query: { type: 'projects', filters: { id: projectId } } },
+ *     extract: (r) => r.data.items[0].reviewInterval,
+ *     expected: { unit: 'weeks', steps: 2 },
+ *     context: 'set_schedule reviewInterval',
+ *   });
+ */
+
+export interface ClientLike {
+  callTool(toolName: string, params?: unknown): Promise<unknown>;
+}
+
+export interface AssertFieldPersistedSpec {
+  /** Tool to call for the read-back (e.g. 'omnifocus_read'). */
+  readTool: string;
+  /** Params for the read-back call. */
+  readParams: unknown;
+  /** Pull the field under test out of the raw read result. */
+  extract: (readResult: any) => unknown;
+  /** Value the field is expected to hold after the mutation. */
+  expected: unknown;
+  /** Short label for the failure message (what was being asserted). */
+  context?: string;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+    return false;
+  }
+  const ak = Object.keys(a as Record<string, unknown>);
+  const bk = Object.keys(b as Record<string, unknown>);
+  if (ak.length !== bk.length) return false;
+  return ak.every(
+    (k) =>
+      Object.prototype.hasOwnProperty.call(b, k) &&
+      deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+  );
+}
+
+function show(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export async function assertFieldPersisted(client: ClientLike, spec: AssertFieldPersistedSpec): Promise<void> {
+  const label = spec.context ? `assertFieldPersisted(${spec.context})` : 'assertFieldPersisted';
+
+  const result = (await client.callTool(spec.readTool, spec.readParams)) as
+    | { success?: boolean; error?: unknown }
+    | undefined;
+
+  if (!result || result.success === false) {
+    const errText = show(result?.error ?? result);
+    throw new Error(`${label}: read-back failed — ${errText}`);
+  }
+
+  const actual = spec.extract(result);
+  if (deepEqual(actual, spec.expected)) {
+    return;
+  }
+
+  throw new Error(`${label}: field did not persist — expected ${show(spec.expected)}, actual ${show(actual)}`);
+}

--- a/tests/integration/helpers/assert-field-persisted.ts
+++ b/tests/integration/helpers/assert-field-persisted.ts
@@ -28,8 +28,15 @@
  *   });
  */
 
+/** The StandardResponseV2-shaped envelope a read-back tool call returns. */
+export interface ReadBackResult {
+  success: boolean;
+  error?: unknown;
+  data?: unknown;
+}
+
 export interface ClientLike {
-  callTool(toolName: string, params?: unknown): Promise<unknown>;
+  callTool(toolName: string, params?: unknown): Promise<ReadBackResult>;
 }
 
 export interface AssertFieldPersistedSpec {
@@ -37,8 +44,12 @@ export interface AssertFieldPersistedSpec {
   readTool: string;
   /** Params for the read-back call. */
   readParams: unknown;
-  /** Pull the field under test out of the raw read result. */
-  extract: (readResult: any) => unknown;
+  /**
+   * Pull the field under test out of the raw read result. `data` is typed
+   * `unknown` — narrow it explicitly in the extractor (this helper exists to
+   * catch silent gaps; loose typing here would defeat its purpose).
+   */
+  extract: (readResult: ReadBackResult) => unknown;
   /** Value the field is expected to hold after the mutation. */
   expected: unknown;
   /** Short label for the failure message (what was being asserted). */
@@ -65,16 +76,16 @@ function show(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
-    return String(value);
+    // Only reached when JSON.stringify throws (circular ref, BigInt). The raw
+    // value is not meaningfully renderable here; name the failure instead.
+    return `[unserializable ${typeof value}]`;
   }
 }
 
 export async function assertFieldPersisted(client: ClientLike, spec: AssertFieldPersistedSpec): Promise<void> {
   const label = spec.context ? `assertFieldPersisted(${spec.context})` : 'assertFieldPersisted';
 
-  const result = (await client.callTool(spec.readTool, spec.readParams)) as
-    | { success?: boolean; error?: unknown }
-    | undefined;
+  const result: ReadBackResult | undefined = await client.callTool(spec.readTool, spec.readParams);
 
   if (!result || result.success === false) {
     const errText = show(result?.error ?? result);

--- a/tests/integration/helpers/assert-field-persisted.ts
+++ b/tests/integration/helpers/assert-field-persisted.ts
@@ -21,9 +21,9 @@
  *   await client.callTool('omnifocus_analyze', { ...set_schedule... });
  *   await assertFieldPersisted(client, {
  *     readTool: 'omnifocus_read',
- *     readParams: { query: { type: 'projects', filters: { id: projectId } } },
- *     extract: (r) => r.data.items[0].reviewInterval,
- *     expected: { unit: 'weeks', steps: 2 },
+ *     readParams: { query: { type: 'projects', filters: { folder }, fields: ['id', 'reviewInterval'] } },
+ *     extract: (r) => r.data.projects.find((p) => p.id === projectId).reviewInterval,
+ *     expected: { unit: 'months', steps: 5 },
  *     context: 'set_schedule reviewInterval',
  *   });
  */

--- a/tests/integration/tools/unified/review-interval-round-trip.test.ts
+++ b/tests/integration/tools/unified/review-interval-round-trip.test.ts
@@ -1,0 +1,147 @@
+/**
+ * OMN-60 / OMN-41 #14 — review interval round-trip.
+ *
+ * Proves the full path works end-to-end: omnifocus_analyze set_schedule with a
+ * reviewInterval → the value actually persists on the project (read back).
+ *
+ * Before the fix this FAILS: the analyze path hardcoded reviewInterval:null
+ * (so the script never received it) and set-review-schedule.ts assigned a
+ * plain object OmniFocus rejects. The assertFieldPersisted helper (OMN-41) is
+ * dogfooded here — it is exactly the silent-no-op detector this bug needed.
+ *
+ * Sandbox conventions: project created in __MCP_TEST_SANDBOX__, name __TEST__,
+ * deleted in afterAll.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, ChildProcess } from 'child_process';
+import path from 'path';
+import { expectOk } from '../../helpers/expect-ok.js';
+import { assertFieldPersisted } from '../../helpers/assert-field-persisted.js';
+import { SANDBOX_FOLDER_NAME, ensureSandboxFolder } from '../../helpers/sandbox-manager.js';
+
+describe('Review interval round-trip (OMN-60)', () => {
+  let serverProcess: ChildProcess;
+  let createdProjectId: string | undefined;
+  let nextId = 1;
+
+  async function sendRequest(request: unknown): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const requestStr = JSON.stringify(request) + '\n';
+      let response = '';
+      const timeout = setTimeout(() => reject(new Error('Request timeout after 120s')), 120000);
+
+      const onData = (data: Buffer) => {
+        response += data.toString();
+        for (const line of response.split('\n')) {
+          if (line.trim().startsWith('{')) {
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.jsonrpc === '2.0' && 'result' in parsed) {
+                clearTimeout(timeout);
+                serverProcess.stdout?.off('data', onData);
+                resolve(parsed.result);
+                return;
+              }
+              if (parsed.jsonrpc === '2.0' && 'error' in parsed) {
+                clearTimeout(timeout);
+                serverProcess.stdout?.off('data', onData);
+                reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
+                return;
+              }
+            } catch {
+              /* keep collecting */
+            }
+          }
+        }
+      };
+      serverProcess.stdout?.on('data', onData);
+      serverProcess.stdin?.write(requestStr);
+    });
+  }
+
+  // assertFieldPersisted ClientLike adapter: tools/call → parsed StandardResponseV2.
+  const client = {
+    callTool: async (name: string, args: unknown) => {
+      const result = await sendRequest({
+        jsonrpc: '2.0',
+        id: ++nextId,
+        method: 'tools/call',
+        params: { name, arguments: args },
+      });
+      const content = (result as { content: Array<{ text: string }> }).content;
+      return JSON.parse(content[0].text);
+    },
+  };
+
+  beforeAll(async () => {
+    const serverPath = path.join(__dirname, '../../../../dist/index.js');
+    serverProcess = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+    await sendRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } },
+    });
+    await ensureSandboxFolder();
+  }, 60000);
+
+  afterAll(async () => {
+    if (createdProjectId) {
+      try {
+        await client.callTool('omnifocus_write', {
+          mutation: { operation: 'delete', target: 'project', target_id: createdProjectId },
+        });
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    serverProcess?.kill();
+  });
+
+  it('persists a reviewInterval set via omnifocus_analyze set_schedule', async () => {
+    const createRes = await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'create',
+        target: 'project',
+        data: {
+          name: `__TEST__ OMN-60 ReviewInterval ${Date.now()}`,
+          folder: SANDBOX_FOLDER_NAME,
+        },
+      },
+    });
+    expectOk(createRes, 'create sandbox project');
+    createdProjectId = createRes.data?.project?.id ?? createRes.data?.project?.projectId ?? createRes.data?.id;
+    expect(createdProjectId, 'created project id').toBeTruthy();
+
+    // Use a NON-DEFAULT interval. OmniFocus' default review interval is
+    // {weeks,2}; setting weeks/2 would pass even if the write no-op'd. months/5
+    // is unambiguous proof the value was actually written.
+    const setRes = await client.callTool('omnifocus_analyze', {
+      analysis: {
+        type: 'manage_reviews',
+        params: {
+          operation: 'set_schedule',
+          projectId: createdProjectId,
+          reviewInterval: { unit: 'month', steps: 5 },
+        },
+      },
+    });
+    expectOk(setRes, 'set_schedule reviewInterval');
+
+    // Read back through the public API: reviewInterval is now a requestable
+    // ProjectFieldEnum field emitted by the AST projects script (OMN-60).
+    await assertFieldPersisted(client, {
+      readTool: 'omnifocus_read',
+      readParams: {
+        query: {
+          type: 'projects',
+          filters: { folder: SANDBOX_FOLDER_NAME },
+          fields: ['id', 'reviewInterval'],
+        },
+      },
+      extract: (r: any) => (r.data?.projects ?? []).find((p: any) => p.id === createdProjectId)?.reviewInterval?.steps,
+      expected: 5,
+      context: 'set_schedule reviewInterval steps round-trip',
+    });
+  }, 120000);
+});

--- a/tests/integration/tools/unified/review-interval-round-trip.test.ts
+++ b/tests/integration/tools/unified/review-interval-round-trip.test.ts
@@ -139,7 +139,12 @@ describe('Review interval round-trip (OMN-60)', () => {
           fields: ['id', 'reviewInterval'],
         },
       },
-      extract: (r: any) => (r.data?.projects ?? []).find((p: any) => p.id === createdProjectId)?.reviewInterval?.steps,
+      extract: (r) => {
+        const projects =
+          (r.data as { projects?: Array<{ id: string; reviewInterval?: { steps?: number } }> } | undefined)?.projects ??
+          [];
+        return projects.find((p) => p.id === createdProjectId)?.reviewInterval?.steps;
+      },
       expected: 5,
       context: 'set_schedule reviewInterval steps round-trip',
     });

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -941,6 +941,12 @@ describe('note truncation in project field projection', () => {
 
     expect(result.script).toContain('note: project.note || ""');
   });
+
+  it('emits a reviewInterval projection when the reviewInterval field is requested (OMN-60)', () => {
+    const result = buildFilteredProjectsScript({}, { fields: ['id', 'reviewInterval'] });
+
+    expect(result.script).toContain('reviewInterval: project.reviewInterval');
+  });
 });
 
 // =============================================================================

--- a/tests/unit/integration-helpers/assert-field-persisted.test.ts
+++ b/tests/unit/integration-helpers/assert-field-persisted.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the assertFieldPersisted integration helper (OMN-41).
+ *
+ * The helper's job: after a mutation, read the entity back and prove a field
+ * actually persisted — catching the silent-no-op class of OmniJS setter bugs
+ * (e.g. set-review-schedule.ts assigning a plain object OmniFocus rejects).
+ *
+ * These tests exercise the helper's own logic with a fake client (the
+ * dependency-injected callTool seam) — no live OmniFocus required.
+ */
+import { describe, it, expect } from 'vitest';
+import { assertFieldPersisted } from '../../../tests/integration/helpers/assert-field-persisted.js';
+
+type FakeResult = { success: boolean; error?: unknown; data?: unknown };
+
+function fakeClient(result: FakeResult) {
+  const calls: Array<{ tool: string; params: unknown }> = [];
+  return {
+    calls,
+    callTool: async (tool: string, params: unknown) => {
+      calls.push({ tool, params });
+      return result;
+    },
+  };
+}
+
+describe('assertFieldPersisted', () => {
+  it('resolves when the extracted field deep-equals the expected value', async () => {
+    const client = fakeClient({
+      success: true,
+      data: { project: { reviewInterval: { unit: 'weeks', steps: 2 } } },
+    });
+
+    await expect(
+      assertFieldPersisted(client, {
+        readTool: 'omnifocus_read',
+        readParams: { query: { type: 'projects' } },
+        extract: (r: any) => r.data.project.reviewInterval,
+        expected: { unit: 'weeks', steps: 2 },
+        context: 'reviewInterval round-trip',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws a diagnostic error naming context, expected, and actual when the field did not persist', async () => {
+    const client = fakeClient({
+      success: true,
+      data: { project: { reviewInterval: null } },
+    });
+
+    await expect(
+      assertFieldPersisted(client, {
+        readTool: 'omnifocus_read',
+        readParams: { query: { type: 'projects' } },
+        extract: (r: any) => r.data.project.reviewInterval,
+        expected: { unit: 'weeks', steps: 2 },
+        context: 'reviewInterval round-trip',
+      }),
+    ).rejects.toThrow(
+      /reviewInterval round-trip[\s\S]*expected[\s\S]*weeks[\s\S]*steps[\s\S]*(actual|got)[\s\S]*null/i,
+    );
+  });
+
+  it('throws and surfaces the read error when the read-back call itself fails', async () => {
+    const client = fakeClient({
+      success: false,
+      error: 'Project not found: abc123',
+    });
+
+    await expect(
+      assertFieldPersisted(client, {
+        readTool: 'omnifocus_read',
+        readParams: { query: { type: 'projects' } },
+        extract: (r: any) => r.data.project.reviewInterval,
+        expected: { unit: 'weeks', steps: 2 },
+        context: 'reviewInterval round-trip',
+      }),
+    ).rejects.toThrow(/read-back failed[\s\S]*Project not found: abc123/i);
+  });
+});

--- a/tests/unit/integration-helpers/assert-field-persisted.test.ts
+++ b/tests/unit/integration-helpers/assert-field-persisted.test.ts
@@ -17,9 +17,9 @@ function fakeClient(result: FakeResult) {
   const calls: Array<{ tool: string; params: unknown }> = [];
   return {
     calls,
-    callTool: async (tool: string, params: unknown) => {
+    callTool: (tool: string, params: unknown) => {
       calls.push({ tool, params });
-      return result;
+      return Promise.resolve(result);
     },
   };
 }
@@ -35,7 +35,7 @@ describe('assertFieldPersisted', () => {
       assertFieldPersisted(client, {
         readTool: 'omnifocus_read',
         readParams: { query: { type: 'projects' } },
-        extract: (r: any) => r.data.project.reviewInterval,
+        extract: (r) => (r.data as { project: { reviewInterval: unknown } }).project.reviewInterval,
         expected: { unit: 'weeks', steps: 2 },
         context: 'reviewInterval round-trip',
       }),
@@ -52,7 +52,7 @@ describe('assertFieldPersisted', () => {
       assertFieldPersisted(client, {
         readTool: 'omnifocus_read',
         readParams: { query: { type: 'projects' } },
-        extract: (r: any) => r.data.project.reviewInterval,
+        extract: (r) => (r.data as { project: { reviewInterval: unknown } }).project.reviewInterval,
         expected: { unit: 'weeks', steps: 2 },
         context: 'reviewInterval round-trip',
       }),
@@ -71,7 +71,7 @@ describe('assertFieldPersisted', () => {
       assertFieldPersisted(client, {
         readTool: 'omnifocus_read',
         readParams: { query: { type: 'projects' } },
-        extract: (r: any) => r.data.project.reviewInterval,
+        extract: (r) => (r.data as { project: { reviewInterval: unknown } }).project.reviewInterval,
         expected: { unit: 'weeks', steps: 2 },
         context: 'reviewInterval round-trip',
       }),

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -699,4 +699,55 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(size).toBeLessThan(1000);
     });
   });
+
+  // ==========================================================================
+  // manage_reviews set_schedule — reviewInterval wiring (OMN-60)
+  // ==========================================================================
+  describe('manage_reviews set_schedule reviewInterval wiring (OMN-60)', () => {
+    it('passes the requested reviewInterval through to the script (not hardcoded null)', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue({
+        success: true,
+        data: { results: { successful: [], failed: [], summary: { successful_count: 0, failed_count: 0 } } },
+      });
+
+      await tool.execute({
+        analysis: {
+          type: 'manage_reviews',
+          params: {
+            operation: 'set_schedule',
+            projectId: 'p1',
+            reviewInterval: { unit: 'week', steps: 2 },
+          },
+        },
+      });
+
+      expect(mockOmni.buildScript).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reviewInterval: { unit: 'week', steps: 2 } }),
+      );
+    });
+
+    it('passes reviewInterval: null when none is supplied (back-compat)', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue({
+        success: true,
+        data: { results: { successful: [], failed: [], summary: { successful_count: 0, failed_count: 0 } } },
+      });
+
+      await tool.execute({
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'set_schedule', projectId: 'p1' },
+        },
+      });
+
+      expect(mockOmni.buildScript).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reviewInterval: null }),
+      );
+    });
+  });
 });

--- a/tests/unit/tools/unified/schemas/analyze-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/analyze-schema.test.ts
@@ -48,4 +48,54 @@ describe('AnalyzeSchema', () => {
     const result = AnalyzeSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
+
+  describe('manage_reviews set_schedule reviewInterval (OMN-60)', () => {
+    it('accepts set_schedule with a reviewInterval and preserves it through parse', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: {
+            operation: 'set_schedule',
+            projectId: 'abc123',
+            reviewInterval: { unit: 'week', steps: 2 },
+          },
+        },
+      };
+
+      const result = AnalyzeSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const params = (result.data.analysis as { params?: Record<string, unknown> }).params;
+        expect(params?.reviewInterval).toEqual({ unit: 'week', steps: 2 });
+      }
+    });
+
+    it('rejects a reviewInterval with an invalid unit', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: {
+            operation: 'set_schedule',
+            projectId: 'abc123',
+            reviewInterval: { unit: 'fortnight', steps: 2 },
+          },
+        },
+      };
+
+      const result = AnalyzeSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts set_schedule without a reviewInterval (field is optional)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'set_schedule', projectId: 'abc123' },
+        },
+      };
+
+      const result = AnalyzeSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -430,7 +430,7 @@ describe('ReadSchema', () => {
       expect(ReadSchema.safeParse(taskInput).success).toBe(false);
     });
 
-    it('should accept all 15 project fields from script-builder', () => {
+    it('should accept all 16 project fields from script-builder', () => {
       const allProjectFields = [
         'id',
         'name',
@@ -446,6 +446,7 @@ describe('ReadSchema', () => {
         'sequential',
         'lastReviewDate',
         'nextReviewDate',
+        'reviewInterval', // OMN-60: readable review interval
         'defaultSingletonActionHolder',
       ];
       const input = {


### PR DESCRIPTION
Resolves **OMN-60** and **OMN-41 #14**. Spawned **OMN-61** (systemic AST field-coverage parity).

## Problem
Setting a project's review interval was impossible through the unified API, and the underlying script had a latent silent-no-op bug:
- `manage_reviews` schema had no `reviewInterval`; both callers hardcoded `reviewInterval: null` → `set-review-schedule.ts`'s interval block was unreachable dead code.
- Even when reached, it assigned a plain object OmniFocus rejects (OMN-41 #14).
- `omnifocus_read` could not return `reviewInterval` in any query shape (absent from `ProjectFieldEnum`, the AST projection, and default fields) — set-but-not-readable.

## Changes
**Write path**
- `analyze-schema.ts`: `reviewInterval {unit,steps,fixed?}` on `manage_reviews.params`; `inputSchema`/description synced; `AnalysisCompiler` type threaded.
- `reviewsSetSchedule`: passes `compiled.params?.reviewInterval ?? null` (was hardcoded `null`).
- `set-review-schedule.ts`: plain-object assignment → **read-modify-reassign** (the only OmniJS-persistent form); truthful comments; loud `results.failed` on no-RI-instance instead of silent no-op; success record echoes the **persisted** value, not the requested one.

**Read path**
- `reviewInterval` added to `ProjectFieldEnum`, `generateProjectFieldProjection`, and `DEFAULT_PROJECT_FIELDS` → requestable/emitted/projectable.

**Tests**
- New `assertFieldPersisted` integration helper (silent-no-op detector) + unit tests.
- Public-API round-trip integration test using a **non-default** interval (`months/5`) to avoid the `{weeks,2}` OmniFocus-default false-pass.

## Verification
- Raw OmniJS probe: read-modify-reassign persists `{months,5}` across separate `evaluateJavascript` contexts → OMN-38's shipped pattern independently confirmed sound (not a false fix).
- TDD: unit RED→GREEN (helper/schema/compiler/wiring/projection); rigorous revert→**RED** (`expected 5, actual 2`) → restore→**GREEN** integration round-trip through the public API.
- Full unit suite **1824/1824**, no regressions; build clean; sandbox isolation clean each run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)