### PR TITLE
test(OMN-61 phase 2): write-side settable-field ↔ mutation-builder parity

### DIFF
--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -86,7 +86,8 @@ const DATE_FORMAT_MSG = 'Date format: YYYY-MM-DD or YYYY-MM-DD HH:mm';
 
 // Create data schema — single source of truth for task/project creation fields.
 // Both the unified write tool and batch-schemas derive from this.
-const CreateDataSchema = z.object({
+// Exported for OMN-61 write-side parity testing (settable field ↔ builder).
+export const CreateDataSchema = z.object({
   name: z.string().min(1),
   note: z.string().optional(),
   project: z.union([z.string(), z.null()]).optional(),
@@ -110,7 +111,8 @@ const CreateDataSchema = z.object({
 });
 
 // Update changes schema
-const UpdateChangesSchema = z
+// Exported for OMN-61 write-side parity testing (settable field ↔ builder).
+export const UpdateChangesSchema = z
   .object({
     name: z.string().optional(),
     note: z.string().optional(),

--- a/tests/unit/architecture/schema-impl-parity.test.ts
+++ b/tests/unit/architecture/schema-impl-parity.test.ts
@@ -656,7 +656,6 @@ describe('Parity: tool inputSchema ↔ Zod schema (OMN-47 S10)', () => {
 // the enum, or allowlist it here.
 
 const TASK_CONTEXT_ONLY_KEYS = ['effectivePlannedDate', 'reason', 'daysOverdue'];
-const PROJECT_CONTEXT_ONLY_KEYS: string[] = [];
 
 describe('Reverse parity: generateFieldProjection ↔ TaskFieldEnum (OMN-61)', () => {
   it('emits no undeclared top-level task projection key', () => {
@@ -668,7 +667,7 @@ describe('Reverse parity: generateFieldProjection ↔ TaskFieldEnum (OMN-61)', (
         performanceMode: 'lite',
       },
     );
-    const emitted = [...script.matchAll(/^\s*([A-Za-z][A-Za-z0-9_]*):\s*task\./gm)].map((m) => m[1]);
+    const emitted = [...script.matchAll(/^[ \t]*([A-Za-z]\w*):[ \t]*task\./gm)].map((m) => m[1]);
     const undeclared = [...new Set(emitted)].filter((k) => !declared.has(k) && !TASK_CONTEXT_ONLY_KEYS.includes(k));
     expect(undeclared, `undeclared task projection key(s): ${undeclared.join(', ')}`).toEqual([]);
   });
@@ -684,8 +683,10 @@ describe('Reverse parity: generateProjectFieldProjection ↔ ProjectFieldEnum (O
         performanceMode: 'lite',
       },
     );
-    const emitted = [...script.matchAll(/^\s*([A-Za-z][A-Za-z0-9_]*):\s*project\./gm)].map((m) => m[1]);
-    const undeclared = [...new Set(emitted)].filter((k) => !declared.has(k) && !PROJECT_CONTEXT_ONLY_KEYS.includes(k));
+    const emitted = [...script.matchAll(/^[ \t]*([A-Za-z]\w*):[ \t]*project\./gm)].map((m) => m[1]);
+    // No PROJECT context-only allowlist: every project projection key today is
+    // a declared ProjectFieldEnum member. Add one here if that ever changes.
+    const undeclared = [...new Set(emitted)].filter((k) => !declared.has(k));
     expect(undeclared, `undeclared project projection key(s): ${undeclared.join(', ')}`).toEqual([]);
   });
 });
@@ -700,17 +701,31 @@ describe('Reverse parity: generateProjectFieldProjection ↔ ProjectFieldEnum (O
 // the OMN-60 `fixed` bug shape (accepted, advertised, never applied). This is
 // the write-side analog of the read-side projection parity above.
 //
-// Builder-internal identifiers that are NOT user-settable schema fields
-// (linkage/placeholder vars) are allowlisted; a new one forces a conscious
-// choice rather than silently widening the accepted-but-internal surface.
-const BUILDER_INTERNAL_REFS = ['parentFolder', 'projectId', 'X'];
+// References the builder makes that are NOT user-settable fields of the two
+// schemas under test, allowlisted so the reverse guard doesn't false-fail:
+//   projectId    — builder's internal remap of the `project` schema field
+//   parentFolder — a field of FolderCreateDataSchema, a different schema this
+//                   gate intentionally does not cover
+// A new entry forces a conscious choice rather than silently widening the
+// accepted-but-internal surface.
+const BUILDER_INTERNAL_REFS = ['parentFolder', 'projectId'];
 
-const mutationBuilderSource = readFileSync(
-  fileURLToPath(new URL('../../../src/contracts/ast/mutation-script-builder.ts', import.meta.url)),
-  'utf8',
+// Strip comments before scanning the (checked-in, bounded) builder source:
+// it has a maintenance comment (`// ... if (data.X) ...`) that would
+// otherwise be captured as a phantom `X` reference, which would then have to
+// be masked by an allowlist entry.
+function stripComments(src: string): string {
+  // `[^\n]*` (not `.*$/m`) keeps the line-comment strip backtracking-free.
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+const mutationBuilderSource = stripComments(
+  readFileSync(
+    fileURLToPath(new URL('../../../src/contracts/ast/mutation-script-builder.ts', import.meta.url)),
+    'utf8',
+  ),
 );
 const builderRefs = new Set(
-  [...mutationBuilderSource.matchAll(/\b(?:data|changes|projectData)\.([A-Za-z][A-Za-z0-9_]*)/g)].map((m) => m[1]),
+  [...mutationBuilderSource.matchAll(/\b(?:data|changes|projectData)\.([A-Za-z]\w*)/g)].map((m) => m[1]),
 );
 
 describe('Parity: CreateDataSchema ↔ mutation-script-builder (OMN-61)', () => {

--- a/tests/unit/architecture/schema-impl-parity.test.ts
+++ b/tests/unit/architecture/schema-impl-parity.test.ts
@@ -9,6 +9,8 @@
 // for the original incidents. Add a new describe block here whenever you
 // introduce a new declaration↔implementation pairing.
 
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi } from 'vitest';
 
 import {
@@ -17,6 +19,7 @@ import {
   SortFieldEnum,
   FILTER_FIELD_NAMES,
 } from '../../../src/tools/unified/schemas/read-schema.js';
+import { CreateDataSchema, UpdateChangesSchema } from '../../../src/tools/unified/schemas/write-schema.js';
 import {
   buildFilteredTasksScript,
   buildFilteredProjectsScript,
@@ -684,5 +687,64 @@ describe('Reverse parity: generateProjectFieldProjection ↔ ProjectFieldEnum (O
     const emitted = [...script.matchAll(/^\s*([A-Za-z][A-Za-z0-9_]*):\s*project\./gm)].map((m) => m[1]);
     const undeclared = [...new Set(emitted)].filter((k) => !declared.has(k) && !PROJECT_CONTEXT_ONLY_KEYS.includes(k));
     expect(undeclared, `undeclared project projection key(s): ${undeclared.join(', ')}`).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Write-side parity: settable schema field ↔ mutation-script-builder (OMN-61)
+// =============================================================================
+//
+// Every field the create/update schemas accept must be *read* by the mutation
+// script builder as `data.<field>` / `changes.<field>` / `projectData.<field>`.
+// A schema field the builder never references is silently dropped on write —
+// the OMN-60 `fixed` bug shape (accepted, advertised, never applied). This is
+// the write-side analog of the read-side projection parity above.
+//
+// Builder-internal identifiers that are NOT user-settable schema fields
+// (linkage/placeholder vars) are allowlisted; a new one forces a conscious
+// choice rather than silently widening the accepted-but-internal surface.
+const BUILDER_INTERNAL_REFS = ['parentFolder', 'projectId', 'X'];
+
+const mutationBuilderSource = readFileSync(
+  fileURLToPath(new URL('../../../src/contracts/ast/mutation-script-builder.ts', import.meta.url)),
+  'utf8',
+);
+const builderRefs = new Set(
+  [...mutationBuilderSource.matchAll(/\b(?:data|changes|projectData)\.([A-Za-z][A-Za-z0-9_]*)/g)].map((m) => m[1]),
+);
+
+describe('Parity: CreateDataSchema ↔ mutation-script-builder (OMN-61)', () => {
+  for (const field of Object.keys(CreateDataSchema.shape)) {
+    it(`mutation builder reads create field "${field}"`, () => {
+      expect(
+        builderRefs.has(field),
+        `CreateDataSchema accepts "${field}" but mutation-script-builder never reads data/changes/projectData.${field} — it is silently dropped on create (OMN-60 bug shape).`,
+      ).toBe(true);
+    });
+  }
+});
+
+describe('Parity: UpdateChangesSchema ↔ mutation-script-builder (OMN-61)', () => {
+  for (const field of Object.keys(UpdateChangesSchema.shape)) {
+    it(`mutation builder reads update field "${field}"`, () => {
+      expect(
+        builderRefs.has(field),
+        `UpdateChangesSchema accepts "${field}" but mutation-script-builder never reads it — silently dropped on update (OMN-60 bug shape).`,
+      ).toBe(true);
+    });
+  }
+});
+
+describe('Reverse write parity: builder reads no undeclared settable key (OMN-61)', () => {
+  it('every data/changes/projectData reference is a schema field or allowlisted internal', () => {
+    const settable = new Set<string>([
+      ...Object.keys(CreateDataSchema.shape),
+      ...Object.keys(UpdateChangesSchema.shape),
+    ]);
+    const undeclared = [...builderRefs].filter((r) => !settable.has(r) && !BUILDER_INTERNAL_REFS.includes(r));
+    expect(
+      undeclared,
+      `mutation-script-builder reads data/changes/projectData key(s) ${JSON.stringify(undeclared)} that no settable schema declares and that are not allowlisted internals — declare them, or add to BUILDER_INTERNAL_REFS with a reason.`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
**OMN-61 Phase 2 of 3.** Write-side analog of the Phase 1 (#11) read-side gate.

## Why
A settable schema field the mutation builder never reads is silently dropped on write — the exact OMN-60 `fixed` bug shape (accepted, advertised, never applied). Nothing currently fails when `CreateDataSchema`/`UpdateChangesSchema` and `mutation-script-builder` drift.

## What
- `write-schema.ts`: export `CreateDataSchema` + `UpdateChangesSchema` (testability export, mirrors read-schema's enum exports).
- `schema-impl-parity.test.ts`: per-field forward parity — every create field (15) and update field (21) must appear as `data.`/`changes.`/`projectData.<field>` in the mutation builder source; plus a reverse guard (no builder ref outside schema or the `BUILDER_INTERNAL_REFS` allowlist: `parentFolder`/`projectId`/`X`).

## Verification
- Proven to bite: adding an unwired field to `CreateDataSchema` fails its per-field test with the OMN-60-bug-shape message.
- Full unit suite 1863/1863 (+37 Phase 2 assertions); build, prettier, eslint clean. No production behavior change (only a testability export).

Phase 3 (per-field round-trip harness, slower/integration) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)