### PR TITLE
fix(OMN-62): omnifocus_read project tags + plannedDate (end-to-end)

### DIFF
--- a/docs/dev/omn-61-phase3-roundtrip-design.md
+++ b/docs/dev/omn-61-phase3-roundtrip-design.md
@@ -58,6 +58,8 @@ illustrative non-defaults.
 | folder                                  | a sandbox folder         | folder         |                             |
 | sequential                              | `true`                   | sequential     | default false               |
 | reviewInterval                          | `{unit:'month',steps:5}` | reviewInterval | OMN-60 — the canonical case |
+| tags                                    | `["__test-rt-<ts>"]`     | tags           | OMN-62 — bridge-applied     |
+| plannedDate                             | a specific future datetime | plannedDate  | OMN-62 — OF 4.7+            |
 
 ### `clear*` rows — two-phase assertion (not a single round-trip)
 

--- a/docs/dev/omn-61-phase3-roundtrip-design.md
+++ b/docs/dev/omn-61-phase3-roundtrip-design.md
@@ -1,12 +1,13 @@
 # OMN-61 Phase 3 — per-field write→read round-trip harness (design)
 
-Status: **BUILT** (2026-05-17) — `tests/integration/tools/unified/field-roundtrip.test.ts`, 26/26 green against live
-OmniFocus, wired into `test:integration` (excluded from `test:unit` by location). Prereqs shipped: Phase 1 (read parity,
-PR #11), Phase 2 (write parity, PR #12), `assertFieldPersisted` helper (OMN-41, in `tests/integration/helpers/`). The
-doc below is retained as the rationale of record; the matrix and hard lessons are now enforced by the harness. Build
-note: the `project.folder` move row initially read back from the _source_ folder — the exact OMN-60 confounded-oracle
-trap this doc warned about. Caught during the live run, root-caused (the writer was correct; the move persisted), and
-fixed by reading back from the _destination_ folder.
+Status: **BUILT** (2026-05-17), **OMN-62 resolved** (2026-05-17 — project `tags`/`plannedDate` promoted from xfail to
+real round-trip rows) — `tests/integration/tools/unified/field-roundtrip.test.ts`, 26/26 green (zero xfails) against
+live OmniFocus, wired into `test:integration` (excluded from `test:unit` by location). Prereqs shipped: Phase 1 (read
+parity, PR #11), Phase 2 (write parity, PR #12), `assertFieldPersisted` helper (OMN-41, in
+`tests/integration/helpers/`). The doc below is retained as the rationale of record; the matrix and hard lessons are now
+enforced by the harness. Build note: the `project.folder` move row initially read back from the _source_ folder — the
+exact OMN-60 confounded-oracle trap this doc warned about. Caught during the live run, root-caused (the writer was
+correct; the move persisted), and fixed by reading back from the _destination_ folder.
 
 ## Goal
 
@@ -72,16 +73,17 @@ Phase 1 is the disambiguator: only after a value is provably visible does a subs
 `clear*` field whose set phase already reads back `undefined` is a read gap (lesson #2) → `xfail` + ticket, not a clear
 failure.
 
-## Known read-gaps → `xfail` + ticket (do NOT treat as persistence failures)
+## Known read-gaps → RESOLVED (OMN-62)
 
-Settable on projects via the shared `CreateDataSchema` but **absent from `ProjectFieldEnum` and the project projection**
-— cannot be read back through the public API (the exact OMN-60 shape, different fields):
+Project **`tags`** and project **`plannedDate`** were settable via the shared `CreateDataSchema` but **absent from
+`ProjectFieldEnum` and the project projection** — unreadable through the public API (the exact OMN-60 shape, different
+fields). Originally filed as **OMN-62** and held in Phase 3 as `it.fails`/`xfail` placeholders.
 
-- project **`tags`**
-- project **`plannedDate`**
-
-Filed as **OMN-62**. Phase 3 marks these `it.fails`/`xfail` with `OMN-62` so the harness is honest: "can't verify — read
-gap", not a green skip. When OMN-62 ships, flip them to real round-trip rows.
+**OMN-62 shipped:** both fields were added to `ProjectFieldEnum`, `generateProjectFieldProjection` (accessors verified
+live via a raw OmniJS probe on OF 4.8.9 — `project.tags.map(t => t.name)`, `project.plannedDate`), and the
+`OmniFocusReadTool` `inputSchema` advertisement. The two `it.fails` placeholders were **promoted to genuine round-trip
+rows** in `projectRows` (not left as xfails — that would silently never exercise the now-working path, a vacuous green).
+No remaining project read-gaps.
 
 ## Mechanics (reuse, don't reinvent)
 
@@ -104,7 +106,8 @@ it like the other integration suites (separate vitest project / `test:integratio
 1. New `tests/integration/.../field-roundtrip.test.ts` from the OMN-60 template.
 2. Encode the matrix above as a table; one parametrized round-trip per row. Encode `clear*` fields as the two-phase
    set→verify-present→clear→verify-null assertion, not a single row.
-3. `xfail` the two known read-gaps with the ticket id.
+3. ~~`xfail` the two known read-gaps with the ticket id.~~ **Done, then resolved by OMN-62** — promoted to real
+   round-trip rows (see "Known read-gaps → RESOLVED" above).
 4. Run once against live OmniFocus; any unexpected non-persistence is a real bug → systematic-debugging (remember:
    confounded-oracle + blind-instrument traps from OMN-60 before blaming the writer).
 5. Wire into `test:integration`, not `test:unit`.

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -1050,6 +1050,8 @@ const DEFAULT_PROJECT_FIELDS = [
   'lastReviewDate',
   'nextReviewDate',
   'reviewInterval', // OMN-60: emitted by the script so it can be projected when requested
+  'tags', // OMN-62: emitted by the script so it can be projected when requested
+  'plannedDate', // OMN-62: emitted by the script so it can be projected when requested
 ];
 
 /**
@@ -1119,6 +1121,14 @@ function generateProjectFieldProjection(fields: string[], context?: { noteTrunca
         break;
       case 'defaultSingletonActionHolder':
         projections.push('defaultSingletonActionHolder: project.defaultSingletonActionHolder || false');
+        break;
+      case 'tags':
+        // OMN-62: mirrors task tags projection; project.tags verified live (OF 4.8.9)
+        projections.push('tags: project.tags ? project.tags.map(t => t.name) : []');
+        break;
+      case 'plannedDate':
+        // OMN-62: OF 4.7+; project.plannedDate accessor verified live via raw OmniJS probe
+        projections.push('plannedDate: project.plannedDate ? project.plannedDate.toISOString() : null');
         break;
     }
   }

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -137,6 +137,11 @@ export const MINIMAL_PROJECT_FIELDS = ['id', 'name', 'status', 'flagged', 'dueDa
 
 /**
  * Heavier project fields gated behind details=true.
+ *
+ * Deliberately excludes OMN-62's `tags`/`plannedDate` (and OMN-60's
+ * `reviewInterval`): those are emitted by the script via DEFAULT_PROJECT_FIELDS
+ * but surface ONLY when explicitly requested via `fields`, never on a bare
+ * `details:true` — keeps the detailed response token-cheap and shape-stable.
  */
 export const DETAIL_PROJECT_FIELDS = ['note', 'folderPath', 'sequential', 'lastReviewDate', 'nextReviewDate'];
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -183,7 +183,7 @@ RESPONSE CONTROL:
 - fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true)
 - ID lookup always returns all fields with full notes
 - fields (tasks): id, name, completed, flagged, blocked, available, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox
-- fields (projects): id, name, status, flagged, note, dueDate, deferDate, completedDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder
+- fields (projects): id, name, status, flagged, note, dueDate, deferDate, completedDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder, tags, plannedDate
 - sort: [{ field: "dueDate", direction: "asc" }]
 - limit/offset: Pagination (default limit: 25, max: 500)
 - countOnly: true returns only count (33x faster for "how many" questions) — tasks only

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -141,6 +141,8 @@ export const ProjectFieldEnum = z.enum([
   'nextReviewDate',
   'reviewInterval', // OMN-60: readable review interval { unit, steps }
   'defaultSingletonActionHolder',
+  'tags', // OMN-62: settable via CreateDataSchema, now readable
+  'plannedDate', // OMN-62: OF 4.7+ planned date, settable via CreateDataSchema, now readable
 ]);
 
 // Sort field enum for type safety

--- a/tests/integration/tools/unified/field-roundtrip.test.ts
+++ b/tests/integration/tools/unified/field-roundtrip.test.ts
@@ -383,6 +383,28 @@ describe('OMN-61 Phase 3: per-field write→read round-trip', () => {
       extract: (p) => p?.reviewInterval?.steps,
       expected: 5,
     },
+    {
+      // OMN-62: was an it.fails read-gap (settable via CreateDataSchema but
+      // absent from ProjectFieldEnum/projection). Now a genuine round-trip.
+      // Bridge-applied like task tags — high silent-fail risk. Normalized
+      // oracle: name-array (project.tags.map(t => t.name)).
+      field: 'tags',
+      op: 'create',
+      setValue: [`__test-rt-${TS}`],
+      readFields: ['tags'],
+      extract: (p) => p?.tags,
+      expected: [`__test-rt-${TS}`],
+    },
+    {
+      // OMN-62: was an it.fails read-gap. OF 4.7+ planned date; accessor
+      // verified live via raw OmniJS probe. Epoch-normalized oracle.
+      field: 'plannedDate',
+      op: 'create',
+      setValue: TEST_DATETIME,
+      readFields: ['plannedDate'],
+      extract: (p) => (p?.plannedDate ? new Date(p.plannedDate).getTime() : p?.plannedDate),
+      expected: TEST_DATETIME_EPOCH,
+    },
   ];
 
   describe('project scalar fields', () => {
@@ -537,53 +559,12 @@ describe('OMN-61 Phase 3: per-field write→read round-trip', () => {
     );
   });
 
-  // ── Known read-gaps → xfail + OMN-62 ──────────────────────────────────
-  // Settable on projects via the shared CreateDataSchema but ABSENT from
-  // ProjectFieldEnum / generateProjectFieldProjection — cannot be read back
-  // through the public API. This is the OMN-60 shape for two more fields.
-  // Failure mechanism: ProjectQuerySchema is .strict() and `fields` is
-  // z.array(ProjectFieldEnum), so requesting 'tags'/'plannedDate' is rejected
-  // by Zod at the tool boundary — the read returns success:false and
-  // assertFieldPersisted throws at its `success === false` guard (the
-  // extractor never runs). it.fails keeps the harness honest: "can't verify —
-  // read gap", not a green skip. When OMN-62 ships (adds them to the enum +
-  // projection) these flip green automatically; promote them to real rows in
-  // projectRows above.
-  describe('known read-gaps (OMN-62 — settable but unreadable on projects)', () => {
-    it.fails(
-      'project.tags — OMN-62: not in ProjectFieldEnum, cannot round-trip',
-      async () => {
-        const id = await createProject({ tags: [`__test-rt-${TS}`] });
-        // `fields: ['id','tags']` is rejected by ProjectQuerySchema (.strict,
-        // tags ∉ ProjectFieldEnum) → read success:false → assertFieldPersisted
-        // throws at its success guard. EXPECTED to throw until OMN-62 lands.
-        await assertFieldPersisted(client, {
-          readTool: 'omnifocus_read',
-          readParams: projectQuery(['tags']),
-          extract: (r) => findProject(r, id)?.tags,
-          expected: [`__test-rt-${TS}`],
-          context: 'project.tags (OMN-62 read gap)',
-        });
-      },
-      120000,
-    );
-
-    it.fails(
-      'project.plannedDate — OMN-62: not in ProjectFieldEnum, cannot round-trip',
-      async () => {
-        const id = await createProject({ plannedDate: TEST_DATETIME });
-        await assertFieldPersisted(client, {
-          readTool: 'omnifocus_read',
-          readParams: projectQuery(['plannedDate']),
-          extract: (r) => {
-            const v = findProject(r, id)?.plannedDate;
-            return v ? new Date(v).getTime() : v;
-          },
-          expected: TEST_DATETIME_EPOCH,
-          context: 'project.plannedDate (OMN-62 read gap)',
-        });
-      },
-      120000,
-    );
-  });
+  // ── OMN-62 RESOLVED ───────────────────────────────────────────────────
+  // project.tags and project.plannedDate were settable via the shared
+  // CreateDataSchema but absent from ProjectFieldEnum /
+  // generateProjectFieldProjection (the OMN-60 shape). OMN-62 added both to
+  // the enum + projection + inputSchema; they are now genuine round-trip
+  // rows in `projectRows` above. The former it.fails xfail placeholders are
+  // intentionally gone — keeping them would silently never exercise the
+  // now-working path (a vacuous green).
 });


### PR DESCRIPTION
## OMN-62 — project `tags` / `plannedDate` read gap

Both fields were **settable** via the shared `CreateDataSchema` but **unreadable** through `omnifocus_read` — absent from `ProjectFieldEnum` and the project projection. The exact OMN-60 shape, two more fields.

### Changes
- **`ProjectFieldEnum`** (`read-schema.ts`): add `tags`, `plannedDate` — the Zod read gate.
- **`generateProjectFieldProjection`** (`script-builder.ts`): add projection cases, mirroring the task shapes. Accessors verified **live** via a raw JXA→OmniJS probe on OF 4.8.9 (`project.tags.map(t => t.name)`; `project.plannedDate.toISOString()`) — OMN-60 discipline (never trust an unprobed accessor).
- **`DEFAULT_PROJECT_FIELDS`** (`script-builder.ts`): add both. **Root cause** of the initial round-trip failure: `handleProjectQuery` never threads `fields` into `buildFilteredProjectsScript`, so the OmniJS script always emits exactly `DEFAULT_PROJECT_FIELDS` and `projectFieldsOnResult` narrows that fixed superset post-hoc. A project field is requestable **iff** it is in `DEFAULT_PROJECT_FIELDS` — the same mechanism OMN-60 used for `reviewInterval`. The projects cache key intentionally excludes `fields`; threading `fields` into the script would corrupt the shared-superset cache (out of scope and wrong).
- **`OmniFocusReadTool` `inputSchema`**: advertise the two new project fields (CLAUDE.md dual-schema sync).
- **OMN-61 Phase 3 harness**: the two `it.fails` read-gap placeholders are **promoted to genuine round-trip rows** in `projectRows` (non-default values; normalized oracles: tags = name-array, plannedDate = epoch) and the xfail block removed — keeping `it.fails` would silently never exercise the now-working path (a vacuous green). Design doc + matrix updated.

### Verification
- `npm run build` clean.
- `npm run test:unit` — 1865 green, incl. the Phase-1 parity gate (`schema-impl-parity.test.ts`) which now auto-covers `projects "tags"` / `projects "plannedDate"`.
- `field-roundtrip.test.ts` against **live OmniFocus**: **26/26 green, zero xfails** (both new project rows genuinely round-trip; no regression in task/relational/clear paths).

Cross-ref: **OMN-60** (`reviewInterval`, identical read-gap shape + the `DEFAULT_PROJECT_FIELDS` mechanism) · **OMN-61** (Phase 3 round-trip harness this extends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)