### PR TITLE
OMN-59: ESLint rule hardening — snake_case 12 metadata keys, fix SystemTool gap, flip warn→error

### DIFF
--- a/docs/superpowers/plans/2026-05-17-omn-59-eslint-hardening.md
+++ b/docs/superpowers/plans/2026-05-17-omn-59-eslint-hardening.md
@@ -1,0 +1,316 @@
+# OMN-59 ESLint Rule Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve all four parts of OMN-59 — close the SystemTool annotation-text enforcement gap, rename 12 camelCase response-metadata keys to snake_case, document two rule assumptions, and flip the response-contract ESLint rules from `warn` to `error` with `lint:strict` green.
+
+**Architecture:** Test-first. Lock the SystemTool gap fix with a RuleTester regression test (red→green), then make the minimal `eslint-rules/index.js` regex change, then the mechanical metadata-key rename, then the documenting comments + conditional regex tweak, then the `eslint.config.js` severity flip. Each task is independently verifiable via `npm run lint` / `npm run lint:strict` / `npm run test:unit`.
+
+**Tech Stack:** TypeScript, ESLint 9 flat config, custom rules in `eslint-rules/index.js`, ESLint `RuleTester` wired into vitest (harness established by PR #7), `@typescript-eslint/parser`.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| ---- | -------------- | ------ |
+| `tests/unit/eslint-rules/use-standard-response.test.ts` | RuleTester coverage for `use-standard-response`: SystemResponse-alias gap + StandardResponseV2 regression guard + valid case | Create |
+| `eslint-rules/index.js` | `use-standard-response` (~line 72) and `use-handle-error` (~line 111) annotation-text gate; `export-zod-schema` inline-only comment (~line 189) | Modify |
+| `src/tools/unified/OmniFocusAnalyzeTool.ts` | 12 camelCase metadata keys at 4 `createAnalyticsResponseV2` emit-sites | Modify |
+| `eslint.config.js` | rule severities (lines 141–143, 154); double-gate comment (~line 150) | Modify |
+
+---
+
+## Task 1: Lock the SystemTool gap with a failing RuleTester test
+
+**Files:**
+- Create: `tests/unit/eslint-rules/use-standard-response.test.ts`
+- Reference (mirror harness): `tests/unit/eslint-rules/metadata-snake-case.test.ts:1-21`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/eslint-rules/use-standard-response.test.ts`. Note the two differences from the metadata-snake-case test: (a) this rule reads `fn.returnType`, so `RuleTester` MUST use `@typescript-eslint/parser`; (b) the rule is filename-gated (`/tools/` + `*Tool.ts`), so every case MUST set `filename`.
+
+```ts
+import { afterAll, describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import plugin from '../../../eslint-rules/index.js';
+
+// Wire ESLint's RuleTester into vitest's runner (see metadata-snake-case.test.ts).
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const rule = (plugin as { rules: Record<string, unknown> }).rules['use-standard-response'];
+if (!rule) {
+  throw new Error('use-standard-response rule not found on plugin export');
+}
+
+// This rule inspects TS return-type annotations (fn.returnType) — espree
+// cannot parse those; the typescript-eslint parser is required or the rule
+// silently never engages (vacuous green).
+const ruleTester = new RuleTester({
+  languageOptions: { parser: tsParser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+// The rule is gated to files matching /tools/ AND ending in Tool.ts.
+const FILENAME = 'src/tools/system/SystemTool.ts';
+
+ruleTester.run('use-standard-response', rule as never, {
+  valid: [
+    {
+      // SystemResponse-alias method that DOES use a builder — must not report,
+      // and (post-fix) proves the rule engages on the alias without false-firing.
+      filename: FILENAME,
+      code: 'class T { async f(): Promise<SystemResponse> { return createSuccessResponseV2("op", {}); } }',
+    },
+  ],
+  invalid: [
+    {
+      // GAP BEING CLOSED: SystemResponse is a type alias for StandardResponseV2.
+      // The substring gate missed it, so this bare {success,data} return was
+      // silently unchecked. Must report after the fix.
+      filename: FILENAME,
+      code: 'class T { async f(): Promise<SystemResponse> { return { success: true, data: {} }; } }',
+      errors: [{ messageId: 'useStandardResponse' }],
+    },
+    {
+      // REGRESSION GUARD: a StandardResponseV2-annotated method must STILL be
+      // checked after the gate change. Locks against the trailing-\b class of
+      // regression (would match SystemResponse but break StandardResponseV2).
+      filename: FILENAME,
+      code: 'class T { async f(): Promise<StandardResponseV2<Foo>> { return { success: true, data: {} }; } }',
+      errors: [{ messageId: 'useStandardResponse' }],
+    },
+  ],
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails (red)**
+
+Run: `npx vitest run tests/unit/eslint-rules/use-standard-response.test.ts`
+Expected: FAIL. The first `invalid` case (`Promise<SystemResponse>`) reports "Should have 1 error but had 0" — the current substring gate `annText.includes('StandardResponse')` skips the alias. (The `StandardResponseV2` regression-guard case already passes; the valid case already passes.)
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/eslint-rules/use-standard-response.test.ts
+git commit -m "test(OMN-59): failing RuleTester case for use-standard-response SystemResponse-alias gap"
+```
+
+---
+
+## Task 2: Fix the SystemTool annotation-text gap (#2)
+
+**Files:**
+- Modify: `eslint-rules/index.js:72` (`use-standard-response`) and `eslint-rules/index.js:111` (`use-handle-error`)
+
+- [ ] **Step 1: Replace the gate in `use-standard-response` (line ~72)**
+
+Current line (inside the `ReturnStatement` handler):
+```js
+            const annText = context.sourceCode.getText(fn.returnType);
+            if (!annText.includes('StandardResponse')) return;
+```
+Replace the `if` line with:
+```js
+            // Response-contract type names whose presence in a method's
+            // return-type annotation means the method produces a tool response
+            // and is subject to this rule. `SystemResponse` (SystemTool.ts) is
+            // a type alias for StandardResponseV2; matched explicitly because
+            // the old substring check missed it. NO trailing \b — plain
+            // `StandardResponse` must still match the longer `StandardResponseV2`
+            // (no word boundary exists between `...Response` and `V2`); a
+            // trailing \b would silently stop enforcing the ~8 methods annotated
+            // StandardResponseV2<...> that are checked today.
+            if (!/\b(StandardResponse|SystemResponse)/.test(annText)) return;
+```
+
+- [ ] **Step 2: Replace the identical gate in `use-handle-error` (line ~111)**
+
+The `use-handle-error` rule has the same two lines inside its `CatchClause` handler:
+```js
+            const annText = context.sourceCode.getText(fn.returnType);
+            if (!annText.includes('StandardResponse')) return;
+```
+Apply the same replacement (the same comment + `if (!/\b(StandardResponse|SystemResponse)/.test(annText)) return;`).
+
+- [ ] **Step 3: Run the test to verify it passes (green)**
+
+Run: `npx vitest run tests/unit/eslint-rules/use-standard-response.test.ts`
+Expected: PASS (valid + both invalid cases).
+
+- [ ] **Step 4: Verify no new violations surfaced (executeValidated conforms)**
+
+Run: `npm run lint:strict 2>&1 | grep -oE "local-rules/[a-z-]+" | sort | uniq -c`
+Expected: exactly `12 local-rules/metadata-snake-case` and nothing else. If any `use-standard-response` / `use-handle-error` lines appear, STOP — the spec's "executeValidated conforms" premise is violated; do not proceed, surface to the human.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eslint-rules/index.js
+git commit -m "fix(OMN-59): use-standard-response/use-handle-error recognize the SystemResponse alias"
+```
+
+---
+
+## Task 3: Rename the 12 metadata keys to snake_case (#1)
+
+**Files:**
+- Modify: `src/tools/unified/OmniFocusAnalyzeTool.ts` (4 `createAnalyticsResponseV2` metadata emit-sites: `productivity_stats` ~485; `task_velocity` cached ~671 and fresh ~729; `analyze_overdue` ~930)
+
+- [ ] **Step 1: Rename keys at all 4 emit-sites**
+
+In each `createAnalyticsResponseV2(...)` metadata object literal, rename ONLY the key (leave the value expression unchanged):
+
+| camelCase key | → snake_case key |
+| ------------- | ---------------- |
+| `includeProjectStats` | `include_project_stats` |
+| `includeTagStats` | `include_tag_stats` |
+| `startDate` | `start_date` |
+| `endDate` | `end_date` |
+| `groupBy` | `group_by` |
+| `includeWeekends` | `include_weekends` |
+| `includeCompleted` | `include_completed` |
+
+These are shorthand or `key: value` properties inside the metadata object. Examples of the exact edits:
+- `includeProjectStats,` → `include_project_stats: includeProjectStats,`
+- `includeTagStats,` → `include_tag_stats: includeTagStats,`
+- `startDate: rangeStart,` → `start_date: rangeStart,`
+- `endDate: rangeEnd,` → `end_date: rangeEnd,`
+- `groupBy,` → `group_by: groupBy,`
+- `includeWeekends,` → `include_weekends: includeWeekends,`
+- `includeCompleted: includeRecentlyCompleted,` → `include_completed: includeRecentlyCompleted,`
+
+Do NOT rename the local variables, input-parameter names, schema fields, or data-payload keys — only the metadata object keys at these 4 `createAnalyticsResponseV2` calls. Use `npm run lint` (Step 2) to confirm exactly the 12 expected warnings disappear.
+
+- [ ] **Step 2: Verify the 12 warnings are gone**
+
+Run: `npm run lint:strict 2>&1 | grep -c "local-rules/metadata-snake-case" || echo 0`
+Expected: `0`.
+Run: `npm run lint 2>&1 | grep -oE "[0-9]+ problems? \([0-9]+ errors?, [0-9]+ warnings?\)" | tail -1`
+Expected: `0 problems (0 errors, 0 warnings)`.
+
+- [ ] **Step 3: Verify no behavior/test regression**
+
+Run: `npm run build` — Expected: exit 0.
+Run: `npm run test:unit 2>&1 | grep -E "Test Files|Tests "` — Expected: all pass (count = prior 1877 baseline + the new `use-standard-response.test.ts` cases; no failures). If any analytics test fails asserting `metadata.<oldKey>`, that contradicts the spec's "no consumer" finding — STOP and surface.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusAnalyzeTool.ts
+git commit -m "fix(OMN-59): snake_case the 12 analytics response-metadata keys"
+```
+
+---
+
+## Task 4: Minor hardening — documenting comments + conditional regex tweak (#3)
+
+**Files:**
+- Modify: `eslint-rules/index.js` (`export-zod-schema`, ~line 189)
+- Modify: `eslint.config.js` (~line 150, the `src/tools/**/schemas/**` block)
+
+- [ ] **Step 1: Document the `export-zod-schema` inline-only assumption**
+
+In `eslint-rules/index.js`, immediately above the `export-zod-schema` filename gate (`if (!filename.includes('/schemas/') || !filename.endsWith('.ts')) return {};`), add:
+```js
+        // ASSUMPTION: detects only inline `export const XSchema = ...`. All
+        // schema files use that form today; `export { XSchema }` / re-export
+        // forms are intentionally not handled (YAGNI — no such file exists).
+```
+
+- [ ] **Step 2: Document the deliberate double-gate**
+
+In `eslint.config.js`, inside the `{ files: ['src/tools/**/schemas/**/*.ts', ...] }` block (the one whose rules set `local-rules/export-zod-schema`), add a comment above the `files:` line:
+```js
+    // Double-gate is deliberate: this config glob scopes the rule to schema
+    // dirs, and the rule body re-checks `filename.includes('/schemas/')` so it
+    // stays correct if applied via a broader config. Keep both in sync.
+```
+
+- [ ] **Step 3: Conditional `metadata-snake-case` leading-capital tweak**
+
+Locate the camelCase detection in `metadata-snake-case` (regex `/[a-z][A-Z]/` on metadata keys). Change the predicate so a key is flagged unless it matches strict snake_case `^[a-z0-9]+(_[a-z0-9]+)*$` (this also catches leading-capital keys like `HTTPStatus`).
+Then run: `npm run lint:strict 2>&1 | grep -oE "local-rules/[a-z-]+" | sort | uniq -c`
+- If output is empty (zero warnings): KEEP the tweak.
+- If ANY warning appears: REVERT the predicate change (restore `/[a-z][A-Z]/`) and add a one-line code comment: `// Leading-capital keys (e.g. HTTPStatus) intentionally not flagged — tightening the predicate surfaced pre-existing keys; deferred to avoid blocking the warn→error flip (OMN-59).`
+
+- [ ] **Step 4: Verify still clean**
+
+Run: `npm run lint:strict 2>&1 | grep -oE "local-rules/[a-z-]+" | sort | uniq -c || echo "0 (clean)"`
+Expected: `0 (clean)` (no local-rules warnings).
+Run: `npx vitest run tests/unit/eslint-rules/` — Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eslint-rules/index.js eslint.config.js
+git commit -m "docs(OMN-59): document export-zod-schema + double-gate assumptions; metadata-snake-case predicate (conditional)"
+```
+
+---
+
+## Task 5: Flip warn→error and restore lint:strict green (#4)
+
+**Files:**
+- Modify: `eslint.config.js:141`, `:142`, `:143`, `:154`
+
+- [ ] **Step 1: Flip severities**
+
+In `eslint.config.js`, change each `'warn'` to `'error'`:
+- line 141: `'local-rules/use-standard-response': 'warn',` → `'error',`
+- line 142: `'local-rules/use-handle-error': 'warn',` → `'error',`
+- line 143: `'local-rules/metadata-snake-case': 'warn',` → `'error',`
+- line 154: `'local-rules/export-zod-schema': 'warn',` → `'error',`
+
+- [ ] **Step 2: Verify CI lint gate stays green (errors-only)**
+
+Run: `npm run lint 2>&1 | grep -oE "[0-9]+ problems? \([0-9]+ errors?, [0-9]+ warnings?\)" | tail -1`
+Expected: `0 problems (0 errors, 0 warnings)`. (CI gate is ≤50 errors; 0 is green.)
+
+- [ ] **Step 3: Verify lint:strict restored to green**
+
+Run: `npm run lint:strict; echo "exit=$?"`
+Expected: `exit=0` (no warnings, no errors).
+
+- [ ] **Step 4: Full verification**
+
+Run: `npm run build` — Expected: exit 0.
+Run: `npm run test:unit 2>&1 | grep -E "Test Files|Tests "` — Expected: all pass, no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add eslint.config.js
+git commit -m "chore(OMN-59): flip response-contract local rules warn→error; lint:strict green"
+```
+
+---
+
+## Task 6: Final verification gate
+
+- [ ] **Step 1: Run the complete verification matrix**
+
+```bash
+npm run build
+npm run test:unit
+npm run lint
+npm run lint:strict
+npx vitest run tests/unit/eslint-rules/
+```
+Expected: build exit 0; all unit tests pass; `npm run lint` = 0 errors; `lint:strict` exit 0; eslint-rules tests green (incl. `use-standard-response.test.ts`).
+
+- [ ] **Step 2: Confirm scope discipline**
+
+`git diff main...HEAD --stat` should touch only: `tests/unit/eslint-rules/use-standard-response.test.ts`, `eslint-rules/index.js`, `src/tools/unified/OmniFocusAnalyzeTool.ts`, `eslint.config.js`, and the spec/plan docs. No input-parameter, schema, or data-payload renames. No OMN-54 work.
+
+---
+
+## Post-plan (project convention — handled at execution handoff, not a plan task)
+
+PR to `kip-d/omnifocus-mcp` cross-referencing OMN-59; mandatory code-reviewer subagent gated on a SAFE verdict; `gh pr merge --squash --auto` (never `--admin`); then comment + close OMN-59 (all four parts delivered; note pointer `kCI0AtWNycZ` addressed) and clean up the worktree/branch.

--- a/docs/superpowers/plans/2026-05-17-omn-59-eslint-hardening.md
+++ b/docs/superpowers/plans/2026-05-17-omn-59-eslint-hardening.md
@@ -188,6 +188,8 @@ These are shorthand or `key: value` properties inside the metadata object. Examp
 
 Do NOT rename the local variables, input-parameter names, schema fields, or data-payload keys — only the metadata object keys at these 4 `createAnalyticsResponseV2` calls. Use `npm run lint` (Step 2) to confirm exactly the 12 expected warnings disappear.
 
+**Edit-disambiguation note:** several of these strings are NOT unique in the file — `groupBy,` (shorthand) recurs at the velocity-cached, velocity-fresh, and overdue sites, and `startDate: rangeStart,` / `endDate: rangeEnd,` are byte-identical at the velocity-cached (~671) and velocity-fresh (~729) sites. An exact-string editor will hit "not unique" failures. Disambiguate by the differing preceding line — the metadata object opens with `from_cache: true,` at the cached site (~671) and `from_cache: false,` at the fresh site (~729) — or edit each emit-site by reading its surrounding block first. The Step 2 warning-count gate catches any missed occurrence.
+
 - [ ] **Step 2: Verify the 12 warnings are gone**
 
 Run: `npm run lint:strict 2>&1 | grep -c "local-rules/metadata-snake-case" || echo 0`
@@ -198,7 +200,7 @@ Expected: `0 problems (0 errors, 0 warnings)`.
 - [ ] **Step 3: Verify no behavior/test regression**
 
 Run: `npm run build` — Expected: exit 0.
-Run: `npm run test:unit 2>&1 | grep -E "Test Files|Tests "` — Expected: all pass (count = prior 1877 baseline + the new `use-standard-response.test.ts` cases; no failures). If any analytics test fails asserting `metadata.<oldKey>`, that contradicts the spec's "no consumer" finding — STOP and surface.
+Run: `npm run test:unit 2>&1 | grep -E "Test Files|Tests "` — Expected: **zero failures** (the suite count is the pre-existing baseline plus the new `use-standard-response.test.ts` cases; do not assert an exact number — verify "0 failed", not equality). If any analytics test fails asserting `metadata.<oldKey>`, that contradicts the spec's "no consumer" finding — STOP and surface.
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md
@@ -1,0 +1,153 @@
+# OMN-59 — ESLint rule hardening: clear 12 snake_case warnings, fix SystemTool annotation gap, flip warn→error
+
+Date: 2026-05-17
+Linear: OMN-59
+Status: Design approved (2026-05-17), pending spec review
+
+## Problem
+
+Three coupled ESLint-rule issues block tightening the response-contract rules from advisory (`warn`) to
+enforced (`error`):
+
+1. **12 camelCase metadata keys.** `src/tools/unified/OmniFocusAnalyzeTool.ts` passes camelCase keys into
+   the `createAnalyticsResponseV2` *metadata* envelope at 3 call-sites. They sit beside already-snake_case
+   metadata keys (`from_cache`, `query_time_ms` via `timer.toMetadata()`), so they are a genuine
+   inconsistency, not an aged-out rule premise. PR #7 (`0683d6f`) added `createAnalyticsResponseV2` to the
+   rule's `METADATA_ARG_INDEX`, which is what surfaced these 12 as warnings.
+2. **SystemTool annotation-text gap.** `use-standard-response` and `use-handle-error` only enforce inside
+   methods whose return-type annotation *text* contains the substring `StandardResponse`
+   (`eslint-rules/index.js`). `SystemTool.executeValidated` is annotated `Promise<SystemResponse>` where
+   `SystemResponse` is a type alias (`SystemTool.ts:87`) for `StandardResponseV2<...>`. The substring is
+   absent, so both rules **silently skip the entire SystemTool dispatch method**.
+3. **Rules stuck at `warn`.** Until #1 and #2 are resolved, `metadata-snake-case`,
+   `use-standard-response`, and `use-handle-error` cannot be flipped to `error` and `lint:strict` cannot
+   be restored to green.
+
+## Investigated facts (basis for the design)
+
+- The 12 keys are purely informational echo in the response *metadata* envelope. Verified: **no test and
+  no internal code** reads them as response-metadata keys (grep across `tests/` and `src/` returns only
+  input-parameter / schema / data-payload references, never `result.metadata.<key>` assertions).
+- `executeValidated` (`SystemTool.ts:163`) returns only delegated method calls
+  (`getVersion()/runDiagnostics()/getMetrics()/handleCacheOperation()`) plus one
+  `createErrorResponseV2(...)` in the `default` branch, and has **no `catch` block**. Once the heuristic
+  is widened it will be checked and **passes with zero new violations** — no SystemTool code change
+  required.
+- `npm run lint:strict` (all local rules, `--max-warnings=0`) on current `main` reports **exactly 12
+  warnings, all `metadata-snake-case`, and nothing else**. After the rename + #2 fix, flipping the three
+  rules to `error` yields **0 errors** → `lint:strict` green, CI green (CI gates on `npm run lint` error
+  count ≤ 50; warnings excluded).
+
+## Scope
+
+In scope (full OMN-59):
+
+1. Rename the 12 response-metadata keys to snake_case.
+2. Fix the SystemTool annotation-text gap in the two rules.
+3. Minor rule hardening (documented assumptions; conditional regex tweak).
+4. Flip the rules `warn`→`error`; restore `lint:strict` to green.
+5. Add a RuleTester regression test locking fix #2.
+
+Out of scope (correctly):
+
+- OMN-54 (the meta-check that rules with empty monitored sets should fail) — separate ticket.
+- Any rename of *input-parameter* names or *data-payload* keys. Only response `metadata` keys change.
+- Type-aware (`parserServices`) linting — not wired in this ESLint config; YAGNI given one alias.
+
+## Design
+
+### 1. Rename 12 metadata keys — `src/tools/unified/OmniFocusAnalyzeTool.ts`
+
+Rename in the `createAnalyticsResponseV2` metadata objects at the 3 call-sites (`productivity_stats`
+~485; `task_velocity` cached ~671 and fresh ~729; `analyze_overdue` ~930):
+
+| camelCase (current)   | snake_case (new)         |
+| --------------------- | ------------------------ |
+| `includeProjectStats` | `include_project_stats`  |
+| `includeTagStats`     | `include_tag_stats`      |
+| `startDate`           | `start_date`             |
+| `endDate`             | `end_date`               |
+| `groupBy`             | `group_by`               |
+| `includeWeekends`     | `include_weekends`       |
+| `includeCompleted`    | `include_completed`      |
+
+Only the metadata *key* changes; the value expression (e.g. `rangeStart`, `groupBy`, `includeWeekends`
+local variables) is unchanged — `start_date: rangeStart`, `group_by: groupBy`, etc. This is the only
+client-visible change and is confined to diagnostic response metadata.
+
+### 2. Fix SystemTool annotation-text gap — `eslint-rules/index.js`
+
+In both `use-standard-response` and `use-handle-error`, replace the brittle substring gate:
+
+```js
+if (!annText.includes('StandardResponse')) return;
+```
+
+with a named-response-contract-type regex:
+
+```js
+// Response-contract type names whose presence in a method's return-type
+// annotation means the method produces a tool response and is subject to
+// this rule. `SystemResponse` (SystemTool.ts) is a type alias for
+// StandardResponseV2; matched explicitly because the substring check missed it.
+const RESPONSE_CONTRACT_TYPES = /\b(StandardResponse|SystemResponse)\b/;
+if (!RESPONSE_CONTRACT_TYPES.test(annText)) return;
+```
+
+`StandardResponseV2` still matches (it contains `StandardResponse`, and `\bStandardResponse` matches at
+its start). Chosen over type-aware `parserServices` because exactly one alias exists and typed linting is
+not configured (YAGNI, low risk). The naming comment also discharges one #3 hardening item (documenting
+the gate's assumption).
+
+### 3. Minor hardening
+
+- **`export-zod-schema` inline-only assumption:** add a one-line comment in the rule stating it detects
+  only inline `export const XSchema =` and that all 9 schema files use that form. No speculative
+  `ExportSpecifier`/`ExportAllDeclaration` branch (YAGNI — "works today" per the ticket).
+- **`eslint.config.js` ↔ rule double-gate:** add a one-line comment noting the deliberate double-gate
+  between the config glob and the in-rule `filename.includes('/schemas/')` check.
+- **`metadata-snake-case` leading-capital regex (`HTTPStatus`):** conditional. After steps 1–2, change
+  the detection predicate and re-run `npm run lint:strict`. Ship the tweak **only if** the warning set is
+  still exactly the expected zero (no unexpected new warnings). If it surfaces anything, do **not** ship
+  the tweak; leave a one-line code comment recording the deferral and rationale (changing the detection
+  predicate is the one change that could break the clean `warn`→`error` flip). This item must not gate
+  the rest of OMN-59.
+
+### 4. Flip warn→error — `eslint.config.js`
+
+Change `local-rules/use-standard-response`, `local-rules/use-handle-error`,
+`local-rules/metadata-snake-case` from `'warn'` to `'error'`. Also flip
+`local-rules/export-zod-schema` to `'error'` for consistency (verified 0 warnings, so safe). Result:
+`lint:strict` green; `npm run lint` 0 errors.
+
+### 5. Regression test — `tests/unit/eslint-rules/`
+
+Using the RuleTester→vitest harness merged in PR #7, add a test that proves `use-standard-response`
+(and/or `use-handle-error`) now fires inside a method whose return type is an alias resolving to the
+response contract (the `Promise<SystemResponse>` shape). The test must be red against the pre-fix
+substring gate and green after — locking fix #2 against silent regression. Co-locate with or extend the
+existing `tests/unit/eslint-rules/metadata-snake-case.test.ts` pattern (separate rule → a sibling test
+file for the relevant rule).
+
+## Verification
+
+1. `npm run build` — exit 0.
+2. `npm run test:unit` — expect 1877 → still green (rename touches no logic; no test asserts these
+   metadata keys; the new RuleTester case adds to the count).
+3. `npm run lint` — 0 errors.
+4. `npm run lint:strict` — 0 warnings (green).
+5. The eslint-rules RuleTester suite green, including the new #2 regression case.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| A consumer relies on a camelCase metadata key | Verified none in tests/src; metadata is diagnostic, not contract-load-bearing. Accepted by the user as the chosen approach. |
+| #3 regex tweak surfaces new warnings, breaking the flip | Made conditional and explicitly non-gating; ship only if `lint:strict` stays clean. |
+| #2 heuristic widening surfaces real violations in SystemTool | Pre-verified: `executeValidated` conforms; zero new violations. |
+| Future response-type alias reintroduces the gap | Regression test (step 5) + the documenting comment naming the gated types. |
+
+## Linear
+
+On completion: comment OMN-59 with the resolution and **close it** (all four parts delivered). The
+follow-up pointer `kCI0AtWNycZ` referenced for item #2 can be noted as addressed.

--- a/docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md
@@ -10,7 +10,9 @@ Three coupled ESLint-rule issues block tightening the response-contract rules fr
 enforced (`error`):
 
 1. **12 camelCase metadata keys.** `src/tools/unified/OmniFocusAnalyzeTool.ts` passes camelCase keys into
-   the `createAnalyticsResponseV2` *metadata* envelope at 3 call-sites. They sit beside already-snake_case
+   the `createAnalyticsResponseV2` *metadata* envelope at 4 emit-sites across 3 analysis types
+   (`productivity_stats`; `task_velocity` in both its cached and fresh paths; `analyze_overdue`). They sit
+   beside already-snake_case
    metadata keys (`from_cache`, `query_time_ms` via `timer.toMetadata()`), so they are a genuine
    inconsistency, not an aged-out rule premise. PR #7 (`0683d6f`) added `createAnalyticsResponseV2` to the
    rule's `METADATA_ARG_INDEX`, which is what surfaced these 12 as warnings.
@@ -90,14 +92,22 @@ with a named-response-contract-type regex:
 // annotation means the method produces a tool response and is subject to
 // this rule. `SystemResponse` (SystemTool.ts) is a type alias for
 // StandardResponseV2; matched explicitly because the substring check missed it.
-const RESPONSE_CONTRACT_TYPES = /\b(StandardResponse|SystemResponse)\b/;
+// NOTE: NO trailing \b — `StandardResponse` must still match the longer
+// `StandardResponseV2` (no word boundary exists between `...Response` and
+// `V2`). A trailing \b would silently stop enforcing the ~8 methods annotated
+// `StandardResponseV2<...>` that are checked today — the exact regression this
+// fix must avoid.
+const RESPONSE_CONTRACT_TYPES = /\b(StandardResponse|SystemResponse)/;
 if (!RESPONSE_CONTRACT_TYPES.test(annText)) return;
 ```
 
-`StandardResponseV2` still matches (it contains `StandardResponse`, and `\bStandardResponse` matches at
-its start). Chosen over type-aware `parserServices` because exactly one alias exists and typed linting is
-not configured (YAGNI, low risk). The naming comment also discharges one #3 hardening item (documenting
-the gate's assumption).
+The leading `\b` anchors to the type-name start (annotations read `Promise<StandardResponseV2<...>>` /
+`Promise<SystemResponse>`, so the char before is `<`, a non-word char — boundary holds). **No trailing
+`\b`**: `\bStandardResponse` matches `StandardResponse`, `StandardResponseV2`, and any future
+`StandardResponseV3`; `\bSystemResponse` matches the alias. This preserves today's enforcement on all
+`StandardResponseV2`-annotated methods and additionally closes the `SystemResponse` gap. Chosen over
+type-aware `parserServices` because exactly one alias exists and typed linting is not configured (YAGNI,
+low risk). The naming comment also discharges one #3 hardening item (documenting the gate's assumption).
 
 ### 3. Minor hardening
 
@@ -122,12 +132,19 @@ Change `local-rules/use-standard-response`, `local-rules/use-handle-error`,
 
 ### 5. Regression test — `tests/unit/eslint-rules/`
 
-Using the RuleTester→vitest harness merged in PR #7, add a test that proves `use-standard-response`
-(and/or `use-handle-error`) now fires inside a method whose return type is an alias resolving to the
-response contract (the `Promise<SystemResponse>` shape). The test must be red against the pre-fix
-substring gate and green after — locking fix #2 against silent regression. Co-locate with or extend the
-existing `tests/unit/eslint-rules/metadata-snake-case.test.ts` pattern (separate rule → a sibling test
-file for the relevant rule).
+Using the RuleTester→vitest harness merged in PR #7, add tests for the relevant rule
+(`use-standard-response` and/or `use-handle-error`) covering **both**:
+
+1. **The gap being closed:** the rule fires inside a method whose return type is an alias resolving to
+   the response contract (the `Promise<SystemResponse>` shape) — red against the pre-fix substring gate,
+   green after.
+2. **The regression guard:** the rule still fires inside a method annotated
+   `Promise<StandardResponseV2<...>>` — this locks specifically against the trailing-`\b` class of
+   regression (a boundary bug that would match `SystemResponse` but break `StandardResponseV2`). A valid
+   case (a properly-conforming method) should also be present so the suite is non-vacuous.
+
+Co-locate with or extend the existing `tests/unit/eslint-rules/metadata-snake-case.test.ts` pattern
+(separate rule → a sibling test file for the relevant rule).
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-17-omn-59-eslint-hardening-design.md
@@ -60,8 +60,8 @@ Out of scope (correctly):
 
 ### 1. Rename 12 metadata keys — `src/tools/unified/OmniFocusAnalyzeTool.ts`
 
-Rename in the `createAnalyticsResponseV2` metadata objects at the 3 call-sites (`productivity_stats`
-~485; `task_velocity` cached ~671 and fresh ~729; `analyze_overdue` ~930):
+Rename in the `createAnalyticsResponseV2` metadata objects at the 4 emit-sites across 3 analysis types
+(`productivity_stats` ~485; `task_velocity` cached ~671 and fresh ~729; `analyze_overdue` ~930):
 
 | camelCase (current)   | snake_case (new)         |
 | --------------------- | ------------------------ |

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -182,7 +182,7 @@ const plugin = {
             if (call.arguments[metaIndex] !== objExpr) return;
 
             const key = (node.key && (node.key.name || node.key.value)) || null;
-            if (typeof key === 'string' && /[a-z][A-Z]/.test(key)) {
+            if (typeof key === 'string' && !/^[a-z0-9]+(_[a-z0-9]+)*$/.test(key)) {
               context.report({ node, messageId: 'snakeCaseMetadata', data: { key } });
             }
           },
@@ -204,6 +204,9 @@ const plugin = {
       },
       create(context) {
         const filename = context.filename;
+        // ASSUMPTION: detects only inline `export const XSchema = ...`. All
+        // schema files use that form today; `export { XSchema }` / re-export
+        // forms are intentionally not handled (YAGNI — no such file exists).
         if (!filename.includes('/schemas/') || !filename.endsWith('.ts')) return {};
 
         // Files named *helper*.ts are utility modules (e.g., coerceBoolean factories)

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -69,7 +69,16 @@ const plugin = {
             const fn = enclosingFunction(node);
             if (!fn || !fn.returnType) return;
             const annText = context.sourceCode.getText(fn.returnType);
-            if (!annText.includes('StandardResponse')) return;
+            // Response-contract type names whose presence in a method's
+            // return-type annotation means the method produces a tool response
+            // and is subject to this rule. `SystemResponse` (SystemTool.ts) is
+            // a type alias for StandardResponseV2; matched explicitly because
+            // the old substring check missed it. NO trailing \b — plain
+            // `StandardResponse` must still match the longer `StandardResponseV2`
+            // (no word boundary exists between `...Response` and `V2`); a
+            // trailing \b would silently stop enforcing the ~8 methods annotated
+            // StandardResponseV2<...> that are checked today.
+            if (!/\b(StandardResponse|SystemResponse)/.test(annText)) return;
 
             const keys = node.argument.properties
               .map((p) => (p.type === 'Property' && p.key && (p.key.name || p.key.value)) || null)
@@ -108,7 +117,16 @@ const plugin = {
             const fn = enclosingFunction(node);
             if (!fn || !fn.returnType) return;
             const annText = context.sourceCode.getText(fn.returnType);
-            if (!annText.includes('StandardResponse')) return;
+            // Response-contract type names whose presence in a method's
+            // return-type annotation means the method produces a tool response
+            // and is subject to this rule. `SystemResponse` (SystemTool.ts) is
+            // a type alias for StandardResponseV2; matched explicitly because
+            // the old substring check missed it. NO trailing \b — plain
+            // `StandardResponse` must still match the longer `StandardResponseV2`
+            // (no word boundary exists between `...Response` and `V2`); a
+            // trailing \b would silently stop enforcing the ~8 methods annotated
+            // StandardResponseV2<...> that are checked today.
+            if (!/\b(StandardResponse|SystemResponse)/.test(annText)) return;
 
             const text = context.sourceCode.getText(node.body);
             // Side-effecting catch blocks (no return) record sub-task results

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -15,6 +15,16 @@ function enclosingFunction(node) {
   return null;
 }
 
+// Response-contract type names whose presence in a method's return-type
+// annotation means the method produces a tool response and is subject to
+// the use-standard-response / use-handle-error rules. `SystemResponse`
+// (SystemTool.ts) is a type alias for StandardResponseV2; matched explicitly
+// because the old substring check missed it. NO trailing \b — plain
+// `StandardResponse` must still match the longer `StandardResponseV2` (no word
+// boundary exists between `...Response` and `V2`); a trailing \b would silently
+// stop enforcing the ~8 methods annotated StandardResponseV2<...> checked today.
+const RESPONSE_CONTRACT_TYPES = /\b(StandardResponse|SystemResponse)/;
+
 const plugin = {
   meta: {
     name: 'omnifocus-mcp-local',
@@ -69,16 +79,7 @@ const plugin = {
             const fn = enclosingFunction(node);
             if (!fn || !fn.returnType) return;
             const annText = context.sourceCode.getText(fn.returnType);
-            // Response-contract type names whose presence in a method's
-            // return-type annotation means the method produces a tool response
-            // and is subject to this rule. `SystemResponse` (SystemTool.ts) is
-            // a type alias for StandardResponseV2; matched explicitly because
-            // the old substring check missed it. NO trailing \b — plain
-            // `StandardResponse` must still match the longer `StandardResponseV2`
-            // (no word boundary exists between `...Response` and `V2`); a
-            // trailing \b would silently stop enforcing the ~8 methods annotated
-            // StandardResponseV2<...> that are checked today.
-            if (!/\b(StandardResponse|SystemResponse)/.test(annText)) return;
+            if (!RESPONSE_CONTRACT_TYPES.test(annText)) return;
 
             const keys = node.argument.properties
               .map((p) => (p.type === 'Property' && p.key && (p.key.name || p.key.value)) || null)
@@ -117,16 +118,7 @@ const plugin = {
             const fn = enclosingFunction(node);
             if (!fn || !fn.returnType) return;
             const annText = context.sourceCode.getText(fn.returnType);
-            // Response-contract type names whose presence in a method's
-            // return-type annotation means the method produces a tool response
-            // and is subject to this rule. `SystemResponse` (SystemTool.ts) is
-            // a type alias for StandardResponseV2; matched explicitly because
-            // the old substring check missed it. NO trailing \b — plain
-            // `StandardResponse` must still match the longer `StandardResponseV2`
-            // (no word boundary exists between `...Response` and `V2`); a
-            // trailing \b would silently stop enforcing the ~8 methods annotated
-            // StandardResponseV2<...> that are checked today.
-            if (!/\b(StandardResponse|SystemResponse)/.test(annText)) return;
+            if (!RESPONSE_CONTRACT_TYPES.test(annText)) return;
 
             const text = context.sourceCode.getText(node.body);
             // Side-effecting catch blocks (no return) record sub-task results

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,9 @@ export default [
   },
 
   // Custom OmniFocus MCP rules — applied to schema modules
+  // Double-gate is deliberate: this config glob scopes the rule to schema
+  // dirs, and the rule body re-checks `filename.includes('/schemas/')` so it
+  // stays correct if applied via a broader config. Keep both in sync.
   {
     files: ['src/tools/**/schemas/**/*.ts', 'src/tools/schemas/**/*.ts'],
     plugins: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -138,9 +138,9 @@ export default [
     },
     rules: {
       'local-rules/extend-base-tool': 'error',
-      'local-rules/use-standard-response': 'warn',
-      'local-rules/use-handle-error': 'warn',
-      'local-rules/metadata-snake-case': 'warn',
+      'local-rules/use-standard-response': 'error',
+      'local-rules/use-handle-error': 'error',
+      'local-rules/metadata-snake-case': 'error',
     },
   },
 
@@ -154,7 +154,7 @@ export default [
       'local-rules': localRules,
     },
     rules: {
-      'local-rules/export-zod-schema': 'warn',
+      'local-rules/export-zod-schema': 'error',
     },
   },
 

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -482,8 +482,8 @@ SCOPE FILTERING:
       return createAnalyticsResponseV2('productivity_stats', responseData, 'Productivity Analysis', keyFindings, {
         from_cache: false,
         period,
-        includeProjectStats,
-        includeTagStats,
+        include_project_stats: includeProjectStats,
+        include_tag_stats: includeTagStats,
         ...timer.toMetadata(),
       });
     } catch (error) {
@@ -668,10 +668,10 @@ SCOPE FILTERING:
           this.extractVelocityKeyFindings(cached as Parameters<typeof this.extractVelocityKeyFindings>[0]),
           {
             from_cache: true,
-            startDate: rangeStart,
-            endDate: rangeEnd,
-            groupBy,
-            includeWeekends,
+            start_date: rangeStart,
+            end_date: rangeEnd,
+            group_by: groupBy,
+            include_weekends: includeWeekends,
             ...timer.toMetadata(),
           },
         );
@@ -726,10 +726,10 @@ SCOPE FILTERING:
 
       return createAnalyticsResponseV2('task_velocity', responseData, 'Task Velocity Analysis', keyFindings, {
         from_cache: false,
-        startDate: rangeStart,
-        endDate: rangeEnd,
-        groupBy,
-        includeWeekends,
+        start_date: rangeStart,
+        end_date: rangeEnd,
+        group_by: groupBy,
+        include_weekends: includeWeekends,
         ...timer.toMetadata(),
       });
     } catch (error) {
@@ -927,8 +927,8 @@ SCOPE FILTERING:
 
       return createAnalyticsResponseV2('analyze_overdue', responseData, 'Overdue Task Analysis', keyFindings, {
         from_cache: false,
-        groupBy,
-        includeCompleted: includeRecentlyCompleted,
+        group_by: groupBy,
+        include_completed: includeRecentlyCompleted,
         ...timer.toMetadata(),
       });
     } catch (error) {

--- a/tests/unit/eslint-rules/use-standard-response.test.ts
+++ b/tests/unit/eslint-rules/use-standard-response.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import plugin from '../../../eslint-rules/index.js';
+
+// Wire ESLint's RuleTester into vitest's runner (see metadata-snake-case.test.ts).
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const rule = (plugin as { rules: Record<string, unknown> }).rules['use-standard-response'];
+if (!rule) {
+  throw new Error('use-standard-response rule not found on plugin export');
+}
+
+// This rule inspects TS return-type annotations (fn.returnType) — espree
+// cannot parse those; the typescript-eslint parser is required or the rule
+// silently never engages (vacuous green).
+const ruleTester = new RuleTester({
+  languageOptions: { parser: tsParser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+// The rule is gated to files matching /tools/ AND ending in Tool.ts.
+const FILENAME = 'src/tools/system/SystemTool.ts';
+
+ruleTester.run('use-standard-response', rule as never, {
+  valid: [
+    {
+      // SystemResponse-alias method that DOES use a builder — must not report,
+      // and (post-fix) proves the rule engages on the alias without false-firing.
+      filename: FILENAME,
+      code: 'class T { async f(): Promise<SystemResponse> { return createSuccessResponseV2("op", {}); } }',
+    },
+  ],
+  invalid: [
+    {
+      // GAP BEING CLOSED: SystemResponse is a type alias for StandardResponseV2.
+      // The substring gate missed it, so this bare {success,data} return was
+      // silently unchecked. Must report after the fix.
+      filename: FILENAME,
+      code: 'class T { async f(): Promise<SystemResponse> { return { success: true, data: {} }; } }',
+      errors: [{ messageId: 'useStandardResponse' }],
+    },
+    {
+      // REGRESSION GUARD: a StandardResponseV2-annotated method must STILL be
+      // checked after the gate change. Locks against the trailing-\b class of
+      // regression (would match SystemResponse but break StandardResponseV2).
+      filename: FILENAME,
+      code: 'class T { async f(): Promise<StandardResponseV2<Foo>> { return { success: true, data: {} }; } }',
+      errors: [{ messageId: 'useStandardResponse' }],
+    },
+  ],
+});


### PR DESCRIPTION
## OMN-59 — full remediation (all four parts)

Brainstormed → spec → plan → subagent-driven TDD execution. Spec + plan committed in this branch (`docs/superpowers/specs/`, `docs/superpowers/plans/`).

### Changes
1. **12 metadata keys → snake_case** (`OmniFocusAnalyzeTool.ts`): renamed at all 4 `createAnalyticsResponseV2` metadata emit-sites (`include_project_stats`, `include_tag_stats`, `start_date`, `end_date`, `group_by`, `include_weekends`, `include_completed`) so they match the rest of the metadata contract (`from_cache`, `query_time_ms`). Key-only; values unchanged. Verified no test/internal consumer reads these as metadata keys.
2. **SystemTool annotation-gap fix** (`eslint-rules/index.js`): `use-standard-response`/`use-handle-error` gated on the substring `annText.includes('StandardResponse')`, silently skipping `executeValidated` (annotated `Promise<SystemResponse>`, an alias for `StandardResponseV2`). Replaced with a hoisted module-scope `RESPONSE_CONTRACT_TYPES = /\b(StandardResponse|SystemResponse)/` (no trailing `\b` — must still match `StandardResponseV2`; this subtlety is documented once at the constant). Pre-verified `executeValidated` conforms → zero new violations.
3. **Minor hardening**: documented the `export-zod-schema` inline-only assumption and the `eslint.config.js`↔in-rule double-gate; tightened `metadata-snake-case` predicate to strict snake_case (`!/^[a-z0-9]+(_[a-z0-9]+)*$/`, also catches leading-capital like `HTTPStatus`) — kept because `lint:strict` stayed clean (the spec's conditional was satisfied).
4. **Flip warn→error**: `use-standard-response`, `use-handle-error`, `metadata-snake-case`, `export-zod-schema` → `error`; `lint:strict` restored to green.
5. **Regression test** (`tests/unit/eslint-rules/use-standard-response.test.ts`): RuleTester (with `@typescript-eslint/parser` + per-case `filename`) — a `SystemResponse`-alias case (the gap, RED before fix), a `StandardResponseV2` regression-guard case (locks the trailing-`\b` class), and a valid case. Built test-first (proven RED at commit `870cbb1`).

### Quality gates
- Spec-review loop caught and fixed a real regex word-boundary bug before implementation (a trailing `\b` would have silently disabled enforcement on ~8 already-checked methods).
- Two-stage subagent review: spec compliance **Compliant** + code quality **Approved**; nit-1 dedup refactor re-reviewed (behavior-neutral, byte-identical regex).

### Verification
`npm run build` exit 0 · `npm run test:unit` 1880/1880 · `npm run lint` 0 errors / 0 warnings · `npm run lint:strict` exit 0 · `tests/unit/eslint-rules/` 15/15.

Resolves **OMN-59** (addresses follow-up pointer `kCI0AtWNycZ`). Cross-ref OMN-54 (the meta-check) — explicitly out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)