### PR TITLE
fix(OMN-63): guarantee data.task.taskId on the create response

### DIFF
--- a/docs/superpowers/plans/2026-05-17-omn-63-taskid-normalize.md
+++ b/docs/superpowers/plans/2026-05-17-omn-63-taskid-normalize.md
@@ -1,0 +1,219 @@
+# OMN-63 — Guarantee `data.task.taskId` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `omnifocus_write` create response always carry a non-null `data.task.taskId` by backfilling it from the already-coalesced `createdTaskId` in `parseAndValidateCreateResult`, eliminating the OMN-57 #2/#3 "success:true but taskId undefined" flake class.
+
+**Architecture:** One `??=` normalization statement at the end of `parseAndValidateCreateResult` (after the validation guard that already proves `parsedResult` is an object and `taskId||id` is truthy, so `createdTaskId` is non-null there). TDD anchor is a fast unit test driving the create path through the existing `OmniFocusWriteTool.test.ts` mock harness with a script result that has `id` but no `taskId` (RED → GREEN). No live OmniFocus needed to prove determinism; the two ex-OMN-57 integration tests are verification only.
+
+**Tech Stack:** TypeScript, vitest, the existing `execJson` spy + `createScriptSuccess` test harness.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-omn-63-taskid-normalize-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| ---- | -------------- | ------ |
+| `tests/unit/tools/unified/OmniFocusWriteTool.test.ts` | 3 unit cases in the `describe('task create', …)` block: bug-shape backfill (RED), preservation, `??=` no-op | Modify |
+| `src/tools/unified/OmniFocusWriteTool.ts` | `parseAndValidateCreateResult` — one normalization statement before the final `return` (~line 591) | Modify |
+
+No new files. Reuse the existing `execJsonSpy` / `createScriptSuccess` / `tool.execute(...)` harness pattern (`OmniFocusWriteTool.test.ts:44-65`).
+
+---
+
+## Task 1: Add the create-response taskId unit cases (RED)
+
+**Files:**
+- Modify: `tests/unit/tools/unified/OmniFocusWriteTool.test.ts` — inside `describe('task create', () => { … })`
+
+- [ ] **Step 1: Add three test cases**
+
+Mirror the existing harness exactly (`execJsonSpy.mockResolvedValue(createScriptSuccess({ ok:true, v:'3', data:{…} }))` → `await tool.execute({ mutation:{ operation:'create', target:'task', data:{ name } } })` → assert on `result`). Add inside the `describe('task create', …)` block:
+
+```ts
+it('OMN-63: backfills data.task.taskId from id when script omits taskId', async () => {
+  execJsonSpy.mockResolvedValue(
+    createScriptSuccess({
+      ok: true,
+      v: '3',
+      data: { id: 'task-xyz', name: 'No taskId here' }, // NOTE: no `taskId`
+    }),
+  );
+
+  const result = (await tool.execute({
+    mutation: { operation: 'create', target: 'task', data: { name: 'No taskId here' } },
+  })) as any;
+
+  expect(result.success).toBe(true);
+  expect(result.data.task.taskId).toBe('task-xyz'); // backfilled from id
+  expect(result.data.id).toBe('task-xyz');          // unchanged
+});
+
+it('OMN-63: preserves a script-emitted taskId (no id present)', async () => {
+  execJsonSpy.mockResolvedValue(
+    createScriptSuccess({
+      ok: true,
+      v: '3',
+      data: { taskId: 'real-tid', name: 'Has taskId' },
+    }),
+  );
+
+  const result = (await tool.execute({
+    mutation: { operation: 'create', target: 'task', data: { name: 'Has taskId' } },
+  })) as any;
+
+  expect(result.success).toBe(true);
+  expect(result.data.task.taskId).toBe('real-tid'); // unclobbered
+});
+
+it('OMN-63: ??= is a no-op when both taskId and a differing id are present', async () => {
+  execJsonSpy.mockResolvedValue(
+    createScriptSuccess({
+      ok: true,
+      v: '3',
+      data: { taskId: 'tid-1', id: 'id-2', name: 'Both present' },
+    }),
+  );
+
+  const result = (await tool.execute({
+    mutation: { operation: 'create', target: 'task', data: { name: 'Both present' } },
+  })) as any;
+
+  expect(result.success).toBe(true);
+  expect(result.data.task.taskId).toBe('tid-1'); // taskId wins; not overwritten by id
+});
+```
+
+- [ ] **Step 2: Run — verify the bug-shape case is RED**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusWriteTool.test.ts -t "OMN-63"`
+Expected: the **backfill** case FAILS (`result.data.task.taskId` is `undefined`, expected `'task-xyz'` — current code returns `parsedResult` verbatim with no `taskId`). The **preservation** and **no-op** cases PASS already (their script result has `taskId`, so it survives untouched even without the fix) — this is correct: they are regression guards, not the RED anchor.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+git commit -m "test(OMN-63): create response must carry data.task.taskId (RED)"
+```
+
+---
+
+## Task 2: Normalize `parsedResult.taskId` (GREEN)
+
+**Files:**
+- Modify: `src/tools/unified/OmniFocusWriteTool.ts` — `parseAndValidateCreateResult`, immediately before `return { parsedResult, createdTaskId };` (~line 591)
+
+- [ ] **Step 1: Insert the normalization statement**
+
+The current tail of `parseAndValidateCreateResult` is:
+
+```ts
+    const createdTaskId =
+      (parsedResult as { taskId?: string; id?: string }).taskId || (parsedResult as { id?: string }).id || null;
+    this.logger.debug('Post-create task ID', { createdTaskId });
+
+    return { parsedResult, createdTaskId };
+```
+
+Insert the normalization between the `logger.debug` line and the `return` (so it sits after the
+validation block that guarantees `parsedResult` is a non-null object and `taskId || id` is truthy →
+`createdTaskId` is non-null here):
+
+```ts
+    this.logger.debug('Post-create task ID', { createdTaskId });
+
+    // OMN-63: data.task is parsedResult verbatim; the create script emits
+    // `taskId` but some paths/races yield only `id` (or a transient JXA id),
+    // leaving data.task.taskId undefined while success:true. Backfill from
+    // createdTaskId (= taskId || id, guaranteed non-null here by the
+    // validation above) so the create-response contract holds deterministically.
+    // `??=` never clobbers a valid script-emitted taskId.
+    (parsedResult as Record<string, unknown>).taskId ??= createdTaskId;
+
+    return { parsedResult, createdTaskId };
+```
+
+Do not change the signature, the validation, `createdTaskId`, or the caller. Use the
+`Record<string, unknown>` cast exactly as shown (NOT `as any` — `lint:strict` must stay green; that
+rule is error-class since OMN-59).
+
+- [ ] **Step 2: Run the OMN-63 unit cases — verify GREEN**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusWriteTool.test.ts -t "OMN-63"`
+Expected: all three PASS.
+
+- [ ] **Step 3: Full unit suite + lint (no collateral breakage)**
+
+Run: `npm run build` — Expected: exit 0.
+Run: `npm run test:unit 2>&1 | grep -E "Test Files|Tests "` — Expected: 0 failures. In particular the
+existing `OmniFocusWriteTool.test.ts` cases reading `data.id` (L62, basic create) and `data.task.id`
+(L151/180/226, v3/update paths) MUST still pass — this change only adds a `taskId` key when missing
+and never alters `id` or paths that already have a `taskId`. If any of those break, STOP and surface
+(would indicate the change touched more than intended).
+Run: `npm run lint:strict; echo "exit=$?"` — Expected: `exit=0` (no new `any`/warnings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusWriteTool.ts
+git commit -m "fix(OMN-63): backfill data.task.taskId from createdTaskId in parseAndValidateCreateResult"
+```
+
+---
+
+## Task 3: Live integration verification (the ex-OMN-57 flakes)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the two formerly-flaky tests against live OmniFocus**
+
+Run: `npx vitest tests/integration/tools/unified/end-to-end.test.ts -t "should update task with new planned date" --run`
+Run: `npx vitest tests/integration/tools/unified/end-to-end.test.ts -t "should create task with daily repeat rule" --run`
+Expected: both PASS (they assert `data.task.taskId` toBeDefined; the normalization makes this
+deterministic).
+
+- [ ] **Step 2: Determinism re-check**
+
+Re-run each of the two tests one more time (back-to-back). Expected: PASS again. The unit test
+already proves determinism structurally; this is belt-and-suspenders against any residual
+environmental flake. If either test fails or flakes, STOP and surface — the normalization should make
+`data.task.taskId` deterministic; a remaining failure indicates a *different* root cause (e.g. the
+create itself returning `success:false`), which is out of OMN-63's scope.
+
+- [ ] **Step 3: Commit (only if a verification-driven tweak was required; otherwise skip — no edits expected)**
+
+```bash
+git add -A && git commit -m "test(OMN-63): integration verification adjustments"
+```
+
+---
+
+## Task 4: Final gate
+
+**Files:** none
+
+- [ ] **Step 1: Verification matrix**
+
+```bash
+npm run build
+npm run test:unit
+npm run lint:strict; echo "lint:strict exit=$?"
+```
+Expected: build exit 0; unit 0 failures (incl. the 3 OMN-63 cases); `lint:strict exit=0`.
+
+- [ ] **Step 2: Scope discipline**
+
+`git diff main...HEAD --stat` touches only `src/tools/unified/OmniFocusWriteTool.ts`,
+`tests/unit/tools/unified/OmniFocusWriteTool.test.ts`, and the spec/plan docs. No change to
+`mutation-script-builder.ts` (script race is out of scope), no consumer migration, no `data.id` /
+`metadata.created_id` / validation changes.
+
+---
+
+## Post-plan (project convention — execution handoff, not a plan task)
+
+PR to `kip-d/omnifocus-mcp` cross-referencing OMN-63 (and OMN-57 #2/#3 lineage); mandatory
+code-reviewer subagent gated on a SAFE verdict; `gh pr merge --squash --auto` (never `--admin`); then
+comment OMN-63 with the unit-proven determinism + the two integration tests green, and close OMN-63.

--- a/docs/superpowers/specs/2026-05-17-omn-63-taskid-normalize-design.md
+++ b/docs/superpowers/specs/2026-05-17-omn-63-taskid-normalize-design.md
@@ -1,0 +1,124 @@
+# OMN-63 — Guarantee `data.task.taskId` on the create response
+
+Date: 2026-05-17
+Linear: OMN-63 (split from OMN-57 #2/#3)
+Status: Design approved (2026-05-17), pending spec review
+
+## Problem
+
+`omnifocus_write` create returns `success: true` but `data.task.taskId` is sometimes `undefined`
+(OMN-57 #2/#3: `end-to-end.test.ts` "should update task with new planned date" L584 and "should create
+task with daily repeat rule" L689 — latent flakes that pass only when a JXA-id race lands favorably).
+
+### Root cause (code-verified, current main `d9f783a`)
+
+`OmniFocusWriteTool.handleTaskCreate` builds the success response as
+`createSuccessResponseV2('omnifocus_write', { task: parsedResult, id: createdTaskId, name, operation }, …)`
+(L401-405). `data.task` is `parsedResult` — the raw create-script object verbatim. The create script
+(`mutation-script-builder.ts:800`) emits `taskId` (never `id`), but:
+
+- `parseAndValidateCreateResult` (`OmniFocusWriteTool.ts:534`) accepts the result if **either**
+  `taskId` **or** `id` is present (L569-571) and returns `parsedResult` unmodified.
+- `createdTaskId = parsedResult.taskId || parsedResult.id || null` (L587-588) — correctly coalesced,
+  used for `data.id` and `metadata.created_id`, so the *envelope* always has the id.
+- But `data.task` (the echoed script object) is **not** normalized. Any create path/race that yields a
+  `parsedResult` lacking `taskId` (only `id`, or a transient/empty JXA `.id()` before the
+  OmniJS-`primaryKey` upgrade at `mutation-script-builder.ts:~588-610`) → `data.task.taskId` is
+  `undefined` while `success:true` and `data.id` is fine.
+
+### Canonical field (resolved by codebase evidence, not a fork)
+
+`taskId` is unambiguously canonical for the create response: the create script emits `taskId`; the
+broad ecosystem reads `data.task.taskId` (`mcp-protocol.test.ts:118`, smoke-test-v2,
+omnifocus-sanity, test-tag-*, test-parent-child, test-move-to-parent, test-as-claude-desktop's
+`taskId || id`). `data.task.id` is read only on update/v3-envelope paths (a different response shape,
+out of scope). The fix is to **guarantee** `data.task.taskId`, not migrate consumers.
+
+## Scope
+
+In scope: one normalization statement in `parseAndValidateCreateResult` + unit tests proving it +
+integration verification of the two OMN-57 flakes.
+
+Out of scope (explicit):
+- The script-side JXA-`.id()` → OmniJS-`primaryKey` race (`mutation-script-builder.ts:~588-610`).
+  Normalization makes the contract deterministic regardless of that race; chasing it is a separate,
+  riskier concern (tracked implicitly by the existing bridge-nonce code; file separately if pursued).
+- `data.id`, `metadata.created_id`, the validation guard, all consumers — unchanged.
+- The update / v3-envelope create-response paths (`data.task.id`) — unchanged.
+- No consumer migration; no behavior change for any path that already returned a `taskId`.
+
+## Design
+
+### Change — `src/tools/unified/OmniFocusWriteTool.ts`, `parseAndValidateCreateResult`
+
+After the structure-validation block (which guarantees `parsedResult` is an object and
+`parsedResult.taskId || parsedResult.id` is truthy) and after `const createdTaskId = …` (therefore
+**non-null** at this point: validation forbids both being absent), and immediately before
+`return { parsedResult, createdTaskId };`, insert:
+
+```ts
+// OMN-63: data.task is parsedResult verbatim; the create script emits `taskId`
+// but some paths/races yield only `id` (or a transient JXA id), leaving
+// data.task.taskId undefined while success:true. Backfill from createdTaskId
+// (already = taskId || id, non-null here per the validation above) so the
+// create-response contract — data.task.taskId — holds deterministically.
+// `??=` never clobbers a valid script-emitted taskId.
+(parsedResult as Record<string, unknown>).taskId ??= createdTaskId;
+```
+
+Rationale for the specifics:
+- `??=` (not `=`): only fills when `taskId` is `null`/`undefined`; when the script already emitted a
+  valid `taskId`, `createdTaskId` equals it anyway, so `??=` is both safe and a no-op there.
+- `Record<string, unknown>` cast (not the ticket's `as any`): satisfies `@typescript-eslint/no-explicit-any`
+  (lint cleanliness — that rule is `warn`, and `lint:strict` must stay green per OMN-59); `parsedResult`
+  is a freshly-parsed local object, safe to mutate.
+- Placed after validation so `parsedResult` is guaranteed a non-null object and `createdTaskId` is
+  guaranteed non-null — no new null-guard needed.
+
+No change to the function signature, return shape, the validation, or the caller.
+
+### Tests
+
+**Unit (the TDD anchor — fast, deterministic, no live OmniFocus):**
+`tests/unit/tools/unified/OmniFocusWriteTool.test.ts` (existing suite for this tool). Add cases
+exercising the create path through `handleTaskCreate` (the existing tests in this file already mock
+the script result and assert `result.data.task.*`):
+
+1. **Bug shape:** script result has `id` but **no** `taskId` → assert `result.data.task.taskId`
+   equals that `id` (and `result.data.id` unchanged). RED before the change (parsedResult passed
+   verbatim → `taskId` undefined), GREEN after.
+2. **Preservation:** script result has a real `taskId` (and no `id`) → assert `result.data.task.taskId`
+   is that exact value, unclobbered (guards against accidental `=` semantics).
+
+Mirror the existing mocking/assertion pattern in that test file (it already drives create and reads
+`result.data.task.id` / `result.data.id` for v3 cases — use the same harness).
+
+**Integration (verification, not the anchor):**
+`tests/integration/tools/unified/end-to-end.test.ts` "should update task with new planned date" and
+"should create task with daily repeat rule" — already assert `data.task.taskId` toBeDefined; with the
+fix they pass deterministically. No test edits expected; if either still flakes, STOP and surface (the
+normalization should make them deterministic — a remaining flake means a different root cause).
+
+## Verification
+
+1. `npm run build` — exit 0.
+2. `npm run test:unit` — new unit cases green; the existing `OmniFocusWriteTool.test.ts` cases that
+   read `data.id` / `data.task.id` (lines ~62/151/180/226 — update/v3 paths) **still green**
+   (unchanged by this change); full suite 0 failures.
+3. `npm run lint:strict` — exit 0 (no new `any`/warnings; OMN-59 left it clean).
+4. Integration: the two OMN-57 #2/#3 tests pass against live OmniFocus; optionally run each in
+   isolation a few times to confirm determinism (the unit test already proves it).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `??=` clobbers a valid taskId | It only assigns when nullish; and `createdTaskId` === `taskId` when taskId present. Unit test #2 guards this. |
+| `createdTaskId` could be null → taskId set to null | Impossible here: validation (L569-571) rejects both-absent, so `taskId || id` is truthy → `createdTaskId` non-null at the insertion point. |
+| Mutating `parsedResult` affects other paths | `parsedResult` is a per-call freshly-parsed local; the only consumer is the response builder in the same function's caller. No shared state. |
+| Lint regression (`any`) | Use `Record<string, unknown>`; `lint:strict` in verification. |
+
+## Linear
+
+On completion: comment OMN-63 with the unit-proven determinism + the two integration flakes now
+green; close OMN-63. (OMN-57 already closed; OMN-64/OMN-65 remain independent.)

--- a/docs/superpowers/specs/2026-05-17-omn-63-taskid-normalize-design.md
+++ b/docs/superpowers/specs/2026-05-17-omn-63-taskid-normalize-design.md
@@ -89,6 +89,9 @@ the script result and assert `result.data.task.*`):
    verbatim → `taskId` undefined), GREEN after.
 2. **Preservation:** script result has a real `taskId` (and no `id`) → assert `result.data.task.taskId`
    is that exact value, unclobbered (guards against accidental `=` semantics).
+3. **`??=` no-op under both present:** script result has both `taskId` and a *different* `id` →
+   assert `result.data.task.taskId` is the original `taskId` (not the `id`), proving `??=` does not
+   overwrite and `createdTaskId`'s `taskId || id` precedence is consistent.
 
 Mirror the existing mocking/assertion pattern in that test file (it already drives create and reads
 `result.data.task.id` / `result.data.id` for v3 cases — use the same harness).
@@ -102,9 +105,10 @@ normalization should make them deterministic — a remaining flake means a diffe
 ## Verification
 
 1. `npm run build` — exit 0.
-2. `npm run test:unit` — new unit cases green; the existing `OmniFocusWriteTool.test.ts` cases that
-   read `data.id` / `data.task.id` (lines ~62/151/180/226 — update/v3 paths) **still green**
-   (unchanged by this change); full suite 0 failures.
+2. `npm run test:unit` — new unit cases green; the existing `OmniFocusWriteTool.test.ts` cases
+   **still green** unchanged: L62 reads `data.id` on the basic create path; L151/180/226 read
+   `data.task.id` on v3/update paths — this change only backfills a missing `taskId`, never alters
+   `id` or any path that already has a `taskId`. Full suite 0 failures.
 3. `npm run lint:strict` — exit 0 (no new `any`/warnings; OMN-59 left it clean).
 4. Integration: the two OMN-57 #2/#3 tests pass against live OmniFocus; optionally run each in
    isolation a few times to confirm determinism (the unit test already proves it).

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -588,6 +588,14 @@ SAFETY:
       (parsedResult as { taskId?: string; id?: string }).taskId || (parsedResult as { id?: string }).id || null;
     this.logger.debug('Post-create task ID', { createdTaskId });
 
+    // OMN-63: data.task is parsedResult verbatim; the create script emits
+    // `taskId` but some paths/races yield only `id` (or a transient JXA id),
+    // leaving data.task.taskId undefined while success:true. Backfill from
+    // createdTaskId (= taskId || id, guaranteed non-null here by the
+    // validation above) so the create-response contract holds deterministically.
+    // `??=` never clobbers a valid script-emitted taskId.
+    (parsedResult as Record<string, unknown>).taskId ??= createdTaskId;
+
     return { parsedResult, createdTaskId };
   }
 

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -130,6 +130,58 @@ describe('OmniFocusWriteTool task operations', () => {
       expect(result.success).toBe(false);
     });
 
+    it('OMN-63: backfills data.task.taskId from id when script omits taskId', async () => {
+      execJsonSpy.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: { id: 'task-xyz', name: 'No taskId here' }, // NOTE: no `taskId`
+        }),
+      );
+
+      const result = (await tool.execute({
+        mutation: { operation: 'create', target: 'task', data: { name: 'No taskId here' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.task.taskId).toBe('task-xyz'); // backfilled from id
+      expect(result.data.id).toBe('task-xyz'); // unchanged
+    });
+
+    it('OMN-63: preserves a script-emitted taskId (no id present)', async () => {
+      execJsonSpy.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: { taskId: 'real-tid', name: 'Has taskId' },
+        }),
+      );
+
+      const result = (await tool.execute({
+        mutation: { operation: 'create', target: 'task', data: { name: 'Has taskId' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.task.taskId).toBe('real-tid'); // unclobbered
+    });
+
+    it('OMN-63: ??= is a no-op when both taskId and a differing id are present', async () => {
+      execJsonSpy.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: { taskId: 'tid-1', id: 'id-2', name: 'Both present' },
+        }),
+      );
+
+      const result = (await tool.execute({
+        mutation: { operation: 'create', target: 'task', data: { name: 'Both present' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.task.taskId).toBe('tid-1'); // taskId wins; not overwritten by id
+    });
+
     it('unwraps v3 envelope from create result', async () => {
       execJsonSpy.mockResolvedValue(
         createScriptSuccess({


### PR DESCRIPTION
## OMN-63 — create-response `data.task.taskId` undefined (split from OMN-57 #2/#3)

Brainstorm → spec → plan → subagent-driven TDD. Spec/plan in `docs/superpowers/{specs,plans}/2026-05-17-omn-63-taskid-normalize*`.

### Root cause
`OmniFocusWriteTool` builds the create response as `data: { task: parsedResult, id: createdTaskId }`. `data.task` is the create-script object **verbatim**. The script emits `taskId`, but some paths/races yield only `id` (or a transient JXA `.id()` before the OmniJS-`primaryKey` upgrade) → `data.task.taskId` is `undefined` while `success:true` and `data.id` is fine. This is the OMN-57 #2/#3 latent-flake class (`end-to-end.test.ts` "update task with new planned date" / "create task with daily repeat rule").

### Fix (one statement)
In `parseAndValidateCreateResult`, after the validation guard (which proves `taskId || id` truthy, so `createdTaskId = taskId || id` is non-null) and before the return:
```ts
(parsedResult as Record<string, unknown>).taskId ??= createdTaskId;
```
`??=` backfills only when missing — never clobbers a script-emitted `taskId`. `data.task.taskId` now holds deterministically for **all** create paths. `Record<string,unknown>` cast (not `as any`) keeps `lint:strict` green (error-class since OMN-59).

**Out of scope (unchanged):** the script-side JXA-`.id()`→`primaryKey` race (`mutation-script-builder.ts`), `data.id`/`metadata.created_id`, the validation guard, all consumers, the update/v3-envelope paths (`data.task.id`).

### Tests
3 unit cases via the existing mock harness: bug-shape (`id`-only → backfill; **RED before, GREEN after**), preservation (script `taskId` unclobbered), `??=` no-op (both present → `taskId` wins). TDD RED→GREEN independently re-verified by the spec reviewer (checked out the test-only commit, saw the AssertionError).

### Verification
`npm run build` 0 · `npm run test:unit` **1884/1884** · `npm run lint:strict` exit 0 · the two ex-OMN-57 integration tests pass deterministically (2/2 runs each, live OmniFocus). Two-stage subagent review: spec compliance **Compliant**, code quality **Approved** (0 blocking, 0 actionable nits).

Closes **OMN-63**. (OMN-57 closed; OMN-64/OMN-65 remain independent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)