### PR TITLE
feat(OMN-67): consolidated STARTUP COMPLETE timing line

### DIFF
--- a/docs/superpowers/plans/2026-05-18-omn-67-startup-timing.md
+++ b/docs/superpowers/plans/2026-05-18-omn-67-startup-timing.md
@@ -342,6 +342,10 @@ startupTimer.mark('ready');
 logger.info(startupTimer.summary('http'));
 ```
 
+Note (cosmetic, expected): this prints `STARTUP COMPLETE … [http]` _before_ the existing
+`logger.info('HTTP server ready and accepting connections')` at line ~287. Intentional — `ready` is marked when the
+listener is up (`start()` resolved), not at the later human-readable banner. No functional impact.
+
 - [ ] **Step 7: Build + run the integration test (now GREEN)**
 
 Run: `npm run build && npx vitest run tests/integration/startup-timing.test.ts` Expected: PASS — exactly one

--- a/docs/superpowers/plans/2026-05-18-omn-67-startup-timing.md
+++ b/docs/superpowers/plans/2026-05-18-omn-67-startup-timing.md
@@ -1,0 +1,411 @@
+# STARTUP COMPLETE Timing Line — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit one always-on `STARTUP COMPLETE` INFO line per process start that decomposes startup into six phases
+(`load init perms warm register ready`) so the operator sees which phase dominates without reading code or subtracting
+timestamps.
+
+**Architecture:** A new `src/utils/startup-timer.ts` with a _pure_ `formatStartupSummary(marks, mode)` (the unit-tested
+contract) and a thin `StartupTimer` class (clock-injectable) that records `performance.now()` at six boundaries. A
+module-level `StartupTimer` instance in `src/index.ts` (constructed at the first executable statement so `load` captures
+Node bootstrap + ESM import-graph cost) is `mark()`ed at boundaries and emitted via the existing `logger` after the
+`ready` boundary in both stdio and HTTP modes. Additive only — no behavior change to warm/transport/shutdown.
+
+**Tech Stack:** TypeScript (ESM), Vitest, Node `perf_hooks` (`performance.now`), `@modelcontextprotocol/sdk`.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md`
+
+---
+
+## File Structure
+
+| File                                                | Responsibility                                                                                                                                                              |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/utils/startup-timer.ts` (create)               | `StartupMode`/`StartupCheckpoint`/`StartupMarks` types; pure `formatStartupSummary`; `StartupTimer` class (clock-injectable)                                                |
+| `tests/unit/utils/startup-timer.test.ts` (create)   | The contract: formatter exactness, sum-to-total, stdio/http, missing `registerEnd`, clock-injected timer                                                                    |
+| `tests/integration/startup-timing.test.ts` (create) | End-to-end wiring: spawn built server (`NODE_ENV=test`), assert exactly one `STARTUP COMPLETE … [stdio]` line, phases parse and sum                                         |
+| `src/index.ts` (modify)                             | Import + module-level instance (first executable statement); 4 shared `mark()`s; stdio `registerEnd`+`ready`+emit; http `ready`+emit; fix 2 stale `(non-blocking)` comments |
+
+---
+
+## Task 1: StartupTimer + pure formatter (the contract)
+
+**Files:**
+
+- Create: `src/utils/startup-timer.ts`
+- Test: `tests/unit/utils/startup-timer.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/utils/startup-timer.test.ts
+import { describe, it, expect } from 'vitest';
+import { StartupTimer, formatStartupSummary, type StartupMarks } from '../../../src/utils/startup-timer.js';
+
+describe('formatStartupSummary', () => {
+  it('renders all six phases for stdio, summing to total', () => {
+    const marks: StartupMarks = {
+      load: 8210,
+      initEnd: 8214,
+      permsEnd: 8354,
+      warmEnd: 30954,
+      registerEnd: 31067,
+      ready: 31280,
+    };
+    const line = formatStartupSummary(marks, 'stdio');
+    expect(line).toBe(
+      'STARTUP COMPLETE 31280ms  load 8210 · init 4 · perms 140 · warm 22600 · register 113 · ready 213  [stdio]',
+    );
+    // sum-to-total invariant (rounded parts within phase-count ms of total)
+    const nums = [...line.matchAll(/(?:load|init|perms|warm|register|ready) (\d+)/g)].map((m) => Number(m[1]));
+    const total = Number(line.match(/COMPLETE (\d+)ms/)![1]);
+    expect(Math.abs(nums.reduce((a, b) => a + b, 0) - total)).toBeLessThanOrEqual(6);
+  });
+
+  it('treats missing registerEnd as register 0 (http path) and still sums', () => {
+    const marks: StartupMarks = { load: 5000, initEnd: 5002, permsEnd: 5100, warmEnd: 27000, ready: 27210 };
+    const line = formatStartupSummary(marks, 'http');
+    expect(line).toBe(
+      'STARTUP COMPLETE 27210ms  load 5000 · init 2 · perms 98 · warm 21900 · register 0 · ready 210  [http]',
+    );
+  });
+
+  it('handles warm disabled (warmEnd == permsEnd) as warm 0', () => {
+    const marks: StartupMarks = { load: 400, initEnd: 402, permsEnd: 440, warmEnd: 440, registerEnd: 510, ready: 700 };
+    expect(formatStartupSummary(marks, 'stdio')).toContain('warm 0 ·');
+  });
+});
+
+describe('StartupTimer', () => {
+  it('captures load at construction and marks via injected clock', () => {
+    let t = 100;
+    const timer = new StartupTimer(() => t);
+    t = 105;
+    timer.mark('initEnd');
+    t = 250;
+    timer.mark('permsEnd');
+    t = 9000;
+    timer.mark('warmEnd');
+    t = 9100;
+    timer.mark('registerEnd');
+    t = 9300;
+    timer.mark('ready');
+    expect(timer.summary('stdio')).toBe(
+      'STARTUP COMPLETE 9300ms  load 100 · init 5 · perms 145 · warm 8750 · register 100 · ready 200  [stdio]',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/utils/startup-timer.test.ts` Expected: FAIL —
+`Cannot find module '../../../src/utils/startup-timer.js'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/utils/startup-timer.ts
+export type StartupMode = 'stdio' | 'http';
+export type StartupCheckpoint = 'initEnd' | 'permsEnd' | 'warmEnd' | 'registerEnd' | 'ready';
+
+export interface StartupMarks {
+  /** ms from process start to timer construction (≈ Node bootstrap + ESM import graph). */
+  load: number;
+  initEnd?: number;
+  permsEnd?: number;
+  warmEnd?: number;
+  registerEnd?: number; // stdio-only; absent in HTTP mode → register renders 0
+  ready?: number;
+}
+
+/**
+ * Pure. Given recorded marks (ms relative to process start) and the server mode,
+ * render the single STARTUP COMPLETE line. Phases are consecutive deltas, so
+ * load+init+perms+warm+register+ready === total (within rounding). A missing
+ * checkpoint collapses its phase to 0 (e.g. HTTP has no registerEnd).
+ */
+export function formatStartupSummary(marks: StartupMarks, mode: StartupMode): string {
+  const initEnd = marks.initEnd ?? marks.load;
+  const permsEnd = marks.permsEnd ?? initEnd;
+  const warmEnd = marks.warmEnd ?? permsEnd;
+  const registerEnd = marks.registerEnd ?? warmEnd;
+  const ready = marks.ready ?? registerEnd;
+
+  const load = Math.round(marks.load);
+  const init = Math.round(initEnd - marks.load);
+  const perms = Math.round(permsEnd - initEnd);
+  const warm = Math.round(warmEnd - permsEnd);
+  const register = Math.round(registerEnd - warmEnd);
+  const readyMs = Math.round(ready - registerEnd);
+  const total = Math.round(ready);
+
+  return (
+    `STARTUP COMPLETE ${total}ms  load ${load} · init ${init} · perms ${perms} · ` +
+    `warm ${warm} · register ${register} · ready ${readyMs}  [${mode}]`
+  );
+}
+
+export class StartupTimer {
+  private readonly marks: StartupMarks;
+  private readonly now: () => number;
+
+  constructor(now: () => number = () => performance.now()) {
+    this.now = now;
+    this.marks = { load: now() };
+  }
+
+  mark(checkpoint: StartupCheckpoint): void {
+    this.marks[checkpoint] = this.now();
+  }
+
+  summary(mode: StartupMode): string {
+    return formatStartupSummary(this.marks, mode);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/utils/startup-timer.test.ts` Expected: PASS (3 + 1 = all green)
+
+- [ ] **Step 5: Lint the new files**
+
+Run: `npx eslint src/utils/startup-timer.ts tests/unit/utils/startup-timer.test.ts` Expected: no output (clean)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/startup-timer.ts tests/unit/utils/startup-timer.test.ts
+git commit -m "feat(OMN-67): StartupTimer + pure formatStartupSummary contract
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Integration smoke test (RED — wiring not present yet)
+
+**Files:**
+
+- Create: `tests/integration/startup-timing.test.ts`
+
+This test spawns the built server with `NODE_ENV=test` (cache warming disabled → fast, no OmniFocus needed; the line is
+always-on so it still emits with `warm 0`) and `stdin` closed (triggers the graceful-exit path). It is written BEFORE
+the `src/index.ts` wiring so it fails first.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/integration/startup-timing.test.ts
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const entry = join(repoRoot, 'dist', 'index.js');
+
+function runServerOnce(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entry], {
+      env: { ...process.env, NODE_ENV: 'test' },
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.stdin.end(); // EOF → graceful exit after startup
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('server did not exit within 20s'));
+    }, 20_000);
+    child.on('close', () => {
+      clearTimeout(timer);
+      resolve(stderr);
+    });
+    child.on('error', reject);
+  });
+}
+
+describe('startup timing line (integration)', () => {
+  it('emits exactly one STARTUP COMPLETE [stdio] line whose phases sum to total', async () => {
+    const stderr = await runServerOnce();
+    const matches = stderr.match(/STARTUP COMPLETE .*\[stdio\]/g) ?? [];
+    expect(matches).toHaveLength(1);
+    const line = matches[0];
+    const total = Number(line.match(/COMPLETE (\d+)ms/)![1]);
+    const parts = [...line.matchAll(/(?:load|init|perms|warm|register|ready) (\d+)/g)].map((m) => Number(m[1]));
+    expect(parts).toHaveLength(6);
+    expect(Math.abs(parts.reduce((a, b) => a + b, 0) - total)).toBeLessThanOrEqual(6);
+  }, 25_000);
+});
+```
+
+- [ ] **Step 2: Build, then run the test to verify it fails**
+
+Run: `npm run build && npx vitest run tests/integration/startup-timing.test.ts` Expected: FAIL —
+`expected [] to have length 1` (no `STARTUP COMPLETE` line emitted yet; server still starts/exits cleanly)
+
+- [ ] **Step 3: Commit the RED test**
+
+```bash
+git add tests/integration/startup-timing.test.ts
+git commit -m "test(OMN-67): integration smoke for STARTUP COMPLETE line (RED)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire StartupTimer into src/index.ts (GREEN)
+
+**Files:**
+
+- Modify: `src/index.ts` (import after line 15; instance as first executable statement ~line 17; `mark('initEnd')` after
+  line 63; `mark('permsEnd')` after line 76; `mark('warmEnd')` after line 125; stdio `mark('registerEnd')` after line
+  162 and `mark('ready')`+emit after line 218; http `mark('ready')`+emit after line 257; comment fixes at lines 62
+  and 78)
+
+All boundary line numbers are relative to the file as read; if drift occurs, anchor on the quoted code, not the number.
+
+- [ ] **Step 1: Add the import**
+
+After `import { HttpServerManager } from './http-server.js';` add:
+
+```ts
+import { StartupTimer } from './utils/startup-timer.js';
+```
+
+- [ ] **Step 2: Construct the timer as the FIRST executable statement**
+
+Immediately after the import block and BEFORE `const logger = createLogger('server');`, insert:
+
+```ts
+// First executable statement: performance.now() here ≈ Node bootstrap + ESM
+// import-graph load (the cold-`npm ci` FS cost). Must precede parseCLIArgs.
+const startupTimer = new StartupTimer();
+```
+
+- [ ] **Step 3: Fix the two stale `(non-blocking)` comments (doc-only)**
+
+`// Perform initial permission check (non-blocking)` →
+`// Perform initial permission check (blocking — awaited before the transport connects)`
+
+`// Warm cache with frequently accessed data (non-blocking)` →
+`// Warm cache with frequently accessed data (blocking — awaited before the transport connects)`
+
+- [ ] **Step 4: Add the four shared `mark()` calls in `runServer()`**
+
+After `const permissionChecker = PermissionChecker.getInstance();` (line ~63):
+
+```ts
+startupTimer.mark('initEnd');
+```
+
+After the permission-check `try { … } catch { … }` block closes (line ~76, before the `// Warm cache …` comment):
+
+```ts
+startupTimer.mark('permsEnd');
+```
+
+After the entire cache-warm `if/else if/else if/else` block closes (line ~125, before
+`// Check if we're running in HTTP mode`):
+
+```ts
+startupTimer.mark('warmEnd');
+```
+
+- [ ] **Step 5: Add stdio `registerEnd` + `ready` + emit**
+
+In `runStdioServer`, after `registerPrompts(stdioServer);` (line ~162):
+
+```ts
+startupTimer.mark('registerEnd');
+```
+
+At the end of `runStdioServer`, after `await stdioServer.connect(transport);` (line ~218):
+
+```ts
+startupTimer.mark('ready');
+logger.info(startupTimer.summary('stdio'));
+```
+
+- [ ] **Step 6: Add http `ready` + emit**
+
+In `runHttpServer`, immediately after the `try { await httpServerManager.start(); } catch { … }` block (line ~257,
+before the `gracefulShutdown` definition):
+
+```ts
+startupTimer.mark('ready');
+logger.info(startupTimer.summary('http'));
+```
+
+- [ ] **Step 7: Build + run the integration test (now GREEN)**
+
+Run: `npm run build && npx vitest run tests/integration/startup-timing.test.ts` Expected: PASS — exactly one
+`STARTUP COMPLETE … [stdio]` line, 6 phases, sum ≈ total
+
+- [ ] **Step 8: Lint the modified file**
+
+Run: `npx eslint src/index.ts` Expected: no output (clean)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(OMN-67): emit STARTUP COMPLETE timing line (stdio+HTTP, always-on)
+
+Wire module-level StartupTimer; mark load/init/perms/warm/register/ready;
+emit after ready in both modes. Correct two stale (non-blocking) comments
+(:62 perms, :78 warm — both are awaited/blocking). Additive only.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full gate verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build**
+
+Run: `npm run build` Expected: exit 0, clean `tsc`
+
+- [ ] **Step 2: Full unit suite**
+
+Run: `npm run test:unit` Expected: all pass, including the new `startup-timer.test.ts` (suite count increases)
+
+- [ ] **Step 3: Strict lint**
+
+Run: `npm run lint:strict` Expected: exit 0, no warnings (`--max-warnings=0`)
+
+- [ ] **Step 4: Integration smoke (re-confirm)**
+
+Run: `npx vitest run tests/integration/startup-timing.test.ts` Expected: PASS
+
+- [ ] **Step 5: Update spec status + commit**
+
+Edit the spec header `Status:` line to `Status: Implemented (2026-05-18) — pending review/merge`.
+
+```bash
+git add docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
+git commit -m "docs(OMN-67): mark spec implemented
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Definition of Done
+
+- `npm run build` 0 · `npm run test:unit` all green (incl. new contract tests) · `npm run lint:strict` 0
+- `tests/integration/startup-timing.test.ts` GREEN: exactly one `STARTUP COMPLETE … [stdio]` line, six phases, sum
+  within rounding of total
+- `src/index.ts`: module-level `StartupTimer` is the first executable statement; six boundaries marked; emitted after
+  `ready` in both stdio and HTTP; both stale `(non-blocking)` comments corrected
+- No behavior change to warm/transport/mode-branch/shutdown (additive logging only)
+- `~/bin/of-mcp-redeploy` (already greps `STARTUP COMPLETE`) will surface the line on next prod redeploy with zero
+  script change

--- a/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
+++ b/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
@@ -1,0 +1,124 @@
+# OMN-67 — Consolidated STARTUP COMPLETE timing line
+
+Date: 2026-05-18 Linear: OMN-67 Status: Design approved (2026-05-18), pending spec review
+
+## Problem
+
+The MCP server blocks its transport behind an awaited `cacheWarmer.warmCache()`: in `src/index.ts`,
+`await cacheWarmer.warmCache()` (≈:117) runs in `main()` **before** the mode branch
+(`if (cliConfig.httpMode) runHttpServer else runStdioServer`, ≈:127–132) and therefore before the stdio transport
+`connect()` (≈:218) or the HTTP listener start. On a cold start this exceeds the client's fixed 30s connect window, so
+the first `/mcp` reconnect times out and only the second works (root cause diagnosed and empirically verified
+2026-05-18: warm alone ≈15.4s even on a fully hot machine; a cold redeploy adds cold `node_modules` FS read after
+`npm ci`, cold OmniFocus DB materialization, and possible TCC re-eval on top).
+
+Existing logs are timestamped and the cache warmer already logs
+`Cache warming completed: N/N operations succeeded in NNNNNms` plus a per-category breakdown
+(`projects … / tags … / tasks_unified … / perspectives …`). What is missing:
+
+1. The **module-load / Node-bootstrap slice** — everything before the first log line, which is exactly the cold-`npm ci`
+   FS cost — is invisible.
+2. A single **at-a-glance summary** that localizes _which_ phase dominated, so the operator never has to subtract
+   timestamps by hand or guess by reading code.
+
+A `time`-wrapped pre-warm already yields the true end-to-end cold wall (it measures the whole process). This work is
+purely about **decomposition and turnkey visibility**, not about producing a number that is otherwise unobtainable.
+
+## Key facts (reuse, don't reinvent)
+
+- **`load` is derivable for free.** `performance.now()` is measured relative to `performance.timeOrigin` (≈ process
+  init). ESM hoists all `import` statements above any executable code, so by the time `main()` runs the entire
+  dependency graph is already loaded. Therefore the value of `performance.now()` at the **first executable statement of
+  the entrypoint** _is_ the `load` duration (Node bootstrap + full import graph). No separate first-imported timing
+  module is required.
+- **The expensive phases are pre-branch and shared.** `load`, `init`, `perms`, `warm` are all captured in `main()`
+  _before_ the stdio/HTTP split. Only the final `ready` boundary differs by mode. Instrumenting both modes is one extra
+  emit call reusing identical timestamps — excluding HTTP would add a conditional, not remove code.
+- **The warm phase already has drill-down.** `CacheWarmer` logs its per-category durations on the line immediately
+  preceding where the summary will emit. The summary carries the six top-level phases; the warmer's existing line
+  remains the drill-down for the dominant phase. No nesting/coupling needed.
+- Additive logging only. No behavior change to the warm, transport, mode-branch, or shutdown paths.
+
+## Decision
+
+Add a small `StartupTimer` (`mark(name)` capturing `performance.now()`; a **pure** `formatStartupSummary(marks, mode)`),
+place `mark()` calls at six boundaries in `main()` and each mode function, and emit one `STARTUP COMPLETE` INFO line in
+**both** stdio and HTTP modes, **always-on** (even when warming is disabled — the `warm` slice then shows `0`). The
+cache warmer's existing per-category line is the drill-down for the dominant phase.
+
+## Phases (derived from `src/index.ts` `main()`)
+
+| Phase      | Boundary                                                    | A spike here means                                                           |
+| ---------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `load`     | process start (`timeOrigin`) → first `mark()` at entrypoint | Cold `node_modules` FS read after `npm ci` + Node bootstrap                  |
+| `init`     | entry → `CacheManager` + `PermissionChecker` constructed    | Usually ≈0; flags a config/env surprise                                      |
+| `perms`    | `checkPermissions()` start→end                              | macOS Automation/Apple-Events TCC re-eval after file changes                 |
+| `warm`     | `cacheWarmer.warmCache()` start→end                         | Dominant cost; scales with DB size (drill-down already logged by the warmer) |
+| `register` | `registerTools` + prompt registration start→end             | Tool/prompt registration (~113ms observed)                                   |
+| `ready`    | transport `connect()` (stdio) / HTTP listener up (HTTP)     | Final handshake readiness                                                    |
+
+**Output (one INFO line, both modes):**
+
+```
+STARTUP COMPLETE 31280ms  load 8210 · init 4 · perms 140 · warm 22600 · register 113 · ready 213  [stdio]
+```
+
+Per-phase values in ms; they sum to `total` within rounding; mode tag (`[stdio]`/`[http]`) at the end.
+
+## Scope
+
+In scope:
+
+- **New module** `src/utils/startup-timer.ts`:
+  - `class StartupTimer` with `mark(phase: StartupPhase): void` recording `performance.now()` keyed by phase name (first
+    `mark` establishes the `load` value from its own `performance.now()`).
+  - Pure `formatStartupSummary(marks, mode): string` — deterministic, no clock/IO access; computes per-phase deltas +
+    total from recorded marks; renders the line above.
+- **Wiring in `src/index.ts`**: instantiate the timer at the top of the entrypoint; `mark()` at the six boundaries; emit
+  the formatted line via the existing `logger` (`server` channel, INFO) after the final `ready` mark in **both**
+  `runStdioServer` and `runHttpServer`.
+- Correct the now-stale `// (non-blocking)` comment at `src/index.ts:78` as an in-region drive-by (the warm is
+  awaited/blocking; this is documentation accuracy, no behavior change).
+
+Out of scope:
+
+- Any change to warm/transport/shutdown behavior or ordering.
+- Nesting the warmer's per-category breakdown into the summary line (it already exists adjacent; folding it in would
+  couple the timer to the warmer — explicitly rejected as approach B).
+- A generic arbitrary-`mark` registry (rejected as approach C: unbounded output, weak contract, non-deterministic to
+  test).
+- Splitting `load` into Node-bootstrap vs import-graph sub-slices (YAGNI; one `load` slice answers the operator
+  question).
+- Persisting/exporting timings anywhere beyond the existing logger.
+
+## Testing
+
+- **Unit (pure formatter, the contract):** `formatStartupSummary` with synthetic marks → exact expected string;
+  per-phase deltas correct; phases sum to `total` within rounding; `[stdio]` vs `[http]` tag; graceful handling when a
+  phase mark is missing (e.g., warm disabled → `warm 0`); ordering of phases stable regardless of `mark()` call order.
+- **Integration:** on stdio startup the `STARTUP COMPLETE` line is emitted exactly once, `load` is present and non-zero,
+  and the `mode` tag is `[stdio]`. (HTTP-mode emission asserted analogously where the existing harness permits;
+  otherwise covered by the unit contract on the mode parameter plus a wiring assertion that `runHttpServer` calls the
+  emit.)
+- All existing gates green: `npm run build`, `npm run test:unit`, `npm run lint:strict`.
+
+## Risks / non-goals
+
+- **Risk:** a `mark()` placed on the wrong side of a boundary mis-attributes time. Mitigation: phases sum-to-total
+  assertion in unit tests catches gross misattribution; boundary placement is reviewed against the `main()` control flow
+  in the plan/code-review gates.
+- **Risk:** `performance.timeOrigin` semantics differ from expectation, skewing `load`. Mitigation: `load` is defined
+  operationally as "first `mark()`'s `performance.now()`"; the integration test asserts it is present and non-zero
+  (sanity), not an exact value.
+- **Non-goal:** reducing startup time. This is observability only; the fix for the 30s symptom is the operational
+  pre-warm (`~/bin/of-mcp-redeploy`), not this ticket.
+
+## Acceptance
+
+- One `STARTUP COMPLETE` line per process start in both stdio and HTTP modes, always-on.
+- Six phases present; values sum to `total` within rounding; correct mode tag.
+- `load` slice demonstrably non-zero and reflects bootstrap (sanity-checked in integration; larger immediately after
+  `npm ci` in the field, not asserted in CI).
+- `~/bin/of-mcp-redeploy` already greps for `STARTUP COMPLETE`; it lights up automatically once this lands (no script
+  change required).
+- Build / `test:unit` / `lint:strict` all green.

--- a/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
+++ b/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
@@ -1,6 +1,7 @@
 # OMN-67 — Consolidated STARTUP COMPLETE timing line
 
-Date: 2026-05-18 Linear: OMN-67 Status: Design approved (2026-05-18), pending spec review
+Date: 2026-05-18 Linear: OMN-67 Status: Approved — spec-review (Approved + 3 advisories folded in) and user, 2026-05-18;
+ready for implementation plan
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
+++ b/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
@@ -5,7 +5,7 @@ Date: 2026-05-18 Linear: OMN-67 Status: Design approved (2026-05-18), pending sp
 ## Problem
 
 The MCP server blocks its transport behind an awaited `cacheWarmer.warmCache()`: in `src/index.ts`,
-`await cacheWarmer.warmCache()` (≈:117) runs in `main()` **before** the mode branch
+`await cacheWarmer.warmCache()` (≈:117) runs in `runServer()` **before** the mode branch
 (`if (cliConfig.httpMode) runHttpServer else runStdioServer`, ≈:127–132) and therefore before the stdio transport
 `connect()` (≈:218) or the HTTP listener start. On a cold start this exceeds the client's fixed 30s connect window, so
 the first `/mcp` reconnect times out and only the second works (root cause diagnosed and empirically verified
@@ -27,13 +27,20 @@ purely about **decomposition and turnkey visibility**, not about producing a num
 ## Key facts (reuse, don't reinvent)
 
 - **`load` is derivable for free.** `performance.now()` is measured relative to `performance.timeOrigin` (≈ process
-  init). ESM hoists all `import` statements above any executable code, so by the time `main()` runs the entire
+  init). ESM hoists all `import` statements above any executable code, so by the time `runServer()` runs the entire
   dependency graph is already loaded. Therefore the value of `performance.now()` at the **first executable statement of
   the entrypoint** _is_ the `load` duration (Node bootstrap + full import graph). No separate first-imported timing
-  module is required.
-- **The expensive phases are pre-branch and shared.** `load`, `init`, `perms`, `warm` are all captured in `main()`
-  _before_ the stdio/HTTP split. Only the final `ready` boundary differs by mode. Instrumenting both modes is one extra
-  emit call reusing identical timestamps — excluding HTTP would add a conditional, not remove code.
+  module is required. Placement note: `src/index.ts` has a few module-top-level statements (`createLogger`,
+  `parseCLIArgs`) that run before `runServer()` is invoked. The `StartupTimer` must therefore be instantiated /
+  first-marked at **module top level** (as early as possible), not at the top of `runServer()`, so the `load` value is
+  not undercounted by the top-level CLI parse. The plan must pin this placement.
+- **The expensive phases are pre-branch and shared.** `load`, `init`, `perms`, `warm` are all captured in `runServer()`
+  _before_ the stdio/HTTP split. Only the final `ready` boundary differs by mode, and `register` is **stdio-only**:
+  `runHttpServer` never calls `registerTools`/`registerPrompts` — HTTP registers tools lazily per-session inside
+  `SessionManager` (`session-manager.ts`), after the listener is already up (i.e. after `ready`). In HTTP mode
+  `register` therefore renders `0`, exactly the way `warm` renders `0` when warming is disabled. Instrumenting both
+  modes is one extra emit call reusing the shared pre-branch timestamps — excluding HTTP would add a conditional, not
+  remove code.
 - **The warm phase already has drill-down.** `CacheWarmer` logs its per-category durations on the line immediately
   preceding where the summary will emit. The summary carries the six top-level phases; the warmer's existing line
   remains the drill-down for the dominant phase. No nesting/coupling needed.
@@ -42,11 +49,11 @@ purely about **decomposition and turnkey visibility**, not about producing a num
 ## Decision
 
 Add a small `StartupTimer` (`mark(name)` capturing `performance.now()`; a **pure** `formatStartupSummary(marks, mode)`),
-place `mark()` calls at six boundaries in `main()` and each mode function, and emit one `STARTUP COMPLETE` INFO line in
-**both** stdio and HTTP modes, **always-on** (even when warming is disabled — the `warm` slice then shows `0`). The
-cache warmer's existing per-category line is the drill-down for the dominant phase.
+place `mark()` calls at six boundaries in `runServer()` and each mode function, and emit one `STARTUP COMPLETE` INFO
+line in **both** stdio and HTTP modes, **always-on** (even when warming is disabled — the `warm` slice then shows `0`).
+The cache warmer's existing per-category line is the drill-down for the dominant phase.
 
-## Phases (derived from `src/index.ts` `main()`)
+## Phases (derived from `src/index.ts` `runServer()`)
 
 | Phase      | Boundary                                                    | A spike here means                                                           |
 | ---------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
@@ -54,7 +61,7 @@ cache warmer's existing per-category line is the drill-down for the dominant pha
 | `init`     | entry → `CacheManager` + `PermissionChecker` constructed    | Usually ≈0; flags a config/env surprise                                      |
 | `perms`    | `checkPermissions()` start→end                              | macOS Automation/Apple-Events TCC re-eval after file changes                 |
 | `warm`     | `cacheWarmer.warmCache()` start→end                         | Dominant cost; scales with DB size (drill-down already logged by the warmer) |
-| `register` | `registerTools` + prompt registration start→end             | Tool/prompt registration (~113ms observed)                                   |
+| `register` | `registerTools` + prompt registration start→end             | Tool/prompt registration (~113ms; stdio-only — renders `0` in HTTP)          |
 | `ready`    | transport `connect()` (stdio) / HTTP listener up (HTTP)     | Final handshake readiness                                                    |
 
 **Output (one INFO line, both modes):**
@@ -77,8 +84,9 @@ In scope:
 - **Wiring in `src/index.ts`**: instantiate the timer at the top of the entrypoint; `mark()` at the six boundaries; emit
   the formatted line via the existing `logger` (`server` channel, INFO) after the final `ready` mark in **both**
   `runStdioServer` and `runHttpServer`.
-- Correct the now-stale `// (non-blocking)` comment at `src/index.ts:78` as an in-region drive-by (the warm is
-  awaited/blocking; this is documentation accuracy, no behavior change).
+- Correct the now-stale `// (non-blocking)` comments in this region as an in-region drive-by: the one at
+  `src/index.ts:78` (the awaited/blocking cache warm) and the analogous one at `src/index.ts:62` (the awaited permission
+  check) — both are documentation-accuracy only, no behavior change.
 
 Out of scope:
 
@@ -105,8 +113,8 @@ Out of scope:
 ## Risks / non-goals
 
 - **Risk:** a `mark()` placed on the wrong side of a boundary mis-attributes time. Mitigation: phases sum-to-total
-  assertion in unit tests catches gross misattribution; boundary placement is reviewed against the `main()` control flow
-  in the plan/code-review gates.
+  assertion in unit tests catches gross misattribution; boundary placement is reviewed against the `runServer()` control
+  flow in the plan/code-review gates.
 - **Risk:** `performance.timeOrigin` semantics differ from expectation, skewing `load`. Mitigation: `load` is defined
   operationally as "first `mark()`'s `performance.now()`"; the integration test asserts it is present and non-zero
   (sanity), not an exact value.
@@ -116,7 +124,8 @@ Out of scope:
 ## Acceptance
 
 - One `STARTUP COMPLETE` line per process start in both stdio and HTTP modes, always-on.
-- Six phases present; values sum to `total` within rounding; correct mode tag.
+- Six phases present; values sum to `total` within rounding; correct mode tag. In HTTP mode `register` is expected to
+  render `0` (lazy per-session registration occurs after `ready`); the sum-to-total contract still holds.
 - `load` slice demonstrably non-zero and reflects bootstrap (sanity-checked in integration; larger immediately after
   `npm ci` in the field, not asserted in CI).
 - `~/bin/of-mcp-redeploy` already greps for `STARTUP COMPLETE`; it lights up automatically once this lands (no script

--- a/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
+++ b/docs/superpowers/specs/2026-05-18-omn-67-startup-timing-design.md
@@ -1,7 +1,6 @@
 # OMN-67 — Consolidated STARTUP COMPLETE timing line
 
-Date: 2026-05-18 Linear: OMN-67 Status: Approved — spec-review (Approved + 3 advisories folded in) and user, 2026-05-18;
-ready for implementation plan
+Date: 2026-05-18 Linear: OMN-67 Status: Implemented (2026-05-18) — pending review/merge
 
 ## Problem
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ import { setPendingOperationsTracker } from './omnifocus/OmniAutomation.js';
 import { parseCLIArgs, validateCLIConfig, CLIConfig } from './utils/cli.js';
 import { SessionManager } from './session-manager.js';
 import { HttpServerManager } from './http-server.js';
+import { StartupTimer } from './utils/startup-timer.js';
+
+// First executable statement: performance.now() here ≈ Node bootstrap + ESM
+// import-graph load (the cold-`npm ci` FS cost). Must precede parseCLIArgs.
+const startupTimer = new StartupTimer();
 
 const logger = createLogger('server');
 
@@ -59,8 +64,9 @@ export async function runServer() {
     logger.debug('Failed to get version info:', error);
   }
 
-  // Perform initial permission check (non-blocking)
+  // Perform initial permission check (blocking — awaited before the transport connects)
   const permissionChecker = PermissionChecker.getInstance();
+  startupTimer.mark('initEnd');
   try {
     const result = await permissionChecker.checkPermissions();
     if (!result.hasPermission) {
@@ -74,8 +80,9 @@ export async function runServer() {
   } catch (error) {
     logger.error('Failed to check permissions:', error);
   }
+  startupTimer.mark('permsEnd');
 
-  // Warm cache with frequently accessed data (non-blocking)
+  // Warm cache with frequently accessed data (blocking — awaited before the transport connects)
   // Disable cache warming in CI environments (Linux, no OmniFocus), test mode, or benchmark mode
   // ENABLE_CACHE_WARMING=true overrides test mode (for integration tests that want realistic behavior)
   const isCIEnvironment = process.env.CI === 'true' || process.platform === 'linux';
@@ -123,6 +130,7 @@ export async function runServer() {
       logger.warn('Cache warming failed:', error);
     }
   }
+  startupTimer.mark('warmEnd');
 
   // Check if we're running in HTTP mode
   if (cliConfig.httpMode) {
@@ -160,6 +168,7 @@ async function runStdioServer(cacheManager: CacheManager) {
   // Register all tools and prompts AFTER server creation but BEFORE connection
   await registerTools(stdioServer, cacheManager, pendingOperations);
   registerPrompts(stdioServer);
+  startupTimer.mark('registerEnd');
 
   const transport = new StdioServerTransport();
 
@@ -216,6 +225,8 @@ async function runStdioServer(cacheManager: CacheManager) {
   });
 
   await stdioServer.connect(transport);
+  startupTimer.mark('ready');
+  logger.info(startupTimer.summary('stdio'));
 }
 
 /**
@@ -255,6 +266,8 @@ async function runHttpServer(cacheManager: CacheManager, cliConfig: CLIConfig) {
     });
     process.exit(1);
   }
+  startupTimer.mark('ready');
+  logger.info(startupTimer.summary('http'));
 
   // Handle graceful shutdown for HTTP mode
   const gracefulShutdown = async (signal: string) => {

--- a/src/utils/startup-timer.ts
+++ b/src/utils/startup-timer.ts
@@ -1,0 +1,57 @@
+export type StartupMode = 'stdio' | 'http';
+export type StartupCheckpoint = 'initEnd' | 'permsEnd' | 'warmEnd' | 'registerEnd' | 'ready';
+
+export interface StartupMarks {
+  /** ms from process start to timer construction (≈ Node bootstrap + ESM import graph). */
+  load: number;
+  initEnd?: number;
+  permsEnd?: number;
+  warmEnd?: number;
+  registerEnd?: number; // stdio-only; absent in HTTP mode → register renders 0
+  ready?: number;
+}
+
+/**
+ * Pure. Given recorded marks (ms relative to process start) and the server mode,
+ * render the single STARTUP COMPLETE line. Phases are consecutive deltas, so
+ * load+init+perms+warm+register+ready === total (within rounding). A missing
+ * checkpoint collapses its phase to 0 (e.g. HTTP has no registerEnd).
+ */
+export function formatStartupSummary(marks: StartupMarks, mode: StartupMode): string {
+  const initEnd = marks.initEnd ?? marks.load;
+  const permsEnd = marks.permsEnd ?? initEnd;
+  const warmEnd = marks.warmEnd ?? permsEnd;
+  const registerEnd = marks.registerEnd ?? warmEnd;
+  const ready = marks.ready ?? registerEnd;
+
+  const load = Math.round(marks.load);
+  const init = Math.round(initEnd - marks.load);
+  const perms = Math.round(permsEnd - initEnd);
+  const warm = Math.round(warmEnd - permsEnd);
+  const register = Math.round(registerEnd - warmEnd);
+  const readyMs = Math.round(ready - registerEnd);
+  const total = Math.round(ready);
+
+  return (
+    `STARTUP COMPLETE ${total}ms  load ${load} · init ${init} · perms ${perms} · ` +
+    `warm ${warm} · register ${register} · ready ${readyMs}  [${mode}]`
+  );
+}
+
+export class StartupTimer {
+  private readonly marks: StartupMarks;
+  private readonly now: () => number;
+
+  constructor(now: () => number = () => performance.now()) {
+    this.now = now;
+    this.marks = { load: now() };
+  }
+
+  mark(checkpoint: StartupCheckpoint): void {
+    this.marks[checkpoint] = this.now();
+  }
+
+  summary(mode: StartupMode): string {
+    return formatStartupSummary(this.marks, mode);
+  }
+}

--- a/tests/integration/startup-timing.test.ts
+++ b/tests/integration/startup-timing.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const entry = join(repoRoot, 'dist', 'index.js');
+
+function runServerOnce(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entry], {
+      env: { ...process.env, NODE_ENV: 'test' },
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.stdin.end(); // EOF → graceful exit after startup
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('server did not exit within 20s'));
+    }, 20_000);
+    child.on('close', () => {
+      clearTimeout(timer);
+      resolve(stderr);
+    });
+    child.on('error', reject);
+  });
+}
+
+describe('startup timing line (integration)', () => {
+  it('emits exactly one STARTUP COMPLETE [stdio] line whose phases sum to total', async () => {
+    const stderr = await runServerOnce();
+    const matches = stderr.match(/STARTUP COMPLETE .*\[stdio\]/g) ?? [];
+    expect(matches).toHaveLength(1);
+    const line = matches[0];
+    const total = Number(line.match(/COMPLETE (\d+)ms/)![1]);
+    const parts = [...line.matchAll(/(?:load|init|perms|warm|register|ready) (\d+)/g)].map((m) => Number(m[1]));
+    expect(parts).toHaveLength(6);
+    expect(Math.abs(parts.reduce((a, b) => a + b, 0) - total)).toBeLessThanOrEqual(6);
+  }, 25_000);
+});

--- a/tests/unit/utils/startup-timer.test.ts
+++ b/tests/unit/utils/startup-timer.test.ts
@@ -16,9 +16,14 @@ describe('formatStartupSummary', () => {
       'STARTUP COMPLETE 31280ms  load 8210 · init 4 · perms 140 · warm 22600 · register 113 · ready 213  [stdio]',
     );
     // sum-to-total invariant (rounded parts within phase-count ms of total)
-    const nums = [...line.matchAll(/(?:load|init|perms|warm|register|ready) (\d+)/g)].map((m) => Number(m[1]));
-    const total = Number(line.match(/COMPLETE (\d+)ms/)![1]);
-    expect(Math.abs(nums.reduce((a, b) => a + b, 0) - total)).toBeLessThanOrEqual(6);
+    const pattern = /(?:load|init|perms|warm|register|ready) (\d+)/g;
+    const nums: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(line)) !== null) {
+      nums.push(Number(m[1]));
+    }
+    const total = Number(/COMPLETE (\d+)ms/.exec(line)![1]);
+    expect(Math.abs(nums.reduce((a, b) => a + b, 0) - total)).toBeLessThanOrEqual(3);
   });
 
   it('treats missing registerEnd as register 0 (http path) and still sums', () => {

--- a/tests/unit/utils/startup-timer.test.ts
+++ b/tests/unit/utils/startup-timer.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { StartupTimer, formatStartupSummary, type StartupMarks } from '../../../src/utils/startup-timer.js';
+
+describe('formatStartupSummary', () => {
+  it('renders all six phases for stdio, summing to total', () => {
+    const marks: StartupMarks = {
+      load: 8210,
+      initEnd: 8214,
+      permsEnd: 8354,
+      warmEnd: 30954,
+      registerEnd: 31067,
+      ready: 31280,
+    };
+    const line = formatStartupSummary(marks, 'stdio');
+    expect(line).toBe(
+      'STARTUP COMPLETE 31280ms  load 8210 · init 4 · perms 140 · warm 22600 · register 113 · ready 213  [stdio]',
+    );
+    // sum-to-total invariant (rounded parts within phase-count ms of total)
+    const nums = [...line.matchAll(/(?:load|init|perms|warm|register|ready) (\d+)/g)].map((m) => Number(m[1]));
+    const total = Number(line.match(/COMPLETE (\d+)ms/)![1]);
+    expect(Math.abs(nums.reduce((a, b) => a + b, 0) - total)).toBeLessThanOrEqual(6);
+  });
+
+  it('treats missing registerEnd as register 0 (http path) and still sums', () => {
+    const marks: StartupMarks = { load: 5000, initEnd: 5002, permsEnd: 5100, warmEnd: 27000, ready: 27210 };
+    const line = formatStartupSummary(marks, 'http');
+    expect(line).toBe(
+      'STARTUP COMPLETE 27210ms  load 5000 · init 2 · perms 98 · warm 21900 · register 0 · ready 210  [http]',
+    );
+  });
+
+  it('handles warm disabled (warmEnd == permsEnd) as warm 0', () => {
+    const marks: StartupMarks = { load: 400, initEnd: 402, permsEnd: 440, warmEnd: 440, registerEnd: 510, ready: 700 };
+    expect(formatStartupSummary(marks, 'stdio')).toContain('warm 0 ·');
+  });
+});
+
+describe('StartupTimer', () => {
+  it('captures load at construction and marks via injected clock', () => {
+    let t = 100;
+    const timer = new StartupTimer(() => t);
+    t = 105;
+    timer.mark('initEnd');
+    t = 250;
+    timer.mark('permsEnd');
+    t = 9000;
+    timer.mark('warmEnd');
+    t = 9100;
+    timer.mark('registerEnd');
+    t = 9300;
+    timer.mark('ready');
+    expect(timer.summary('stdio')).toBe(
+      'STARTUP COMPLETE 9300ms  load 100 · init 5 · perms 145 · warm 8750 · register 100 · ready 200  [stdio]',
+    );
+  });
+});


### PR DESCRIPTION
## OMN-67 — consolidated startup-timing line

Brainstorm → spec → plan → subagent-driven TDD. Spec/plan in `docs/superpowers/{specs,plans}/2026-05-18-omn-67-startup-timing*`.

### Why
The MCP server blocks its transport behind an awaited `cacheWarmer.warmCache()` (runs in `runServer()` before the stdio/HTTP branch and before `connect()`). On a cold start this exceeds the client's fixed 30s connect window → first `/mcp` reconnect times out, second works (root cause diagnosed + empirically verified 2026-05-18; warm alone ≈15.4s even fully hot). Existing logs are timestamped but the **module-load/bootstrap slice is invisible** and there's no at-a-glance "which phase is slow" summary.

### What
Additive observability only — **no behavior change** to warm/transport/mode-branch/shutdown.

- **New** `src/utils/startup-timer.ts`: pure `formatStartupSummary(marks, mode)` (the unit-tested contract) + clock-injectable `StartupTimer`. Provably non-throwing (no IO/clock in the formatter; constructor only reads a clock).
- **`src/index.ts`** (+17/-2): module-level `StartupTimer` as the **first executable statement** (so `load` captures Node bootstrap + ESM import graph — the cold-`npm ci` FS cost); marks at `initEnd`/`permsEnd`/`warmEnd` (shared), `registerEnd` (stdio-only), `ready` (both); one always-on INFO line emitted after `ready` in **both** stdio and HTTP. Two stale `(non-blocking)` comments (`:62` perms, `:78` warm — both awaited/blocking) corrected.
- Phases are consecutive deltas telescoping to total; missing `registerEnd` (HTTP) → `register 0`, warm disabled → `warm 0`, sum-to-total invariant preserved.

Output: `STARTUP COMPLETE 31280ms  load 8210 · init 4 · perms 140 · warm 22600 · register 113 · ready 213  [stdio]`

`~/bin/of-mcp-redeploy` already greps `STARTUP COMPLETE` — lights up automatically on next prod redeploy, no script change.

### Quality gates
spec-review Approved (3 advisories folded: `main()`→`runServer()`, register stdio-only, both comment fixes) + user-approved. plan-review Approved (9 code anchors + 4 TDD expected-strings verified arithmetically). Subagent-driven TDD: per-task spec-compliance + code-quality review (Task 1 had one code-review fix loop: `RegExp.exec` + tightened tolerance, re-reviewed Approved). RED→GREEN integration smoke. **Final pre-merge code-reviewer: VERDICT SAFE** — all 4 gates independently reproduced, real line reproduced. build 0 · `test:unit` **1848/1848** (incl. 4 new contract tests) · `lint:strict` 0 · integration GREEN.

Closes **OMN-67**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)