### PR TITLE
docs(OMN-68): CLAUDE.md stable-anchors refactor + path-resolution guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,17 @@ JXA `task.tags = …` and `task.addTags()` silently no-op. Assign tags via OmniJ
   Historical references like "introduced in v3.0.0" are fine — descriptive labels like "(current v4.1.0)" go stale on
   every release.
 
+## Referencing code in this doc
+
+Cite **stable anchors**, never volatile specifics — this is the version-pin rule generalized:
+
+- ✅ directories (`src/contracts/ast/`), grep targets ("grep for `bridgeSetTags`"), command invocations
+  (`npm run test:unit`)
+- ❌ `file.ts:NN` line numbers, hardcoded version strings, hardcoded test/size counts
+
+Volatile references rot silently; `tests/unit/docs/claude-md-paths.test.ts` fails CI when a path reference stops
+resolving, but it cannot catch a stale line number or count — those must not be written in the first place.
+
 ## 🚨 MCP Bridge Type Coercion
 
 Claude Desktop converts ALL parameters to strings. Handle both:
@@ -218,6 +229,13 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 
 Run `git pull --rebase` before `git push` to avoid failures from diverged remote branches (common when work spans
 multiple machines or sessions).
+
+## Workflow norms
+
+- PRs target `kip-d/omnifocus-mcp` (use `--repo kip-d/omnifocus-mcp`), not any upstream fork.
+- Run a code-review subagent before merge; gate the merge on a Safe/Approved verdict.
+- Merge via `gh pr merge --squash --auto` — never `--admin`.
+- `git pull --rebase` before `git push` (work spans multiple machines/sessions).
 
 ## Debugging & Investigation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,13 @@ semantics).
 
 ## 📚 Architecture Documentation
 
-| Document                              | Purpose                                  |
-| ------------------------------------- | ---------------------------------------- |
-| `/docs/dev/PATTERNS.md`               | Quick symptom lookup (START HERE)        |
-| `/docs/dev/ARCHITECTURE.md`           | Execution patterns                       |
-| `/docs/dev/JXA-VS-OMNIJS-PATTERNS.md` | Syntax differences (source of many bugs) |
-| `/docs/dev/LESSONS_LEARNED.md`        | Hard-won insights                        |
+| Document                              | Purpose                                    |
+| ------------------------------------- | ------------------------------------------ |
+| `/docs/dev/PATTERNS.md`               | Quick symptom lookup (START HERE)          |
+| `/docs/dev/ARCHITECTURE.md`           | Execution patterns                         |
+| `/docs/dev/JXA-VS-OMNIJS-PATTERNS.md` | Syntax differences (source of many bugs)   |
+| `/docs/dev/LESSONS_LEARNED.md`        | Hard-won insights                          |
+| `/docs/dev/SETTER-PATTERNS.md`        | OmniJS/JXA property setter decision matrix |
 
 **JXA vs OmniJS Quick Reference:**
 
@@ -92,26 +93,26 @@ semantics).
 
 ## 🔍 Quick Symptom Index
 
-| Symptom                                 | Quick Fix                                                 |
-| --------------------------------------- | --------------------------------------------------------- |
-| Tool returns 0s/empty but has data      | Test MCP integration first! Compare script vs tool output |
-| Test expects data.id but gets undefined | Test MCP response structure first                         |
-| Tags not saving/empty                   | Use `bridgeSetTags()` from `minimal-tag-bridge.ts`        |
-| Script timeout (25+ seconds)            | Never use `.where()/.whose()`                             |
-| Dates wrong time                        | Use `YYYY-MM-DD HH:mm` not ISO+Z                          |
-| Parent/folder returns null              | Use OmniJS bridge: `project.parentFolder`                 |
-| "X is not a function" error             | You're in OmniJS - remove `()`                            |
-| Property returns function not value     | You're in JXA - add `()`                                  |
+| Symptom                                              | Quick Fix                                                 |
+| ---------------------------------------------------- | --------------------------------------------------------- |
+| Tool returns 0s/empty but has data                   | Test MCP integration first! Compare script vs tool output |
+| Test expects data.id but gets undefined              | Test MCP response structure first                         |
+| Tags not saving/empty                                | Assign via OmniJS `addTag()` — see Tag Operations         |
+| Typed-value write returns success but didn't persist | Read-back required — see `docs/dev/SETTER-PATTERNS.md`    |
+| Script timeout (25+ seconds)                         | Never use `.where()/.whose()`                             |
+| Dates wrong time                                     | Use `YYYY-MM-DD HH:mm` not ISO+Z                          |
+| Parent/folder returns null                           | Use OmniJS bridge: `project.parentFolder`                 |
+| "X is not a function" error                          | You're in OmniJS - remove `()`                            |
+| Property returns function not value                  | You're in JXA - add `()`                                  |
 
 **Full symptom guide:** `/docs/dev/PATTERNS.md`
 
 ## Key Files
 
-| File                                                 | Purpose           |
-| ---------------------------------------------------- | ----------------- |
-| `src/omnifocus/scripts/shared/helpers.ts`            | Core utilities    |
-| `src/omnifocus/scripts/shared/bridge-helpers.ts`     | Bridge operations |
-| `src/omnifocus/scripts/shared/minimal-tag-bridge.ts` | Tag operations    |
+| File                                      | Purpose                                        |
+| ----------------------------------------- | ---------------------------------------------- |
+| `src/omnifocus/scripts/shared/helpers.ts` | Core utilities                                 |
+| `src/contracts/ast/`                      | Mutation + tag script builders (setters, tags) |
 
 ## JavaScript Execution
 
@@ -123,16 +124,9 @@ semantics).
 
 ## 🏷️ Tag Operations
 
-```javascript
-// ❌ These fail silently
-task.addTags(tags);
-task.tags = tags;
-
-// ✅ Use bridge for assignment
-const bridgeResult = bridgeSetTags(app, taskId, tagNames);
-```
-
-**Function:** `bridgeSetTags()` in `src/omnifocus/scripts/shared/minimal-tag-bridge.ts:41`
+JXA `task.tags = …` and `task.addTags()` silently no-op. Assign tags via OmniJS `addTag()` inside the mutation script
+(`src/contracts/ast/mutation-script-builder.ts`) or the AST tag builders
+(`src/contracts/ast/tag-mutation-script-builder.ts`).
 
 ## Code & Writing Standards
 
@@ -175,9 +169,8 @@ Convert natural language ("tomorrow") to `YYYY-MM-DD` or `YYYY-MM-DD HH:mm` befo
 
 - **JXA Direct:** 523KB limit
 - **OmniJS Bridge:** 261KB limit
-- **Current largest script:** 31KB (6% of limit)
 
-**See:** `/docs/dev/SCRIPT_SIZE_LIMITS.md`
+**See:** `/docs/dev/SCRIPT_SIZE_LIMITS.md` (live measurement of the largest script)
 
 ## MCP Lifecycle
 
@@ -196,23 +189,24 @@ process.stdin.on('end', async () => {
 ```bash
 # Build & Test
 npm run build                    # Required before running
-npm run test:unit                # ~2 seconds, ~1644 tests
-npm run test:integration         # ~2 minutes, 73 tests (use npm, not bun)
+npm run test:unit                # (counts vary; run it)
+npm run test:integration         # (counts vary; run it — use npm, not bun)
 
 # MCP Testing
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' | node dist/index.js
+# protocolVersion is the client-declared value; use one your installed @modelcontextprotocol/sdk supports
 ```
 
 ## MCP Specification
 
-**Spec:** https://modelcontextprotocol.io/specification/2025-06-18/
+**Spec:** https://modelcontextprotocol.io/specification/
 
-| Detail           | Value                                                           |
-| ---------------- | --------------------------------------------------------------- |
-| Protocol Version | 2025-06-18                                                      |
-| Transport        | stdio (stdin/stdout)                                            |
-| SDK              | @modelcontextprotocol/sdk@1.17.4                                |
-| Response Format  | `{ content: [{ type: 'text', text: JSON.stringify(result) }] }` |
+| Detail           | Value                                                                        |
+| ---------------- | ---------------------------------------------------------------------------- |
+| Protocol Version | determined by the installed `@modelcontextprotocol/sdk` (see `package.json`) |
+| Transport        | stdio (stdin/stdout)                                                         |
+| SDK              | see `package.json` → `@modelcontextprotocol/sdk`                             |
+| Response Format  | `{ content: [{ type: 'text', text: JSON.stringify(result) }] }`              |
 
 ## Project Structure
 

--- a/docs/superpowers/plans/2026-05-18-claudemd-stable-anchors.md
+++ b/docs/superpowers/plans/2026-05-18-claudemd-stable-anchors.md
@@ -255,7 +255,7 @@ npm run typecheck
 npx eslint tests/unit/docs/claude-md-paths.test.ts --ext .ts
 npx vitest tests/unit/docs --run
 ```
-Expected: all green. (Note: `npm run lint` only scans `src/`, so the test file is lint-checked explicitly here. If eslint flat-config ignores `tests/**`, eslint exits 0 with no output — acceptable; `tsc --noEmit` still type-checks the file.)
+Expected: all green. (Note: `npm run lint` only scans `src/`, so the test file is lint-checked explicitly here. `eslint.config.js` includes `tests/**/*.ts`, so this genuinely lints the file; `tsc --noEmit` additionally type-checks it.)
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-05-18-claudemd-stable-anchors.md
+++ b/docs/superpowers/plans/2026-05-18-claudemd-stable-anchors.md
@@ -1,0 +1,315 @@
+# CLAUDE.md Stable-Anchors Refactor + Regression Guard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix CLAUDE.md's factual rot at the root cause and add a vitest guard that fails when any `src/`/`docs/` reference in `CLAUDE.md` or `docs/dev/*.md` no longer resolves on disk.
+
+**Architecture:** One self-contained vitest test file holds both the pure extraction/normalization helpers (fixture-tested, TDD) and the real-docs assertion. CLAUDE.md content fixes are surgical edits, no restructuring. The guard's correctness is proven against fixtures *before* it is pointed at the real (post-fix) docs, satisfying both TDD and the spec's ordering constraint.
+
+**Tech Stack:** TypeScript, vitest, Node `fs`/`path`. No new dependencies (uses `node:fs` `readdirSync`/`existsSync`/`statSync`). Spec: `docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tests/unit/docs/claude-md-paths.test.ts` | Create. Pure helpers (`extractRefs`, `normalizeRef`, `classifyRef`) + fixture tests + real-docs assertion. Self-contained; helpers exported for fixture tests in the same file. |
+| `CLAUDE.md` | Modify. §1 surgical fact fixes; §2 stable-anchors note; §3 Workflow norms section. |
+
+vitest default include matches `*.test.ts` only, so a single test file is the cleanest home — no separate helper module (avoids accidental non-collection and keeps the matcher logic beside its fixtures). `tests/unit/docs/` follows the existing `tests/unit/<area>/` convention.
+
+---
+
+## Task 1: Path-reference matcher (TDD against fixtures only)
+
+Builds and proves the guard's pure logic with in-memory fixture strings. Does **not** touch real `CLAUDE.md` yet (spec ordering constraint: §1 fixes precede pointing the guard at the real file).
+
+**Files:**
+- Create: `tests/unit/docs/claude-md-paths.test.ts`
+
+- [ ] **Step 1: Write the failing fixture tests**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ---- Pure helpers (exported for fixture tests) ----
+
+/** Extract candidate path strings from inline code, fenced code, and markdown link targets only. */
+export function extractRefs(markdown: string): string[] {
+  const spans: string[] = [];
+  // Fenced code blocks first, then remove them so inline regex doesn't re-scan.
+  let rest = markdown.replace(/```[\s\S]*?```/g, (m) => { spans.push(m); return ''; });
+  for (const m of rest.matchAll(/`[^`\n]+`/g)) spans.push(m[0]);
+  // Markdown link targets: take the (...) target string FIRST, then tokenize.
+  for (const m of markdown.matchAll(/\]\(([^)]+)\)/g)) spans.push(m[1]);
+  const refs: string[] = [];
+  for (const span of spans) {
+    for (const m of span.matchAll(/\/?(?:src|docs)\/[^\s`)]+/g)) refs.push(m[0]);
+  }
+  return refs;
+}
+
+/** Normalize a raw token: strip leading '/', trailing :NN[:CC], trailing sentence punctuation. */
+export function normalizeRef(token: string): string {
+  let t = token.replace(/^\//, '');           // leading '/' => repo-root
+  t = t.replace(/:\d+(?::\d+)?$/, '');         // strip :NN or :NN:CC
+  t = t.replace(/[.,);:]+$/, '');              // strip trailing sentence punctuation
+  return t;
+}
+
+const ALLOWED_EXT = /\.(ts|js|md|dot|json)$/;
+
+/** 'dir' | 'file' | 'malformed' */
+export function classifyRef(norm: string): 'dir' | 'file' | 'malformed' {
+  if (norm.endsWith('/')) return 'dir';
+  if (ALLOWED_EXT.test(norm)) return 'file';
+  return 'malformed';
+}
+
+describe('claude-md path matcher', () => {
+  it('extracts only from code spans and link targets, not bare prose or link text', () => {
+    const md = [
+      'bare src/foo.ts in prose should be ignored',
+      'inline `src/a.ts` here',
+      '[docs/DOCS_MAP.md](docs/DOCS_MAP.md) link',
+      '```\nsrc/b.ts\n```',
+    ].join('\n');
+    expect(extractRefs(md).sort()).toEqual(['docs/DOCS_MAP.md', 'src/a.ts', 'src/b.ts'].sort());
+  });
+
+  it('ignores tokens not starting src/ or docs/ (urls, dist)', () => {
+    const md = 'see `node dist/index.js` and `https://modelcontextprotocol.io/specification/2025-06-18/`';
+    expect(extractRefs(md)).toEqual([]);
+  });
+
+  it('normalizes leading slash to repo-root form', () => {
+    expect(normalizeRef('/docs/dev/PATTERNS.md')).toBe('docs/dev/PATTERNS.md');
+  });
+
+  it('strips :NN line suffix', () => {
+    expect(normalizeRef('src/x.ts:41')).toBe('src/x.ts');
+    expect(normalizeRef('src/x.ts:41:7')).toBe('src/x.ts');
+  });
+
+  it('strips trailing sentence punctuation', () => {
+    expect(normalizeRef('docs/dev/PATTERNS.md).')).toBe('docs/dev/PATTERNS.md');
+  });
+
+  it('classifies dir, file, malformed', () => {
+    expect(classifyRef('src/tools/unified/')).toBe('dir');
+    expect(classifyRef('docs/dev/x.dot')).toBe('file');
+    expect(classifyRef('src/tools/unified')).toBe('malformed'); // no ext, no trailing /
+  });
+});
+```
+
+- [ ] **Step 2: Run the fixture tests, verify they pass**
+
+Run: `npx vitest tests/unit/docs/claude-md-paths.test.ts --run`
+Expected: PASS (6 tests). These prove the matcher; if any fail, fix the helper, not the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/docs/claude-md-paths.test.ts
+git commit -m "test(OMN-68): path-reference matcher proven against fixtures"
+```
+
+---
+
+## Task 2: §1 surgical content fixes to CLAUDE.md
+
+Fix the rotted facts so the real-docs guard (Task 4) can go green. Each edit is one fact. Verify replacements against the live codebase before writing.
+
+**Files:**
+- Modify: `CLAUDE.md` (Key Files table, Tag Operations §, Quick Symptom Index, Architecture Documentation table, MCP Specification §, Quick Reference, Script Size Limits, MCP-test `echo`)
+
+- [ ] **Step 1: Verify the live replacement targets**
+
+Run:
+```bash
+ls src/contracts/ast/tag-mutation-script-builder.ts src/contracts/ast/mutation-script-builder.ts src/omnifocus/scripts/shared/helpers.ts
+grep -n '"@modelcontextprotocol/sdk"' package.json
+grep -rn "protocolVersion\|2025-" src/index.ts | head
+```
+Expected: the three ast/shared files exist; note the exact SDK version and protocol string for the doc.
+
+- [ ] **Step 2: Apply the content fixes**
+
+Edits (each a single Edit call against `CLAUDE.md`):
+
+1. **Key Files table** — remove the `bridge-helpers.ts` and `minimal-tag-bridge.ts` rows; keep `helpers.ts`; add a row `src/contracts/ast/` — "Mutation + tag script builders (setters, tags)".
+2. **Tag Operations §** — replace the `bridgeSetTags()` code block with: JXA `task.tags = …` / `task.addTags()` silently no-op; assign tags via OmniJS `addTag()` inside the mutation script (`src/contracts/ast/mutation-script-builder.ts`) or the AST tag builders (`src/contracts/ast/tag-mutation-script-builder.ts`). Remove the `Function: bridgeSetTags() in …:41` line.
+3. **Quick Symptom Index** — change the "Tags not saving/empty" Quick Fix to "Assign via OmniJS `addTag()` — see Tag Operations". Add a row: `Typed-value write returns success but didn't persist` → `Read-back required — see docs/dev/SETTER-PATTERNS.md`.
+4. **Architecture Documentation table** — add row: `/docs/dev/SETTER-PATTERNS.md` | "OmniJS/JXA property setter decision matrix".
+5. **MCP Specification table** — replace the `SDK` row value with "see `package.json` (`@modelcontextprotocol/sdk`)" and the `Protocol Version` row with "see `src/index.ts`"; change the `Spec:` line to the version-agnostic `https://modelcontextprotocol.io/specification/`.
+6. **MCP-test `echo` block** — replace the hardcoded `"protocolVersion":"2025-06-18"` with the value confirmed from `src/index.ts` in Step 1 (single source kept in sync) — or, preferred, add a one-line note "protocolVersion must match `src/index.ts`" and keep an example value.
+7. **Quick Reference** — drop "~2 seconds, ~1644 tests" and "~2 minutes, 73 tests"; keep the bare commands with "(counts vary; run it)".
+8. **Script Size Limits** — remove the "Current largest script: 31KB (6% of limit)" bullet; keep the JXA/OmniJS limit constants; keep the `SCRIPT_SIZE_LIMITS.md` pointer for the live measurement.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(OMN-68): fix rotted facts in CLAUDE.md (§1 surgical)"
+```
+
+---
+
+## Task 3: §2 stable-anchors principle + §3 Workflow norms
+
+Additive sections; no existing content removed.
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the "Referencing code in this doc" note (§2)**
+
+Add (near the existing "Documentation" section that already states the version rule), generalizing it:
+
+```markdown
+## Referencing code in this doc
+
+Cite **stable anchors**, never volatile specifics — this is the version-pin rule generalized:
+
+- ✅ directories (`src/contracts/ast/`), grep targets ("grep for `bridgeSetTags`"), command
+  invocations (`npm run test:unit`)
+- ❌ `file.ts:NN` line numbers, hardcoded version strings, hardcoded test/size counts
+
+Volatile references rot silently; `tests/unit/docs/claude-md-paths.test.ts` fails CI when a
+path reference stops resolving, but it cannot catch a stale line number or count — those must
+not be written in the first place.
+```
+
+- [ ] **Step 2: Add the "Workflow norms" section (§3)**
+
+```markdown
+## Workflow norms
+
+- PRs target `kip-d/omnifocus-mcp` (use `--repo kip-d/omnifocus-mcp`), not any upstream fork.
+- Run a code-review subagent before merge; gate the merge on a Safe/Approved verdict.
+- Merge via `gh pr merge --squash --auto` — never `--admin`.
+- `git pull --rebase` before `git push` (work spans multiple machines/sessions).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(OMN-68): add stable-anchors principle + workflow norms (§2/§3)"
+```
+
+---
+
+## Task 4: Point the guard at the real docs
+
+Now that §1/§2/§3 fixes have landed, add the real-docs assertion. Before the fixes this would have been red (proving the guard works); after them it must be green.
+
+**Files:**
+- Modify: `tests/unit/docs/claude-md-paths.test.ts`
+
+- [ ] **Step 1: Add the real-docs describe block**
+
+Append to the test file:
+
+```typescript
+describe('CLAUDE.md and docs/dev/*.md path references all resolve', () => {
+  const root = process.cwd(); // vitest runs from repo root
+  const files = ['CLAUDE.md', ...readdirSync(join(root, 'docs/dev'))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => `docs/dev/${f}`)];
+
+  it('every src/ and docs/ reference resolves on disk', () => {
+    const failures: string[] = [];
+    for (const rel of files) {
+      const md = readFileSyncSafe(join(root, rel));
+      for (const raw of extractRefs(md)) {
+        const norm = normalizeRef(raw);
+        const kind = classifyRef(norm);
+        const abs = join(root, norm);
+        if (kind === 'malformed') {
+          failures.push(`${rel}: malformed reference "${raw}" (no allowed extension, no trailing /)`);
+        } else if (kind === 'dir') {
+          if (!(existsSync(abs) && statSync(abs).isDirectory()))
+            failures.push(`${rel}: directory "${norm}" does not resolve`);
+        } else if (!(existsSync(abs) && statSync(abs).isFile())) {
+          failures.push(`${rel}: file "${norm}" does not resolve`);
+        }
+      }
+    }
+    expect(failures, `\n${failures.join('\n')}\n`).toEqual([]);
+  });
+});
+```
+
+Add the helper near the imports:
+
+```typescript
+import { readFileSync } from 'node:fs';
+function readFileSyncSafe(p: string): string { return readFileSync(p, 'utf8'); }
+```
+
+- [ ] **Step 2: Run the full guard, verify green**
+
+Run: `npx vitest tests/unit/docs/claude-md-paths.test.ts --run`
+Expected: PASS. If it fails, the message lists each unresolved/malformed ref + source file — fix the offending CLAUDE.md/docs reference (it is genuinely rotted), do not loosen the matcher.
+
+- [ ] **Step 3: Run lint + typecheck + the unit glob**
+
+Run:
+```bash
+npm run typecheck && npm run lint && npx vitest tests/unit/docs --run
+```
+Expected: all green. (`npx eslint` over the new test file must be clean.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/docs/claude-md-paths.test.ts
+git commit -m "test(OMN-68): guard now asserts real CLAUDE.md + docs/dev paths resolve"
+```
+
+---
+
+## Task 5: Full verification + PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Full unit suite**
+
+Run: `npm run test:unit`
+Expected: all pass, including the new `tests/unit/docs/claude-md-paths.test.ts`. Note the real test count (do not hardcode it anywhere).
+
+- [ ] **Step 2: Sanity-read CLAUDE.md**
+
+Re-read CLAUDE.md end to end: confirm no dead `bridgeSetTags`/`minimal-tag-bridge` remains, the SDK/protocol/count assertions are gone, §2/§3 read cleanly, and section structure is otherwise unchanged.
+
+Run: `grep -n "bridgeSetTags\|minimal-tag-bridge\|1644\|1\.17\.4\|2025-06-18" CLAUDE.md`
+Expected: no matches (or only an intentional, sourced reference).
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin worktree-omn-68-claudemd-stable-anchors
+gh pr create --repo kip-d/omnifocus-mcp --base main \
+  --head worktree-omn-68-claudemd-stable-anchors \
+  --title "docs(OMN-68): CLAUDE.md stable-anchors refactor + path-resolution guard" \
+  --body "<summary of §1–§4 + verification; closes the OMN-41 follow-up doc-rot thread>"
+```
+
+- [ ] **Step 4: Code-review gate (repo norm)**
+
+Dispatch a code-review subagent over the diff. Gate merge on a Safe/Approved verdict; fix any blocking findings and re-review. Then merge `gh pr merge --squash --auto`. Move OMN-68 → Done in Linear.
+
+---
+
+## Notes for the implementer
+
+- **Spec ordering is load-bearing:** Task 1 (fixtures) and Task 4 (real docs) are deliberately split so the matcher is proven before it judges the real file, and so §1 fixes precede the real-docs assertion. Do not merge them.
+- **Do not loosen the matcher to make Task 4 pass.** A failure there means a real rotted reference — fix the reference.
+- **No restructuring** of CLAUDE.md sections; conceptual content (JXA/OmniJS rules, date table, dual-schema) is accurate and out of scope.
+- `npx vitest … --run` for single-file runs; `npm run test:unit` for the full gate.
+- @docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md is the source of truth for matcher rules.

--- a/docs/superpowers/plans/2026-05-18-claudemd-stable-anchors.md
+++ b/docs/superpowers/plans/2026-05-18-claudemd-stable-anchors.md
@@ -2,11 +2,13 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Fix CLAUDE.md's factual rot at the root cause and add a vitest guard that fails when any `src/`/`docs/` reference in `CLAUDE.md` or `docs/dev/*.md` no longer resolves on disk.
+**Goal:** Fix CLAUDE.md's factual rot at the root cause and add a vitest guard that fails when any `src/`/`docs/` reference in `CLAUDE.md` no longer resolves on disk.
 
-**Architecture:** One self-contained vitest test file holds both the pure extraction/normalization helpers (fixture-tested, TDD) and the real-docs assertion. CLAUDE.md content fixes are surgical edits, no restructuring. The guard's correctness is proven against fixtures *before* it is pointed at the real (post-fix) docs, satisfying both TDD and the spec's ordering constraint.
+> **Scope note (2026-05-18):** Guard covers `CLAUDE.md` only. The original `docs/dev/*.md` coverage was dropped during plan review — it surfaced ~36 pre-existing rotted/non-literal refs across 15+ historical docs (only 3 in CLAUDE.md); that is a separate optional follow-up. See the spec's §4 scope decision.
 
-**Tech Stack:** TypeScript, vitest, Node `fs`/`path`. No new dependencies (uses `node:fs` `readdirSync`/`existsSync`/`statSync`). Spec: `docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md`.
+**Architecture:** One self-contained vitest test file holds both the pure extraction/normalization helpers (fixture-tested, TDD) and the real-doc assertion against `CLAUDE.md`. CLAUDE.md content fixes are surgical edits, no restructuring. The guard's correctness is proven against fixtures *before* it is pointed at the real (post-fix) `CLAUDE.md`, satisfying both TDD and the spec's ordering constraint.
+
+**Tech Stack:** TypeScript, vitest, Node `fs`/`path`. No new dependencies (uses `node:fs` `readFileSync`/`existsSync`/`statSync`). Spec: `docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md`.
 
 ---
 
@@ -32,7 +34,7 @@ Builds and proves the guard's pure logic with in-memory fixture strings. Does **
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { readdirSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 // ---- Pure helpers (exported for fixture tests) ----
@@ -133,9 +135,9 @@ Run:
 ```bash
 ls src/contracts/ast/tag-mutation-script-builder.ts src/contracts/ast/mutation-script-builder.ts src/omnifocus/scripts/shared/helpers.ts
 grep -n '"@modelcontextprotocol/sdk"' package.json
-grep -rn "protocolVersion\|2025-" src/index.ts | head
+grep -rn "MCP 20\|protocolVersion" src/index.ts | head
 ```
-Expected: the three ast/shared files exist; note the exact SDK version and protocol string for the doc.
+Expected: the three ast/shared files exist. Note: `src/index.ts` does **not** contain a literal `protocolVersion` value — only a `// … MCP <date> metadata` comment; the protocol version is supplied by `@modelcontextprotocol/sdk`. So the doc must **not** claim a value "from src/index.ts"; it points at the SDK (package.json) instead. Record the SDK semver and the MCP-date comment string for use below.
 
 - [ ] **Step 2: Apply the content fixes**
 
@@ -145,8 +147,8 @@ Edits (each a single Edit call against `CLAUDE.md`):
 2. **Tag Operations §** — replace the `bridgeSetTags()` code block with: JXA `task.tags = …` / `task.addTags()` silently no-op; assign tags via OmniJS `addTag()` inside the mutation script (`src/contracts/ast/mutation-script-builder.ts`) or the AST tag builders (`src/contracts/ast/tag-mutation-script-builder.ts`). Remove the `Function: bridgeSetTags() in …:41` line.
 3. **Quick Symptom Index** — change the "Tags not saving/empty" Quick Fix to "Assign via OmniJS `addTag()` — see Tag Operations". Add a row: `Typed-value write returns success but didn't persist` → `Read-back required — see docs/dev/SETTER-PATTERNS.md`.
 4. **Architecture Documentation table** — add row: `/docs/dev/SETTER-PATTERNS.md` | "OmniJS/JXA property setter decision matrix".
-5. **MCP Specification table** — replace the `SDK` row value with "see `package.json` (`@modelcontextprotocol/sdk`)" and the `Protocol Version` row with "see `src/index.ts`"; change the `Spec:` line to the version-agnostic `https://modelcontextprotocol.io/specification/`.
-6. **MCP-test `echo` block** — replace the hardcoded `"protocolVersion":"2025-06-18"` with the value confirmed from `src/index.ts` in Step 1 (single source kept in sync) — or, preferred, add a one-line note "protocolVersion must match `src/index.ts`" and keep an example value.
+5. **MCP Specification table** — replace the `SDK` row value with "see `package.json` → `@modelcontextprotocol/sdk`" and the `Protocol Version` row with "determined by the installed `@modelcontextprotocol/sdk` (see `package.json`)"; change the `Spec:` line to the version-agnostic `https://modelcontextprotocol.io/specification/`. Do **not** substitute a new hardcoded date — that just relocates the rot.
+6. **MCP-test `echo` block** — the `protocolVersion` here is a *client-declared request param* in an example handshake, not a server constant. Keep an example value but add an inline comment after the block: `# protocolVersion is the client-declared value; use one your installed @modelcontextprotocol/sdk supports`. Do not pin it to a specific date in prose.
 7. **Quick Reference** — drop "~2 seconds, ~1644 tests" and "~2 minutes, 73 tests"; keep the bare commands with "(counts vary; run it)".
 8. **Script Size Limits** — remove the "Current largest script: 31KB (6% of limit)" bullet; keep the JXA/OmniJS limit constants; keep the `SCRIPT_SIZE_LIMITS.md` pointer for the live measurement.
 
@@ -204,40 +206,35 @@ git commit -m "docs(OMN-68): add stable-anchors principle + workflow norms (§2/
 
 ---
 
-## Task 4: Point the guard at the real docs
+## Task 4: Point the guard at the real CLAUDE.md
 
-Now that §1/§2/§3 fixes have landed, add the real-docs assertion. Before the fixes this would have been red (proving the guard works); after them it must be green.
+Now that §1/§2/§3 fixes have landed, add the real-doc assertion. Before the fixes this would have been red (3 known dead refs — proving the guard works); after them it must be green. Scope: `CLAUDE.md` only (per spec §4 scope decision — `docs/dev/*.md` deliberately not scanned).
 
 **Files:**
 - Modify: `tests/unit/docs/claude-md-paths.test.ts`
 
-- [ ] **Step 1: Add the real-docs describe block**
+- [ ] **Step 1: Add the real-doc describe block**
 
-Append to the test file:
+Append to the test file (`readFileSync`, `existsSync`, `statSync`, `join` are already imported in Task 1):
 
 ```typescript
-describe('CLAUDE.md and docs/dev/*.md path references all resolve', () => {
-  const root = process.cwd(); // vitest runs from repo root
-  const files = ['CLAUDE.md', ...readdirSync(join(root, 'docs/dev'))
-    .filter((f) => f.endsWith('.md'))
-    .map((f) => `docs/dev/${f}`)];
+describe('CLAUDE.md path references all resolve', () => {
+  const root = process.cwd(); // vitest runs from repo root (verified: worktree IS the project root)
 
-  it('every src/ and docs/ reference resolves on disk', () => {
+  it('every src/ and docs/ reference in CLAUDE.md resolves on disk', () => {
+    const md = readFileSync(join(root, 'CLAUDE.md'), 'utf8');
     const failures: string[] = [];
-    for (const rel of files) {
-      const md = readFileSyncSafe(join(root, rel));
-      for (const raw of extractRefs(md)) {
-        const norm = normalizeRef(raw);
-        const kind = classifyRef(norm);
-        const abs = join(root, norm);
-        if (kind === 'malformed') {
-          failures.push(`${rel}: malformed reference "${raw}" (no allowed extension, no trailing /)`);
-        } else if (kind === 'dir') {
-          if (!(existsSync(abs) && statSync(abs).isDirectory()))
-            failures.push(`${rel}: directory "${norm}" does not resolve`);
-        } else if (!(existsSync(abs) && statSync(abs).isFile())) {
-          failures.push(`${rel}: file "${norm}" does not resolve`);
-        }
+    for (const raw of extractRefs(md)) {
+      const norm = normalizeRef(raw);
+      const kind = classifyRef(norm);
+      const abs = join(root, norm);
+      if (kind === 'malformed') {
+        failures.push(`CLAUDE.md: malformed reference "${raw}" (no allowed extension, no trailing /)`);
+      } else if (kind === 'dir') {
+        if (!(existsSync(abs) && statSync(abs).isDirectory()))
+          failures.push(`CLAUDE.md: directory "${norm}" does not resolve`);
+      } else if (!(existsSync(abs) && statSync(abs).isFile())) {
+        failures.push(`CLAUDE.md: file "${norm}" does not resolve`);
       }
     }
     expect(failures, `\n${failures.join('\n')}\n`).toEqual([]);
@@ -245,31 +242,26 @@ describe('CLAUDE.md and docs/dev/*.md path references all resolve', () => {
 });
 ```
 
-Add the helper near the imports:
-
-```typescript
-import { readFileSync } from 'node:fs';
-function readFileSyncSafe(p: string): string { return readFileSync(p, 'utf8'); }
-```
-
 - [ ] **Step 2: Run the full guard, verify green**
 
 Run: `npx vitest tests/unit/docs/claude-md-paths.test.ts --run`
-Expected: PASS. If it fails, the message lists each unresolved/malformed ref + source file — fix the offending CLAUDE.md/docs reference (it is genuinely rotted), do not loosen the matcher.
+Expected: PASS (fixtures from Task 1 + this real-doc test). If the real-doc test fails, the message lists each unresolved/malformed ref — fix the offending CLAUDE.md reference (it is genuinely rotted) or, if it is an intentional non-literal anchor, restructure the wording per §2. **Do not loosen the matcher.**
 
-- [ ] **Step 3: Run lint + typecheck + the unit glob**
+- [ ] **Step 3: Typecheck + lint the new file + the unit glob**
 
 Run:
 ```bash
-npm run typecheck && npm run lint && npx vitest tests/unit/docs --run
+npm run typecheck
+npx eslint tests/unit/docs/claude-md-paths.test.ts --ext .ts
+npx vitest tests/unit/docs --run
 ```
-Expected: all green. (`npx eslint` over the new test file must be clean.)
+Expected: all green. (Note: `npm run lint` only scans `src/`, so the test file is lint-checked explicitly here. If eslint flat-config ignores `tests/**`, eslint exits 0 with no output — acceptable; `tsc --noEmit` still type-checks the file.)
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add tests/unit/docs/claude-md-paths.test.ts
-git commit -m "test(OMN-68): guard now asserts real CLAUDE.md + docs/dev paths resolve"
+git commit -m "test(OMN-68): guard asserts real CLAUDE.md paths resolve"
 ```
 
 ---
@@ -308,7 +300,7 @@ Dispatch a code-review subagent over the diff. Gate merge on a Safe/Approved ver
 
 ## Notes for the implementer
 
-- **Spec ordering is load-bearing:** Task 1 (fixtures) and Task 4 (real docs) are deliberately split so the matcher is proven before it judges the real file, and so §1 fixes precede the real-docs assertion. Do not merge them.
+- **Spec ordering is load-bearing:** Task 1 (fixtures) and Task 4 (real `CLAUDE.md`) are deliberately split so the matcher is proven before it judges the real file, and so §1 fixes precede the real-doc assertion. Do not merge them.
 - **Do not loosen the matcher to make Task 4 pass.** A failure there means a real rotted reference — fix the reference.
 - **No restructuring** of CLAUDE.md sections; conceptual content (JXA/OmniJS rules, date table, dual-schema) is accurate and out of scope.
 - `npx vitest … --run` for single-file runs; `npm run test:unit` for the full gate.

--- a/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
+++ b/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
@@ -1,0 +1,121 @@
+# OMN-68 — CLAUDE.md stable-anchors refactor + regression guard
+
+**Date:** 2026-05-18
+**Linear:** OMN-68 (High)
+**Status:** Design approved; spec under review
+
+## Problem
+
+The project `CLAUDE.md` is structurally sound but factually rotted, and the rot is
+concentrated in its highest-stakes section. It does not merely lag the code — in the Tag
+Operations section it instructs a fresh Claude to call `bridgeSetTags()`, a function that no
+longer exists. A silent doc is safer than a confidently wrong one; this is the exact failure
+`CLAUDE.md`'s own Debugging section warns against.
+
+Discovered while completing OMN-41: a new doc (`docs/dev/SETTER-PATTERNS.md`) inherited a dead
+path copied straight from CLAUDE.md's Key Files table. The code-review gate caught it — a
+parse/lint/test pass is structurally blind to "this path 404s."
+
+## Root cause
+
+Every rotted item is the same anti-pattern: a **volatile specific** (exact file path,
+`file.ts:NN` line number, version pin, hardcoded count) stated inline. CLAUDE.md already
+states the cure for one case ("Don't hardcode the current version in prose; `package.json` /
+`CHANGELOG.md` are the single source of truth") but never generalizes it. A one-time scrub
+re-rots in ~2 months. The durable fix is a style change plus a mechanical guard.
+
+## Audit findings (verified against the codebase, 2026-05-18)
+
+| Location | Problem | Reality |
+|---|---|---|
+| Key Files table | `bridge-helpers.ts`, `minimal-tag-bridge.ts` rows dead | Deleted `f143e44`; only `helpers.ts` survives |
+| Tag Operations § code example | `bridgeSetTags()` gone | OmniJS `addTag()` in `mutation-script-builder.ts`; AST builders in `src/contracts/ast/tag-mutation-script-builder.ts` |
+| Quick Symptom Index — "Tags not saving" | Dead `bridgeSetTags()` / `minimal-tag-bridge.ts` | Same as above |
+| MCP Specification §, MCP-test `echo` | SDK `1.17.4` → `^1.25.1`; protocol `2025-06-18` → `2025-11-25` (wrong in 3 places) | `package.json` / `src/index.ts` |
+| Quick Reference | `~1644` unit tests; "73 integration tests" | `~1812+` unit; the 73 was unit *files* |
+| Script Size Limits | "Current largest 31KB" | ~35KB (`workflow-analysis-v3.ts`); low harm, drift-prone |
+
+Conceptual content — JXA-vs-OmniJS property/method rule, date-format table, dual-schema sync
+warning, process-cluster index *structure* — is accurate and **out of scope** for rewrite.
+
+## Design
+
+### 1. Content fixes (surgical)
+
+Section structure preserved. Per-location changes:
+
+- **Key Files table:** drop the two dead rows; keep `helpers.ts`; add `src/contracts/ast/`
+  (mutation + tag script builders) as the real setter/tag home.
+- **Tag Operations §:** replace the `bridgeSetTags()` example with the current mechanism
+  (OmniJS `addTag()` + `tag-mutation-script-builder.ts`). Keep the durable fact: JXA
+  `task.tags = …` / `task.addTags()` silently no-op.
+- **Quick Symptom Index:** fix the "Tags not saving" row to the real mechanism; **add** a
+  row — typed-value write returns `success` but didn't persist → `docs/dev/SETTER-PATTERNS.md`.
+- **Architecture Documentation table:** add a `SETTER-PATTERNS.md` row.
+- **MCP Specification § + test `echo`:** remove the hardcoded SDK version and protocol date
+  from prose; point at `package.json` / the SDK. Keep the spec a generic single reference.
+- **Quick Reference:** remove the `~1644` / `73` count assertions; keep the bare commands,
+  note "counts vary; run it."
+- **Script Size Limits:** remove "current largest 31KB"; keep the limit constants (stable);
+  point at `SCRIPT_SIZE_LIMITS.md` for the live measurement.
+
+### 2. Stable-anchors principle (generalize the existing rule)
+
+Add a short "Referencing code in this doc" note: cite directories, grep targets, and command
+invocations — never `file.ts:NN`, version strings, or counts. This promotes the
+anti-hardcoding rule from version-only to general, so future edits don't re-introduce rot.
+
+### 3. Surface tribal norms
+
+Add a brief "Workflow norms" section: PRs target `kip-d/omnifocus-mcp`; run a code-review
+subagent before merge; merge via `gh pr merge --squash --auto` (never `--admin`). These
+currently live only in agent memory, invisible to a fresh session.
+
+### 4. Regression guard — `tests/unit/docs/claude-md-paths.test.ts`
+
+A vitest unit test that:
+
+- Reads `CLAUDE.md` and globs `docs/dev/*.md`.
+- Extracts inline-code / link tokens matching `src/…` or `docs/…` with a file-ish extension
+  or a trailing `/` (directory).
+- **Strips** any `:NN` line suffix and trailing punctuation before resolving — line numbers
+  are precisely what we discourage, so the guard resolves the *file*, not the line.
+- Asserts each reference resolves on disk (repo-root relative); directory refs checked as
+  directories. Failure lists every unresolved reference.
+- Runs in `test:unit` → already gated in `test:pre-push` and `.github/workflows/ci.yml`. No
+  new CI wiring, no new npm script.
+
+The guard is itself TDD'd: a fixture-based test proves it (a) fails on a known-dead path and
+(b) passes on resolvable ones, before it is pointed at the real docs.
+
+## Testing strategy
+
+- Guard test: TDD with fixtures (dead-path fixture → red; resolvable fixture → green) before
+  wiring to the real docs.
+- Content fixes verified by the guard going green plus a manual read for semantic accuracy
+  (the guard proves paths resolve, not that prose is correct).
+- `npm run test:unit`, `npm run lint`, `npm run typecheck` must stay green.
+- Code-review subagent gate before merge (repo norm); merge `--squash --auto`.
+
+## Scope guards (YAGNI)
+
+- No section reorganization. No rewrite of accurate conceptual content.
+- The guard validates **resolution only**, not anchor *quality* — a test cannot
+  mechanically distinguish a good anchor from a bad one. Style is enforced by the written
+  principle (§2) + code review, not the test.
+- `docs/superpowers/specs` excluded from the guard: spec docs legitimately reference
+  planned/future paths and would produce false positives.
+- Out of scope: the user's global `~/.claude/CLAUDE.md` (separate concern, not project-owned).
+
+## Deliverables
+
+1. Surgical content fixes to `CLAUDE.md` per §1.
+2. "Referencing code in this doc" stable-anchors note (§2).
+3. "Workflow norms" section (§3).
+4. `tests/unit/docs/claude-md-paths.test.ts` regression guard (§4), TDD'd, green in
+   `test:unit` / pre-push / CI.
+
+## Origin
+
+OMN-41 follow-up session, 2026-05-18 (PR #22 merged). Filed because the rot misleads every
+fresh Claude session until fixed.

--- a/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
+++ b/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
@@ -75,7 +75,17 @@ currently live only in agent memory, invisible to a fresh session.
 
 A vitest unit test that:
 
-**Input set.** `CLAUDE.md` plus glob `docs/dev/*.md`, read from the repo root.
+**Input set.** `CLAUDE.md` only, read from the repo root.
+
+> **Scope decision (2026-05-18, supersedes the original design choice).** The guard was
+> originally scoped to `CLAUDE.md` + `docs/dev/*.md`. Running the matcher against the live
+> repo during plan review surfaced ~36 pre-existing rotted/non-literal references across 15+
+> `docs/dev` files (historical session logs, benchmark snapshots, intentional line-range and
+> glob references) — only 3 failures were in `CLAUDE.md`. Folding a 36-reference cleanup of
+> point-in-time historical docs into this ticket would be scope creep and partly wrong
+> (session logs are records, not living docs). User decision: **guard covers `CLAUDE.md`
+> only**; `docs/dev` rot is a separate optional follow-up. This also makes line-range
+> (`:NN-MM`) and glob (`src/**/*.ts`) token handling moot — `CLAUDE.md` contains neither.
 
 **Extraction surface (exact).** Scan only two Markdown constructs, never bare prose:
 
@@ -137,9 +147,14 @@ pointed at the real docs.
 - The guard validates **resolution only**, not anchor *quality* — a test cannot
   mechanically distinguish a good anchor from a bad one. Style is enforced by the written
   principle (§2) + code review, not the test.
-- `docs/superpowers/specs` excluded from the guard: spec docs legitimately reference
-  planned/future paths and would produce false positives.
+- Guard covers `CLAUDE.md` only (see §4 scope decision). `docs/dev/*.md` and
+  `docs/superpowers/specs` are **not** scanned: the former carries a large pre-existing
+  backlog of intentional/historical non-literal refs (separate optional follow-up ticket);
+  the latter legitimately references planned/future paths. Both would be false-positive heavy.
 - Out of scope: the user's global `~/.claude/CLAUDE.md` (separate concern, not project-owned).
+- Follow-up (not this ticket): a `docs/dev/*.md` rot audit, if desired, is its own scoped
+  effort — ~36 refs across 15+ files, several being point-in-time session logs that should
+  arguably not be "fixed" at all.
 
 ## Deliverables
 

--- a/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
+++ b/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
@@ -81,7 +81,9 @@ A vitest unit test that:
 
 1. Inline-code spans (`` `…` ``) and fenced-code-block contents.
 2. Markdown link *targets* — the `(...)` of `[text](target)`. The link *text* is **not**
-   scanned (avoids double-counting `[docs/DOCS_MAP.md](docs/DOCS_MAP.md)`).
+   scanned (avoids double-counting `[docs/DOCS_MAP.md](docs/DOCS_MAP.md)`). Extract the
+   target string from inside `(...)` *first*, then tokenize/normalize — so the link-syntax
+   close paren is never mistaken for path punctuation in normalization step 3.
 
 Within a scanned span, a **candidate** is the first whitespace/backtick-delimited token that,
 after the normalization below, matches `^/?(src|docs)/` and ends in an allowed extension

--- a/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
+++ b/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
@@ -75,18 +75,50 @@ currently live only in agent memory, invisible to a fresh session.
 
 A vitest unit test that:
 
-- Reads `CLAUDE.md` and globs `docs/dev/*.md`.
-- Extracts inline-code / link tokens matching `src/…` or `docs/…` with a file-ish extension
-  or a trailing `/` (directory).
-- **Strips** any `:NN` line suffix and trailing punctuation before resolving — line numbers
-  are precisely what we discourage, so the guard resolves the *file*, not the line.
-- Asserts each reference resolves on disk (repo-root relative); directory refs checked as
-  directories. Failure lists every unresolved reference.
-- Runs in `test:unit` → already gated in `test:pre-push` and `.github/workflows/ci.yml`. No
-  new CI wiring, no new npm script.
+**Input set.** `CLAUDE.md` plus glob `docs/dev/*.md`, read from the repo root.
 
-The guard is itself TDD'd: a fixture-based test proves it (a) fails on a known-dead path and
-(b) passes on resolvable ones, before it is pointed at the real docs.
+**Extraction surface (exact).** Scan only two Markdown constructs, never bare prose:
+
+1. Inline-code spans (`` `…` ``) and fenced-code-block contents.
+2. Markdown link *targets* — the `(...)` of `[text](target)`. The link *text* is **not**
+   scanned (avoids double-counting `[docs/DOCS_MAP.md](docs/DOCS_MAP.md)`).
+
+Within a scanned span, a **candidate** is the first whitespace/backtick-delimited token that,
+after the normalization below, matches `^/?(src|docs)/` and ends in an allowed extension
+**or** a trailing `/` (directory). Tokens not starting `src/` or `docs/` are ignored — this
+deliberately excludes `dist/index.js`, `node …`, and any `http(s)://…` URL (so the
+`modelcontextprotocol.io/...2025-06-18` URL in the MCP-test line is out of scope by
+construction; URLs never start `src/` or `docs/`).
+
+**Allowed extensions (explicit allowlist):** `.ts`, `.js`, `.md`, `.dot`, `.json`. A token
+matching `^/?(src|docs)/` with no allowed extension and no trailing `/` is reported as
+*malformed reference* (fail), not silently skipped.
+
+**Normalization before resolution, in order:**
+
+1. Strip a single leading `/` if present — CLAUDE.md uses both `docs/x.md` and
+   `/docs/dev/x.md` forms; a leading `/` means **repo-root**, never filesystem root. After
+   stripping, resolve as `path.join(repoRoot, token)`.
+2. Strip a trailing `:NN` (or `:NN:CC`) line/column suffix — line numbers are the volatile
+   specifics we discourage; the guard resolves the *file*, not the line.
+3. Strip trailing sentence punctuation (`.`, `,`, `)`, `;`, `:`) not part of the path.
+
+**Assertion.** Each normalized reference must resolve on disk: file refs via
+`fs.existsSync` as a file; refs ending `/` must exist **and** be a directory. The test
+fails with a list of every unresolved/malformed reference and its source file+line.
+
+**Ordering constraint.** The guard asserts the **post-§1-fix** state of `CLAUDE.md`. §1's
+content fixes (which delete the `minimal-tag-bridge.ts:41` token and other dead paths) land
+before the guard is pointed at the real `CLAUDE.md`. The guard's own correctness is proven
+independently against fixtures first (below).
+
+**CI/enforcement.** The test lives under `tests/unit/`, so it is picked up by the
+`vitest tests/unit` glob that both `npm run test:unit` (used in `test:pre-push`) and CI's
+`npm run test:quick` (`.github/workflows/ci.yml`) execute. No new npm script or CI wiring.
+
+The guard is itself TDD'd: fixture strings (a known-dead path → red; a resolvable path,
+a leading-slash path, and a `:NN`-suffixed path → green) prove the matcher before it is
+pointed at the real docs.
 
 ## Testing strategy
 

--- a/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
+++ b/docs/superpowers/specs/2026-05-18-claudemd-stable-anchors-design.md
@@ -95,12 +95,23 @@ A vitest unit test that:
    target string from inside `(...)` *first*, then tokenize/normalize — so the link-syntax
    close paren is never mistaken for path punctuation in normalization step 3.
 
-Within a scanned span, a **candidate** is the first whitespace/backtick-delimited token that,
-after the normalization below, matches `^/?(src|docs)/` and ends in an allowed extension
-**or** a trailing `/` (directory). Tokens not starting `src/` or `docs/` are ignored — this
-deliberately excludes `dist/index.js`, `node …`, and any `http(s)://…` URL (so the
-`modelcontextprotocol.io/...2025-06-18` URL in the MCP-test line is out of scope by
-construction; URLs never start `src/` or `docs/`).
+Within a scanned span, a **candidate** is a token whose `src/` or `docs/` segment sits at a
+**path-token boundary** — i.e. the (optionally single-leading-`/`) `src/`/`docs/` is preceded
+by start-of-span, whitespace, a backtick, `(`, `[`, or `]`. It must, after the normalization
+below, end in an allowed extension **or** a trailing `/` (directory). Tokens not *starting*
+`src/` or `docs/` are ignored — this deliberately excludes `dist/index.js`, `node …`, and any
+`http(s)://…` URL (URLs never start `src/` or `docs/`).
+
+**Boundary-anchored, not substring (load-bearing).** The `src/`/`docs/` must begin the path
+token, not appear mid-path. A reference like `` `tests/unit/docs/claude-md-paths.test.ts` ``
+is a `tests/`-rooted path — **out of the guard's scope** (the guard validates `src/`- and
+`docs/`-rooted references only). A substring matcher would wrongly extract the inner
+`docs/claude-md-paths.test.ts` and false-positive on a perfectly valid reference. The
+regex therefore requires a preceding boundary char (lookbehind), e.g.
+`/(?<=^|[\s\`(\[\]])\/?(?:src|docs)\/[^\s\`)]+/g`. Concretely: `` `/docs/dev/x.md` ``,
+`` `docs/X.md` ``, link target `(docs/X.md)`, and `src/contracts/ast/` after whitespace all
+match; `tests/unit/docs/…`, `foo/src/bar.ts` do **not** (their `docs/`/`src/` is preceded by
+`/`, not a boundary). This must have explicit fixture coverage.
 
 **Allowed extensions (explicit allowlist):** `.ts`, `.js`, `.md`, `.dot`, `.json`. A token
 matching `^/?(src|docs)/` with no allowed extension and no trailing `/` is reported as

--- a/tests/unit/docs/claude-md-paths.test.ts
+++ b/tests/unit/docs/claude-md-paths.test.ts
@@ -8,22 +8,25 @@ import { join } from 'node:path';
 export function extractRefs(markdown: string): string[] {
   const spans: string[] = [];
   // Fenced code blocks first, then remove them so inline regex doesn't re-scan.
-  let rest = markdown.replace(/```[\s\S]*?```/g, (m) => { spans.push(m); return ''; });
+  let rest = markdown.replace(/```[\s\S]*?```/g, (m) => {
+    spans.push(m);
+    return '';
+  });
   for (const m of rest.matchAll(/`[^`\n]+`/g)) spans.push(m[0]);
   // Markdown link targets: take the (...) target string FIRST, then tokenize.
   for (const m of markdown.matchAll(/\]\(([^)]+)\)/g)) spans.push(m[1]);
   const refs: string[] = [];
   for (const span of spans) {
-    for (const m of span.matchAll(/\/?(?:src|docs)\/[^\s`)]+/g)) refs.push(m[0]);
+    for (const m of span.matchAll(/(?<=^|[\s`([\]])\/?(?:src|docs)\/[^\s`)]+/g)) refs.push(m[0]);
   }
   return refs;
 }
 
 /** Normalize a raw token: strip leading '/', trailing :NN[:CC], trailing sentence punctuation. */
 export function normalizeRef(token: string): string {
-  let t = token.replace(/^\//, '');           // leading '/' => repo-root
-  t = t.replace(/:\d+(?::\d+)?$/, '');         // strip :NN or :NN:CC
-  t = t.replace(/[.,);:]+$/, '');              // strip trailing sentence punctuation
+  let t = token.replace(/^\//, ''); // leading '/' => repo-root
+  t = t.replace(/:\d+(?::\d+)?$/, ''); // strip :NN or :NN:CC
+  t = t.replace(/[.,);:]+$/, ''); // strip trailing sentence punctuation
   return t;
 }
 
@@ -69,5 +72,41 @@ describe('claude-md path matcher', () => {
     expect(classifyRef('src/tools/unified/')).toBe('dir');
     expect(classifyRef('docs/dev/x.dot')).toBe('file');
     expect(classifyRef('src/tools/unified')).toBe('malformed'); // no ext, no trailing /
+  });
+
+  it('anchors src/ and docs/ at a path-token boundary (no mid-path partial match)', () => {
+    // CLAUDE.md §2 self-reference: tests/-rooted; inner docs/ must NOT partial-match.
+    expect(extractRefs('`tests/unit/docs/claude-md-paths.test.ts`')).toEqual([]);
+    // Mid-path src/ is not a boundary -> not matched.
+    expect(extractRefs('`foo/src/bar.ts`')).toEqual([]);
+    // Leading-slash boundary still matches; normalization strips the '/' later.
+    expect(extractRefs('`/docs/dev/x.md`')).toEqual(['/docs/dev/x.md']);
+    // Backtick boundary still works for both prefixes.
+    const both = extractRefs('see `src/a.ts` and `docs/b.md`');
+    expect(both).toContain('src/a.ts');
+    expect(both).toContain('docs/b.md');
+  });
+});
+
+describe('CLAUDE.md path references all resolve', () => {
+  const root = process.cwd(); // vitest runs from repo root (verified: worktree IS the project root)
+
+  it('every src/ and docs/ reference in CLAUDE.md resolves on disk', () => {
+    const md = readFileSync(join(root, 'CLAUDE.md'), 'utf8');
+    const failures: string[] = [];
+    for (const raw of new Set(extractRefs(md))) {
+      const norm = normalizeRef(raw);
+      const kind = classifyRef(norm);
+      const abs = join(root, norm);
+      if (kind === 'malformed') {
+        failures.push(`CLAUDE.md: malformed reference "${raw}" (no allowed extension, no trailing /)`);
+      } else if (kind === 'dir') {
+        if (!(existsSync(abs) && statSync(abs).isDirectory()))
+          failures.push(`CLAUDE.md: directory "${norm}" does not resolve`);
+      } else if (!(existsSync(abs) && statSync(abs).isFile())) {
+        failures.push(`CLAUDE.md: file "${norm}" does not resolve`);
+      }
+    }
+    expect(failures, `\n${failures.join('\n')}\n`).toEqual([]);
   });
 });

--- a/tests/unit/docs/claude-md-paths.test.ts
+++ b/tests/unit/docs/claude-md-paths.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ---- Pure helpers (exported for fixture tests) ----
+
+/** Extract candidate path strings from inline code, fenced code, and markdown link targets only. */
+export function extractRefs(markdown: string): string[] {
+  const spans: string[] = [];
+  // Fenced code blocks first, then remove them so inline regex doesn't re-scan.
+  let rest = markdown.replace(/```[\s\S]*?```/g, (m) => { spans.push(m); return ''; });
+  for (const m of rest.matchAll(/`[^`\n]+`/g)) spans.push(m[0]);
+  // Markdown link targets: take the (...) target string FIRST, then tokenize.
+  for (const m of markdown.matchAll(/\]\(([^)]+)\)/g)) spans.push(m[1]);
+  const refs: string[] = [];
+  for (const span of spans) {
+    for (const m of span.matchAll(/\/?(?:src|docs)\/[^\s`)]+/g)) refs.push(m[0]);
+  }
+  return refs;
+}
+
+/** Normalize a raw token: strip leading '/', trailing :NN[:CC], trailing sentence punctuation. */
+export function normalizeRef(token: string): string {
+  let t = token.replace(/^\//, '');           // leading '/' => repo-root
+  t = t.replace(/:\d+(?::\d+)?$/, '');         // strip :NN or :NN:CC
+  t = t.replace(/[.,);:]+$/, '');              // strip trailing sentence punctuation
+  return t;
+}
+
+const ALLOWED_EXT = /\.(ts|js|md|dot|json)$/;
+
+/** 'dir' | 'file' | 'malformed' */
+export function classifyRef(norm: string): 'dir' | 'file' | 'malformed' {
+  if (norm.endsWith('/')) return 'dir';
+  if (ALLOWED_EXT.test(norm)) return 'file';
+  return 'malformed';
+}
+
+describe('claude-md path matcher', () => {
+  it('extracts only from code spans and link targets, not bare prose or link text', () => {
+    const md = [
+      'bare src/foo.ts in prose should be ignored',
+      'inline `src/a.ts` here',
+      '[docs/DOCS_MAP.md](docs/DOCS_MAP.md) link',
+      '```\nsrc/b.ts\n```',
+    ].join('\n');
+    expect(extractRefs(md).sort()).toEqual(['docs/DOCS_MAP.md', 'src/a.ts', 'src/b.ts'].sort());
+  });
+
+  it('ignores tokens not starting src/ or docs/ (urls, dist)', () => {
+    const md = 'see `node dist/index.js` and `https://modelcontextprotocol.io/specification/2025-06-18/`';
+    expect(extractRefs(md)).toEqual([]);
+  });
+
+  it('normalizes leading slash to repo-root form', () => {
+    expect(normalizeRef('/docs/dev/PATTERNS.md')).toBe('docs/dev/PATTERNS.md');
+  });
+
+  it('strips :NN line suffix', () => {
+    expect(normalizeRef('src/x.ts:41')).toBe('src/x.ts');
+    expect(normalizeRef('src/x.ts:41:7')).toBe('src/x.ts');
+  });
+
+  it('strips trailing sentence punctuation', () => {
+    expect(normalizeRef('docs/dev/PATTERNS.md).')).toBe('docs/dev/PATTERNS.md');
+  });
+
+  it('classifies dir, file, malformed', () => {
+    expect(classifyRef('src/tools/unified/')).toBe('dir');
+    expect(classifyRef('docs/dev/x.dot')).toBe('file');
+    expect(classifyRef('src/tools/unified')).toBe('malformed'); // no ext, no trailing /
+  });
+});


### PR DESCRIPTION
Closes the OMN-41 follow-up doc-rot thread. Fixes CLAUDE.md's factual rot at the root cause and adds a CI guard so path references can't silently rot again.

## Changes
- **§1 surgical fact-fixes** (`b0f8fd2`): removed dead `bridgeSetTags`/`minimal-tag-bridge`/`bridge-helpers` refs → real OmniJS `addTag()` mechanism; de-hardcoded SDK/protocol version & test counts to point at sources; added `SETTER-PATTERNS.md` cross-refs. Surgical — no section restructure, conceptual content untouched.
- **§2 "Referencing code in this doc"** (`55d3b81`): generalizes the existing don't-hardcode-the-version rule into a stable-anchors-not-volatile-specifics principle.
- **§3 "Workflow norms"**: surfaces PR-target / review-before-merge / `--squash --auto` / rebase-before-push norms previously only in agent memory.
- **Path-resolution guard** (`12a8ee1` fixtures, `bf01323` real-doc + boundary fix): `tests/unit/docs/claude-md-paths.test.ts` — fails CI when any `src/`/`docs/` reference in CLAUDE.md stops resolving. Boundary-anchored matcher (TDD'd, 8 tests), consumer-side dedup. Scope: CLAUDE.md only (docs/dev rot is a separate follow-up — see spec §4 scope decision).

## Process
Full brainstorm→spec→plan pipeline. Spec review (2 iterations), plan review (2 iterations — caught a real scope gap → user scoped to CLAUDE.md-only). Subagent-driven execution with two-stage (spec + code-quality) review per task; implementer caught a real matcher false-positive (the §2 self-reference), fixed via boundary-anchored regex + fixture.

## Verification
`npm run test:unit` → **1856 passed** (incl. the new 8-test guard). `tsc` clean, `eslint` clean on the new file. Spec + plan in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)