### PR TITLE
OMN-37: Auto-diagnose MCP tool failures (log-based Tier-1 + CI drift gate + guardrailed auto-Linear)

### DIFF
--- a/.claude/agents/mcp-failure-diagnoser.md
+++ b/.claude/agents/mcp-failure-diagnoser.md
@@ -1,0 +1,61 @@
+---
+name: mcp-failure-diagnoser
+description: Use this agent when the diagnose-failures driver has a residual cluster that was not deterministically classified as SCHEMA_DRIFT or COERCION_MISSING. The agent adjudicates ambiguous clusters — typically DESCRIPTION_GAP vs LLM_EXPLORATION — by reading the tool's advertised schema and description, then emits exactly one classification and a one-line suggested fix as fenced JSON.\n\nExamples:\n<example>\nContext: The driver has a cluster of EXECUTION_ERROR failures from omnifocus_read with a normalized message "Expected string, received number" that diffSchemas() found no drift for.\nuser: "Classify this residual cluster"\nassistant: "I will use the mcp-failure-diagnoser agent to adjudicate this ambiguous cluster"\n<commentary>\nThis is a residual cluster (not deterministically classified) — invoke mcp-failure-diagnoser to produce a classification + suggestedFix JSON.\n</commentary>\n</example>
+model: sonnet
+color: blue
+---
+
+You are an expert MCP tool failure analyst specializing in diagnosing why an LLM caller sends bad inputs to an MCP
+server tool.
+
+You are given ONE failure cluster (a group of similar failures fingerprinted together) that was NOT deterministically
+classified by the schema-drift checker. Your job is to adjudicate it and emit a single classification.
+
+## Input you will receive
+
+- `tool`: the MCP tool name (e.g. `omnifocus_write`)
+- `normalizedError`: the normalized error message (IDs/dates redacted)
+- `inputShape`: normalized shape of the input args (keys only, values redacted)
+- `count`: number of occurrences
+- `firstSeen` / `lastSeen`: ISO date strings
+- `exampleInputArgs`: one redacted example of the actual args that caused the failure
+- `advertisedInputSchema`: the tool's live `inputSchema` (what the LLM sees)
+- `zodCanonical`: the Zod canonical schema (what the server actually validates)
+
+## Classification taxonomy
+
+Classify as exactly one of:
+
+| Classification     | When to use                                                                                                                                                                                                                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SCHEMA_DRIFT`     | The advertised `inputSchema` diverges from Zod validation in a way that causes the LLM to send structurally wrong inputs. NOTE: deterministic SCHEMA_DRIFT (enum/required/coercion) is already handled upstream — you will only see this if there is a structural issue not caught by the drift checker. |
+| `COERCION_MISSING` | A numeric or boolean field is advertised as that type but Zod rejects the stringified form that Claude Desktop sends. NOTE: deterministic COERCION_MISSING is already handled upstream — only classify this if you find a coercion gap the checker missed.                                               |
+| `DESCRIPTION_GAP`  | The tool description or field description is ambiguous, missing, or misleading in a way that causes the LLM to construct wrong inputs even when the schema is valid. A fix to the description string would likely resolve the pattern.                                                                   |
+| `LLM_EXPLORATION`  | The LLM is probing the tool with unusual/out-of-spec inputs as part of exploratory use. No fix is required — this is expected behavior.                                                                                                                                                                  |
+| `DATA_ERROR`       | The failure is caused by bad caller data (e.g. invalid task IDs, non-existent project names) rather than a schema or description issue. No fix to the tool is required.                                                                                                                                  |
+
+## Decision process
+
+1. Read the tool's advertised `inputSchema` and `zodCanonical` carefully.
+2. Look at `normalizedError` and `inputShape` together. Ask: does the error pattern suggest the LLM misunderstood the
+   schema structure (→ DESCRIPTION_GAP) or was just exploring (→ LLM_EXPLORATION)?
+3. If the error looks like a bad data value (wrong ID, missing required name, etc.) → DATA_ERROR.
+4. If you see a structural schema gap the drift checker missed → SCHEMA_DRIFT or COERCION_MISSING.
+5. Otherwise adjudicate DESCRIPTION_GAP vs LLM_EXPLORATION based on whether a description fix would plausibly prevent
+   recurrence.
+
+## Output format
+
+Emit exactly one fenced JSON block — no prose before or after:
+
+```json
+{
+  "classification": "DESCRIPTION_GAP",
+  "suggestedFix": "Add an example to the 'limit' field description showing it accepts integer values only"
+}
+```
+
+Valid `classification` values: `SCHEMA_DRIFT`, `DESCRIPTION_GAP`, `COERCION_MISSING`, `LLM_EXPLORATION`, `DATA_ERROR`.
+
+`suggestedFix` must be a single line (no newlines). For `LLM_EXPLORATION` and `DATA_ERROR` (no-op classes), use
+`"no fix required"`.

--- a/docs/dev/PATTERNS.md
+++ b/docs/dev/PATTERNS.md
@@ -268,10 +268,11 @@ expect(response.data?.task?.taskId).toBeDefined();
 
 ## Documentation Map
 
-| Doc                   | Content                     |
-| --------------------- | --------------------------- |
-| PATTERNS.md           | This file - symptom lookup  |
-| ARCHITECTURE.md       | JXA vs Bridge decisions     |
-| LESSONS_LEARNED.md    | War stories, empirical data |
-| DEBUGGING_WORKFLOW.md | Systematic approach         |
-| PATTERN_INDEX.md      | Pattern search reference    |
+| Doc                      | Content                                     |
+| ------------------------ | ------------------------------------------- |
+| PATTERNS.md              | This file - symptom lookup                  |
+| ARCHITECTURE.md          | JXA vs Bridge decisions                     |
+| LESSONS_LEARNED.md       | War stories, empirical data                 |
+| DEBUGGING_WORKFLOW.md    | Systematic approach                         |
+| PATTERN_INDEX.md         | Pattern search reference                    |
+| mcp-failure-diagnosis.md | MCP failure diagnosis pipeline + scheduling |

--- a/docs/dev/mcp-failure-diagnosis.md
+++ b/docs/dev/mcp-failure-diagnosis.md
@@ -10,7 +10,7 @@ Covers the full failure-diagnosis pipeline: what it does, how to run it, how to 
 MCP tool use
     │
     ▼
-src/omnifocus/logger.ts           ← writes ~/.omnifocus-mcp/tool-failures/failures-YYYY-MM-DD.jsonl
+src/tools/base.ts (logToolFailure) ← writes ~/.omnifocus-mcp/tool-failures/failures-YYYY-MM-DD.jsonl
     │
     ▼
 scripts/analyze-tool-failures.ts  ← npm run analyze-failures   (read-only analysis, stdout)

--- a/docs/dev/mcp-failure-diagnosis.md
+++ b/docs/dev/mcp-failure-diagnosis.md
@@ -1,0 +1,228 @@
+# MCP Failure Diagnosis — Operator Guide
+
+Covers the full failure-diagnosis pipeline: what it does, how to run it, how to configure it, and how to schedule it.
+
+---
+
+## Pipeline Overview
+
+```
+MCP tool use
+    │
+    ▼
+src/omnifocus/logger.ts           ← writes ~/.omnifocus-mcp/tool-failures/failures-YYYY-MM-DD.jsonl
+    │
+    ▼
+scripts/analyze-tool-failures.ts  ← npm run analyze-failures   (read-only analysis, stdout)
+    │
+    ▼
+scripts/diagnose-failures.ts      ← npm run diagnose-failures  (classify + write triage doc + ledger)
+    │
+    ├── src/diagnostics/clustering.ts        (fingerprint + escalation thresholds)
+    ├── src/diagnostics/schema-drift.ts      (deterministic SCHEMA_DRIFT / COERCION_MISSING)
+    ├── src/diagnostics/ledger.ts            (seen-patterns dedup)
+    ├── src/diagnostics/triage-doc.ts        (render docs/dev/mcp-failure-triage.md)
+    └── src/diagnostics/linear-filer.ts      (optional auto-Linear filing, cap-guarded)
+```
+
+---
+
+## npm Scripts
+
+| Script                                         | Description                                                                                                                                                              |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `npm run analyze-failures`                     | Read-only. Clusters and summarizes failures from the JSONL logs. No writes.                                                                                              |
+| `npm run diagnose-failures`                    | Classifies escalated clusters, writes `docs/dev/mcp-failure-triage.md`, updates ledger.                                                                                  |
+| `npm run diagnose-failures -- --create-issues` | Same, plus notes that SCHEMA_DRIFT rows are ready for manual or Claude-runtime filing. Auto-filing requires the Linear MCP `graphql` action (Claude-runtime-only in v1). |
+
+### Threshold flags (passed to `runDiagnosis`)
+
+| Flag             | Default | Meaning                                          |
+| ---------------- | ------- | ------------------------------------------------ |
+| `--days=N`       | 90      | How many days of JSONL logs to scan.             |
+| `minOccurrences` | 3       | Cluster must have ≥ N occurrences to escalate.   |
+| `minSpanDays`    | 2       | Cluster must span ≥ N calendar days to escalate. |
+
+Thresholds are currently hard-coded in the CLI wrapper in `scripts/diagnose-failures.ts`. Change them there or inject
+via `runDiagnosis` opts in tests.
+
+---
+
+## File Locations
+
+| Path                                                       | Description                                                                                     |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `~/.omnifocus-mcp/tool-failures/failures-YYYY-MM-DD.jsonl` | Per-day failure log written by the MCP server.                                                  |
+| `~/.omnifocus-mcp/diagnosed-patterns.json`                 | Seen-patterns ledger (sibling of `tool-failures/`). Deduplicates across runs.                   |
+| `~/.omnifocus-mcp/fresh-failures.tsv`                      | Tier-2 marker file written by `scripts/mcp-failure-marker.sh` (one line per PostToolUse event). |
+| `docs/dev/mcp-failure-triage.md`                           | Committed triage doc updated by `npm run diagnose-failures`.                                    |
+
+---
+
+## Tier-2 PostToolUse Marker Hook (local only)
+
+`scripts/mcp-failure-marker.sh` is a cheap shell appender — one `ISO8601<TAB>tool` line per MCP tool use. It is called
+by the `hooks.PostToolUse` entry in `.claude/settings.local.json`.
+
+**This hook is local-only and gitignored.** Only `scripts/mcp-failure-marker.sh` ships in the repo. The settings file is
+never committed.
+
+To activate the hook, add the following to `.claude/settings.local.json` (create it if absent):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "mcp__omnifocus__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/mcp-failure-marker.sh \"$TOOL_NAME\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The marker file (`~/.omnifocus-mcp/fresh-failures.tsv`) is a lightweight complement to the JSONL log. It records every
+tool call (not just failures), enabling faster "did anything unusual happen recently?" queries without parsing JSONL.
+
+---
+
+## Agent-Based Classification
+
+Clusters not resolved by the deterministic path (schema-drift / coercion check) are routed to the
+`.claude/agents/mcp-failure-diagnoser.md` agent. The agent adjudicates between `DESCRIPTION_GAP` and `LLM_EXPLORATION`.
+
+The agent is **only invoked from inside the Claude runtime** (e.g., via `npm run diagnose-failures` run under Claude
+Code). The standalone CLI marks unresolved clusters `NEEDS_LLM` and skips them.
+
+### Classification legend
+
+| Classification      | Meaning                                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `SCHEMA_DRIFT`      | Advertised `inputSchema` diverged from Zod validation — deterministic.                                                |
+| `COERCION_MISSING`  | Numeric field present in advertised schema, Zod rejects string input — deterministic.                                 |
+| `DESCRIPTION_GAP`   | Tool description unclear; LLM-adjudicated.                                                                            |
+| `LLM_EXPLORATION`   | No-op: LLM is probing the API; no fix required.                                                                       |
+| `DATA_ERROR`        | No-op: bad caller data; not a schema issue.                                                                           |
+| `NEEDS_LLM`         | Agent not configured or unavailable — manual investigation required.                                                  |
+| `CAP_GUARD_TRIPPED` | Auto-Linear filing skipped because open issue count >= cap threshold.                                                 |
+| `FILE_FAILED`       | One or more SCHEMA_DRIFT clusters could not be filed to Linear (createIssue rejected); successes were still ledgered. |
+
+---
+
+## Auto-Filing to Linear (`--create-issues`)
+
+**v1 limitation:** `--create-issues` is recognized by the standalone CLI but does NOT auto-file. The concrete
+`LinearClient` implementation uses the Linear MCP `graphql` action, which is only callable from inside an MCP client
+(Claude's runtime). Introducing a direct Linear HTTP credential is explicitly out of scope for v1.
+
+When `--create-issues` is passed from the standalone CLI, `diagnose-failures` logs a clear message explaining this and
+outputs the triage doc with `SCHEMA_DRIFT` rows ready for manual filing.
+
+Auto-filing guards (enforced by `src/diagnostics/linear-filer.ts`):
+
+| Guard             | Behavior                                                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Class filter      | Only `SCHEMA_DRIFT` clusters are eligible for filing.                                                                          |
+| Cap threshold     | If open issue count >= `capThreshold` (default 230), no issues are created; `CAP_GUARD_TRIPPED` row appears in the triage doc. |
+| Fingerprint dedup | Searches for existing issues with the cluster fingerprint in the body; skips if found.                                         |
+| Per-run limit     | At most `perRunLimit` (default 3) issues created per run.                                                                      |
+
+---
+
+## Scheduling: `~/bin/of-mcp-diagnose` (NOT committed — machine-specific)
+
+> This recipe is **not committed to the repo**. It is a local ops script, following the same convention as
+> `~/bin/of-mcp-redeploy`.
+
+Create `~/bin/of-mcp-diagnose`:
+
+```bash
+#!/usr/bin/env bash
+# ~/bin/of-mcp-diagnose — local cron/launchd wrapper for diagnose-failures
+# NOT committed; machine-specific. See docs/dev/mcp-failure-diagnosis.md.
+set -euo pipefail
+
+REPO_DIR="$HOME/omnifocus-mcp"
+LOG="$HOME/.omnifocus-mcp/diagnose-failures.log"
+
+cd "$REPO_DIR"
+npm run diagnose-failures -- --days=90 >> "$LOG" 2>&1
+```
+
+Make it executable:
+
+```bash
+chmod +x ~/bin/of-mcp-diagnose
+```
+
+### launchd plist (weekly, Sunday 09:00)
+
+Save as `~/Library/LaunchAgents/com.omnifocus-mcp.diagnose.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.omnifocus-mcp.diagnose</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>/Users/kip/bin/of-mcp-diagnose</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Weekday</key>
+      <integer>0</integer>
+      <key>Hour</key>
+      <integer>9</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/kip/.omnifocus-mcp/diagnose-failures-launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/kip/.omnifocus-mcp/diagnose-failures-launchd.log</string>
+  </dict>
+</plist>
+```
+
+Load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.omnifocus-mcp.diagnose.plist
+```
+
+### cron alternative (weekly, Sunday 09:00)
+
+```cron
+0 9 * * 0 $HOME/bin/of-mcp-diagnose
+```
+
+Add via `crontab -e`.
+
+---
+
+## Tool Schema Registry
+
+`src/diagnostics/tool-schema-registry.ts` exports `TOOL_SCHEMA_REGISTRY` — the list of tools whose schemas are compared
+by the drift checker. When a new tool is added, add an entry here so its schema stays under CI drift-gate coverage.
+
+---
+
+## Related Docs
+
+| Doc                              | Purpose                                                     |
+| -------------------------------- | ----------------------------------------------------------- |
+| `docs/dev/mcp-failure-triage.md` | Live triage output, updated by `npm run diagnose-failures`. |
+| `docs/dev/PATTERNS.md`           | Symptom lookup for debugging.                               |

--- a/docs/dev/mcp-failure-diagnosis.md
+++ b/docs/dev/mcp-failure-diagnosis.md
@@ -78,7 +78,7 @@ To activate the hook, add the following to `.claude/settings.local.json` (create
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/mcp-failure-marker.sh \"$TOOL_NAME\""
+            "command": "bash scripts/mcp-failure-marker.sh"
           }
         ]
       }
@@ -86,6 +86,10 @@ To activate the hook, add the following to `.claude/settings.local.json` (create
   }
 }
 ```
+
+> **Do not add a positional `$TOOL_NAME` arg.** Claude Code command-type hooks do NOT export `$TOOL_NAME`; they deliver
+> a JSON payload on **stdin** (with a `tool_name` field). The marker script parses `tool_name` from that stdin JSON via
+> `jq` — see https://code.claude.com/docs/en/hooks.
 
 The marker file (`~/.omnifocus-mcp/fresh-failures.tsv`) is a lightweight complement to the JSONL log. It records every
 tool call (not just failures), enabling faster "did anything unusual happen recently?" queries without parsing JSONL.
@@ -162,6 +166,9 @@ chmod +x ~/bin/of-mcp-diagnose
 ```
 
 ### launchd plist (weekly, Sunday 09:00)
+
+> launchd does NOT expand `$HOME` or `~` in `ProgramArguments` — substitute your own absolute username path (replace
+> `/Users/kip/...` below). The cron alternative further down uses `$HOME` and is fine as-is.
 
 Save as `~/Library/LaunchAgents/com.omnifocus-mcp.diagnose.plist`:
 

--- a/docs/dev/mcp-failure-triage.md
+++ b/docs/dev/mcp-failure-triage.md
@@ -1,6 +1,6 @@
 # MCP Failure Triage
 
-_Generated at: 2026-05-18T18:56:49.454Z_
+_Generated at: 2026-05-18T19:45:50.071Z_
 
 ## Diagnosed Patterns
 
@@ -9,11 +9,13 @@ _Generated at: 2026-05-18T18:56:49.454Z_
 
 ## Legend
 
-| Classification    | Meaning                                                                              |
-| ----------------- | ------------------------------------------------------------------------------------ |
-| SCHEMA_DRIFT      | advertised inputSchema diverged from Zod validation — deterministic                  |
-| COERCION_MISSING  | numeric field present in advertised schema, Zod rejects string input — deterministic |
-| DESCRIPTION_GAP   | tool description unclear; LLM-adjudicated                                            |
-| LLM_EXPLORATION   | no-op: LLM is probing the API; no fix required                                       |
-| DATA_ERROR        | no-op: bad caller data; not a schema issue                                           |
-| CAP_GUARD_TRIPPED | auto-Linear filing skipped because open issue count >= cap threshold                 |
+| Classification    | Meaning                                                                                                              |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| SCHEMA_DRIFT      | advertised inputSchema diverged from Zod validation — deterministic                                                  |
+| COERCION_MISSING  | numeric field present in advertised schema, Zod rejects string input — deterministic                                 |
+| DESCRIPTION_GAP   | tool description unclear; LLM-adjudicated                                                                            |
+| LLM_EXPLORATION   | no-op: LLM is probing the API; no fix required                                                                       |
+| DATA_ERROR        | no-op: bad caller data; not a schema issue                                                                           |
+| NEEDS_LLM         | agent not configured or unavailable — manual investigation required                                                  |
+| CAP_GUARD_TRIPPED | auto-Linear filing skipped because open issue count >= cap threshold                                                 |
+| FILE_FAILED       | one or more SCHEMA_DRIFT clusters could not be filed to Linear (createIssue rejected); successes were still ledgered |

--- a/docs/dev/mcp-failure-triage.md
+++ b/docs/dev/mcp-failure-triage.md
@@ -1,0 +1,19 @@
+# MCP Failure Triage
+
+_Generated at: 2026-05-18T18:56:49.454Z_
+
+## Diagnosed Patterns
+
+| Fingerprint | Tool | Classification | Suggested fix | First seen | Last seen | Count |
+| ----------- | ---- | -------------- | ------------- | ---------- | --------- | ----- |
+
+## Legend
+
+| Classification    | Meaning                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| SCHEMA_DRIFT      | advertised inputSchema diverged from Zod validation — deterministic                  |
+| COERCION_MISSING  | numeric field present in advertised schema, Zod rejects string input — deterministic |
+| DESCRIPTION_GAP   | tool description unclear; LLM-adjudicated                                            |
+| LLM_EXPLORATION   | no-op: LLM is probing the API; no fix required                                       |
+| DATA_ERROR        | no-op: bad caller data; not a schema issue                                           |
+| CAP_GUARD_TRIPPED | auto-Linear filing skipped because open issue count >= cap threshold                 |

--- a/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
+++ b/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
@@ -147,7 +147,9 @@ export interface FailureCategorization {
 export interface FailureRecord {
   timestamp: string;
   tool: string;
-  errorType: 'VALIDATION_ERROR' | 'EXECUTION_ERROR';
+  // Usually 'VALIDATION_ERROR' | 'EXECUTION_ERROR', but base.ts:303/639 can also write a raw
+  // ScriptErrorType string. Keep it `string`; classification keys off `categorization.errorType`.
+  errorType: string;
   errorMessage: string;
   validationErrors?: Array<{ path?: (string | number)[]; message?: string }>;
   inputArgs: unknown; // already redacted upstream by redactArgs()
@@ -610,7 +612,7 @@ import { describe, it, expect } from 'vitest';
 import { canonicalizeInputSchema } from '../../../src/diagnostics/schema-drift.js';
 
 describe('canonicalizeInputSchema', () => {
-  it('flattens advertised JSON schema to { field: { type, required, enum } }', () => {
+  it('flattens a flat advertised JSON schema (system tool — no wrapper)', () => {
     const adv = {
       type: 'object',
       properties: {
@@ -619,9 +621,28 @@ describe('canonicalizeInputSchema', () => {
       },
       required: ['operation'],
     };
-    const c = canonicalizeInputSchema(adv);
+    const c = canonicalizeInputSchema(adv); // wrapperKey omitted
     expect(c.operation).toEqual({ type: 'string', required: true, enum: ['version', 'cache'] });
     expect(c.limit).toEqual({ type: 'number', required: false, enum: undefined });
+  });
+
+  it('descends into a single wrapper key (read/write/analyze nest real fields under query/mutation/analysis)', () => {
+    // Mirrors OmniFocusReadTool.inputSchema: { properties: { query: { properties: {...}, required: ['type'] } } }
+    const adv = {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'object',
+          properties: { type: { type: 'string', enum: ['tasks', 'projects'] }, limit: { type: 'number' } },
+          required: ['type'],
+        },
+      },
+      required: ['query'],
+    };
+    const c = canonicalizeInputSchema(adv, 'query');
+    expect(c.type).toEqual({ type: 'string', required: true, enum: ['tasks', 'projects'] });
+    expect(c.limit).toEqual({ type: 'number', required: false, enum: undefined });
+    expect(c.query).toBeUndefined(); // the wrapper itself is not a field
   });
 });
 ```
@@ -641,9 +662,29 @@ export interface CanonicalField {
 }
 export type CanonicalSchema = Record<string, CanonicalField>;
 
-export function canonicalizeInputSchema(advertised: Record<string, unknown>): CanonicalSchema {
-  const props = (advertised.properties ?? {}) as Record<string, { type?: string; enum?: (string | number)[] }>;
-  const required = new Set((advertised.required as string[] | undefined) ?? []);
+type JsonSchemaNode = {
+  type?: string;
+  enum?: (string | number)[];
+  properties?: Record<string, JsonSchemaNode>;
+  required?: string[];
+};
+
+/**
+ * Canonicalize the advertised JSON schema.
+ * @param wrapperKey  For read/write/analyze the real fields are nested one level under a single
+ *                     wrapper property ('query' | 'mutation' | 'analysis'). Pass it to descend.
+ *                     Omit for flat schemas (the `system` tool).
+ */
+export function canonicalizeInputSchema(advertised: Record<string, unknown>, wrapperKey?: string): CanonicalSchema {
+  let node = advertised as JsonSchemaNode;
+  if (wrapperKey) {
+    const wrapped = node.properties?.[wrapperKey];
+    if (!wrapped)
+      throw new Error(`canonicalizeInputSchema: wrapper key '${wrapperKey}' not found in advertised schema`);
+    node = wrapped;
+  }
+  const props = node.properties ?? {};
+  const required = new Set(node.required ?? []);
   const out: CanonicalSchema = {};
   for (const [name, def] of Object.entries(props)) {
     out[name] = { type: def.type ?? 'unknown', required: required.has(name), enum: def.enum };
@@ -689,6 +730,27 @@ describe('canonicalizeZodSchema', () => {
     expect(c.mode.enum).toEqual(['x', 'y']);
     expect(c.note.required).toBe(false);
   });
+
+  it('descends a single wrapper key whose inner is z.preprocess(...) over a discriminatedUnion (the real read/write/analyze shape)', () => {
+    // Mirrors ReadSchema = z.object({ query: coerceObject(QuerySchema) }),
+    // QuerySchema = z.discriminatedUnion('type', [...]). coerceObject = z.preprocess(fn, inner).
+    const coerceObject = <T extends z.ZodTypeAny>(s: T) => z.preprocess((v) => v, s);
+    const QuerySchema = z.discriminatedUnion('type', [
+      z.object({ type: z.literal('tasks'), limit: z.coerce.number().optional(), flagged: z.boolean().optional() }),
+      z.object({ type: z.literal('projects'), limit: z.coerce.number().optional() }),
+    ]);
+    const ReadSchema = z.object({ query: coerceObject(QuerySchema) });
+
+    const c = canonicalizeZodSchema(ReadSchema, 'query');
+    // Discriminator: union of member literal values.
+    expect(c.type.enum?.sort()).toEqual(['projects', 'tasks']);
+    expect(c.type.required).toBe(true); // required in every member
+    // limit present in all members -> required iff required in all (it's optional -> not required), and coercible.
+    expect(c.limit.coercible).toBe(true);
+    expect(c.limit.required).toBe(false);
+    // flagged present in only ONE member -> not required (absent from a member counts as not-required).
+    expect(c.flagged.required).toBe(false);
+  });
 });
 ```
 
@@ -700,52 +762,113 @@ describe('canonicalizeZodSchema', () => {
 ```typescript
 import { z } from 'zod';
 
+type ZDef = {
+  typeName?: string;
+  schema?: z.ZodTypeAny; // ZodEffects (z.preprocess / z.transform)
+  innerType?: z.ZodTypeAny; // ZodOptional / ZodDefault / ZodNullable
+  values?: unknown[]; // ZodEnum
+  value?: unknown; // ZodLiteral
+  discriminator?: string; // ZodDiscriminatedUnion
+  options?: Map<unknown, z.ZodTypeAny> | z.ZodTypeAny[]; // ZodDiscriminatedUnion members
+};
+const defOf = (s: z.ZodTypeAny): ZDef => (s as unknown as { _def: ZDef })._def;
+
+/** Peel ZodEffects (preprocess/transform — this is what coerceObject is), Optional, Default, Nullable. */
+function unwrap(s: z.ZodTypeAny): z.ZodTypeAny {
+  let cur = s;
+  for (;;) {
+    const d = defOf(cur);
+    if (d.typeName === 'ZodEffects' && d.schema) cur = d.schema;
+    else if (
+      (d.typeName === 'ZodOptional' || d.typeName === 'ZodDefault' || d.typeName === 'ZodNullable') &&
+      d.innerType
+    )
+      cur = d.innerType;
+    else return cur;
+  }
+}
+
 function isCoercibleNumber(field: z.ZodTypeAny): boolean {
-  // Behavioral: a number field is "coercible" iff a stringified number survives validation.
-  // Catches z.coerce.number(), z.preprocess(...), z.union([z.number(), z.string().transform()]) alike.
+  // Behavioral probe — NEVER pattern-match source. A number field is "coercible" iff a stringified
+  // number survives validation. Catches z.coerce.number(), z.preprocess(...), z.union([...]) alike.
   return field.safeParse('5').success;
 }
 
-function zodTypeName(field: z.ZodTypeAny): { type: string; enum?: (string | number)[] } {
-  const def = (field as { _def?: { typeName?: string; values?: unknown[] } })._def;
-  const tn = def?.typeName ?? '';
-  if (tn === 'ZodEnum') return { type: 'string', enum: def?.values as (string | number)[] };
-  if (tn === 'ZodNumber' || tn === 'ZodNumber') return { type: 'number' };
-  if (tn === 'ZodBoolean') return { type: 'boolean' };
-  if (tn === 'ZodString') return { type: 'string' };
+function fieldType(field: z.ZodTypeAny): { type: string; enum?: (string | number)[] } {
+  const inner = unwrap(field);
+  const d = defOf(inner);
+  if (d.typeName === 'ZodEnum') return { type: 'string', enum: d.values as (string | number)[] };
+  if (d.typeName === 'ZodLiteral')
+    return { type: typeof d.value === 'number' ? 'number' : 'string', enum: [d.value as string | number] };
+  if (d.typeName === 'ZodNumber') return { type: 'number' };
+  if (d.typeName === 'ZodBoolean') return { type: 'boolean' };
+  if (d.typeName === 'ZodString') return { type: 'string' };
   return { type: 'object' };
 }
 
-export function canonicalizeZodSchema(schema: z.ZodTypeAny): CanonicalSchema {
-  // Unwrap effects/optional/default wrappers to reach the object shape.
-  let obj = schema;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const d = (obj as { _def?: { typeName?: string; schema?: z.ZodTypeAny; innerType?: z.ZodTypeAny } })._def;
-    if (d?.typeName === 'ZodEffects' && d.schema) obj = d.schema;
-    else if ((d?.typeName === 'ZodOptional' || d?.typeName === 'ZodDefault') && d.innerType) obj = d.innerType;
-    else break;
-  }
-  const shape = (obj as z.ZodObject<z.ZodRawShape>).shape ?? {};
+function membersOf(du: z.ZodTypeAny): z.ZodTypeAny[] {
+  const opts = defOf(du).options;
+  if (!opts) return [];
+  return Array.isArray(opts) ? opts : [...opts.values()];
+}
+
+/** Merge object/discriminated-union members into one CanonicalSchema.
+ *  required(field) := present AND required in EVERY member (absence in any member ⇒ not required).
+ *  enum/coercible := unioned across members (discriminator literal values collapse to one enum). */
+function mergeShapes(members: z.ZodTypeAny[]): CanonicalSchema {
   const out: CanonicalSchema = {};
-  for (const [name, raw] of Object.entries(shape)) {
-    const field = raw as z.ZodTypeAny;
-    const isOptional = field.isOptional?.() ?? false;
-    const probeNumber = isCoercibleNumber(field);
-    const { type, enum: en } = zodTypeName(field);
-    out[name] = {
-      type: type === 'number' || probeNumber ? (type === 'object' ? 'number' : type) : type,
-      required: !isOptional,
-      enum: en,
-      coercible: probeNumber,
-    };
+  const presentCount: Record<string, number> = {};
+  for (const m of members) {
+    const shape = (unwrap(m) as z.ZodObject<z.ZodRawShape>).shape ?? {};
+    for (const [name, raw] of Object.entries(shape)) {
+      const field = raw as z.ZodTypeAny;
+      presentCount[name] = (presentCount[name] ?? 0) + 1;
+      const required = !(field.isOptional?.() ?? false);
+      const probe = isCoercibleNumber(field);
+      const { type, enum: en } = fieldType(field);
+      const prev = out[name];
+      const mergedEnum = [...new Set([...(prev?.enum ?? []), ...(en ?? [])])];
+      out[name] = {
+        type: prev?.type ?? type,
+        required: prev ? prev.required && required : required,
+        enum: mergedEnum.length ? mergedEnum : undefined,
+        coercible: (prev?.coercible ?? false) || probe,
+      };
+    }
+  }
+  // A field absent from any member cannot be globally required.
+  for (const [name, f] of Object.entries(out)) {
+    if (presentCount[name] !== members.length) f.required = false;
   }
   return out;
 }
+
+/**
+ * Canonicalize a tool's Zod schema.
+ * @param wrapperKey  read/write/analyze wrap the real schema under one key
+ *                     ('query'|'mutation'|'analysis') via coerceObject (= z.preprocess) over a
+ *                     z.discriminatedUnion. Pass it to descend. Omit for the flat `system` schema.
+ */
+export function canonicalizeZodSchema(schema: z.ZodTypeAny, wrapperKey?: string): CanonicalSchema {
+  const top = unwrap(schema) as z.ZodObject<z.ZodRawShape>;
+  let target: z.ZodTypeAny = top;
+  if (wrapperKey) {
+    const wrapped = top.shape?.[wrapperKey];
+    if (!wrapped) throw new Error(`canonicalizeZodSchema: wrapper key '${wrapperKey}' not found`);
+    target = unwrap(wrapped); // peels coerceObject's z.preprocess → inner discriminatedUnion/object
+  }
+  const td = defOf(target);
+  if (td.typeName === 'ZodDiscriminatedUnion' || td.typeName === 'ZodUnion') {
+    return mergeShapes(membersOf(target));
+  }
+  // Plain object (system tool, or a non-union wrapper).
+  return mergeShapes([target]);
+}
 ```
 
-- [ ] **Step 4: Run, verify pass.** Expected: PASS. If `zodTypeName` mis-detects on the real schemas, adjust unwrap
-      order — the behavioral probe (`isCoercibleNumber`) is the load-bearing part and must stay a `safeParse` call.
+- [ ] **Step 4: Run, verify pass.** Expected: PASS (both tests, incl. the discriminated-union case). If `fieldType`
+      mis-detects on the real schemas, fix the `_def.typeName` mapping — but the behavioral probe (`isCoercibleNumber`)
+      and the unwrap/merge structure are load-bearing and must not be replaced by source pattern-matching.
 - [ ] **Step 5: Commit**
 
 ```bash
@@ -879,13 +1002,13 @@ describe('inputSchema <-> Zod drift gate (fails CI on drift)', () => {
   for (const entry of TOOL_SCHEMA_REGISTRY) {
     it(`${entry.name}: advertised schema matches Zod validation`, () => {
       const findings = diffSchemas(
-        canonicalizeInputSchema(entry.getInputSchema()),
-        canonicalizeZodSchema(entry.zodSchema),
+        canonicalizeInputSchema(entry.getInputSchema(), entry.wrapperKey),
+        canonicalizeZodSchema(entry.zodSchema, entry.wrapperKey),
       );
       // Some advertised-vs-validated asymmetry is intentional (compact advertised schema).
       // The gate fails ONLY on the high-signal kinds: enum/required/coercion drift.
       const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');
-      expect(blocking, JSON.stringify(findings, null, 2)).toEqual([]);
+      expect(blocking, `${entry.name} drift: ${JSON.stringify(findings, null, 2)}`).toEqual([]);
     });
   }
 });
@@ -900,44 +1023,58 @@ describe('inputSchema <-> Zod drift gate (fails CI on drift)', () => {
 import type { z } from 'zod';
 import { CacheManager } from '../cache/CacheManager.js';
 import { SystemTool } from '../tools/system/SystemTool.js';
-import { SystemToolSchema } from '../tools/schemas/system-schemas.js';
 import { OmniFocusReadTool } from '../tools/unified/OmniFocusReadTool.js';
 import { OmniFocusWriteTool } from '../tools/unified/OmniFocusWriteTool.js';
 import { OmniFocusAnalyzeTool } from '../tools/unified/OmniFocusAnalyzeTool.js';
-import { ReadToolSchema } from '../tools/unified/schemas/read-schema.js';
-import { WriteToolSchema } from '../tools/unified/schemas/write-schema.js';
-import { AnalyzeToolSchema } from '../tools/unified/schemas/analyze-schema.js';
 
 export interface ToolSchemaEntry {
   name: string;
+  /** Single nesting key for read/write/analyze; undefined for the flat `system` schema. */
+  wrapperKey?: 'query' | 'mutation' | 'analysis';
   getInputSchema: () => Record<string, unknown>;
   zodSchema: z.ZodTypeAny;
 }
 
+// Every BaseTool subclass exposes its Zod schema as a public instance property `schema`
+// (SystemTool.ts:93 `schema = SystemToolSchema`; OmniFocusReadTool.ts:205 `schema = ReadSchema`;
+// Write:164 `schema = WriteSchema`; Analyze:300 `schema = AnalyzeSchema`). Reading the instance
+// property avoids importing non-exported symbols (SystemToolSchema is a non-exported const) and
+// needs zero source edits.
 const cache = new CacheManager();
+const sys = new SystemTool(cache);
+const read = new OmniFocusReadTool(cache);
+const write = new OmniFocusWriteTool(cache);
+const analyze = new OmniFocusAnalyzeTool(cache);
+
 export const TOOL_SCHEMA_REGISTRY: ToolSchemaEntry[] = [
-  { name: 'system', getInputSchema: () => new SystemTool(cache).inputSchema, zodSchema: SystemToolSchema },
-  { name: 'omnifocus_read', getInputSchema: () => new OmniFocusReadTool(cache).inputSchema, zodSchema: ReadToolSchema },
-  {
-    name: 'omnifocus_write',
-    getInputSchema: () => new OmniFocusWriteTool(cache).inputSchema,
-    zodSchema: WriteToolSchema,
-  },
+  { name: 'system', getInputSchema: () => sys.inputSchema, zodSchema: sys.schema },
+  { name: 'omnifocus_read', wrapperKey: 'query', getInputSchema: () => read.inputSchema, zodSchema: read.schema },
+  { name: 'omnifocus_write', wrapperKey: 'mutation', getInputSchema: () => write.inputSchema, zodSchema: write.schema },
   {
     name: 'omnifocus_analyze',
-    getInputSchema: () => new OmniFocusAnalyzeTool(cache).inputSchema,
-    zodSchema: AnalyzeToolSchema,
+    wrapperKey: 'analysis',
+    getInputSchema: () => analyze.inputSchema,
+    zodSchema: analyze.schema,
   },
 ];
 ```
 
-> **Implementer note:** verify the exact exported Zod schema symbol + path for each tool
-> (`grep -rn "export const .*Schema" src/tools/unified/schemas/ src/tools/schemas/`). The symbols above are the expected
-> names; correct them to the actual exports. If a tool's top-level Zod schema is a `discriminatedUnion` (write/analyze
-> use operation discriminators), `canonicalizeZodSchema` must fall back gracefully — extend the unwrap in Task 7 to take
-> the **common base fields** across union members, or scope the gate to `system` + `omnifocus_read` (object schemas) for
-> v1 and file a follow-up for the discriminated tools. Decide based on actual schema shapes; document the decision in
-> the commit message.
+> **Implementer note (verified on `2ce9255`):** the four schemas have two distinct shapes, both handled by Tasks 6–7:
+>
+> | Tool                | Zod schema (instance `.schema`)                                                                                                 | Advertised `inputSchema`                                                     | `wrapperKey` |
+> | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------ |
+> | `system`            | `SystemToolSchema` — flat `z.object({...})`                                                                                     | flat `properties`                                                            | — (none)     |
+> | `omnifocus_read`    | `ReadSchema = z.object({ query: coerceObject(QuerySchema) })`, `QuerySchema = z.discriminatedUnion('type', […])`                | fields nested under `properties.query.properties`, inner `required:['type']` | `'query'`    |
+> | `omnifocus_write`   | `WriteSchema = z.object({ mutation: coerceObject(MutationSchema) })`, `MutationSchema = z.discriminatedUnion('operation', […])` | nested under `properties.mutation`                                           | `'mutation'` |
+> | `omnifocus_analyze` | `AnalyzeSchema = z.object({ analysis: coerceObject(AnalysisSchema) })`, `AnalysisSchema = z.discriminatedUnion('type', […])`    | nested under `properties.analysis`                                           | `'analysis'` |
+>
+> `coerceObject(x)` is `z.preprocess(fn, x)` (`src/tools/schemas/coercion-helpers.ts:35`) → a `ZodEffects`, which
+> `unwrap()` (Task 7) peels to reach the inner `z.discriminatedUnion`. `mergeShapes` then unions the
+> per-`operation`/`type` member shapes, collapsing each discriminator's literals into one enum and treating a field as
+> required only if required in **every** member. This is NOT a `discriminatedUnion`-at-top-level case and there is NO
+> viable "scope to system + read" shortcut — read/write/analyze are all the same wrapped-DU shape; the merge is
+> mandatory for Phase 2 to deliver any value (do not let the gate pass vacuously — see the session "vacuous-green"
+> lesson, OMN-65).
 
 - [ ] **Step 4: Run, verify pass** (or surface real drift)
 

--- a/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
+++ b/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
@@ -1,0 +1,1393 @@
+# OMN-37 MCP Failure Diagnosis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the already-captured MCP tool-failure JSONL stream into automated, deduplicated, classified triage —
+catching dual-schema drift before it compounds.
+
+**Architecture:** A pure `failure-clustering` module (shared by the existing `analyze-failures` CLI and a new
+`diagnose-failures` driver) feeds a static `inputSchema`↔Zod drift checker (also wired as a CI-failing unit test). The
+driver classifies clusters deterministically, dispatches only the residue to an LLM agent, writes a committed triage
+doc, and — behind guardrails — files Linear issues for deterministic drift. An optional local-only PostToolUse hook adds
+a dev-feedback prioritization marker; scheduling lives in an untracked `~/bin` wrapper.
+
+**Tech Stack:** TypeScript, Zod, vitest (`npm run test:unit` = `vitest tests/unit --run`), tsx scripts, Linear MCP
+(`graphql` action).
+
+**Spec:** `docs/superpowers/specs/2026-05-18-omn-37-mcp-failure-diagnosis-design.md`
+
+---
+
+## Key codebase facts (verified on worktree branch `worktree-omn-37-failure-diagnosis`, base `2ce9255`)
+
+- **Failure log shape** (`src/tools/base.ts` `logToolFailure()` ≈:316–334):
+  `{ timestamp:ISO, tool:string, errorType:'VALIDATION_ERROR'|'EXECUTION_ERROR', errorMessage:string, validationErrors?:ZodIssue[], inputArgs:<redacted>, schemaDescription:string, categorization?:{ errorType:ScriptErrorType, severity, recoverable, actionable, context } }`.
+  Files: `~/.omnifocus-mcp/tool-failures/failures-YYYY-MM-DD.jsonl`.
+- **Existing normalization** (`scripts/analyze-tool-failures.ts:119–122`):
+  `errorMessage.replace(/[0-9a-f]{8,}/gi,'ID').replace(/\d{4}-\d{2}-\d{2}/g,'DATE').substring(0,100)`. This is the logic
+  to **extract, not duplicate**.
+- **Taxonomy** (`src/utils/error-taxonomy.ts`): `ScriptErrorType` enum members include `INVALID_ID`, `NULL_RESULT`,
+  `OMNIFOCUS_NOT_RUNNING`, `SCRIPT_TIMEOUT`, `CONNECTION_TIMEOUT` (the ignore-set), plus `getErrorSeverity()`,
+  `isRecoverableError()`.
+- **inputSchema getters**: `OmniFocusReadTool.ts get inputSchema()`, `OmniFocusWriteTool.ts`, `OmniFocusAnalyzeTool.ts`,
+  `SystemTool.ts` — each returns `{ type:'object', properties:{ <field>:{ type, enum?, description } }, required?:[] }`.
+- **Zod schemas**: `src/tools/unified/schemas/{read,write,analyze,batch}-schema*.ts`. Tool Zod schema symbols:
+  `SystemToolSchema` (SystemTool). Read/Write/Analyze tools validate via their unified schemas.
+- **Coercion convention reality** (NOT as CLAUDE.md prose states): `src/tools/schemas/coercion-helpers.ts` exports
+  `coerceNumber = () => z.coerce.number()`, `coerceBoolean`, `coerceObject`. **Do not pattern-match
+  `z.union([z.number(),...])`** — detect coercibility by runtime probe (see Task 7).
+- **`redactArgs`**: `src/utils/logger.ts:45` (already applied before logging — the module consumes already-redacted
+  `inputArgs`; never re-redact, never log raw).
+- Test files live flat/foldered under `tests/unit/`; vitest. No `src/diagnostics/` dir yet.
+
+---
+
+## File Structure
+
+| File                                      | Responsibility                                                               | Phase |
+| ----------------------------------------- | ---------------------------------------------------------------------------- | ----- |
+| `src/diagnostics/failure-log.ts`          | Types + tolerant JSONL parse (`FailureRecord`, `parseFailureLog`)            | 1     |
+| `src/diagnostics/normalize.ts`            | `normalizeErrorMessage`, `normalizeInputShape` (extracted from CLI)          | 1     |
+| `src/diagnostics/clustering.ts`           | `clusterFailures`, `classifyCluster`, `fingerprint`, ignore-set              | 1     |
+| `scripts/analyze-tool-failures.ts`        | Refactored to consume the module; CLI output unchanged                       | 1     |
+| `src/diagnostics/schema-drift.ts`         | `canonicalizeInputSchema`, `canonicalizeZodSchema`, `diffSchemas`            | 2     |
+| `src/diagnostics/tool-schema-registry.ts` | Maps each tool name → `{ getInputSchema(), zodSchema }`                      | 2     |
+| `src/diagnostics/ledger.ts`               | Seen-patterns ledger read/write (`~/.omnifocus-mcp/diagnosed-patterns.json`) | 3     |
+| `src/diagnostics/triage-doc.ts`           | Render `docs/dev/mcp-failure-triage.md` from diagnosed clusters              | 3     |
+| `src/diagnostics/linear-filer.ts`         | Guardrailed auto-Linear (cap guard, fingerprint dedup, per-run limit)        | 4     |
+| `scripts/diagnose-failures.ts`            | Tier-1 driver orchestrating all of the above                                 | 3,4   |
+| `.claude/agents/mcp-failure-diagnoser.md` | LLM agent for residual non-deterministic clusters                            | 3     |
+| `.claude/settings.local.json`             | Tier-2 PostToolUse marker hook (gitignored)                                  | 5     |
+| `docs/dev/mcp-failure-diagnosis.md`       | Operator doc incl. the untracked `~/bin` scheduling wrapper recipe           | 5     |
+| `tests/unit/diagnostics/*.test.ts`        | Unit + golden tests per module                                               | all   |
+
+Each `src/diagnostics/*.ts` file is pure/side-effect-free except `ledger.ts` (fs), `linear-filer.ts` (Linear calls —
+injected, mockable), and the driver.
+
+---
+
+## Phase 1 — `failure-clustering` module (independently shippable; behavior-preserving for `npm run analyze-failures`)
+
+### Task 1: Failure-log types + tolerant parser
+
+**Files:**
+
+- Create: `src/diagnostics/failure-log.ts`
+- Test: `tests/unit/diagnostics/failure-log.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/failure-log.test.ts
+import { describe, it, expect } from 'vitest';
+import { parseFailureLog } from '../../../src/diagnostics/failure-log.js';
+
+describe('parseFailureLog', () => {
+  it('parses valid JSONL lines into FailureRecord[]', () => {
+    const jsonl = [
+      JSON.stringify({
+        timestamp: '2026-05-18T10:00:00.000Z',
+        tool: 'omnifocus_write',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'name: Required',
+        inputArgs: { x: 1 },
+        schemaDescription: 'd',
+      }),
+      JSON.stringify({
+        timestamp: '2026-05-18T10:01:00.000Z',
+        tool: 'omnifocus_read',
+        errorType: 'EXECUTION_ERROR',
+        errorMessage: 'boom',
+        inputArgs: {},
+        schemaDescription: 'd',
+        categorization: { errorType: 'INVALID_ID', severity: 'low', recoverable: true },
+      }),
+    ].join('\n');
+    const recs = parseFailureLog(jsonl);
+    expect(recs).toHaveLength(2);
+    expect(recs[0].tool).toBe('omnifocus_write');
+    expect(recs[1].categorization?.errorType).toBe('INVALID_ID');
+  });
+
+  it('skips malformed lines and blank lines without throwing', () => {
+    const jsonl =
+      'not json\n\n' +
+      JSON.stringify({
+        timestamp: '2026-05-18T10:00:00.000Z',
+        tool: 't',
+        errorType: 'EXECUTION_ERROR',
+        errorMessage: 'e',
+        inputArgs: {},
+        schemaDescription: 'd',
+      });
+    const recs = parseFailureLog(jsonl);
+    expect(recs).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest tests/unit/diagnostics/failure-log.test.ts --run` Expected: FAIL — cannot resolve
+`src/diagnostics/failure-log.js`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/diagnostics/failure-log.ts
+export interface FailureCategorization {
+  errorType: string;
+  severity?: string;
+  recoverable?: boolean;
+  actionable?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface FailureRecord {
+  timestamp: string;
+  tool: string;
+  errorType: 'VALIDATION_ERROR' | 'EXECUTION_ERROR';
+  errorMessage: string;
+  validationErrors?: Array<{ path?: (string | number)[]; message?: string }>;
+  inputArgs: unknown; // already redacted upstream by redactArgs()
+  schemaDescription: string;
+  categorization?: FailureCategorization;
+}
+
+/** Tolerant line-delimited-JSON parse. Never throws; skips malformed/blank lines. */
+export function parseFailureLog(jsonl: string): FailureRecord[] {
+  const out: FailureRecord[] = [];
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed.tool === 'string' && typeof parsed.errorMessage === 'string') {
+        out.push(parsed as FailureRecord);
+      }
+    } catch {
+      // skip malformed line by design
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest tests/unit/diagnostics/failure-log.test.ts --run` Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/failure-log.ts tests/unit/diagnostics/failure-log.test.ts
+git commit -m "feat(OMN-37): failure-log types + tolerant JSONL parser"
+```
+
+---
+
+### Task 2: Normalization (extract the CLI's regex, do not duplicate)
+
+**Files:**
+
+- Create: `src/diagnostics/normalize.ts`
+- Test: `tests/unit/diagnostics/normalize.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/normalize.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeErrorMessage, normalizeInputShape } from '../../../src/diagnostics/normalize.js';
+
+describe('normalizeErrorMessage', () => {
+  it('replaces hex IDs and ISO dates with placeholders and truncates to 100 chars', () => {
+    expect(normalizeErrorMessage('task a1b2c3d4e5 not found on 2026-05-18')).toBe('task ID not found on DATE');
+    expect(normalizeErrorMessage('x'.repeat(200)).length).toBe(100);
+  });
+});
+
+describe('normalizeInputShape', () => {
+  it('produces a stable shape string keyed by sorted top-level keys, not values', () => {
+    expect(normalizeInputShape({ b: 2, a: 'hello' })).toBe(normalizeInputShape({ a: 'world', b: 99 }));
+    expect(normalizeInputShape({ a: 1 })).not.toBe(normalizeInputShape({ a: 1, c: 2 }));
+  });
+  it('handles non-object inputs', () => {
+    expect(normalizeInputShape(null)).toBe('<non-object>');
+    expect(normalizeInputShape('str')).toBe('<non-object>');
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest tests/unit/diagnostics/normalize.test.ts --run` Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/diagnostics/normalize.ts
+
+/** Extracted verbatim from scripts/analyze-tool-failures.ts:119-122 (the canonical normalization). */
+export function normalizeErrorMessage(errorMessage: string): string {
+  return errorMessage
+    .replace(/[0-9a-f]{8,}/gi, 'ID')
+    .replace(/\d{4}-\d{2}-\d{2}/g, 'DATE')
+    .substring(0, 100);
+}
+
+/** Structural fingerprint of the input: sorted top-level key names only (never values — values are PII-redacted but still volatile). */
+export function normalizeInputShape(inputArgs: unknown): string {
+  if (inputArgs === null || typeof inputArgs !== 'object' || Array.isArray(inputArgs)) {
+    return '<non-object>';
+  }
+  return Object.keys(inputArgs as Record<string, unknown>)
+    .sort()
+    .join(',');
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest tests/unit/diagnostics/normalize.test.ts --run` Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/normalize.ts tests/unit/diagnostics/normalize.test.ts
+git commit -m "feat(OMN-37): extract failure-message + input-shape normalization"
+```
+
+---
+
+### Task 3: Clustering with threshold + stable fingerprint
+
+**Files:**
+
+- Create: `src/diagnostics/clustering.ts`
+- Test: `tests/unit/diagnostics/clustering.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/clustering.test.ts
+import { describe, it, expect } from 'vitest';
+import { clusterFailures } from '../../../src/diagnostics/clustering.js';
+import type { FailureRecord } from '../../../src/diagnostics/failure-log.js';
+
+const rec = (over: Partial<FailureRecord>): FailureRecord => ({
+  timestamp: '2026-05-18T10:00:00.000Z',
+  tool: 'omnifocus_write',
+  errorType: 'VALIDATION_ERROR',
+  errorMessage: 'name: Required',
+  inputArgs: { name: 1 },
+  schemaDescription: 'd',
+  ...over,
+});
+
+describe('clusterFailures', () => {
+  it('groups by (tool, normalizedError, inputShape) and assigns a stable fingerprint', () => {
+    const clusters = clusterFailures([rec({}), rec({ inputArgs: { name: 2 } }), rec({})], {
+      minOccurrences: 1,
+      minSpanDays: 999,
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].count).toBe(3);
+    expect(clusters[0].fingerprint).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('escalates a cluster with count >= minOccurrences', () => {
+    const recs = [rec({}), rec({}), rec({})];
+    const [c] = clusterFailures(recs, { minOccurrences: 3, minSpanDays: 999 });
+    expect(c.escalated).toBe(true);
+  });
+
+  it('escalates a low-count cluster that spans >= minSpanDays', () => {
+    const recs = [rec({ timestamp: '2026-05-10T10:00:00.000Z' }), rec({ timestamp: '2026-05-18T10:00:00.000Z' })];
+    const [c] = clusterFailures(recs, { minOccurrences: 99, minSpanDays: 2 });
+    expect(c.escalated).toBe(true);
+    expect(c.count).toBe(2);
+  });
+
+  it('does not escalate a fresh low-count cluster', () => {
+    const [c] = clusterFailures([rec({}), rec({})], { minOccurrences: 3, minSpanDays: 2 });
+    expect(c.escalated).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest tests/unit/diagnostics/clustering.test.ts --run` Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/diagnostics/clustering.ts
+import { createHash } from 'crypto';
+import type { FailureRecord } from './failure-log.js';
+import { normalizeErrorMessage, normalizeInputShape } from './normalize.js';
+
+export interface ClusterOptions {
+  minOccurrences: number; // default 3
+  minSpanDays: number; // default 2
+}
+
+export interface FailureCluster {
+  fingerprint: string;
+  tool: string;
+  normalizedError: string;
+  inputShape: string;
+  count: number;
+  firstSeen: string;
+  lastSeen: string;
+  escalated: boolean;
+  example: FailureRecord; // first occurrence (inputArgs already redacted)
+}
+
+export function fingerprintOf(tool: string, normalizedError: string, inputShape: string): string {
+  return createHash('sha256').update(`${tool} ${normalizedError} ${inputShape}`).digest('hex').slice(0, 16);
+}
+
+export function clusterFailures(records: FailureRecord[], opts: ClusterOptions): FailureCluster[] {
+  const map = new Map<string, FailureCluster>();
+  for (const r of records) {
+    const normalizedError = normalizeErrorMessage(r.errorMessage);
+    const inputShape = normalizeInputShape(r.inputArgs);
+    const fp = fingerprintOf(r.tool, normalizedError, inputShape);
+    const existing = map.get(fp);
+    if (!existing) {
+      map.set(fp, {
+        fingerprint: fp,
+        tool: r.tool,
+        normalizedError,
+        inputShape,
+        count: 1,
+        firstSeen: r.timestamp,
+        lastSeen: r.timestamp,
+        escalated: false,
+        example: r,
+      });
+    } else {
+      existing.count++;
+      if (r.timestamp < existing.firstSeen) existing.firstSeen = r.timestamp;
+      if (r.timestamp > existing.lastSeen) existing.lastSeen = r.timestamp;
+    }
+  }
+  const DAY = 86_400_000;
+  for (const c of map.values()) {
+    const spanDays = (Date.parse(c.lastSeen) - Date.parse(c.firstSeen)) / DAY;
+    c.escalated = c.count >= opts.minOccurrences || spanDays >= opts.minSpanDays;
+  }
+  return [...map.values()];
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest tests/unit/diagnostics/clustering.test.ts --run` Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/clustering.ts tests/unit/diagnostics/clustering.test.ts
+git commit -m "feat(OMN-37): cluster failures with threshold + stable fingerprint"
+```
+
+---
+
+### Task 4: `classifyCluster` + ignore-set
+
+**Files:**
+
+- Modify: `src/diagnostics/clustering.ts` (append `classifyCluster`)
+- Test: `tests/unit/diagnostics/classify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/classify.test.ts
+import { describe, it, expect } from 'vitest';
+import { classifyCluster, isIgnored } from '../../../src/diagnostics/clustering.js';
+import type { FailureCluster } from '../../../src/diagnostics/clustering.js';
+
+const cluster = (over: Partial<FailureCluster>): FailureCluster => ({
+  fingerprint: 'abc',
+  tool: 't',
+  normalizedError: 'e',
+  inputShape: 'a',
+  count: 5,
+  firstSeen: '',
+  lastSeen: '',
+  escalated: true,
+  example: {
+    timestamp: '',
+    tool: 't',
+    errorType: 'VALIDATION_ERROR',
+    errorMessage: 'e',
+    inputArgs: {},
+    schemaDescription: 'd',
+  },
+  ...over,
+});
+
+describe('isIgnored', () => {
+  it('ignores data/infra noise classes', () => {
+    for (const t of ['INVALID_ID', 'NULL_RESULT', 'OMNIFOCUS_NOT_RUNNING', 'SCRIPT_TIMEOUT', 'CONNECTION_TIMEOUT']) {
+      expect(isIgnored(cluster({ example: { ...cluster({}).example, categorization: { errorType: t } } }))).toBe(true);
+    }
+  });
+  it('does not ignore validation errors', () => {
+    expect(isIgnored(cluster({}))).toBe(false);
+  });
+});
+
+describe('classifyCluster', () => {
+  it('classifies a Zod validation cluster as VALIDATION (candidate for drift/coercion/description)', () => {
+    expect(classifyCluster(cluster({}))).toBe('VALIDATION');
+  });
+  it('classifies an ignored cluster as DATA_ERROR', () => {
+    const c = cluster({
+      example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR', categorization: { errorType: 'INVALID_ID' } },
+    });
+    expect(classifyCluster(c)).toBe('DATA_ERROR');
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest tests/unit/diagnostics/classify.test.ts --run` Expected: FAIL — `classifyCluster`/`isIgnored` not
+exported.
+
+- [ ] **Step 3: Implement (append to `src/diagnostics/clustering.ts`)**
+
+```typescript
+const IGNORE_SET = new Set([
+  'INVALID_ID',
+  'NULL_RESULT',
+  'OMNIFOCUS_NOT_RUNNING',
+  'SCRIPT_TIMEOUT',
+  'CONNECTION_TIMEOUT',
+]);
+
+export function isIgnored(c: FailureCluster): boolean {
+  const cat = c.example.categorization?.errorType;
+  return cat !== undefined && IGNORE_SET.has(cat);
+}
+
+export type CoarseClass = 'VALIDATION' | 'EXECUTION' | 'DATA_ERROR';
+
+/** Coarse pre-classification. The fine SCHEMA_DRIFT/COERCION/DESCRIPTION split happens in the driver
+ *  (deterministic via schema-drift) or the LLM agent (residual). */
+export function classifyCluster(c: FailureCluster): CoarseClass {
+  if (isIgnored(c)) return 'DATA_ERROR';
+  return c.example.errorType === 'VALIDATION_ERROR' ? 'VALIDATION' : 'EXECUTION';
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest tests/unit/diagnostics/classify.test.ts --run` Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/clustering.ts tests/unit/diagnostics/classify.test.ts
+git commit -m "feat(OMN-37): coarse cluster classification + ignore-set"
+```
+
+---
+
+### Task 5: Refactor `analyze-tool-failures.ts` onto the module (golden test first)
+
+**Files:**
+
+- Create: `tests/unit/diagnostics/analyze-cli-golden.test.ts`
+- Modify: `scripts/analyze-tool-failures.ts` (replace inline parse + normalization with module imports; **CLI stdout
+  unchanged**)
+
+- [ ] **Step 1: Write the golden test that pins CURRENT output BEFORE refactor**
+
+```typescript
+// tests/unit/diagnostics/analyze-cli-golden.test.ts
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+
+// Drives the CLI against a fixture HOME so output is deterministic.
+function runCli(homeOverride: string): string {
+  return execFileSync('npx', ['tsx', 'scripts/analyze-tool-failures.ts', '--days=3650'], {
+    env: { ...process.env, HOME: homeOverride },
+    encoding: 'utf-8',
+  });
+}
+
+describe('analyze-failures CLI output is behavior-preserving', () => {
+  it('produces identical output before/after the module refactor (golden)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'omn37-'));
+    const dir = join(home, '.omnifocus-mcp', 'tool-failures');
+    mkdirSync(dir, { recursive: true });
+    const rows = [
+      {
+        timestamp: '2026-05-18T10:00:00.000Z',
+        tool: 'omnifocus_write',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'name: Required for task a1b2c3d4e5',
+        validationErrors: [{ path: ['name'], message: 'Required' }],
+        inputArgs: { flagged: true },
+        schemaDescription: 'd',
+      },
+      {
+        timestamp: '2026-05-18T11:00:00.000Z',
+        tool: 'omnifocus_write',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'name: Required for task f9e8d7c6b5',
+        validationErrors: [{ path: ['name'], message: 'Required' }],
+        inputArgs: { flagged: false },
+        schemaDescription: 'd',
+      },
+    ];
+    writeFileSync(join(dir, 'failures-2026-05-18.jsonl'), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    expect(runCli(home)).toMatchSnapshot();
+  });
+});
+```
+
+- [ ] **Step 2: Run to capture the snapshot against the UNMODIFIED script**
+
+Run: `npx vitest tests/unit/diagnostics/analyze-cli-golden.test.ts --run` Expected: PASS — snapshot written
+(`__snapshots__/analyze-cli-golden.test.ts.snap`). This snapshot is the contract.
+
+- [ ] **Step 3: Refactor the script to consume the module (no output change)**
+
+Replace the inline `JSON.parse` loop with `parseFailureLog`, and the inline `simpleError` regex (lines ≈119–122) with
+`normalizeErrorMessage` from `src/diagnostics/normalize.js`. Keep all `console.log` formatting, the `FailureStats`
+aggregation, sorting, recommendations, and arg parsing exactly as-is. Concretely:
+
+- Add imports: `import { parseFailureLog } from '../src/diagnostics/failure-log.js';` and
+  `import { normalizeErrorMessage } from '../src/diagnostics/normalize.js';`
+- Replace lines ≈59–82 (manual per-file `JSON.parse`/`try`) with: read each file's content, `parseFailureLog(content)`,
+  then `if (!specificTool || entry.tool === specificTool) failures.push(entry)`.
+- Replace the `const simpleError = failure.errorMessage.replace(...).replace(...).substring(0,100)` with
+  `const simpleError = normalizeErrorMessage(failure.errorMessage);`.
+
+- [ ] **Step 4: Run the golden test — output MUST be byte-identical**
+
+Run: `npx vitest tests/unit/diagnostics/analyze-cli-golden.test.ts --run` Expected: PASS with **no snapshot diff**. If
+the snapshot differs, the refactor changed behavior — revert and fix until identical.
+
+- [ ] **Step 5: Run full unit suite + commit**
+
+Run: `npm run test:unit` Expected: PASS (all existing + new diagnostics tests).
+
+```bash
+git add scripts/analyze-tool-failures.ts tests/unit/diagnostics/analyze-cli-golden.test.ts tests/unit/diagnostics/__snapshots__
+git commit -m "refactor(OMN-37): analyze-failures consumes shared clustering module (behavior-preserving)"
+```
+
+**Phase 1 ships here** — `npm run analyze-failures` unchanged; module reusable.
+
+---
+
+## Phase 2 — Schema-drift checker (highest standalone value; CI-failing)
+
+### Task 6: `canonicalizeInputSchema`
+
+**Files:**
+
+- Create: `src/diagnostics/schema-drift.ts`
+- Test: `tests/unit/diagnostics/schema-drift.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/schema-drift.test.ts
+import { describe, it, expect } from 'vitest';
+import { canonicalizeInputSchema } from '../../../src/diagnostics/schema-drift.js';
+
+describe('canonicalizeInputSchema', () => {
+  it('flattens advertised JSON schema to { field: { type, required, enum } }', () => {
+    const adv = {
+      type: 'object',
+      properties: {
+        operation: { type: 'string', enum: ['version', 'cache'] },
+        limit: { type: 'number' },
+      },
+      required: ['operation'],
+    };
+    const c = canonicalizeInputSchema(adv);
+    expect(c.operation).toEqual({ type: 'string', required: true, enum: ['version', 'cache'] });
+    expect(c.limit).toEqual({ type: 'number', required: false, enum: undefined });
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail.** `npx vitest tests/unit/diagnostics/schema-drift.test.ts --run` → FAIL (module not
+      found).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/diagnostics/schema-drift.ts
+export interface CanonicalField {
+  type: string;
+  required: boolean;
+  enum?: (string | number)[];
+  coercible?: boolean; // only meaningful for the Zod side
+}
+export type CanonicalSchema = Record<string, CanonicalField>;
+
+export function canonicalizeInputSchema(advertised: Record<string, unknown>): CanonicalSchema {
+  const props = (advertised.properties ?? {}) as Record<string, { type?: string; enum?: (string | number)[] }>;
+  const required = new Set((advertised.required as string[] | undefined) ?? []);
+  const out: CanonicalSchema = {};
+  for (const [name, def] of Object.entries(props)) {
+    out[name] = { type: def.type ?? 'unknown', required: required.has(name), enum: def.enum };
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run, verify pass.** Expected: PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/schema-drift.ts tests/unit/diagnostics/schema-drift.test.ts
+git commit -m "feat(OMN-37): canonicalize advertised inputSchema"
+```
+
+---
+
+### Task 7: `canonicalizeZodSchema` with behavioral coercibility probe
+
+**Files:**
+
+- Modify: `src/diagnostics/schema-drift.ts`
+- Modify: `tests/unit/diagnostics/schema-drift.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+```typescript
+import { z } from 'zod';
+import { canonicalizeZodSchema } from '../../../src/diagnostics/schema-drift.js';
+
+describe('canonicalizeZodSchema', () => {
+  it('marks z.coerce.number() fields coercible and bare z.number() non-coercible (behavioral probe, not syntactic)', () => {
+    const schema = z.object({
+      a: z.coerce.number(),
+      b: z.number(),
+      mode: z.enum(['x', 'y']),
+      note: z.string().optional(),
+    });
+    const c = canonicalizeZodSchema(schema);
+    expect(c.a.coercible).toBe(true); // z.coerce.number().safeParse('5') succeeds
+    expect(c.b.coercible).toBe(false); // z.number().safeParse('5') fails
+    expect(c.mode.enum).toEqual(['x', 'y']);
+    expect(c.note.required).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `canonicalizeZodSchema` not exported.
+
+- [ ] **Step 3: Implement (append). The coercibility check is a RUNTIME PROBE — never pattern-match source (see plan Key
+      Facts).**
+
+```typescript
+import { z } from 'zod';
+
+function isCoercibleNumber(field: z.ZodTypeAny): boolean {
+  // Behavioral: a number field is "coercible" iff a stringified number survives validation.
+  // Catches z.coerce.number(), z.preprocess(...), z.union([z.number(), z.string().transform()]) alike.
+  return field.safeParse('5').success;
+}
+
+function zodTypeName(field: z.ZodTypeAny): { type: string; enum?: (string | number)[] } {
+  const def = (field as { _def?: { typeName?: string; values?: unknown[] } })._def;
+  const tn = def?.typeName ?? '';
+  if (tn === 'ZodEnum') return { type: 'string', enum: def?.values as (string | number)[] };
+  if (tn === 'ZodNumber' || tn === 'ZodNumber') return { type: 'number' };
+  if (tn === 'ZodBoolean') return { type: 'boolean' };
+  if (tn === 'ZodString') return { type: 'string' };
+  return { type: 'object' };
+}
+
+export function canonicalizeZodSchema(schema: z.ZodTypeAny): CanonicalSchema {
+  // Unwrap effects/optional/default wrappers to reach the object shape.
+  let obj = schema;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const d = (obj as { _def?: { typeName?: string; schema?: z.ZodTypeAny; innerType?: z.ZodTypeAny } })._def;
+    if (d?.typeName === 'ZodEffects' && d.schema) obj = d.schema;
+    else if ((d?.typeName === 'ZodOptional' || d?.typeName === 'ZodDefault') && d.innerType) obj = d.innerType;
+    else break;
+  }
+  const shape = (obj as z.ZodObject<z.ZodRawShape>).shape ?? {};
+  const out: CanonicalSchema = {};
+  for (const [name, raw] of Object.entries(shape)) {
+    const field = raw as z.ZodTypeAny;
+    const isOptional = field.isOptional?.() ?? false;
+    const probeNumber = isCoercibleNumber(field);
+    const { type, enum: en } = zodTypeName(field);
+    out[name] = {
+      type: type === 'number' || probeNumber ? (type === 'object' ? 'number' : type) : type,
+      required: !isOptional,
+      enum: en,
+      coercible: probeNumber,
+    };
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run, verify pass.** Expected: PASS. If `zodTypeName` mis-detects on the real schemas, adjust unwrap
+      order — the behavioral probe (`isCoercibleNumber`) is the load-bearing part and must stay a `safeParse` call.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/schema-drift.ts tests/unit/diagnostics/schema-drift.test.ts
+git commit -m "feat(OMN-37): canonicalize Zod schema with behavioral coercibility probe"
+```
+
+---
+
+### Task 8: `diffSchemas` → `DriftFinding[]`
+
+**Files:**
+
+- Modify: `src/diagnostics/schema-drift.ts`
+- Modify: `tests/unit/diagnostics/schema-drift.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+```typescript
+import { diffSchemas } from '../../../src/diagnostics/schema-drift.js';
+
+describe('diffSchemas', () => {
+  it('reports FIELD_MISSING, ENUM_MISMATCH, REQUIRED_MISMATCH, COERCION_GAP', () => {
+    const advertised = canonicalizeInputSchema({
+      type: 'object',
+      properties: { mode: { type: 'string', enum: ['a', 'b'] }, limit: { type: 'number' }, ghost: { type: 'string' } },
+      required: ['mode'],
+    });
+    const zod = canonicalizeZodSchema(
+      z.object({
+        mode: z.enum(['a']), // ENUM_MISMATCH (b advertised, not validated)
+        limit: z.number(), // COERCION_GAP (advertised numeric, not coercible)
+        extra: z.string(), // advertised-missing (validated field never advertised)
+      }),
+    );
+    const findings = diffSchemas(advertised, zod);
+    const kinds = findings.map((f) => f.kind).sort();
+    expect(kinds).toContain('FIELD_MISSING'); // ghost advertised, not validated
+    expect(kinds).toContain('FIELD_MISSING'); // extra validated, not advertised
+    expect(kinds).toContain('ENUM_MISMATCH');
+    expect(kinds).toContain('COERCION_GAP');
+  });
+
+  it('returns [] for an aligned schema (no false positives on coerced numerics)', () => {
+    const advertised = canonicalizeInputSchema({
+      type: 'object',
+      properties: { limit: { type: 'number' } },
+      required: [],
+    });
+    const zod = canonicalizeZodSchema(z.object({ limit: z.coerce.number().optional() }));
+    expect(diffSchemas(advertised, zod)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement (append)**
+
+```typescript
+export type DriftKind = 'FIELD_MISSING' | 'ENUM_MISMATCH' | 'REQUIRED_MISMATCH' | 'COERCION_GAP';
+export interface DriftFinding {
+  kind: DriftKind;
+  field: string;
+  detail: string;
+}
+
+export function diffSchemas(advertised: CanonicalSchema, zod: CanonicalSchema): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  const fields = new Set([...Object.keys(advertised), ...Object.keys(zod)]);
+  for (const f of fields) {
+    const a = advertised[f];
+    const z = zod[f];
+    if (a && !z) {
+      findings.push({ kind: 'FIELD_MISSING', field: f, detail: 'advertised to LLM but not validated by Zod' });
+      continue;
+    }
+    if (!a && z) {
+      findings.push({ kind: 'FIELD_MISSING', field: f, detail: 'validated by Zod but never advertised to LLM' });
+      continue;
+    }
+    if (!a || !z) continue;
+    if (a.enum && z.enum && JSON.stringify([...a.enum].sort()) !== JSON.stringify([...z.enum].sort())) {
+      findings.push({ kind: 'ENUM_MISMATCH', field: f, detail: `advertised [${a.enum}] vs validated [${z.enum}]` });
+    }
+    if (a.required !== z.required) {
+      findings.push({
+        kind: 'REQUIRED_MISMATCH',
+        field: f,
+        detail: `advertised required=${a.required} vs validated required=${z.required}`,
+      });
+    }
+    if (a.type === 'number' && z.coercible === false) {
+      findings.push({
+        kind: 'COERCION_GAP',
+        field: f,
+        detail: 'advertised numeric but Zod rejects stringified input (Claude Desktop stringifies all params)',
+      });
+    }
+  }
+  return findings;
+}
+```
+
+- [ ] **Step 4: Run, verify pass.** Expected: PASS (both tests).
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/schema-drift.ts tests/unit/diagnostics/schema-drift.test.ts
+git commit -m "feat(OMN-37): diffSchemas drift findings (field/enum/required/coercion)"
+```
+
+---
+
+### Task 9: Tool-schema registry + CI-failing drift test for all 4 tools
+
+**Files:**
+
+- Create: `src/diagnostics/tool-schema-registry.ts`
+- Create: `tests/unit/diagnostics/schema-drift-tools.test.ts`
+
+- [ ] **Step 1: Write the test (this is the CI gate)**
+
+```typescript
+// tests/unit/diagnostics/schema-drift-tools.test.ts
+import { describe, it, expect } from 'vitest';
+import { TOOL_SCHEMA_REGISTRY } from '../../../src/diagnostics/tool-schema-registry.js';
+import { canonicalizeInputSchema, canonicalizeZodSchema, diffSchemas } from '../../../src/diagnostics/schema-drift.js';
+
+describe('inputSchema <-> Zod drift gate (fails CI on drift)', () => {
+  for (const entry of TOOL_SCHEMA_REGISTRY) {
+    it(`${entry.name}: advertised schema matches Zod validation`, () => {
+      const findings = diffSchemas(
+        canonicalizeInputSchema(entry.getInputSchema()),
+        canonicalizeZodSchema(entry.zodSchema),
+      );
+      // Some advertised-vs-validated asymmetry is intentional (compact advertised schema).
+      // The gate fails ONLY on the high-signal kinds: enum/required/coercion drift.
+      const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');
+      expect(blocking, JSON.stringify(findings, null, 2)).toEqual([]);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — registry not found.
+
+- [ ] **Step 3: Implement the registry**
+
+```typescript
+// src/diagnostics/tool-schema-registry.ts
+import type { z } from 'zod';
+import { CacheManager } from '../cache/CacheManager.js';
+import { SystemTool } from '../tools/system/SystemTool.js';
+import { SystemToolSchema } from '../tools/schemas/system-schemas.js';
+import { OmniFocusReadTool } from '../tools/unified/OmniFocusReadTool.js';
+import { OmniFocusWriteTool } from '../tools/unified/OmniFocusWriteTool.js';
+import { OmniFocusAnalyzeTool } from '../tools/unified/OmniFocusAnalyzeTool.js';
+import { ReadToolSchema } from '../tools/unified/schemas/read-schema.js';
+import { WriteToolSchema } from '../tools/unified/schemas/write-schema.js';
+import { AnalyzeToolSchema } from '../tools/unified/schemas/analyze-schema.js';
+
+export interface ToolSchemaEntry {
+  name: string;
+  getInputSchema: () => Record<string, unknown>;
+  zodSchema: z.ZodTypeAny;
+}
+
+const cache = new CacheManager();
+export const TOOL_SCHEMA_REGISTRY: ToolSchemaEntry[] = [
+  { name: 'system', getInputSchema: () => new SystemTool(cache).inputSchema, zodSchema: SystemToolSchema },
+  { name: 'omnifocus_read', getInputSchema: () => new OmniFocusReadTool(cache).inputSchema, zodSchema: ReadToolSchema },
+  {
+    name: 'omnifocus_write',
+    getInputSchema: () => new OmniFocusWriteTool(cache).inputSchema,
+    zodSchema: WriteToolSchema,
+  },
+  {
+    name: 'omnifocus_analyze',
+    getInputSchema: () => new OmniFocusAnalyzeTool(cache).inputSchema,
+    zodSchema: AnalyzeToolSchema,
+  },
+];
+```
+
+> **Implementer note:** verify the exact exported Zod schema symbol + path for each tool
+> (`grep -rn "export const .*Schema" src/tools/unified/schemas/ src/tools/schemas/`). The symbols above are the expected
+> names; correct them to the actual exports. If a tool's top-level Zod schema is a `discriminatedUnion` (write/analyze
+> use operation discriminators), `canonicalizeZodSchema` must fall back gracefully — extend the unwrap in Task 7 to take
+> the **common base fields** across union members, or scope the gate to `system` + `omnifocus_read` (object schemas) for
+> v1 and file a follow-up for the discriminated tools. Decide based on actual schema shapes; document the decision in
+> the commit message.
+
+- [ ] **Step 4: Run, verify pass** (or surface real drift)
+
+Run: `npx vitest tests/unit/diagnostics/schema-drift-tools.test.ts --run` Expected: PASS. **If it reports real drift,
+that is a genuine OMN-37 find** — do NOT loosen the assertion to make it pass. Record the finding, fix the underlying
+schema mismatch in a separate commit, or (if the drift is intentional/compact-by-design) add a narrowly-scoped
+documented allowlist entry. Escalate to the controller if unsure.
+
+- [ ] **Step 5: Run full suite + commit**
+
+Run: `npm run test:unit`
+
+```bash
+git add src/diagnostics/tool-schema-registry.ts tests/unit/diagnostics/schema-drift-tools.test.ts
+git commit -m "feat(OMN-37): CI drift gate for all advertised tool schemas"
+```
+
+**Phase 2 ships here** — drift now fails CI.
+
+---
+
+## Phase 3 — Diagnoser agent + Tier-1 driver
+
+### Task 10: Seen-patterns ledger
+
+**Files:**
+
+- Create: `src/diagnostics/ledger.ts`
+- Test: `tests/unit/diagnostics/ledger.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/ledger.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadLedger, recordDiagnosis, isKnown } from '../../../src/diagnostics/ledger.js';
+
+describe('seen-patterns ledger', () => {
+  it('round-trips and recognizes a known fingerprint', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'omn37led-')), 'diagnosed-patterns.json');
+    let ledger = loadLedger(path); // missing file → empty
+    expect(isKnown(ledger, 'fp1')).toBe(false);
+    ledger = recordDiagnosis(ledger, path, {
+      fingerprint: 'fp1',
+      classification: 'SCHEMA_DRIFT',
+      linearIssueId: 'OMN-99',
+    });
+    expect(isKnown(loadLedger(path), 'fp1')).toBe(true);
+    expect(loadLedger(path).entries['fp1'].linearIssueId).toBe('OMN-99');
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/diagnostics/ledger.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+
+export interface LedgerEntry {
+  fingerprint: string;
+  classification: string;
+  linearIssueId?: string;
+  diagnosedAt: string;
+}
+export interface Ledger {
+  entries: Record<string, LedgerEntry>;
+}
+
+/** Default path: ~/.omnifocus-mcp/diagnosed-patterns.json — SIBLING of tool-failures/, not nested inside it. */
+export function defaultLedgerPath(): string {
+  return join(homedir(), '.omnifocus-mcp', 'diagnosed-patterns.json');
+}
+
+export function loadLedger(path = defaultLedgerPath()): Ledger {
+  if (!existsSync(path)) return { entries: {} };
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Ledger;
+  } catch {
+    return { entries: {} };
+  }
+}
+
+export function isKnown(ledger: Ledger, fingerprint: string): boolean {
+  return fingerprint in ledger.entries;
+}
+
+export function recordDiagnosis(ledger: Ledger, path: string, e: Omit<LedgerEntry, 'diagnosedAt'>): Ledger {
+  const next: Ledger = {
+    entries: { ...ledger.entries, [e.fingerprint]: { ...e, diagnosedAt: new Date().toISOString() } },
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(next, null, 2));
+  return next;
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostics/ledger.ts tests/unit/diagnostics/ledger.test.ts
+git commit -m "feat(OMN-37): seen-patterns ledger (sibling of tool-failures/)"
+```
+
+---
+
+### Task 11: Triage-doc renderer
+
+**Files:**
+
+- Create: `src/diagnostics/triage-doc.ts`
+- Test: `tests/unit/diagnostics/triage-doc.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/diagnostics/triage-doc.test.ts
+import { describe, it, expect } from 'vitest';
+import { renderTriageDoc } from '../../../src/diagnostics/triage-doc.js';
+
+describe('renderTriageDoc', () => {
+  it('renders a tables-over-prose markdown doc, one row per pattern, with fingerprint', () => {
+    const md = renderTriageDoc(
+      [
+        {
+          fingerprint: 'abc123',
+          tool: 'omnifocus_write',
+          classification: 'SCHEMA_DRIFT',
+          suggestedFix: 'add coerceNumber to limit',
+          firstSeen: '2026-05-10',
+          lastSeen: '2026-05-18',
+          count: 7,
+        },
+      ],
+      new Date('2026-05-18T12:00:00Z'),
+    );
+    expect(md).toContain('# MCP Failure Triage');
+    expect(md).toContain('| Fingerprint | Tool | Classification |');
+    expect(md).toContain('| abc123 | omnifocus_write | SCHEMA_DRIFT |');
+    expect(md).toContain('CAP_GUARD'); // legend documents the sentinel even when unused
+  });
+});
+```
+
+- [ ] **Step 2–4:** Run-fail → implement `renderTriageDoc(rows, now)` returning a deterministic markdown string: title,
+      generated-at line, a single sorted table
+      (`Fingerprint | Tool | Classification | Suggested fix | First seen | Last seen | Count`), and a legend explaining
+      classes + the `CAP_GUARD_TRIPPED` sentinel row. Sort rows by `count` desc then `fingerprint` for deterministic
+      output. Run-pass.
+- [ ] **Step 5: Commit** `feat(OMN-37): triage-doc markdown renderer`
+
+---
+
+### Task 12: `mcp-failure-diagnoser` agent file
+
+**Files:**
+
+- Create: `.claude/agents/mcp-failure-diagnoser.md`
+- Test: `tests/unit/diagnostics/diagnoser-agent.test.ts` (structural)
+
+- [ ] **Step 1: Write the structural test**
+
+```typescript
+// tests/unit/diagnostics/diagnoser-agent.test.ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('mcp-failure-diagnoser agent', () => {
+  it('has frontmatter name/description and enumerates the five classifications', () => {
+    const md = readFileSync(join(process.cwd(), '.claude/agents/mcp-failure-diagnoser.md'), 'utf-8');
+    expect(md).toMatch(/^---[\s\S]*name:\s*mcp-failure-diagnoser[\s\S]*---/);
+    for (const k of ['SCHEMA_DRIFT', 'DESCRIPTION_GAP', 'COERCION_MISSING', 'LLM_EXPLORATION', 'DATA_ERROR']) {
+      expect(md).toContain(k);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** (file absent).
+- [ ] **Step 3: Author the agent** — sibling style to `.claude/agents/code-standards-reviewer.md`. Frontmatter
+      `name: mcp-failure-diagnoser`, `description:` (when to use). Body: role = given ONE cluster (tool, normalized
+      error, example redacted inputArgs, the tool's live advertised inputSchema + Zod canonical), read the tool
+      description, emit exactly one classification of {SCHEMA_DRIFT, DESCRIPTION_GAP, COERCION_MISSING, LLM_EXPLORATION
+      (no-op), DATA_ERROR (no-op)} + one-line suggested fix. Explicit instruction: deterministic SCHEMA_DRIFT/COERCION
+      already handled upstream — only adjudicate ambiguous DESCRIPTION_GAP vs LLM_EXPLORATION. Output a fenced JSON
+      block `{ "classification": "...", "suggestedFix": "..." }`.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** `feat(OMN-37): mcp-failure-diagnoser agent`
+
+---
+
+### Task 13: `diagnose-failures` driver (deterministic path) + npm script
+
+**Files:**
+
+- Create: `scripts/diagnose-failures.ts`
+- Modify: `package.json` (add `"diagnose-failures": "npx tsx scripts/diagnose-failures.ts"`)
+- Test: `tests/unit/diagnostics/diagnose-driver.test.ts`
+
+- [ ] **Step 1: Write the failing test (pure orchestration via injected deps)**
+
+Structure `scripts/diagnose-failures.ts` so the orchestration core is an exported pure function
+`runDiagnosis(opts: { logDir, ledgerPath, now, registry, fileSink, agentRunner?, linearFiler? })` and the CLI is a thin
+wrapper. Test:
+
+```typescript
+// tests/unit/diagnostics/diagnose-driver.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { runDiagnosis } from '../../../scripts/diagnose-failures.js';
+import { z } from 'zod';
+
+it('deterministically classifies a coercion-gap cluster without invoking the agent', async () => {
+  const agentRunner = vi.fn();
+  const sink = vi.fn();
+  await runDiagnosis({
+    records: [
+      /* 3x omnifocus_x failures whose inputShape includes a numeric field the Zod rejects as string */
+    ],
+    registry: [
+      {
+        name: 'omnifocus_x',
+        getInputSchema: () => ({ type: 'object', properties: { limit: { type: 'number' } } }),
+        zodSchema: z.object({ limit: z.number() }),
+      },
+    ],
+    ledgerPath: '/tmp/omn37-test-ledger.json',
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    agentRunner,
+  });
+  expect(agentRunner).not.toHaveBeenCalled(); // deterministic class → no LLM
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+  expect(md).toContain('COERCION');
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement `runDiagnosis`**: parse→cluster (Task 3) with thresholds → drop
+      ignored/un-escalated/ledger-known → for each escalated cluster: run `diffSchemas` for that tool (Task 8); if drift
+      findings → deterministic classification (`COERCION_GAP`→`COERCION_MISSING`, others→`SCHEMA_DRIFT`); else push to
+      `agentRunner` (residual). Build triage rows, call `writeTriageDoc(renderTriageDoc(rows, now))`, record each into
+      the ledger. CLI wrapper resolves real deps (`logDir = ~/.omnifocus-mcp/tool-failures`,
+      `registry = TOOL_SCHEMA_REGISTRY`, `writeTriageDoc` = write `docs/dev/mcp-failure-triage.md`, `agentRunner` =
+      spawn the agent or, if unavailable, mark `NEEDS_LLM` and skip). `agentRunner` is OPTIONAL and **omitted in
+      tests**.
+- [ ] **Step 4: Run, verify pass** + `npm run test:unit`.
+- [ ] **Step 5: Commit** `feat(OMN-37): diagnose-failures Tier-1 driver (deterministic path)`
+
+**Phase 3 ships here** — `npm run diagnose-failures` writes the committed triage doc; agent invoked only for residue.
+
+---
+
+## Phase 4 — Auto-Linear (guardrailed)
+
+### Task 14: `linear-filer` — cap guard, fingerprint dedup, per-run limit
+
+**Files:**
+
+- Create: `src/diagnostics/linear-filer.ts`
+- Test: `tests/unit/diagnostics/linear-filer.test.ts`
+
+The Linear API is injected as `LinearClient` interface
+(`{ openIssueCount(): Promise<number>; searchByLabelAndBody(label, needle): Promise<string[]>; createIssue(input): Promise<string> }`)
+— fully mocked in tests; no network in unit tests.
+
+- [ ] **Step 1: Write the failing tests** (one per guard)
+
+```typescript
+// tests/unit/diagnostics/linear-filer.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { fileDriftIssues } from '../../../src/diagnostics/linear-filer.js';
+
+const cluster = (fp: string, cls: string) => ({
+  fingerprint: fp,
+  tool: 't',
+  classification: cls,
+  suggestedFix: 'fix',
+  firstSeen: '',
+  lastSeen: '',
+  count: 5,
+});
+
+it('files ONLY SCHEMA_DRIFT, never judgment/no-op classes', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue([]),
+    createIssue: vi.fn().mockResolvedValue('OMN-1'),
+  };
+  await fileDriftIssues(
+    [cluster('a', 'SCHEMA_DRIFT'), cluster('b', 'DESCRIPTION_GAP'), cluster('c', 'COERCION_MISSING')],
+    { client, perRunLimit: 3, capThreshold: 230 },
+  );
+  expect(client.createIssue).toHaveBeenCalledTimes(1);
+});
+
+it('trips the cap guard at >= capThreshold and creates nothing', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(230),
+    searchByLabelAndBody: vi.fn(),
+    createIssue: vi.fn(),
+  };
+  const r = await fileDriftIssues([cluster('a', 'SCHEMA_DRIFT')], { client, perRunLimit: 3, capThreshold: 230 });
+  expect(client.createIssue).not.toHaveBeenCalled();
+  expect(r.capGuardTripped).toBe(true);
+});
+
+it('dedups against an existing issue with the same fingerprint in body', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue(['OMN-7']),
+    createIssue: vi.fn(),
+  };
+  await fileDriftIssues([cluster('dup', 'SCHEMA_DRIFT')], { client, perRunLimit: 3, capThreshold: 230 });
+  expect(client.createIssue).not.toHaveBeenCalled();
+});
+
+it('caps creations at perRunLimit', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue([]),
+    createIssue: vi.fn().mockResolvedValue('OMN-X'),
+  };
+  await fileDriftIssues(
+    [
+      cluster('a', 'SCHEMA_DRIFT'),
+      cluster('b', 'SCHEMA_DRIFT'),
+      cluster('c', 'SCHEMA_DRIFT'),
+      cluster('d', 'SCHEMA_DRIFT'),
+    ],
+    { client, perRunLimit: 3, capThreshold: 230 },
+  );
+  expect(client.createIssue).toHaveBeenCalledTimes(3);
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement `fileDriftIssues`** enforcing, in order: (1) filter to `classification === 'SCHEMA_DRIFT'`;
+      (2) `await client.openIssueCount()` — if `>= capThreshold` return `{ created: [], capGuardTripped: true }` (caller
+      emits the `CAP_GUARD_TRIPPED` triage row); (3) per cluster, `searchByLabelAndBody('omn-37-auto', fingerprint)` —
+      non-empty → skip; (4) stop at `perRunLimit`; (5) `createIssue` with body embedding the fingerprint verbatim +
+      label `omn-37-auto`; return created IDs for the ledger. Document that the concrete `LinearClient` impl uses the
+      Linear MCP **`graphql` action** (not typed `search`) for both `openIssueCount`
+      (`state.type nin [completed,canceled]` across OMN+GATE) and the dedup query.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** `feat(OMN-37): guardrailed auto-Linear filer (cap/dedup/limit)`
+
+---
+
+### Task 15: Wire `--create-issues` into the driver
+
+**Files:**
+
+- Modify: `scripts/diagnose-failures.ts`
+- Modify: `tests/unit/diagnostics/diagnose-driver.test.ts`
+
+- [ ] **Step 1: Add a test** asserting that without `--create-issues` the injected `linearFiler` is never called, and
+      with it, only `SCHEMA_DRIFT` clusters are passed and the returned issue IDs are written into the ledger, and a
+      `CAP_GUARD_TRIPPED` row is appended to the triage doc when `capGuardTripped`.
+- [ ] **Step 2:** Run, verify fail.
+- [ ] **Step 3:** Thread an optional `linearFiler` dep + `createIssues` flag through `runDiagnosis`; default off. CLI
+      wires the real graphql-backed `LinearClient` only when `--create-issues` is passed.
+- [ ] **Step 4:** Run, verify pass + `npm run test:unit`.
+- [ ] **Step 5: Commit** `feat(OMN-37): opt-in --create-issues wiring with ledger + cap-row`
+
+**Phase 4 ships here.**
+
+---
+
+## Phase 5 — Tier-2 hook (local, optional) + scheduling doc
+
+### Task 16: PostToolUse marker hook in `.claude/settings.local.json`
+
+**Files:**
+
+- Modify/Create: `.claude/settings.local.json` (gitignored — confirm via `git check-ignore .claude/settings.local.json`)
+- Create: `scripts/mcp-failure-marker.sh` (in-repo, the cheap appender the hook calls)
+- Test: `tests/unit/diagnostics/marker-script.test.ts`
+
+- [ ] **Step 1: Write the failing test** — invoke `scripts/mcp-failure-marker.sh` with a fake tool name + a temp marker
+      path env var; assert it appends exactly one `ISO8601\ttool` line and never spawns anything (grep the script: must
+      NOT contain `claude -p`).
+- [ ] **Step 2:** Run, verify fail.
+- [ ] **Step 3:** Implement the 3-line shell appender
+      (`echo "$(date -u +%FT%TZ)\t$1" >> "${OMN37_MARKER:-$HOME/.omnifocus-mcp/fresh-failures.tsv}"`). Add the
+      `.claude/settings.local.json` `hooks.PostToolUse` entry: matcher `mcp__omnifocus__*`, command invoking the marker
+      script with the tool name, no condition that could spawn an agent. Document that this file is local-only.
+- [ ] **Step 4:** Run, verify pass.
+- [ ] **Step 5: Commit** `feat(OMN-37): Tier-2 PostToolUse marker hook (local, no agent spawn)` (only
+      `scripts/mcp-failure-marker.sh` + test are committed; settings.local.json is gitignored — note this in the commit
+      body).
+
+---
+
+### Task 17: Operator doc incl. untracked `~/bin` scheduling wrapper
+
+**Files:**
+
+- Create: `docs/dev/mcp-failure-diagnosis.md`
+- Modify: `docs/dev/PATTERNS.md` (one symptom-index row → link the new doc) — only if PATTERNS.md has a stable section
+  to append to; else skip and note.
+
+- [ ] **Step 1:** Write `docs/dev/mcp-failure-diagnosis.md` (tables-over-prose per repo standards): the pipeline
+      overview, `npm run analyze-failures` vs `npm run diagnose-failures [--create-issues]`, the threshold flags, the
+      ledger location, the triage doc location, the Tier-2 hook (local), and a copy-pasteable **untracked**
+      `~/bin/of-mcp-diagnose` cron/launchd recipe (sibling precedent: `of-mcp-redeploy`) — explicitly stated as NOT
+      committed and machine-specific.
+- [ ] **Step 2:** Verify all referenced `src/`+`docs/` paths resolve (CLAUDE.md path guard from OMN-68 will fail CI
+      otherwise): `npm run test:unit -- tests/unit/docs/claude-md-paths.test.ts` is unaffected (we don't edit
+      CLAUDE.md), but keep the new doc's internal refs literal.
+- [ ] **Step 3:** `npm run test:unit` (full) + `npm run build`.
+- [ ] **Step 4: Commit** `docs(OMN-37): operator guide + scheduling recipe`
+
+**Phase 5 ships here. Feature complete.**
+
+---
+
+## Final verification (before requesting review / PR)
+
+- [ ] `npm run build` — clean.
+- [ ] `npm run test:unit` — all green, including the new drift gate and golden snapshot.
+- [ ] `npm run analyze-failures` — manual smoke: output visually identical to pre-refactor (golden test already pins
+      this).
+- [ ] `npm run diagnose-failures` against a seeded fixture log — triage doc generated, ledger written, agent not spawned
+      for deterministic classes.
+- [ ] Confirm `.claude/settings.local.json` is gitignored and NOT staged.
+- [ ] Per repo norm (memory: `feedback_review_before_merge`): dispatch a code-reviewer subagent as a hard pre-merge
+      gate; gate the PR on a SAFE/Yes verdict; merge via `gh pr merge --squash --auto` (never `--admin`); PR targets
+      `kip-d/omnifocus-mcp`.
+
+## Notes for the implementer
+
+- TDD is mandatory (`superpowers:test-driven-development`): test → red → minimal green → commit, every task.
+- The Phase-2 drift gate finding **real** drift is success, not failure — never weaken an assertion to get green;
+  surface it.
+- `inputArgs` in the log is already redacted (`redactArgs`, logger.ts:45). Never re-redact, never print raw, never add
+  new PII sinks.
+- The coercibility check is a **runtime `safeParse` probe**, never a source pattern-match (CLAUDE.md's `z.union`
+  phrasing is stale; reality is `coercion-helpers.ts`).
+- Zod schema symbol names in Task 9 are expected names — `grep` and correct to actual exports before implementing;
+  handle discriminated-union top-level schemas per the Task 9 implementer note.
+- Phases 1, 2, 3, 4, 5 are each independently shippable in that order; a reviewer/PR boundary after Phase 2 is
+  reasonable if scope needs splitting.

--- a/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
+++ b/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
@@ -725,6 +725,9 @@ describe('canonicalizeZodSchema', () => {
       note: z.string().optional(),
     });
     const c = canonicalizeZodSchema(schema);
+    // NOTE: `coercible` is only meaningful for NUMERIC fields. A non-numeric optional like
+    // `note` also probes coercible=true (z.string().optional().safeParse('5') succeeds); that
+    // is harmless because diffSchemas only consults `coercible` when advertised type==='number'.
     expect(c.a.coercible).toBe(true); // z.coerce.number().safeParse('5') succeeds
     expect(c.b.coercible).toBe(false); // z.number().safeParse('5') fails
     expect(c.mode.enum).toEqual(['x', 'y']);
@@ -1075,6 +1078,12 @@ export const TOOL_SCHEMA_REGISTRY: ToolSchemaEntry[] = [
 > viable "scope to system + read" shortcut — read/write/analyze are all the same wrapped-DU shape; the merge is
 > mandatory for Phase 2 to deliver any value (do not let the gate pass vacuously — see the session "vacuous-green"
 > lesson, OMN-65).
+>
+> **Scope boundary (intentional, not a bug):** this static gate canonicalizes only the depth-1 field shape of each tool.
+> Deeper nested sub-schemas — e.g. the per-item `operation` inside `WriteSchema`'s batch array, or nested object filters
+> — are deliberately out of scope; both canonicalizers read one level so they stay symmetric and the gate confirms 0
+> drift. A future maintainer should not "fix" the depth-1 limitation: deeper drift detection is a separate, larger
+> effort (candidate follow-up), not an omission in this task.
 
 - [ ] **Step 4: Run, verify pass** (or surface real drift)
 

--- a/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
+++ b/docs/superpowers/plans/2026-05-18-omn-37-mcp-failure-diagnosis.md
@@ -1300,7 +1300,10 @@ wrapper. Test:
 
 ```typescript
 // tests/unit/diagnostics/diagnose-driver.test.ts
-import { describe, it, expect, vi } from 'vitest';
+import { it, expect, vi } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { runDiagnosis } from '../../../scripts/diagnose-failures.js';
 import { z } from 'zod';
 
@@ -1308,9 +1311,27 @@ it('deterministically classifies a coercion-gap cluster without invoking the age
   const agentRunner = vi.fn();
   const sink = vi.fn();
   await runDiagnosis({
-    records: [
-      /* 3x omnifocus_x failures whose inputShape includes a numeric field the Zod rejects as string */
-    ],
+    // NON-VACUOUS: 3 real records (spanning the minSpanDays window) for a single
+    // omnifocus_x cluster whose inputArgs send limit:'5' (a string). The advertised
+    // schema says limit:number but Zod (z.number()) rejects '5' → COERCION_GAP →
+    // deterministic COERCION_MISSING, so the agent is bypassed *because it was resolved*,
+    // not because there was nothing to dispatch. Do NOT leave this as an empty array /
+    // placeholder comment — that makes the agent-not-called + COERCION assertions
+    // vacuously true off the static legend (TDD red flag: green before implementation).
+    records: (() => {
+      const base = {
+        tool: 'omnifocus_x',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'Expected number, received string',
+        inputArgs: { limit: '5' },
+        schemaDescription: 'test',
+      };
+      return [
+        { ...base, timestamp: '2026-05-16T10:00:00.000Z' },
+        { ...base, timestamp: '2026-05-17T10:00:00.000Z' },
+        { ...base, timestamp: '2026-05-18T10:00:00.000Z' },
+      ];
+    })(),
     registry: [
       {
         name: 'omnifocus_x',
@@ -1318,7 +1339,7 @@ it('deterministically classifies a coercion-gap cluster without invoking the age
         zodSchema: z.object({ limit: z.number() }),
       },
     ],
-    ledgerPath: '/tmp/omn37-test-ledger.json',
+    ledgerPath: join(mkdtempSync(join(tmpdir(), 'omn37-drv-')), 'ledger.json'),
     now: new Date('2026-05-18T12:00:00Z'),
     thresholds: { minOccurrences: 3, minSpanDays: 2 },
     writeTriageDoc: sink,
@@ -1327,7 +1348,13 @@ it('deterministically classifies a coercion-gap cluster without invoking the age
   expect(agentRunner).not.toHaveBeenCalled(); // deterministic class → no LLM
   expect(sink).toHaveBeenCalledOnce();
   const md = sink.mock.calls[0][0] as string;
-  expect(md).toContain('COERCION');
+  // Assert the actual classified table row — NOT the static legend (the legend line
+  // for COERCION_MISSING does not carry the tool name, so a line with BOTH is the data row).
+  const classifiedRow = md
+    .split('\n')
+    .find((line) => line.includes('omnifocus_x') && line.includes('COERCION_MISSING'));
+  expect(classifiedRow).toBeDefined();
+  expect(classifiedRow).toMatch(/^\|.*\|.*\|/);
 });
 ```
 

--- a/docs/superpowers/specs/2026-05-18-omn-37-mcp-failure-diagnosis-design.md
+++ b/docs/superpowers/specs/2026-05-18-omn-37-mcp-failure-diagnosis-design.md
@@ -1,0 +1,154 @@
+# OMN-37 — Auto-diagnose MCP tool failures (log-based Tier-1, optional Tier-2 hook)
+
+Date: 2026-05-18 Linear: OMN-37 Status: Design approved — pending spec review
+
+## Problem
+
+During dogfooding across multiple Claude Code projects, the LLM occasionally makes MCP calls that fail due to schema
+mismatches or misleading tool descriptions. It self-corrects on retry, so the failure is invisible — but each failure is
+signal for one of: **schema drift** (`inputSchema` advertised to the LLM diverged from the Zod schema that actually
+validates), **description gap** (the description implies a capability/syntax that does not exist), **missing coercion**
+(Claude Desktop stringifies a param the schema does not accept), or **ambiguous field name** (a plausible-but-wrong
+guess). The dual-schema architecture makes drift _inevitable over time_; this work automates its detection and turns the
+ignored failure stream into actionable triage.
+
+The ticket's title proposes a `PostToolUse` hook as the trigger. **That mechanism is rejected as the primary path** and
+demoted to an optional Tier-2: production MCP traffic runs under Claude Desktop, which never executes Claude Code hooks,
+so a hook-first design would be structurally blind to the exact failure population it exists to catch. The durable JSONL
+failure log is client-agnostic and already captures every failure regardless of client.
+
+## Key facts (reuse, don't reinvent)
+
+Verified against current main `2ce9255` (line numbers may shift; symbols are stable anchors):
+
+| Capability                                                                                                                                                                   | Location                                                                                                                                                | Status                                                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Per-failure JSONL log (`failures-YYYY-MM-DD.jsonl`: timestamp, tool, errorType, errorMessage, validationErrors, redacted `inputArgs`, `schemaDescription`, `categorization`) | `src/tools/base.ts` `logToolFailure()` (≈:301; call sites ≈:266 Zod, ≈:280 exec, ≈:639)                                                                 | Mature — reuse as-is                                                                |
+| Error taxonomy                                                                                                                                                               | `src/utils/error-taxonomy.ts` — `ScriptErrorType` enum (≈:13), `categorizeError()` (≈:83), `isRecoverableError()` (≈:360), `getErrorSeverity()` (≈:385) | Mature — classification source of truth                                             |
+| Batch analyzer + normalization (IDs/dates → placeholders)                                                                                                                    | `scripts/analyze-tool-failures.ts` (`npm run analyze-failures`); normalization ≈:119                                                                    | Closest prior art — to be refactored onto the new module                            |
+| Hand-crafted `inputSchema` getters                                                                                                                                           | `OmniFocusReadTool.ts` `get inputSchema()` (≈:217), `OmniFocusWriteTool.ts` (≈:177), `OmniFocusAnalyzeTool.ts` (≈:310), `SystemTool.ts` (≈:128)         | Readable for drift diff                                                             |
+| Zod schemas                                                                                                                                                                  | `src/tools/unified/schemas/` — `read-schema.ts`, `write-schema.ts`, `analyze-schema.ts`, `batch-schemas.ts`                                             | Statically importable for drift diff                                                |
+| Numeric-coercion convention                                                                                                                                                  | CLAUDE.md: `z.union([z.number(), z.string().transform(...)])` for every MCP numeric                                                                     | The `COERCION_MISSING` rule keys off this — flag only numerics _lacking_ this shape |
+
+**Confirmed absent on `2ce9255`** (these are the build targets): no `hooks` block in `.claude/settings*.json`, no
+`mcp-failure-diagnoser` agent, no `docs/dev/mcp-failure-triage.md`, no `diagnose-failures` npm script, no
+inputSchema↔Zod drift checker.
+
+## Scope (decided)
+
+| Decision                    | Resolution                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- |
+| v1 scope                    | **Full phases 1–5**                                                                                     |
+| Phase-3 output sink         | **Triage doc + auto-Linear** (guardrailed — see §4)                                                     |
+| Tier-1 escalation threshold | **≥3 occurrences OR cluster spans ≥2 days** (driver-configurable)                                       |
+| Phase-5 scheduling          | **Untracked local `~/bin` cron wrapper**; the only in-repo deliverable is `npm run diagnose-failures`   |
+| Primary trigger             | **Log-based batch (Tier-1)**. The `PostToolUse` hook is Tier-2 (cheap local prioritization marker only) |
+
+Architectural forks resolved: **A1** (extract one shared clustering module; the existing CLI becomes a thin presenter —
+building a second pipeline would reproduce the very drift this ticket exists to catch), **B1** (static structural schema
+diff, shipped as a CI-failing unit test _and_ exported to the driver), **C1** (deterministic driver classifies inline;
+the LLM agent is invoked _only_ for residual non-deterministic clusters — bounded, reproducible token cost).
+
+## Design
+
+### §1 — Phase 1: `failure-clustering` module
+
+New `src/diagnostics/failure-clustering.ts` + `tests/unit/diagnostics/failure-clustering.test.ts`. Pure,
+side-effect-free functions:
+
+- `parseFailureLog(jsonl: string): FailureRecord[]` — tolerant line parse; skips malformed lines without throwing.
+- `normalizeRecord(r): NormalizedRecord` — IDs/dates/paths → placeholders. Reuses the existing normalization logic from
+  `analyze-tool-failures.ts:119` (extracted, not duplicated).
+- `clusterFailures(records, opts): FailureCluster[]` — groups by `(tool, normalizedError, normalizedInputShape)`;
+  `opts = { minOccurrences: 3, minSpanDays: 2 }`; a cluster escalates if `count ≥ minOccurrences` **OR**
+  `lastSeen − firstSeen ≥ minSpanDays`. Each cluster carries `firstSeen`, `lastSeen`, `count`, an example redacted
+  `inputArgs`, and a stable `fingerprint` (hash of `tool + normalizedError + normalizedInputShape`).
+- `classifyCluster(cluster): TaxonomyClass` — delegates to `error-taxonomy.ts`; the ignore-set (`INVALID_ID`,
+  `NULL_RESULT`, `OMNIFOCUS_NOT_RUNNING`, `*_TIMEOUT`) is filtered here.
+
+`scripts/analyze-tool-failures.ts` is refactored to consume this module; **`npm run analyze-failures` output is
+unchanged** — a golden/snapshot test pins the existing CLI output so the refactor is provably behavior-preserving.
+
+### §2 — Phase 2: schema-drift checker
+
+New `src/diagnostics/schema-drift.ts` + `tests/unit/diagnostics/schema-drift.test.ts`:
+
+- `canonicalizeInputSchema(advertised): CanonicalSchema` and `canonicalizeZodSchema(zod): CanonicalSchema` — both reduce
+  to `{ field → { type, required, enum?, coercible } }`.
+- `diffSchemas(advertised, zod): DriftFinding[]` — finding kinds: `FIELD_MISSING` (advertised/validated asymmetry),
+  `ENUM_MISMATCH`, `REQUIRED_MISMATCH`, `COERCION_GAP`. The `COERCION_GAP` rule encodes the CLAUDE.md
+  `z.union([z.number(), z.string().transform()])` convention so it flags **only** numeric fields lacking that shape —
+  eliminating the false-positive class called out in the investigation's open question #5.
+- Wired into `tests/unit/` so **drift fails CI** for all four tools (`omnifocus_read/write/analyze`, `system`); the same
+  function is exported for the Tier-1 driver.
+
+This is the highest standalone value: it attacks the inevitable dual-schema-drift problem directly, with zero dependency
+on the failure log, agent, or hook.
+
+### §3 — Phase 3: diagnoser agent + Tier-1 driver
+
+- New `.claude/agents/mcp-failure-diagnoser.md` — sibling to `code-standards-reviewer.md` / `jxa-omnifocus-expert.md`.
+  Input: a single deduplicated cluster (tool + normalized error + example `inputArgs` + the tool's live `inputSchema`
+  and Zod schema). It reads description + both schemas and emits one classification: `SCHEMA_DRIFT` / `DESCRIPTION_GAP`
+  / `COERCION_MISSING` / `LLM_EXPLORATION` (no-op) / `DATA_ERROR` (no-op), plus a one-line suggested fix.
+- New `scripts/diagnose-failures.ts` + `npm run diagnose-failures` (mirrors the `analyze-failures` script entry). Flow:
+  1. Cluster the log (§1), keep only clusters above threshold and not in the ignore-set.
+  2. Run schema-drift (§2); deterministic `SCHEMA_DRIFT` / `COERCION_MISSING` are classified **inline** (no LLM).
+  3. Residual clusters (ambiguous / candidate `DESCRIPTION_GAP`) → dispatch to the `mcp-failure-diagnoser` agent (Fork
+     C1 — bounded LLM cost).
+  4. Write `docs/dev/mcp-failure-triage.md` (committed; tables-over-prose per repo standards): one row per pattern —
+     classification, suggested fix, first-seen, last-seen, count, fingerprint.
+- **Seen-patterns ledger** `~/.omnifocus-mcp/diagnosed-patterns.json` (outside the repo; the failure log already lives
+  under `~/.omnifocus-mcp/`). Keyed by `fingerprint`; records classification + any created Linear issue ID. A cluster
+  whose fingerprint is in the ledger is **not** re-diagnosed and **not** re-filed.
+
+### §4 — Phase 3b: auto-Linear (cap-risk surface — explicit guardrails)
+
+The 250 non-archived-issue free-tier cap is **workspace-wide across OMN+GATE**. Auto-creation is constrained:
+
+| Guard                | Rule                                                                                                                                                                              |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Class allowlist      | Create issues **only** for deterministic `SCHEMA_DRIFT`. Never for LLM-judgment classes (`DESCRIPTION_GAP`) or no-op classes.                                                     |
+| Existing-issue dedup | Before creating, Linear-search OMN for the cluster `fingerprint` (embedded verbatim in every auto-issue body). Match → update/skip, never duplicate.                              |
+| Cap-safety guard     | Query open OMN+GATE count (graphql, `state.type nin [completed,canceled]`). If **≥ 230**, skip all creation, write triage rows only, emit a loud `CAP_GUARD_TRIPPED` warning row. |
+| Per-run limit        | Create at most **3** new issues per run.                                                                                                                                          |
+| Traceability         | Every auto-issue carries an `omn-37-auto` label + the fingerprint in the body, so a sweep can find/triage/bulk-archive them.                                                      |
+| Ledger               | Created issue ID written to the seen-patterns ledger → never recreated.                                                                                                           |
+
+### §5 — Phases 4+5: Tier-2 hook + scheduling
+
+- **Phase 4 (Tier-2 hook, optional, dev-only):** a `PostToolUse` matcher `mcp__omnifocus__*` in
+  `.claude/settings.local.json` (gitignored — local, not shared) that on error appends a one-line marker
+  (`tool + timestamp`) to a priority file under `~/.omnifocus-mcp/`. **No inline `claude -p`** — that would spawn an
+  agent on every transient "task not found". Tier-1 reads the marker to prioritize fresh patterns. Purely a dev-feedback
+  accelerator; the system is fully functional without it.
+- **Phase 5 (scheduling):** lives in an **untracked `~/bin` cron/launchd wrapper** (matches the established
+  `of-mcp-redeploy` ops-glue-placement precedent — machine-specific scheduling does not ship in the product). The only
+  in-repo deliverable is `npm run diagnose-failures`; the wrapper invokes it from the log directory on the user's
+  cadence.
+
+## Non-goals
+
+- No change to runtime MCP request handling or to `logToolFailure`'s on-disk format.
+- No interactive/inline per-call LLM diagnosis (cost + Claude-Desktop-blind).
+- No auto-creation for any class other than deterministic `SCHEMA_DRIFT` in v1.
+- The `~/bin` scheduling wrapper itself is out of repo scope (documented, not committed).
+
+## Risks & mitigations
+
+| Risk                                                  | Mitigation                                                                                                            |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Auto-Linear burns the workspace-wide 250 cap          | §4: allowlist + existing-issue dedup + ≥230 cap guard + per-run limit 3 + ledger                                      |
+| Phase-1 refactor regresses `npm run analyze-failures` | Golden/snapshot test pins existing CLI output before refactor                                                         |
+| Schema-drift false positives on numeric coercion      | `COERCION_GAP` rule encodes the CLAUDE.md `z.union` convention; flags only non-conforming numerics                    |
+| Unbounded LLM token cost                              | Fork C1: deterministic classes resolved inline; agent invoked only on residual clusters; ledger prevents re-diagnosis |
+| Tier-2 hook spawns agents on transient errors         | Hook only appends a marker line; never invokes `claude -p`                                                            |
+
+## Phasing (independently shippable)
+
+1. **§1 module** (S) — pure refactor + tests; behavior-preserving for the existing CLI.
+2. **§2 drift checker** (M) — standalone CI value, zero log/agent/hook dependency. _Phases 1–2 deliver most of the
+   value._
+3. **§3 driver + agent** (M) — depends on §1, §2.
+4. **§4 auto-Linear** (S) — depends on §3; guardrail-heavy, lands behind a `--create-issues` flag.
+5. **§5 Tier-2 hook** (S, in-repo: settings.local.json only) + scheduling wrapper (out of repo).

--- a/docs/superpowers/specs/2026-05-18-omn-37-mcp-failure-diagnosis-design.md
+++ b/docs/superpowers/specs/2026-05-18-omn-37-mcp-failure-diagnosis-design.md
@@ -98,22 +98,23 @@ on the failure log, agent, or hook.
      C1 — bounded LLM cost).
   4. Write `docs/dev/mcp-failure-triage.md` (committed; tables-over-prose per repo standards): one row per pattern —
      classification, suggested fix, first-seen, last-seen, count, fingerprint.
-- **Seen-patterns ledger** `~/.omnifocus-mcp/diagnosed-patterns.json` (outside the repo; the failure log already lives
-  under `~/.omnifocus-mcp/`). Keyed by `fingerprint`; records classification + any created Linear issue ID. A cluster
-  whose fingerprint is in the ledger is **not** re-diagnosed and **not** re-filed.
+- **Seen-patterns ledger** at the `~/.omnifocus-mcp/` root: `~/.omnifocus-mcp/diagnosed-patterns.json` — a **sibling
+  of** the `~/.omnifocus-mcp/tool-failures/` log directory, not nested inside it. Outside the repo. Keyed by
+  `fingerprint`; records classification + any created Linear issue ID. A cluster whose fingerprint is in the ledger is
+  **not** re-diagnosed and **not** re-filed.
 
 ### §4 — Phase 3b: auto-Linear (cap-risk surface — explicit guardrails)
 
 The 250 non-archived-issue free-tier cap is **workspace-wide across OMN+GATE**. Auto-creation is constrained:
 
-| Guard                | Rule                                                                                                                                                                              |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Class allowlist      | Create issues **only** for deterministic `SCHEMA_DRIFT`. Never for LLM-judgment classes (`DESCRIPTION_GAP`) or no-op classes.                                                     |
-| Existing-issue dedup | Before creating, Linear-search OMN for the cluster `fingerprint` (embedded verbatim in every auto-issue body). Match → update/skip, never duplicate.                              |
-| Cap-safety guard     | Query open OMN+GATE count (graphql, `state.type nin [completed,canceled]`). If **≥ 230**, skip all creation, write triage rows only, emit a loud `CAP_GUARD_TRIPPED` warning row. |
-| Per-run limit        | Create at most **3** new issues per run.                                                                                                                                          |
-| Traceability         | Every auto-issue carries an `omn-37-auto` label + the fingerprint in the body, so a sweep can find/triage/bulk-archive them.                                                      |
-| Ledger               | Created issue ID written to the seen-patterns ledger → never recreated.                                                                                                           |
+| Guard                | Rule                                                                                                                                                                                                                                                                                                                                         |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Class allowlist      | Create issues **only** for deterministic `SCHEMA_DRIFT`. Never for LLM-judgment classes (`DESCRIPTION_GAP`) or no-op classes.                                                                                                                                                                                                                |
+| Existing-issue dedup | Before creating, dedup via the **`graphql` action** (not the typed `search` action — per project memory that only returns the caller's assigned active issues). Query OMN issues filtered on the `omn-37-auto` label, then string-match the cluster `fingerprint` embedded verbatim in the issue body. Match → update/skip, never duplicate. |
+| Cap-safety guard     | Query open OMN+GATE count (graphql, `state.type nin [completed,canceled]`). If **≥ 230**, skip all creation, write triage rows only, emit a loud `CAP_GUARD_TRIPPED` warning row.                                                                                                                                                            |
+| Per-run limit        | Create at most **3** new issues per run.                                                                                                                                                                                                                                                                                                     |
+| Traceability         | Every auto-issue carries an `omn-37-auto` label + the fingerprint in the body, so a sweep can find/triage/bulk-archive them.                                                                                                                                                                                                                 |
+| Ledger               | Created issue ID written to the seen-patterns ledger → never recreated.                                                                                                                                                                                                                                                                      |
 
 ### §5 — Phases 4+5: Tier-2 hook + scheduling
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prepare": "husky",
     "typecheck": "tsc --noEmit",
     "analyze-failures": "npx tsx scripts/analyze-tool-failures.ts",
+    "diagnose-failures": "npx tsx scripts/diagnose-failures.ts",
     "analyze-tokens": "npx tsx scripts/analyze-token-usage.ts",
     "setup-real-llm": "npx tsx scripts/setup-real-llm-testing.ts",
     "prompts:list": "npx tsx scripts/list-prompts.ts",

--- a/scripts/analyze-tool-failures.ts
+++ b/scripts/analyze-tool-failures.ts
@@ -8,18 +8,8 @@
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { parseFailureLog } from '../src/diagnostics/failure-log.js';
+import { parseFailureLog, type FailureRecord } from '../src/diagnostics/failure-log.js';
 import { normalizeErrorMessage } from '../src/diagnostics/normalize.js';
-
-interface FailureLog {
-  timestamp: string;
-  tool: string;
-  errorType: 'VALIDATION_ERROR' | 'EXECUTION_ERROR';
-  errorMessage: string;
-  validationErrors?: any[];
-  inputArgs: any;
-  schemaDescription: string;
-}
 
 interface FailureStats {
   tool: string;
@@ -28,7 +18,7 @@ interface FailureStats {
   executionErrors: number;
   commonErrors: Map<string, number>;
   commonFields: Map<string, number>;
-  examples: FailureLog[];
+  examples: FailureRecord[];
 }
 
 function analyzeFailures(days: number = 7, specificTool?: string): void {
@@ -58,13 +48,13 @@ function analyzeFailures(days: number = 7, specificTool?: string): void {
   }
 
   // Parse all failures
-  const failures: FailureLog[] = [];
+  const failures: FailureRecord[] = [];
   for (const file of logFiles) {
     const filePath = join(logsDir, file);
     const content = readFileSync(filePath, 'utf-8');
     for (const entry of parseFailureLog(content)) {
       if (!specificTool || entry.tool === specificTool) {
-        failures.push(entry as FailureLog);
+        failures.push(entry);
       }
     }
   }

--- a/scripts/analyze-tool-failures.ts
+++ b/scripts/analyze-tool-failures.ts
@@ -8,6 +8,8 @@
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { parseFailureLog } from '../src/diagnostics/failure-log.js';
+import { normalizeErrorMessage } from '../src/diagnostics/normalize.js';
 
 interface FailureLog {
   timestamp: string;
@@ -60,18 +62,9 @@ function analyzeFailures(days: number = 7, specificTool?: string): void {
   for (const file of logFiles) {
     const filePath = join(logsDir, file);
     const content = readFileSync(filePath, 'utf-8');
-    const lines = content.trim().split('\n');
-
-    for (const line of lines) {
-      if (line) {
-        try {
-          const entry = JSON.parse(line);
-          if (!specificTool || entry.tool === specificTool) {
-            failures.push(entry);
-          }
-        } catch (e) {
-          console.error('Failed to parse log line:', line);
-        }
+    for (const entry of parseFailureLog(content)) {
+      if (!specificTool || entry.tool === specificTool) {
+        failures.push(entry as FailureLog);
       }
     }
   }
@@ -116,10 +109,7 @@ function analyzeFailures(days: number = 7, specificTool?: string): void {
     }
 
     // Track common error messages (simplified)
-    const simpleError = failure.errorMessage
-      .replace(/[0-9a-f]{8,}/gi, 'ID') // Replace IDs with placeholder
-      .replace(/\d{4}-\d{2}-\d{2}/g, 'DATE') // Replace dates
-      .substring(0, 100); // Truncate for grouping
+    const simpleError = normalizeErrorMessage(failure.errorMessage);
 
     stats.commonErrors.set(simpleError, (stats.commonErrors.get(simpleError) || 0) + 1);
 

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -76,8 +76,35 @@ export interface RunDiagnosisOpts {
 // Deterministic classification helpers
 // ---------------------------------------------------------------------------
 
-/** Map a COERCION_GAP drift finding to the fine classification COERCION_MISSING,
- *  other non-FIELD_MISSING findings to SCHEMA_DRIFT. */
+/**
+ * Map drift findings to a deterministic fine classification, or null if none applies
+ * (null → residual path: LLM agent, else NEEDS_LLM).
+ *
+ * DELIBERATE v1 DEVIATION (documented in PR #24's deviation section, alongside the
+ * --create-issues runtime-boundary one): `FIELD_MISSING` is EXCLUDED from the
+ * deterministic — and therefore the auto-file — path on purpose. The spec (§2) lists
+ * FIELD_MISSING as a first-class DriftKind and (§3/§4) treats deterministic
+ * SCHEMA_DRIFT as the auto-fileable class, so a literal reading would auto-file
+ * FIELD_MISSING. We don't, because FIELD_MISSING is BIDIRECTIONAL and, in this
+ * dual-schema codebase, dominated by INTENTIONAL asymmetry: CLAUDE.md mandates
+ * hand-crafted compact `inputSchema` overrides that deliberately omit recursive Zod
+ * internals, so "validated by Zod but never advertised" fires on by-design structure,
+ * not drift. Auto-filing it would manufacture false-positive Linear issues against the
+ * workspace-wide 250-issue cap — exactly the §4 risk the guardrails exist to contain.
+ * FIELD_MISSING-only clusters therefore fall through to the LLM agent for a judgement
+ * call instead of being deterministically classified and auto-filed.
+ *
+ * Known accepted cost (safer-than-spec): this also defers the genuinely-actionable
+ * "advertised to LLM but not validated by Zod" direction to the agent rather than
+ * catching it inline. The open question — split FIELD_MISSING by direction so the
+ * advertised-but-unvalidated half classifies deterministically — is tracked, not done.
+ *
+ * Behaviour pinned by tests/unit/diagnostics/diagnose-driver.test.ts
+ * ("FIELD_MISSING-only cluster is NOT deterministically classified ...").
+ *
+ * Mapping: COERCION_GAP → COERCION_MISSING; any other blocking
+ * (non-FIELD_MISSING) finding → SCHEMA_DRIFT.
+ */
 function deterministicClassification(findings: DriftFinding[]): string | null {
   const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');
   if (blocking.length === 0) return null; // no deterministic classification

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -192,12 +192,27 @@ export async function runDiagnosis(opts: RunDiagnosisOpts): Promise<void> {
       });
     }
 
-    // Update ledger entries with the returned issue IDs
+    // Ledger every successfully-created issue's id — UNCONDITIONALLY, even when some clusters
+    // failed (filerResult.failed non-empty). Partial failure must not lose the successes.
     for (const { fingerprint, id } of filerResult.created) {
       const existing = ledger.entries[fingerprint];
       if (existing) {
         ledger = recordDiagnosis(ledger, ledgerPath, { ...existing, linearIssueId: id }, now);
       }
+    }
+
+    if (filerResult.failed.length > 0) {
+      // Operator-visible FILE_FAILED marker: N clusters could not be filed (createIssue rejected).
+      // Successes above were still ledgered; these need manual filing from the triage doc.
+      triageRows.push({
+        fingerprint: 'FILE_FAILED',
+        tool: '—',
+        classification: 'FILE_FAILED',
+        suggestedFix: `${filerResult.failed.length} cluster(s) failed to file to Linear (createIssue rejected) — file manually; e.g. ${filerResult.failed[0].fingerprint}: ${filerResult.failed[0].error}`,
+        firstSeen: '—',
+        lastSeen: now.toISOString().slice(0, 10),
+        count: filerResult.failed.length,
+      });
     }
   }
 

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -194,10 +194,22 @@ export async function runDiagnosis(opts: RunDiagnosisOpts): Promise<void> {
 
     // Ledger every successfully-created issue's id — UNCONDITIONALLY, even when some clusters
     // failed (filerResult.failed non-empty). Partial failure must not lose the successes.
+    // `recordDiagnosis` preserves the spread `existing.diagnosedAt` (first-diagnosis time);
+    // only linearIssueId is updated here.
     for (const { fingerprint, id } of filerResult.created) {
       const existing = ledger.entries[fingerprint];
       if (existing) {
         ledger = recordDiagnosis(ledger, ledgerPath, { ...existing, linearIssueId: id }, now);
+      } else {
+        // Invariant violation: the filer reported creating a Linear issue for a fingerprint
+        // that has no ledger entry. Cannot happen via the single in-repo call site, but the
+        // injected linearFiler seam makes a future/rogue filer able to reach here. Surface it
+        // loudly (consistent with the feature's explicit-failure philosophy) rather than
+        // silently discarding the issue id.
+        console.warn(
+          `[diagnose-failures] Filed Linear issue ${id} for fingerprint ${fingerprint}, but no ` +
+            'ledger entry exists for it — issue id NOT recorded (invariant violation; manual reconciliation needed).',
+        );
       }
     }
 

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -214,6 +214,18 @@ async function main(): Promise<void> {
   const daysArg = args.find((a) => a.startsWith('--days='));
   const days = daysArg ? parseInt(daysArg.split('=')[1], 10) : 90;
 
+  // --create-issues: recognized here, but the standalone CLI CANNOT auto-file.
+  //
+  // RUNTIME CONSTRAINT (do NOT "complete" this with a LINEAR_API_KEY/HTTP path):
+  // The concrete LinearClient (Task 14 note) is backed by the Linear MCP `graphql`
+  // action, which is ONLY callable from inside an MCP client / Claude's runtime —
+  // NEVER from a plain `npx tsx` Node process like this one. There is therefore no
+  // `linearFiler` to construct here. Auto-filing is intentionally Claude-runtime-only
+  // for v1; introducing a direct Linear HTTP credential would add an un-speced secret
+  // surface and is explicitly out of scope. The flag is still passed through so
+  // runDiagnosis records intent and the operator gets an actionable message below.
+  const createIssues = args.includes('--create-issues');
+
   const logDir = join(homedir(), '.omnifocus-mcp', 'tool-failures');
   const ledgerPath = defaultLedgerPath();
   const triageDocPath = join(process.cwd(), 'docs', 'dev', 'mcp-failure-triage.md');
@@ -257,8 +269,20 @@ async function main(): Promise<void> {
     now: new Date(),
     thresholds: { minOccurrences: 3, minSpanDays: 2 },
     writeTriageDoc,
+    createIssues,
+    // linearFiler intentionally omitted — see RUNTIME CONSTRAINT note at flag parse.
     // agentRunner omitted — Phase 3 does not spawn LLM from CLI yet
   });
+
+  if (createIssues) {
+    console.info(
+      '[diagnose-failures] --create-issues: auto-filing of SCHEMA_DRIFT issues is NOT performed by the ' +
+        'standalone CLI. It requires the Linear MCP `graphql` action, which is only available in the ' +
+        'Claude-driven runtime. SCHEMA_DRIFT rows are in docs/dev/mcp-failure-triage.md for review/filing. ' +
+        'Run the diagnosis under the Claude mcp-failure-diagnoser pipeline (or inject a LinearClient ' +
+        'programmatically) to enable filing.',
+    );
+  }
 }
 
 // Guard: only run main() when this file is the direct entry point, not when imported by tests.

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -148,11 +148,16 @@ export async function runDiagnosis(opts: RunDiagnosisOpts): Promise<void> {
     };
     triageRows.push(row);
 
-    // Record in ledger
-    ledger = recordDiagnosis(ledger, ledgerPath, {
-      fingerprint: cluster.fingerprint,
-      classification,
-    });
+    // Record in ledger (thread injected `now` so a full-ledger snapshot is deterministic)
+    ledger = recordDiagnosis(
+      ledger,
+      ledgerPath,
+      {
+        fingerprint: cluster.fingerprint,
+        classification,
+      },
+      now,
+    );
   }
 
   // 5. Render and write triage doc
@@ -172,21 +177,30 @@ async function main(): Promise<void> {
   const ledgerPath = defaultLedgerPath();
   const triageDocPath = join(process.cwd(), 'docs', 'dev', 'mcp-failure-triage.md');
 
-  // Read all failure records from logDir
+  // Read all failure records from logDir.
+  // Directory-level failure (missing/unreadable dir) → genuine "no logs" path.
+  // Per-file failure (one corrupt/unreadable file) → warn + skip that file, keep processing the rest,
+  // so a single bad file never misreports as "no failure logs found".
   let records: FailureRecord[] = [];
+  let files: string[] = [];
   try {
     const cutoff = new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
-    const files = readdirSync(logDir).filter((f) => {
+    files = readdirSync(logDir).filter((f) => {
       const m = /failures-(\d{4}-\d{2}-\d{2})\.jsonl$/.exec(f);
       return m && m[1] >= cutoff;
     });
-    for (const file of files) {
-      const content = readFileSync(join(logDir, file), 'utf-8');
-      records = records.concat(parseFailureLog(content));
-    }
   } catch {
     // logDir missing or unreadable → treat as empty (graceful no-op)
     console.info(`[diagnose-failures] No failure logs found in ${logDir} — writing empty triage doc.`);
+  }
+  for (const file of files) {
+    try {
+      const content = readFileSync(join(logDir, file), 'utf-8');
+      records = records.concat(parseFailureLog(content));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[diagnose-failures] Skipping unreadable failure log ${file}: ${msg}`);
+    }
   }
 
   const writeTriageDoc = (md: string): void => {

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env npx tsx
+// scripts/diagnose-failures.ts — Tier-1 failure diagnosis driver
+//
+// Exports `runDiagnosis` (pure/injectable orchestration core) and a CLI wrapper.
+// Pure = no direct fs/network access; all I/O injected as deps.
+//
+// Phase 3 ships deterministic path (SCHEMA_DRIFT / COERCION_MISSING) + optional agentRunner residual.
+// Phase 4 adds --create-issues (linearFiler, not wired here).
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { parseFailureLog } from '../src/diagnostics/failure-log.js';
+import { clusterFailures, isIgnored } from '../src/diagnostics/clustering.js';
+import {
+  canonicalizeInputSchema,
+  canonicalizeZodSchema,
+  diffSchemas,
+  type DriftFinding,
+} from '../src/diagnostics/schema-drift.js';
+import { TOOL_SCHEMA_REGISTRY, type ToolSchemaEntry } from '../src/diagnostics/tool-schema-registry.js';
+import { loadLedger, isKnown, recordDiagnosis, defaultLedgerPath } from '../src/diagnostics/ledger.js';
+import { renderTriageDoc, type TriageRow } from '../src/diagnostics/triage-doc.js';
+import type { FailureRecord } from '../src/diagnostics/failure-log.js';
+import type { FailureCluster } from '../src/diagnostics/clustering.js';
+
+// ---------------------------------------------------------------------------
+// Types for injected dependencies
+// ---------------------------------------------------------------------------
+
+export interface DiagnosisThresholds {
+  minOccurrences: number;
+  minSpanDays: number;
+}
+
+export interface AgentResult {
+  classification: string;
+  suggestedFix: string;
+}
+
+export type AgentRunner = (cluster: FailureCluster) => Promise<AgentResult>;
+
+export interface RunDiagnosisOpts {
+  /** Already-parsed failure records (injectable for testing; CLI reads from logDir). */
+  records: FailureRecord[];
+  /** Tool schema registry entries (injectable for testing; CLI uses TOOL_SCHEMA_REGISTRY). */
+  registry: ToolSchemaEntry[];
+  /** Path to the seen-patterns ledger JSON file. */
+  ledgerPath: string;
+  /** Current time (injectable for determinism). */
+  now: Date;
+  /** Escalation thresholds. */
+  thresholds: DiagnosisThresholds;
+  /** Sink for the rendered triage-doc markdown string. */
+  writeTriageDoc: (md: string) => void;
+  /**
+   * Optional: invoked for residual clusters (those not deterministically classified).
+   * OMITTED in tests — deterministic clusters never reach this.
+   */
+  agentRunner?: AgentRunner;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic classification helpers
+// ---------------------------------------------------------------------------
+
+/** Map a COERCION_GAP drift finding to the fine classification COERCION_MISSING,
+ *  other non-FIELD_MISSING findings to SCHEMA_DRIFT. */
+function deterministicClassification(findings: DriftFinding[]): string | null {
+  const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');
+  if (blocking.length === 0) return null; // no deterministic classification
+  const hasCoercionGap = blocking.some((f) => f.kind === 'COERCION_GAP');
+  return hasCoercionGap ? 'COERCION_MISSING' : 'SCHEMA_DRIFT';
+}
+
+function suggestedFixFromFindings(findings: DriftFinding[]): string {
+  const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');
+  if (blocking.length === 0) return 'no fix determined';
+  return blocking.map((f) => `${f.kind} on field '${f.field}': ${f.detail}`).join('; ');
+}
+
+// ---------------------------------------------------------------------------
+// Pure orchestration core (injected deps, no direct fs/network)
+// ---------------------------------------------------------------------------
+
+export async function runDiagnosis(opts: RunDiagnosisOpts): Promise<void> {
+  const { records, registry, ledgerPath, now, thresholds, writeTriageDoc, agentRunner } = opts;
+
+  // 1. Cluster
+  const clusters = clusterFailures(records, thresholds);
+
+  // 2. Filter: drop ignored + un-escalated
+  const escalated = clusters.filter((c) => c.escalated && !isIgnored(c));
+
+  // 3. Load ledger and drop already-known
+  let ledger = loadLedger(ledgerPath);
+  const novel = escalated.filter((c) => !isKnown(ledger, c.fingerprint));
+
+  // 4. Build triage rows
+  const triageRows: TriageRow[] = [];
+
+  for (const cluster of novel) {
+    // Find registry entry for this tool (may be absent for unknown tools)
+    const entry = registry.find((e) => e.name === cluster.tool);
+
+    let classification: string | null = null;
+    let suggestedFix: string = 'needs investigation';
+
+    if (entry) {
+      try {
+        const advSchema = canonicalizeInputSchema(entry.getInputSchema(), entry.wrapperKey);
+        const zodSchema = canonicalizeZodSchema(entry.zodSchema, entry.wrapperKey);
+        const findings = diffSchemas(advSchema, zodSchema);
+        classification = deterministicClassification(findings);
+        if (classification) {
+          suggestedFix = suggestedFixFromFindings(findings);
+        }
+      } catch {
+        // schema diff failed — fall through to agentRunner
+      }
+    }
+
+    if (classification === null && agentRunner) {
+      // Residual: dispatch to LLM agent
+      try {
+        const result = await agentRunner(cluster);
+        classification = result.classification;
+        suggestedFix = result.suggestedFix;
+      } catch {
+        classification = 'NEEDS_LLM';
+        suggestedFix = 'agent unavailable — manual investigation required';
+      }
+    }
+
+    if (classification === null) {
+      classification = 'NEEDS_LLM';
+      suggestedFix = 'no agent configured — manual investigation required';
+    }
+
+    const row: TriageRow = {
+      fingerprint: cluster.fingerprint,
+      tool: cluster.tool,
+      classification,
+      suggestedFix,
+      firstSeen: cluster.firstSeen.slice(0, 10), // ISO date portion
+      lastSeen: cluster.lastSeen.slice(0, 10),
+      count: cluster.count,
+    };
+    triageRows.push(row);
+
+    // Record in ledger
+    ledger = recordDiagnosis(ledger, ledgerPath, {
+      fingerprint: cluster.fingerprint,
+      classification,
+    });
+  }
+
+  // 5. Render and write triage doc
+  writeTriageDoc(renderTriageDoc(triageRows, now));
+}
+
+// ---------------------------------------------------------------------------
+// CLI wrapper — wires real deps and runs
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const daysArg = args.find((a) => a.startsWith('--days='));
+  const days = daysArg ? parseInt(daysArg.split('=')[1], 10) : 90;
+
+  const logDir = join(homedir(), '.omnifocus-mcp', 'tool-failures');
+  const ledgerPath = defaultLedgerPath();
+  const triageDocPath = join(process.cwd(), 'docs', 'dev', 'mcp-failure-triage.md');
+
+  // Read all failure records from logDir
+  let records: FailureRecord[] = [];
+  try {
+    const cutoff = new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+    const files = readdirSync(logDir).filter((f) => {
+      const m = /failures-(\d{4}-\d{2}-\d{2})\.jsonl$/.exec(f);
+      return m && m[1] >= cutoff;
+    });
+    for (const file of files) {
+      const content = readFileSync(join(logDir, file), 'utf-8');
+      records = records.concat(parseFailureLog(content));
+    }
+  } catch {
+    // logDir missing or unreadable → treat as empty (graceful no-op)
+    console.info(`[diagnose-failures] No failure logs found in ${logDir} — writing empty triage doc.`);
+  }
+
+  const writeTriageDoc = (md: string): void => {
+    mkdirSync(dirname(triageDocPath), { recursive: true });
+    writeFileSync(triageDocPath, md, 'utf-8');
+    console.info(`[diagnose-failures] Wrote triage doc to ${triageDocPath}`);
+  };
+
+  await runDiagnosis({
+    records,
+    registry: TOOL_SCHEMA_REGISTRY,
+    ledgerPath,
+    now: new Date(),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc,
+    // agentRunner omitted — Phase 3 does not spawn LLM from CLI yet
+  });
+}
+
+// Guard: only run main() when this file is the direct entry point, not when imported by tests.
+// tsx preserves the .ts extension in import.meta.url, so match against the raw argv[1] path.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main().catch((e: unknown) => {
+    console.error('[diagnose-failures] fatal:', e);
+    process.exit(1);
+  });
+}

--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -21,6 +21,7 @@ import {
 import { TOOL_SCHEMA_REGISTRY, type ToolSchemaEntry } from '../src/diagnostics/tool-schema-registry.js';
 import { loadLedger, isKnown, recordDiagnosis, defaultLedgerPath } from '../src/diagnostics/ledger.js';
 import { renderTriageDoc, type TriageRow } from '../src/diagnostics/triage-doc.js';
+import { type FileDriftResult } from '../src/diagnostics/linear-filer.js';
 import type { FailureRecord } from '../src/diagnostics/failure-log.js';
 import type { FailureCluster } from '../src/diagnostics/clustering.js';
 
@@ -58,6 +59,17 @@ export interface RunDiagnosisOpts {
    * OMITTED in tests — deterministic clusters never reach this.
    */
   agentRunner?: AgentRunner;
+  /**
+   * Optional: guardrailed Linear filer (Task 14).
+   * Pre-configured closure: `(clusters) => fileDriftIssues(clusters, { client, perRunLimit, capThreshold })`.
+   * Injected for testing; CLI wires the real graphql-backed client only when --create-issues is passed.
+   */
+  linearFiler?: (clusters: TriageRow[]) => Promise<FileDriftResult>;
+  /**
+   * When true, passes SCHEMA_DRIFT triage rows to linearFiler (if provided).
+   * Default: false — safe to call without --create-issues risk.
+   */
+  createIssues?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +96,8 @@ function suggestedFixFromFindings(findings: DriftFinding[]): string {
 // ---------------------------------------------------------------------------
 
 export async function runDiagnosis(opts: RunDiagnosisOpts): Promise<void> {
-  const { records, registry, ledgerPath, now, thresholds, writeTriageDoc, agentRunner } = opts;
+  const { records, registry, ledgerPath, now, thresholds, writeTriageDoc, agentRunner, linearFiler, createIssues } =
+    opts;
 
   // 1. Cluster
   const clusters = clusterFailures(records, thresholds);
@@ -160,7 +173,35 @@ export async function runDiagnosis(opts: RunDiagnosisOpts): Promise<void> {
     );
   }
 
-  // 5. Render and write triage doc
+  // 5. (Optional) Auto-file SCHEMA_DRIFT clusters to Linear if --create-issues is set
+  if (createIssues && linearFiler) {
+    const driftRows = triageRows.filter((r) => r.classification === 'SCHEMA_DRIFT');
+    const filerResult = await linearFiler(driftRows);
+
+    if (filerResult.capGuardTripped) {
+      // Append a CAP_GUARD_TRIPPED sentinel row to the data section so the triage doc
+      // records that auto-filing was blocked by the workspace issue cap.
+      triageRows.push({
+        fingerprint: 'CAP_GUARD',
+        tool: '—',
+        classification: 'CAP_GUARD_TRIPPED',
+        suggestedFix: 'open issue count >= cap threshold; no issues auto-filed this run',
+        firstSeen: '—',
+        lastSeen: now.toISOString().slice(0, 10),
+        count: 0,
+      });
+    }
+
+    // Update ledger entries with the returned issue IDs
+    for (const { fingerprint, id } of filerResult.created) {
+      const existing = ledger.entries[fingerprint];
+      if (existing) {
+        ledger = recordDiagnosis(ledger, ledgerPath, { ...existing, linearIssueId: id }, now);
+      }
+    }
+  }
+
+  // 6. Render and write triage doc
   writeTriageDoc(renderTriageDoc(triageRows, now));
 }
 

--- a/scripts/mcp-failure-marker.sh
+++ b/scripts/mcp-failure-marker.sh
@@ -5,13 +5,28 @@
 # NEVER spawns an agent process (no agent spawn, no subshell to Claude CLI) —
 # this is called on EVERY MCP tool use and must not trigger a recursive launch.
 #
-# Usage:
-#   mcp-failure-marker.sh <tool_name>
+# Invoked by the .claude/settings.local.json hooks.PostToolUse entry (gitignored,
+# local only). Claude Code command-type hooks deliver a JSON payload on STDIN
+# (NOT as env vars / positional args). The PostToolUse payload includes a
+# `tool_name` field — see https://code.claude.com/docs/en/hooks.
+#
+#   { "hook_event_name": "PostToolUse", "tool_name": "mcp__omnifocus__...", ... }
 #
 # Env:
 #   OMN37_MARKER  — path to the marker TSV (default: ~/.omnifocus-mcp/fresh-failures.tsv)
 #
-# Called by .claude/settings.local.json hooks.PostToolUse (gitignored, local only).
 # The marker file is read by `npm run diagnose-failures` to surface recent failures.
+#
+# A hook that errors degrades EVERY tool call, so every step fails silent (|| true)
+# and the script always exits 0.
 
-printf '%s\t%s\n' "$(date -u +%FT%TZ)" "$1" >> "${OMN37_MARKER:-$HOME/.omnifocus-mcp/fresh-failures.tsv}"
+MARKER="${OMN37_MARKER:-$HOME/.omnifocus-mcp/fresh-failures.tsv}"
+
+# Parse the tool name from the stdin JSON payload. Empty / non-JSON / missing
+# field → empty string (still appended; never errors).
+tool_name="$(jq -r '.tool_name // ""' 2>/dev/null || true)"
+
+mkdir -p "$(dirname "$MARKER")" 2>/dev/null || true
+printf '%s\t%s\n' "$(date -u +%FT%TZ)" "$tool_name" >> "$MARKER" 2>/dev/null || true
+
+exit 0

--- a/scripts/mcp-failure-marker.sh
+++ b/scripts/mcp-failure-marker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# scripts/mcp-failure-marker.sh — Tier-2 PostToolUse marker hook
+#
+# CHEAP appender: writes one timestamped line to the marker file per call.
+# NEVER spawns an agent process (no agent spawn, no subshell to Claude CLI) —
+# this is called on EVERY MCP tool use and must not trigger a recursive launch.
+#
+# Usage:
+#   mcp-failure-marker.sh <tool_name>
+#
+# Env:
+#   OMN37_MARKER  — path to the marker TSV (default: ~/.omnifocus-mcp/fresh-failures.tsv)
+#
+# Called by .claude/settings.local.json hooks.PostToolUse (gitignored, local only).
+# The marker file is read by `npm run diagnose-failures` to surface recent failures.
+
+printf '%s\t%s\n' "$(date -u +%FT%TZ)" "$1" >> "${OMN37_MARKER:-$HOME/.omnifocus-mcp/fresh-failures.tsv}"

--- a/src/diagnostics/clustering.ts
+++ b/src/diagnostics/clustering.ts
@@ -56,3 +56,25 @@ export function clusterFailures(records: FailureRecord[], opts: ClusterOptions):
   }
   return [...map.values()];
 }
+
+const IGNORE_SET = new Set([
+  'INVALID_ID',
+  'NULL_RESULT',
+  'OMNIFOCUS_NOT_RUNNING',
+  'SCRIPT_TIMEOUT',
+  'CONNECTION_TIMEOUT',
+]);
+
+export function isIgnored(c: FailureCluster): boolean {
+  const cat = c.example.categorization?.errorType;
+  return cat !== undefined && IGNORE_SET.has(cat);
+}
+
+export type CoarseClass = 'VALIDATION' | 'EXECUTION' | 'DATA_ERROR';
+
+/** Coarse pre-classification. The fine SCHEMA_DRIFT/COERCION/DESCRIPTION split happens in the driver
+ *  (deterministic via schema-drift) or the LLM agent (residual). */
+export function classifyCluster(c: FailureCluster): CoarseClass {
+  if (isIgnored(c)) return 'DATA_ERROR';
+  return c.example.errorType === 'VALIDATION_ERROR' ? 'VALIDATION' : 'EXECUTION';
+}

--- a/src/diagnostics/clustering.ts
+++ b/src/diagnostics/clustering.ts
@@ -1,0 +1,58 @@
+// src/diagnostics/clustering.ts
+import { createHash } from 'crypto';
+import type { FailureRecord } from './failure-log.js';
+import { normalizeErrorMessage, normalizeInputShape } from './normalize.js';
+
+export interface ClusterOptions {
+  minOccurrences: number; // default 3
+  minSpanDays: number; // default 2
+}
+
+export interface FailureCluster {
+  fingerprint: string;
+  tool: string;
+  normalizedError: string;
+  inputShape: string;
+  count: number;
+  firstSeen: string;
+  lastSeen: string;
+  escalated: boolean;
+  example: FailureRecord; // first occurrence (inputArgs already redacted)
+}
+
+export function fingerprintOf(tool: string, normalizedError: string, inputShape: string): string {
+  return createHash('sha256').update(`${tool} ${normalizedError} ${inputShape}`).digest('hex').slice(0, 16);
+}
+
+export function clusterFailures(records: FailureRecord[], opts: ClusterOptions): FailureCluster[] {
+  const map = new Map<string, FailureCluster>();
+  for (const r of records) {
+    const normalizedError = normalizeErrorMessage(r.errorMessage);
+    const inputShape = normalizeInputShape(r.inputArgs);
+    const fp = fingerprintOf(r.tool, normalizedError, inputShape);
+    const existing = map.get(fp);
+    if (!existing) {
+      map.set(fp, {
+        fingerprint: fp,
+        tool: r.tool,
+        normalizedError,
+        inputShape,
+        count: 1,
+        firstSeen: r.timestamp,
+        lastSeen: r.timestamp,
+        escalated: false,
+        example: r,
+      });
+    } else {
+      existing.count++;
+      if (r.timestamp < existing.firstSeen) existing.firstSeen = r.timestamp;
+      if (r.timestamp > existing.lastSeen) existing.lastSeen = r.timestamp;
+    }
+  }
+  const DAY = 86_400_000;
+  for (const c of map.values()) {
+    const spanDays = (Date.parse(c.lastSeen) - Date.parse(c.firstSeen)) / DAY;
+    c.escalated = c.count >= opts.minOccurrences || spanDays >= opts.minSpanDays;
+  }
+  return [...map.values()];
+}

--- a/src/diagnostics/clustering.ts
+++ b/src/diagnostics/clustering.ts
@@ -51,7 +51,11 @@ export function clusterFailures(records: FailureRecord[], opts: ClusterOptions):
   }
   const DAY = 86_400_000;
   for (const c of map.values()) {
-    const spanDays = (Date.parse(c.lastSeen) - Date.parse(c.firstSeen)) / DAY;
+    const first = Date.parse(c.firstSeen);
+    const last = Date.parse(c.lastSeen);
+    // Unparseable timestamps ⇒ span = 0 so escalation falls back cleanly to the count rule
+    // (NaN >= minSpanDays silently yields false, breaking the "never misfires" contract).
+    const spanDays = Number.isNaN(first) || Number.isNaN(last) ? 0 : (last - first) / DAY;
     c.escalated = c.count >= opts.minOccurrences || spanDays >= opts.minSpanDays;
   }
   return [...map.values()];

--- a/src/diagnostics/failure-log.ts
+++ b/src/diagnostics/failure-log.ts
@@ -1,0 +1,39 @@
+// src/diagnostics/failure-log.ts
+export interface FailureCategorization {
+  errorType: string;
+  severity?: string;
+  recoverable?: boolean;
+  actionable?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface FailureRecord {
+  timestamp: string;
+  tool: string;
+  // Usually 'VALIDATION_ERROR' | 'EXECUTION_ERROR', but base.ts:303/639 can also write a raw
+  // ScriptErrorType string. Keep it `string`; classification keys off `categorization.errorType`.
+  errorType: string;
+  errorMessage: string;
+  validationErrors?: Array<{ path?: (string | number)[]; message?: string }>;
+  inputArgs: unknown; // already redacted upstream by redactArgs()
+  schemaDescription: string;
+  categorization?: FailureCategorization;
+}
+
+/** Tolerant line-delimited-JSON parse. Never throws; skips malformed/blank lines. */
+export function parseFailureLog(jsonl: string): FailureRecord[] {
+  const out: FailureRecord[] = [];
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed.tool === 'string' && typeof parsed.errorMessage === 'string') {
+        out.push(parsed as FailureRecord);
+      }
+    } catch {
+      // skip malformed line by design
+    }
+  }
+  return out;
+}

--- a/src/diagnostics/ledger.ts
+++ b/src/diagnostics/ledger.ts
@@ -31,14 +31,24 @@ export function isKnown(ledger: Ledger, fingerprint: string): boolean {
   return fingerprint in ledger.entries;
 }
 
+/**
+ * Upsert a diagnosed-pattern entry.
+ *
+ * `diagnosedAt` semantics: it records when the pattern was FIRST diagnosed and must remain
+ * stable across later updates (e.g. attaching a linearIssueId after auto-filing). So if the
+ * incoming entry already carries a `diagnosedAt` (the caller is updating a known entry, typically
+ * by spreading the existing entry), that original timestamp is preserved; only a first write
+ * (no incoming `diagnosedAt`) is stamped with `now`.
+ */
 export function recordDiagnosis(
   ledger: Ledger,
   path: string,
-  e: Omit<LedgerEntry, 'diagnosedAt'>,
+  e: Omit<LedgerEntry, 'diagnosedAt'> & { diagnosedAt?: string },
   now: Date = new Date(),
 ): Ledger {
+  const diagnosedAt = e.diagnosedAt ?? now.toISOString();
   const next: Ledger = {
-    entries: { ...ledger.entries, [e.fingerprint]: { ...e, diagnosedAt: now.toISOString() } },
+    entries: { ...ledger.entries, [e.fingerprint]: { ...e, diagnosedAt } },
   };
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(next, null, 2));

--- a/src/diagnostics/ledger.ts
+++ b/src/diagnostics/ledger.ts
@@ -31,9 +31,14 @@ export function isKnown(ledger: Ledger, fingerprint: string): boolean {
   return fingerprint in ledger.entries;
 }
 
-export function recordDiagnosis(ledger: Ledger, path: string, e: Omit<LedgerEntry, 'diagnosedAt'>): Ledger {
+export function recordDiagnosis(
+  ledger: Ledger,
+  path: string,
+  e: Omit<LedgerEntry, 'diagnosedAt'>,
+  now: Date = new Date(),
+): Ledger {
   const next: Ledger = {
-    entries: { ...ledger.entries, [e.fingerprint]: { ...e, diagnosedAt: new Date().toISOString() } },
+    entries: { ...ledger.entries, [e.fingerprint]: { ...e, diagnosedAt: now.toISOString() } },
   };
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(next, null, 2));

--- a/src/diagnostics/ledger.ts
+++ b/src/diagnostics/ledger.ts
@@ -1,0 +1,41 @@
+// src/diagnostics/ledger.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+
+export interface LedgerEntry {
+  fingerprint: string;
+  classification: string;
+  linearIssueId?: string;
+  diagnosedAt: string;
+}
+export interface Ledger {
+  entries: Record<string, LedgerEntry>;
+}
+
+/** Default path: ~/.omnifocus-mcp/diagnosed-patterns.json — SIBLING of tool-failures/, not nested inside it. */
+export function defaultLedgerPath(): string {
+  return join(homedir(), '.omnifocus-mcp', 'diagnosed-patterns.json');
+}
+
+export function loadLedger(path = defaultLedgerPath()): Ledger {
+  if (!existsSync(path)) return { entries: {} };
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Ledger;
+  } catch {
+    return { entries: {} };
+  }
+}
+
+export function isKnown(ledger: Ledger, fingerprint: string): boolean {
+  return fingerprint in ledger.entries;
+}
+
+export function recordDiagnosis(ledger: Ledger, path: string, e: Omit<LedgerEntry, 'diagnosedAt'>): Ledger {
+  const next: Ledger = {
+    entries: { ...ledger.entries, [e.fingerprint]: { ...e, diagnosedAt: new Date().toISOString() } },
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(next, null, 2));
+  return next;
+}

--- a/src/diagnostics/linear-filer.ts
+++ b/src/diagnostics/linear-filer.ts
@@ -2,12 +2,18 @@
 //
 // Guardrailed auto-Linear filer for SCHEMA_DRIFT clusters.
 //
-// Guard order (mandatory — do NOT reorder):
-//   1. Filter: only SCHEMA_DRIFT clusters are ever filed
-//   2. Cap check: if open OMN+GATE issue count >= capThreshold → return capGuardTripped, create NOTHING
-//   3. Per-cluster dedup: searchByLabelAndBody('omn-37-auto', fingerprint) → non-empty → skip
-//   4. Per-run limit: stop after perRunLimit creations
+// Guard order (mandatory — matches the actual execution order in fileDriftIssues; do NOT reorder):
+//   1. Class filter: only SCHEMA_DRIFT clusters are ever filed
+//   2. Cap check: if open OMN+GATE issue count >= capThreshold → return capGuardTripped, create NOTHING.
+//      Fires ONCE before the loop — unbypassable.
+//   3. Per-run limit: stop the loop after perRunLimit creations
+//   4. Per-cluster dedup: searchByLabelAndBody('omn-37-auto', fingerprint) → non-empty → skip
 //   5. Create: body embeds fingerprint verbatim + label 'omn-37-auto'
+//
+// Note: the per-run LIMIT (3) is checked BEFORE the per-cluster DEDUP search (4) deliberately —
+// once the run limit is hit, dropping the remaining clusters without issuing a
+// searchByLabelAndBody network call avoids unnecessary dedup queries for clusters that would
+// never be created this run anyway.
 //
 // The concrete LinearClient impl uses the Linear MCP `graphql` action (not typed `search`)
 // for both openIssueCount (state.type nin [completed,canceled] across OMN+GATE) and
@@ -40,13 +46,32 @@ export interface CreatedIssue {
   id: string;
 }
 
+export interface FailedIssue {
+  fingerprint: string;
+  error: string;
+}
+
 export interface FileDriftResult {
   /** Issues created this run, each carrying the cluster fingerprint so the caller can update the ledger. */
   created: CreatedIssue[];
+  /**
+   * Clusters whose createIssue call rejected. Always present ([] when none). The run continues
+   * past a failure (one Linear hiccup must not lose the other successfully-created issues), and
+   * the caller still ledgers every `created` entry even when `failed` is non-empty.
+   */
+  failed: FailedIssue[];
   /** True when the cap guard fired — caller should append a CAP_GUARD_TRIPPED triage row. */
   capGuardTripped: boolean;
 }
 
+/**
+ * Input cluster shape for the filer.
+ *
+ * NOTE: this intentionally mirrors `TriageRow` in src/diagnostics/triage-doc.ts field-for-field so
+ * the driver can pass triage rows straight through. They are kept as separate types so linear-filer
+ * stays self-contained (no triage-doc import), but the two MUST stay field-compatible — if either
+ * `DriftCluster` or `TriageRow` gains/renames a field, update the other or the driver hand-off breaks.
+ */
 export interface DriftCluster {
   fingerprint: string;
   tool: string;
@@ -60,32 +85,43 @@ export interface DriftCluster {
 /**
  * File Linear issues for SCHEMA_DRIFT clusters only, with layered guardrails.
  *
- * Guard order is strictly enforced:
- *   class filter → cap check (short-circuits ALL creates) → per-cluster dedup → per-run limit → create
+ * Guard order (matches the code below exactly):
+ *   1 class filter → 2 cap check (short-circuits ALL creates, before the loop) →
+ *   3 per-run limit → 4 per-cluster dedup → 5 create
+ *
+ * The per-run limit (3) is checked before the dedup search (4) on purpose: clusters the run
+ * limit would drop never incur a searchByLabelAndBody network call.
+ *
+ * A createIssue rejection on one cluster is isolated (recorded in `failed`, loop continues) so
+ * one Linear hiccup never loses the issues already created — the caller ledgers all `created`.
  */
 export async function fileDriftIssues(clusters: DriftCluster[], opts: FileDriftOptions): Promise<FileDriftResult> {
   const { client, perRunLimit, capThreshold } = opts;
 
-  // Guard 1: filter to SCHEMA_DRIFT only — judgment-call and no-op classes are never filed
+  // Guard 1: class filter — only SCHEMA_DRIFT; judgment-call and no-op classes are never filed
   const driftOnly = clusters.filter((c) => c.classification === 'SCHEMA_DRIFT');
 
-  // Guard 2: cap check — must happen BEFORE any per-cluster work or creates
+  // Guard 2: cap check — fires ONCE before the loop, BEFORE any per-cluster work or creates (unbypassable)
   const openCount = await client.openIssueCount();
   if (openCount >= capThreshold) {
-    return { created: [], capGuardTripped: true };
+    return { created: [], failed: [], capGuardTripped: true };
   }
 
   const created: CreatedIssue[] = [];
+  const failed: FailedIssue[] = [];
 
   for (const cluster of driftOnly) {
-    // Guard 4: per-run limit — stop before searching/creating once limit is reached
+    // Guard 3: per-run limit — stop before the dedup search so dropped clusters incur no network call
     if (created.length >= perRunLimit) break;
 
-    // Guard 3: dedup — skip if an existing issue already carries this fingerprint
+    // Guard 4: dedup — skip if an existing issue already carries this fingerprint
     const existing = await client.searchByLabelAndBody('omn-37-auto', cluster.fingerprint);
     if (existing.length > 0) continue;
 
-    // Guard 5: create — embed fingerprint verbatim in body so future dedup searches can find it
+    // Guard 5: create — embed fingerprint verbatim in body so future dedup searches can find it.
+    // Per-cluster isolation: a createIssue rejection records the cluster in `failed` and the loop
+    // continues; it must NOT abort the whole run (that would silently lose earlier successes
+    // because the caller would never receive the partial `created[]` to ledger).
     const body = [
       `**Tool:** ${cluster.tool}`,
       `**Suggested fix:** ${cluster.suggestedFix}`,
@@ -96,13 +132,21 @@ export async function fileDriftIssues(clusters: DriftCluster[], opts: FileDriftO
       `<!-- omn-37-auto fingerprint:${cluster.fingerprint} -->`,
     ].join('\n');
 
-    const id = await client.createIssue({
-      title: `[auto] SCHEMA_DRIFT on ${cluster.tool} (${cluster.fingerprint})`,
-      body,
-      label: 'omn-37-auto',
-    });
-    created.push({ fingerprint: cluster.fingerprint, id });
+    try {
+      const id = await client.createIssue({
+        title: `[auto] SCHEMA_DRIFT on ${cluster.tool} (${cluster.fingerprint})`,
+        body,
+        label: 'omn-37-auto',
+      });
+      created.push({ fingerprint: cluster.fingerprint, id });
+    } catch (err: unknown) {
+      failed.push({
+        fingerprint: cluster.fingerprint,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
   }
 
-  return { created, capGuardTripped: false };
+  return { created, failed, capGuardTripped: false };
 }

--- a/src/diagnostics/linear-filer.ts
+++ b/src/diagnostics/linear-filer.ts
@@ -1,0 +1,103 @@
+// src/diagnostics/linear-filer.ts
+//
+// Guardrailed auto-Linear filer for SCHEMA_DRIFT clusters.
+//
+// Guard order (mandatory — do NOT reorder):
+//   1. Filter: only SCHEMA_DRIFT clusters are ever filed
+//   2. Cap check: if open OMN+GATE issue count >= capThreshold → return capGuardTripped, create NOTHING
+//   3. Per-cluster dedup: searchByLabelAndBody('omn-37-auto', fingerprint) → non-empty → skip
+//   4. Per-run limit: stop after perRunLimit creations
+//   5. Create: body embeds fingerprint verbatim + label 'omn-37-auto'
+//
+// The concrete LinearClient impl uses the Linear MCP `graphql` action (not typed `search`)
+// for both openIssueCount (state.type nin [completed,canceled] across OMN+GATE) and
+// the dedup query — typed search only returns the caller's assigned active issues.
+
+export interface LinearClient {
+  /** Count of all open (non-completed, non-canceled) issues across OMN+GATE teams. */
+  openIssueCount(): Promise<number>;
+  /**
+   * Search for existing issues carrying the given label whose body contains the needle string.
+   * Returns an array of issue identifiers (e.g. ['OMN-7']).
+   */
+  searchByLabelAndBody(label: string, needle: string): Promise<string[]>;
+  /**
+   * Create a new issue. Returns the created issue identifier (e.g. 'OMN-42').
+   */
+  createIssue(input: { title: string; body: string; label: string }): Promise<string>;
+}
+
+export interface FileDriftOptions {
+  client: LinearClient;
+  /** Maximum issues to create in a single run (default: 3). */
+  perRunLimit: number;
+  /** If open issue count >= this threshold, create nothing (default: 230). */
+  capThreshold: number;
+}
+
+export interface FileDriftResult {
+  /** Identifiers of issues created this run (e.g. ['OMN-42', 'OMN-43']). */
+  created: string[];
+  /** True when the cap guard fired — caller should append a CAP_GUARD_TRIPPED triage row. */
+  capGuardTripped: boolean;
+}
+
+export interface DriftCluster {
+  fingerprint: string;
+  tool: string;
+  classification: string;
+  suggestedFix: string;
+  firstSeen: string;
+  lastSeen: string;
+  count: number;
+}
+
+/**
+ * File Linear issues for SCHEMA_DRIFT clusters only, with layered guardrails.
+ *
+ * Guard order is strictly enforced:
+ *   class filter → cap check (short-circuits ALL creates) → per-cluster dedup → per-run limit → create
+ */
+export async function fileDriftIssues(clusters: DriftCluster[], opts: FileDriftOptions): Promise<FileDriftResult> {
+  const { client, perRunLimit, capThreshold } = opts;
+
+  // Guard 1: filter to SCHEMA_DRIFT only — judgment-call and no-op classes are never filed
+  const driftOnly = clusters.filter((c) => c.classification === 'SCHEMA_DRIFT');
+
+  // Guard 2: cap check — must happen BEFORE any per-cluster work or creates
+  const openCount = await client.openIssueCount();
+  if (openCount >= capThreshold) {
+    return { created: [], capGuardTripped: true };
+  }
+
+  const created: string[] = [];
+
+  for (const cluster of driftOnly) {
+    // Guard 4: per-run limit — stop before searching/creating once limit is reached
+    if (created.length >= perRunLimit) break;
+
+    // Guard 3: dedup — skip if an existing issue already carries this fingerprint
+    const existing = await client.searchByLabelAndBody('omn-37-auto', cluster.fingerprint);
+    if (existing.length > 0) continue;
+
+    // Guard 5: create — embed fingerprint verbatim in body so future dedup searches can find it
+    const body = [
+      `**Tool:** ${cluster.tool}`,
+      `**Suggested fix:** ${cluster.suggestedFix}`,
+      `**First seen:** ${cluster.firstSeen}`,
+      `**Last seen:** ${cluster.lastSeen}`,
+      `**Occurrences:** ${cluster.count}`,
+      '',
+      `<!-- omn-37-auto fingerprint:${cluster.fingerprint} -->`,
+    ].join('\n');
+
+    const id = await client.createIssue({
+      title: `[auto] SCHEMA_DRIFT on ${cluster.tool} (${cluster.fingerprint})`,
+      body,
+      label: 'omn-37-auto',
+    });
+    created.push(id);
+  }
+
+  return { created, capGuardTripped: false };
+}

--- a/src/diagnostics/linear-filer.ts
+++ b/src/diagnostics/linear-filer.ts
@@ -35,9 +35,14 @@ export interface FileDriftOptions {
   capThreshold: number;
 }
 
+export interface CreatedIssue {
+  fingerprint: string;
+  id: string;
+}
+
 export interface FileDriftResult {
-  /** Identifiers of issues created this run (e.g. ['OMN-42', 'OMN-43']). */
-  created: string[];
+  /** Issues created this run, each carrying the cluster fingerprint so the caller can update the ledger. */
+  created: CreatedIssue[];
   /** True when the cap guard fired — caller should append a CAP_GUARD_TRIPPED triage row. */
   capGuardTripped: boolean;
 }
@@ -70,7 +75,7 @@ export async function fileDriftIssues(clusters: DriftCluster[], opts: FileDriftO
     return { created: [], capGuardTripped: true };
   }
 
-  const created: string[] = [];
+  const created: CreatedIssue[] = [];
 
   for (const cluster of driftOnly) {
     // Guard 4: per-run limit — stop before searching/creating once limit is reached
@@ -96,7 +101,7 @@ export async function fileDriftIssues(clusters: DriftCluster[], opts: FileDriftO
       body,
       label: 'omn-37-auto',
     });
-    created.push(id);
+    created.push({ fingerprint: cluster.fingerprint, id });
   }
 
   return { created, capGuardTripped: false };

--- a/src/diagnostics/normalize.ts
+++ b/src/diagnostics/normalize.ts
@@ -1,0 +1,19 @@
+// src/diagnostics/normalize.ts
+
+/** Extracted verbatim from scripts/analyze-tool-failures.ts:119-122 (the canonical normalization). */
+export function normalizeErrorMessage(errorMessage: string): string {
+  return errorMessage
+    .replace(/[0-9a-f]{8,}/gi, 'ID')
+    .replace(/\d{4}-\d{2}-\d{2}/g, 'DATE')
+    .substring(0, 100);
+}
+
+/** Structural fingerprint of the input: sorted top-level key names only (never values — values are PII-redacted but still volatile). */
+export function normalizeInputShape(inputArgs: unknown): string {
+  if (inputArgs === null || typeof inputArgs !== 'object' || Array.isArray(inputArgs)) {
+    return '<non-object>';
+  }
+  return Object.keys(inputArgs as Record<string, unknown>)
+    .sort()
+    .join(',');
+}

--- a/src/diagnostics/schema-drift.ts
+++ b/src/diagnostics/schema-drift.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export interface CanonicalField {
   type: string;
   required: boolean;
@@ -36,8 +38,17 @@ export function canonicalizeInputSchema(advertised: Record<string, unknown>, wra
   return out;
 }
 
-import { z } from 'zod';
-
+// ---------------------------------------------------------------------------
+// Zod private-API access (`_def`). Zod does NOT expose a stable public reflection
+// API, so canonicalizing a Zod schema means walking `_def`. The `typeName` string
+// constants below ('ZodEffects', 'ZodOptional', 'ZodDiscriminatedUnion', etc.) are
+// stable across all of Zod 3.x (this package pins `^3.25.76`), but a Zod 4 upgrade
+// WILL rename/restructure `_def` and these mappings must be re-derived against the
+// new internals. DIAGNOSIS BREADCRUMB: if `canonicalizeZodSchema` starts returning
+// `{}` for real tool schemas (the CI drift gate's non-vacuity assertion will fire
+// first), start here — `unwrap`/`fieldType`/`membersOf` `typeName` strings are the
+// first thing to re-check after any Zod version bump.
+// ---------------------------------------------------------------------------
 type ZDef = {
   typeName?: string;
   schema?: z.ZodTypeAny; // ZodEffects (z.preprocess / z.transform)
@@ -153,27 +164,31 @@ export function diffSchemas(advertised: CanonicalSchema, zod: CanonicalSchema): 
   const fields = new Set([...Object.keys(advertised), ...Object.keys(zod)]);
   for (const f of fields) {
     const a = advertised[f];
-    const z = zod[f];
-    if (a && !z) {
+    const zf = zod[f];
+    if (a && !zf) {
       findings.push({ kind: 'FIELD_MISSING', field: f, detail: 'advertised to LLM but not validated by Zod' });
       continue;
     }
-    if (!a && z) {
+    if (!a && zf) {
       findings.push({ kind: 'FIELD_MISSING', field: f, detail: 'validated by Zod but never advertised to LLM' });
       continue;
     }
-    if (!a || !z) continue;
-    if (a.enum && z.enum && JSON.stringify([...a.enum].sort()) !== JSON.stringify([...z.enum].sort())) {
-      findings.push({ kind: 'ENUM_MISMATCH', field: f, detail: `advertised [${a.enum}] vs validated [${z.enum}]` });
+    if (!a || !zf) continue;
+    if (a.enum && zf.enum && JSON.stringify([...a.enum].sort()) !== JSON.stringify([...zf.enum].sort())) {
+      findings.push({
+        kind: 'ENUM_MISMATCH',
+        field: f,
+        detail: `advertised [${a.enum.join(', ')}] vs validated [${zf.enum.join(', ')}]`,
+      });
     }
-    if (a.required !== z.required) {
+    if (a.required !== zf.required) {
       findings.push({
         kind: 'REQUIRED_MISMATCH',
         field: f,
-        detail: `advertised required=${a.required} vs validated required=${z.required}`,
+        detail: `advertised required=${a.required} vs validated required=${zf.required}`,
       });
     }
-    if (a.type === 'number' && z.coercible === false) {
+    if (a.type === 'number' && zf.coercible === false) {
       findings.push({
         kind: 'COERCION_GAP',
         field: f,

--- a/src/diagnostics/schema-drift.ts
+++ b/src/diagnostics/schema-drift.ts
@@ -35,3 +35,108 @@ export function canonicalizeInputSchema(advertised: Record<string, unknown>, wra
   }
   return out;
 }
+
+import { z } from 'zod';
+
+type ZDef = {
+  typeName?: string;
+  schema?: z.ZodTypeAny; // ZodEffects (z.preprocess / z.transform)
+  innerType?: z.ZodTypeAny; // ZodOptional / ZodDefault / ZodNullable
+  values?: unknown[]; // ZodEnum
+  value?: unknown; // ZodLiteral
+  discriminator?: string; // ZodDiscriminatedUnion
+  options?: Map<unknown, z.ZodTypeAny> | z.ZodTypeAny[]; // ZodDiscriminatedUnion members
+};
+const defOf = (s: z.ZodTypeAny): ZDef => (s as unknown as { _def: ZDef })._def;
+
+/** Peel ZodEffects (preprocess/transform — this is what coerceObject is), Optional, Default, Nullable. */
+function unwrap(s: z.ZodTypeAny): z.ZodTypeAny {
+  let cur = s;
+  for (;;) {
+    const d = defOf(cur);
+    if (d.typeName === 'ZodEffects' && d.schema) cur = d.schema;
+    else if (
+      (d.typeName === 'ZodOptional' || d.typeName === 'ZodDefault' || d.typeName === 'ZodNullable') &&
+      d.innerType
+    )
+      cur = d.innerType;
+    else return cur;
+  }
+}
+
+function isCoercibleNumber(field: z.ZodTypeAny): boolean {
+  // Behavioral probe — NEVER pattern-match source. A number field is "coercible" iff a stringified
+  // number survives validation. Catches z.coerce.number(), z.preprocess(...), z.union([...]) alike.
+  return field.safeParse('5').success;
+}
+
+function fieldType(field: z.ZodTypeAny): { type: string; enum?: (string | number)[] } {
+  const inner = unwrap(field);
+  const d = defOf(inner);
+  if (d.typeName === 'ZodEnum') return { type: 'string', enum: d.values as (string | number)[] };
+  if (d.typeName === 'ZodLiteral')
+    return { type: typeof d.value === 'number' ? 'number' : 'string', enum: [d.value as string | number] };
+  if (d.typeName === 'ZodNumber') return { type: 'number' };
+  if (d.typeName === 'ZodBoolean') return { type: 'boolean' };
+  if (d.typeName === 'ZodString') return { type: 'string' };
+  return { type: 'object' };
+}
+
+function membersOf(du: z.ZodTypeAny): z.ZodTypeAny[] {
+  const opts = defOf(du).options;
+  if (!opts) return [];
+  return Array.isArray(opts) ? opts : [...opts.values()];
+}
+
+/** Merge object/discriminated-union members into one CanonicalSchema.
+ *  required(field) := present AND required in EVERY member (absence in any member ⇒ not required).
+ *  enum/coercible := unioned across members (discriminator literal values collapse to one enum). */
+function mergeShapes(members: z.ZodTypeAny[]): CanonicalSchema {
+  const out: CanonicalSchema = {};
+  const presentCount: Record<string, number> = {};
+  for (const m of members) {
+    const shape = (unwrap(m) as z.ZodObject<z.ZodRawShape>).shape ?? {};
+    for (const [name, raw] of Object.entries(shape)) {
+      const field = raw as z.ZodTypeAny;
+      presentCount[name] = (presentCount[name] ?? 0) + 1;
+      const required = !(field.isOptional?.() ?? false);
+      const probe = isCoercibleNumber(field);
+      const { type, enum: en } = fieldType(field);
+      const prev = out[name];
+      const mergedEnum = [...new Set([...(prev?.enum ?? []), ...(en ?? [])])];
+      out[name] = {
+        type: prev?.type ?? type,
+        required: prev ? prev.required && required : required,
+        enum: mergedEnum.length ? mergedEnum : undefined,
+        coercible: (prev?.coercible ?? false) || probe,
+      };
+    }
+  }
+  // A field absent from any member cannot be globally required.
+  for (const [name, f] of Object.entries(out)) {
+    if (presentCount[name] !== members.length) f.required = false;
+  }
+  return out;
+}
+
+/**
+ * Canonicalize a tool's Zod schema.
+ * @param wrapperKey  read/write/analyze wrap the real schema under one key
+ *                     ('query'|'mutation'|'analysis') via coerceObject (= z.preprocess) over a
+ *                     z.discriminatedUnion. Pass it to descend. Omit for the flat `system` schema.
+ */
+export function canonicalizeZodSchema(schema: z.ZodTypeAny, wrapperKey?: string): CanonicalSchema {
+  const top = unwrap(schema) as z.ZodObject<z.ZodRawShape>;
+  let target: z.ZodTypeAny = top;
+  if (wrapperKey) {
+    const wrapped = top.shape?.[wrapperKey];
+    if (!wrapped) throw new Error(`canonicalizeZodSchema: wrapper key '${wrapperKey}' not found`);
+    target = unwrap(wrapped); // peels coerceObject's z.preprocess → inner discriminatedUnion/object
+  }
+  const td = defOf(target);
+  if (td.typeName === 'ZodDiscriminatedUnion' || td.typeName === 'ZodUnion') {
+    return mergeShapes(membersOf(target));
+  }
+  // Plain object (system tool, or a non-union wrapper).
+  return mergeShapes([target]);
+}

--- a/src/diagnostics/schema-drift.ts
+++ b/src/diagnostics/schema-drift.ts
@@ -1,0 +1,37 @@
+export interface CanonicalField {
+  type: string;
+  required: boolean;
+  enum?: (string | number)[];
+  coercible?: boolean; // only meaningful for the Zod side
+}
+export type CanonicalSchema = Record<string, CanonicalField>;
+
+type JsonSchemaNode = {
+  type?: string;
+  enum?: (string | number)[];
+  properties?: Record<string, JsonSchemaNode>;
+  required?: string[];
+};
+
+/**
+ * Canonicalize the advertised JSON schema.
+ * @param wrapperKey  For read/write/analyze the real fields are nested one level under a single
+ *                     wrapper property ('query' | 'mutation' | 'analysis'). Pass it to descend.
+ *                     Omit for flat schemas (the `system` tool).
+ */
+export function canonicalizeInputSchema(advertised: Record<string, unknown>, wrapperKey?: string): CanonicalSchema {
+  let node = advertised as JsonSchemaNode;
+  if (wrapperKey) {
+    const wrapped = node.properties?.[wrapperKey];
+    if (!wrapped)
+      throw new Error(`canonicalizeInputSchema: wrapper key '${wrapperKey}' not found in advertised schema`);
+    node = wrapped;
+  }
+  const props = node.properties ?? {};
+  const required = new Set(node.required ?? []);
+  const out: CanonicalSchema = {};
+  for (const [name, def] of Object.entries(props)) {
+    out[name] = { type: def.type ?? 'unknown', required: required.has(name), enum: def.enum };
+  }
+  return out;
+}

--- a/src/diagnostics/schema-drift.ts
+++ b/src/diagnostics/schema-drift.ts
@@ -140,3 +140,46 @@ export function canonicalizeZodSchema(schema: z.ZodTypeAny, wrapperKey?: string)
   // Plain object (system tool, or a non-union wrapper).
   return mergeShapes([target]);
 }
+
+export type DriftKind = 'FIELD_MISSING' | 'ENUM_MISMATCH' | 'REQUIRED_MISMATCH' | 'COERCION_GAP';
+export interface DriftFinding {
+  kind: DriftKind;
+  field: string;
+  detail: string;
+}
+
+export function diffSchemas(advertised: CanonicalSchema, zod: CanonicalSchema): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  const fields = new Set([...Object.keys(advertised), ...Object.keys(zod)]);
+  for (const f of fields) {
+    const a = advertised[f];
+    const z = zod[f];
+    if (a && !z) {
+      findings.push({ kind: 'FIELD_MISSING', field: f, detail: 'advertised to LLM but not validated by Zod' });
+      continue;
+    }
+    if (!a && z) {
+      findings.push({ kind: 'FIELD_MISSING', field: f, detail: 'validated by Zod but never advertised to LLM' });
+      continue;
+    }
+    if (!a || !z) continue;
+    if (a.enum && z.enum && JSON.stringify([...a.enum].sort()) !== JSON.stringify([...z.enum].sort())) {
+      findings.push({ kind: 'ENUM_MISMATCH', field: f, detail: `advertised [${a.enum}] vs validated [${z.enum}]` });
+    }
+    if (a.required !== z.required) {
+      findings.push({
+        kind: 'REQUIRED_MISMATCH',
+        field: f,
+        detail: `advertised required=${a.required} vs validated required=${z.required}`,
+      });
+    }
+    if (a.type === 'number' && z.coercible === false) {
+      findings.push({
+        kind: 'COERCION_GAP',
+        field: f,
+        detail: 'advertised numeric but Zod rejects stringified input (Claude Desktop stringifies all params)',
+      });
+    }
+  }
+  return findings;
+}

--- a/src/diagnostics/tool-schema-registry.ts
+++ b/src/diagnostics/tool-schema-registry.ts
@@ -1,0 +1,38 @@
+// src/diagnostics/tool-schema-registry.ts
+import type { z } from 'zod';
+import { CacheManager } from '../cache/CacheManager.js';
+import { SystemTool } from '../tools/system/SystemTool.js';
+import { OmniFocusReadTool } from '../tools/unified/OmniFocusReadTool.js';
+import { OmniFocusWriteTool } from '../tools/unified/OmniFocusWriteTool.js';
+import { OmniFocusAnalyzeTool } from '../tools/unified/OmniFocusAnalyzeTool.js';
+
+export interface ToolSchemaEntry {
+  name: string;
+  /** Single nesting key for read/write/analyze; undefined for the flat `system` schema. */
+  wrapperKey?: 'query' | 'mutation' | 'analysis';
+  getInputSchema: () => Record<string, unknown>;
+  zodSchema: z.ZodTypeAny;
+}
+
+// Every BaseTool subclass exposes its Zod schema as a public instance property `schema`
+// (SystemTool.ts:93 `schema = SystemToolSchema`; OmniFocusReadTool.ts:205 `schema = ReadSchema`;
+// Write:164 `schema = WriteSchema`; Analyze:300 `schema = AnalyzeSchema`). Reading the instance
+// property avoids importing non-exported symbols (SystemToolSchema is a non-exported const) and
+// needs zero source edits.
+const cache = new CacheManager();
+const sys = new SystemTool(cache);
+const read = new OmniFocusReadTool(cache);
+const write = new OmniFocusWriteTool(cache);
+const analyze = new OmniFocusAnalyzeTool(cache);
+
+export const TOOL_SCHEMA_REGISTRY: ToolSchemaEntry[] = [
+  { name: 'system', getInputSchema: () => sys.inputSchema, zodSchema: sys.schema },
+  { name: 'omnifocus_read', wrapperKey: 'query', getInputSchema: () => read.inputSchema, zodSchema: read.schema },
+  { name: 'omnifocus_write', wrapperKey: 'mutation', getInputSchema: () => write.inputSchema, zodSchema: write.schema },
+  {
+    name: 'omnifocus_analyze',
+    wrapperKey: 'analysis',
+    getInputSchema: () => analyze.inputSchema,
+    zodSchema: analyze.schema,
+  },
+];

--- a/src/diagnostics/triage-doc.ts
+++ b/src/diagnostics/triage-doc.ts
@@ -19,7 +19,10 @@ export interface TriageRow {
 export function renderTriageDoc(rows: TriageRow[], now: Date): string {
   const sorted = [...rows].sort((a, b) => {
     if (b.count !== a.count) return b.count - a.count;
-    return a.fingerprint.localeCompare(b.fingerprint);
+    // Strict byte-wise comparison — localeCompare is locale-sensitive and determinism is a hard requirement.
+    if (a.fingerprint < b.fingerprint) return -1;
+    if (a.fingerprint > b.fingerprint) return 1;
+    return 0;
   });
 
   const generatedAt = now.toISOString();
@@ -43,6 +46,7 @@ export function renderTriageDoc(rows: TriageRow[], now: Date): string {
 | DESCRIPTION_GAP | tool description unclear; LLM-adjudicated |
 | LLM_EXPLORATION | no-op: LLM is probing the API; no fix required |
 | DATA_ERROR | no-op: bad caller data; not a schema issue |
+| NEEDS_LLM | agent not configured or unavailable — manual investigation required |
 | CAP_GUARD_TRIPPED | auto-Linear filing skipped because open issue count >= cap threshold |
 `;
 

--- a/src/diagnostics/triage-doc.ts
+++ b/src/diagnostics/triage-doc.ts
@@ -48,6 +48,7 @@ export function renderTriageDoc(rows: TriageRow[], now: Date): string {
 | DATA_ERROR | no-op: bad caller data; not a schema issue |
 | NEEDS_LLM | agent not configured or unavailable — manual investigation required |
 | CAP_GUARD_TRIPPED | auto-Linear filing skipped because open issue count >= cap threshold |
+| FILE_FAILED | one or more SCHEMA_DRIFT clusters could not be filed to Linear (createIssue rejected); successes were still ledgered |
 `;
 
   return `# MCP Failure Triage

--- a/src/diagnostics/triage-doc.ts
+++ b/src/diagnostics/triage-doc.ts
@@ -1,0 +1,59 @@
+// src/diagnostics/triage-doc.ts
+
+export interface TriageRow {
+  fingerprint: string;
+  tool: string;
+  classification: string;
+  suggestedFix: string;
+  firstSeen: string;
+  lastSeen: string;
+  count: number;
+}
+
+/**
+ * Render a deterministic markdown triage document from a list of diagnosed failure patterns.
+ *
+ * Sort order: count desc, then fingerprint asc (stable, deterministic).
+ * Legend documents the CAP_GUARD_TRIPPED sentinel (Phase 4 adds its use).
+ */
+export function renderTriageDoc(rows: TriageRow[], now: Date): string {
+  const sorted = [...rows].sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.fingerprint.localeCompare(b.fingerprint);
+  });
+
+  const generatedAt = now.toISOString();
+
+  const tableHeader = '| Fingerprint | Tool | Classification | Suggested fix | First seen | Last seen | Count |';
+  const tableSep = '|-------------|------|----------------|---------------|------------|-----------|-------|';
+  const tableRows = sorted
+    .map(
+      (r) =>
+        `| ${r.fingerprint} | ${r.tool} | ${r.classification} | ${r.suggestedFix} | ${r.firstSeen} | ${r.lastSeen} | ${r.count} |`,
+    )
+    .join('\n');
+
+  const legend = `
+## Legend
+
+| Classification | Meaning |
+|----------------|---------|
+| SCHEMA_DRIFT | advertised inputSchema diverged from Zod validation — deterministic |
+| COERCION_MISSING | numeric field present in advertised schema, Zod rejects string input — deterministic |
+| DESCRIPTION_GAP | tool description unclear; LLM-adjudicated |
+| LLM_EXPLORATION | no-op: LLM is probing the API; no fix required |
+| DATA_ERROR | no-op: bad caller data; not a schema issue |
+| CAP_GUARD_TRIPPED | auto-Linear filing skipped because open issue count >= cap threshold |
+`;
+
+  return `# MCP Failure Triage
+
+_Generated at: ${generatedAt}_
+
+## Diagnosed Patterns
+
+${tableHeader}
+${tableSep}
+${tableRows}
+${legend}`;
+}

--- a/tests/unit/diagnostics/__snapshots__/analyze-cli-golden.test.ts.snap
+++ b/tests/unit/diagnostics/__snapshots__/analyze-cli-golden.test.ts.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`analyze-failures CLI output is behavior-preserving > produces identical output before/after the module refactor (golden) 1`] = `
+"═══════════════════════════════════════════════════════════════
+  TOOL FAILURE ANALYSIS - Last 3650 days
+═══════════════════════════════════════════════════════════════
+
+📊 omnifocus_write
+   Total Failures: 2
+   Validation Errors: 2 (100%)
+   Execution Errors: 0 (0%)
+
+   Most Problematic Fields:
+   - name: 2 failures
+
+   Common Error Patterns:
+   - "name: Required for task ID...": 2 times
+
+   Example Failure:
+   Input: {"flagged":true}
+   Error: name: Required for task a1b2c3d4e5
+
+───────────────────────────────────────────────────────────────
+
+📈 SUMMARY
+   Total Tools with Failures: 1
+   Total Failures: 2
+   Validation Errors: 2 (100%)
+   Execution Errors: 0 (0%)
+
+💡 RECOMMENDATIONS
+   • omnifocus_write: Improve description for field "name" (2 failures)
+
+═══════════════════════════════════════════════════════════════
+"
+`;

--- a/tests/unit/diagnostics/analyze-cli-golden.test.ts
+++ b/tests/unit/diagnostics/analyze-cli-golden.test.ts
@@ -1,0 +1,44 @@
+// tests/unit/diagnostics/analyze-cli-golden.test.ts
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Drives the CLI against a fixture HOME so output is deterministic.
+function runCli(homeOverride: string): string {
+  return execFileSync('npx', ['tsx', 'scripts/analyze-tool-failures.ts', '--days=3650'], {
+    env: { ...process.env, HOME: homeOverride },
+    encoding: 'utf-8',
+  });
+}
+
+describe('analyze-failures CLI output is behavior-preserving', () => {
+  it('produces identical output before/after the module refactor (golden)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'omn37-'));
+    const dir = join(home, '.omnifocus-mcp', 'tool-failures');
+    mkdirSync(dir, { recursive: true });
+    const rows = [
+      {
+        timestamp: '2026-05-18T10:00:00.000Z',
+        tool: 'omnifocus_write',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'name: Required for task a1b2c3d4e5',
+        validationErrors: [{ path: ['name'], message: 'Required' }],
+        inputArgs: { flagged: true },
+        schemaDescription: 'd',
+      },
+      {
+        timestamp: '2026-05-18T11:00:00.000Z',
+        tool: 'omnifocus_write',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'name: Required for task f9e8d7c6b5',
+        validationErrors: [{ path: ['name'], message: 'Required' }],
+        inputArgs: { flagged: false },
+        schemaDescription: 'd',
+      },
+    ];
+    writeFileSync(join(dir, 'failures-2026-05-18.jsonl'), rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    expect(runCli(home)).toMatchSnapshot();
+  });
+});

--- a/tests/unit/diagnostics/classify.test.ts
+++ b/tests/unit/diagnostics/classify.test.ts
@@ -1,0 +1,47 @@
+// tests/unit/diagnostics/classify.test.ts
+import { describe, it, expect } from 'vitest';
+import { classifyCluster, isIgnored } from '../../../src/diagnostics/clustering.js';
+import type { FailureCluster } from '../../../src/diagnostics/clustering.js';
+
+const cluster = (over: Partial<FailureCluster>): FailureCluster => ({
+  fingerprint: 'abc',
+  tool: 't',
+  normalizedError: 'e',
+  inputShape: 'a',
+  count: 5,
+  firstSeen: '',
+  lastSeen: '',
+  escalated: true,
+  example: {
+    timestamp: '',
+    tool: 't',
+    errorType: 'VALIDATION_ERROR',
+    errorMessage: 'e',
+    inputArgs: {},
+    schemaDescription: 'd',
+  },
+  ...over,
+});
+
+describe('isIgnored', () => {
+  it('ignores data/infra noise classes', () => {
+    for (const t of ['INVALID_ID', 'NULL_RESULT', 'OMNIFOCUS_NOT_RUNNING', 'SCRIPT_TIMEOUT', 'CONNECTION_TIMEOUT']) {
+      expect(isIgnored(cluster({ example: { ...cluster({}).example, categorization: { errorType: t } } }))).toBe(true);
+    }
+  });
+  it('does not ignore validation errors', () => {
+    expect(isIgnored(cluster({}))).toBe(false);
+  });
+});
+
+describe('classifyCluster', () => {
+  it('classifies a Zod validation cluster as VALIDATION (candidate for drift/coercion/description)', () => {
+    expect(classifyCluster(cluster({}))).toBe('VALIDATION');
+  });
+  it('classifies an ignored cluster as DATA_ERROR', () => {
+    const c = cluster({
+      example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR', categorization: { errorType: 'INVALID_ID' } },
+    });
+    expect(classifyCluster(c)).toBe('DATA_ERROR');
+  });
+});

--- a/tests/unit/diagnostics/classify.test.ts
+++ b/tests/unit/diagnostics/classify.test.ts
@@ -44,4 +44,14 @@ describe('classifyCluster', () => {
     });
     expect(classifyCluster(c)).toBe('DATA_ERROR');
   });
+  it('classifies a non-ignored execution cluster as EXECUTION', () => {
+    // No categorization at all.
+    const noCat = cluster({ example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR' } });
+    expect(classifyCluster(noCat)).toBe('EXECUTION');
+    // Categorization present but errorType NOT in the ignore-set.
+    const nonIgnoredCat = cluster({
+      example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR', categorization: { errorType: 'UNKNOWN_ERROR' } },
+    });
+    expect(classifyCluster(nonIgnoredCat)).toBe('EXECUTION');
+  });
 });

--- a/tests/unit/diagnostics/clustering.test.ts
+++ b/tests/unit/diagnostics/clustering.test.ts
@@ -1,0 +1,44 @@
+// tests/unit/diagnostics/clustering.test.ts
+import { describe, it, expect } from 'vitest';
+import { clusterFailures } from '../../../src/diagnostics/clustering.js';
+import type { FailureRecord } from '../../../src/diagnostics/failure-log.js';
+
+const rec = (over: Partial<FailureRecord>): FailureRecord => ({
+  timestamp: '2026-05-18T10:00:00.000Z',
+  tool: 'omnifocus_write',
+  errorType: 'VALIDATION_ERROR',
+  errorMessage: 'name: Required',
+  inputArgs: { name: 1 },
+  schemaDescription: 'd',
+  ...over,
+});
+
+describe('clusterFailures', () => {
+  it('groups by (tool, normalizedError, inputShape) and assigns a stable fingerprint', () => {
+    const clusters = clusterFailures([rec({}), rec({ inputArgs: { name: 2 } }), rec({})], {
+      minOccurrences: 1,
+      minSpanDays: 999,
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].count).toBe(3);
+    expect(clusters[0].fingerprint).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('escalates a cluster with count >= minOccurrences', () => {
+    const recs = [rec({}), rec({}), rec({})];
+    const [c] = clusterFailures(recs, { minOccurrences: 3, minSpanDays: 999 });
+    expect(c.escalated).toBe(true);
+  });
+
+  it('escalates a low-count cluster that spans >= minSpanDays', () => {
+    const recs = [rec({ timestamp: '2026-05-10T10:00:00.000Z' }), rec({ timestamp: '2026-05-18T10:00:00.000Z' })];
+    const [c] = clusterFailures(recs, { minOccurrences: 99, minSpanDays: 2 });
+    expect(c.escalated).toBe(true);
+    expect(c.count).toBe(2);
+  });
+
+  it('does not escalate a fresh low-count cluster', () => {
+    const [c] = clusterFailures([rec({}), rec({})], { minOccurrences: 3, minSpanDays: 2 });
+    expect(c.escalated).toBe(false);
+  });
+});

--- a/tests/unit/diagnostics/clustering.test.ts
+++ b/tests/unit/diagnostics/clustering.test.ts
@@ -41,4 +41,12 @@ describe('clusterFailures', () => {
     const [c] = clusterFailures([rec({}), rec({})], { minOccurrences: 3, minSpanDays: 2 });
     expect(c.escalated).toBe(false);
   });
+
+  it('treats unparseable timestamps as span=0 (no NaN misfire, falls back to count rule)', () => {
+    const [c] = clusterFailures([rec({ timestamp: '' }), rec({ timestamp: '' })], {
+      minOccurrences: 3,
+      minSpanDays: 2,
+    });
+    expect(c.escalated).toBe(false);
+  });
 });

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { runDiagnosis } from '../../../scripts/diagnose-failures.js';
+import { loadLedger } from '../../../src/diagnostics/ledger.js';
 import { z } from 'zod';
 
 it('deterministically classifies a coercion-gap cluster without invoking the agent', async () => {
@@ -52,4 +53,163 @@ it('deterministically classifies a coercion-gap cluster without invoking the age
     .find((line) => line.includes('omnifocus_x') && line.includes('COERCION_MISSING'));
   expect(classifiedRow, `expected a triage table row classifying omnifocus_x as COERCION_MISSING\n${md}`).toBeDefined();
   expect(classifiedRow).toMatch(/^\|.*\|.*\|/); // it is a markdown table row
+});
+
+// ---------------------------------------------------------------------------
+// Task 15 — --create-issues wiring tests
+// ---------------------------------------------------------------------------
+
+/** Build 3 records spanning >= 2 days for a given tool+error pattern. */
+function makeRecords(tool: string, errorMessage: string) {
+  const base = {
+    tool,
+    errorType: 'VALIDATION_ERROR' as const,
+    errorMessage,
+    inputArgs: {},
+    schemaDescription: 'test',
+  };
+  return [
+    { ...base, timestamp: '2026-05-16T10:00:00.000Z' },
+    { ...base, timestamp: '2026-05-17T10:00:00.000Z' },
+    { ...base, timestamp: '2026-05-18T10:00:00.000Z' },
+  ];
+}
+
+/** Registry entry that yields SCHEMA_DRIFT (REQUIRED_MISMATCH): advertised marks 'mode' required, Zod
+ *  marks it optional → REQUIRED_MISMATCH → deterministicClassification returns SCHEMA_DRIFT. */
+const SCHEMA_DRIFT_ENTRY = {
+  name: 'omnifocus_sd',
+  getInputSchema: () => ({
+    type: 'object',
+    required: ['mode'],
+    properties: { mode: { type: 'string' } },
+  }),
+  zodSchema: z.object({ mode: z.string().optional() }),
+};
+
+/** Registry entry that yields COERCION_MISSING (COERCION_GAP): advertised says number, Zod rejects '5'. */
+const COERCION_MISSING_ENTRY = {
+  name: 'omnifocus_cm',
+  getInputSchema: () => ({ type: 'object', properties: { limit: { type: 'number' } } }),
+  zodSchema: z.object({ limit: z.number() }),
+};
+
+it('does NOT invoke linearFiler when createIssues is false (default)', async () => {
+  // NON-VACUOUS: the cluster would be SCHEMA_DRIFT-classified (the filer should handle it if wired),
+  // but createIssues is not set, so the filer must never be called. Removing the createIssues
+  // guard from runDiagnosis would cause this test to FAIL (filer would be called once).
+  const filer = vi.fn().mockResolvedValue({ created: [], capGuardTripped: false });
+  const sink = vi.fn();
+  const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15a-')), 'ledger.json');
+
+  await runDiagnosis({
+    records: makeRecords('omnifocus_sd', 'Required field mode is missing'),
+    registry: [SCHEMA_DRIFT_ENTRY],
+    ledgerPath,
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    linearFiler: filer,
+    // createIssues deliberately omitted (defaults to false)
+  });
+
+  expect(filer).not.toHaveBeenCalled();
+  expect(sink).toHaveBeenCalledOnce();
+});
+
+it('passes ONLY SCHEMA_DRIFT clusters to filer, writes returned issue ID to ledger', async () => {
+  // NON-VACUOUS proof:
+  // — If the class filter in runDiagnosis were removed, the filer would also receive the
+  //   omnifocus_cm cluster (COERCION_MISSING), making createIssue called 2× instead of 1×.
+  // — If ledger update for linearIssueId were missing, the ledger assertion would fail.
+  const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15b-')), 'ledger.json');
+  const sink = vi.fn();
+
+  // Filer mock: inspect the clusters passed in and return a created entry using the REAL
+  // fingerprint that runDiagnosis computes (so the ledger update can find it by key).
+  const filer = vi.fn().mockImplementation((clusters: Array<{ fingerprint: string; classification: string }>) =>
+    Promise.resolve({
+      created: clusters
+        .filter((c) => c.classification === 'SCHEMA_DRIFT')
+        .slice(0, 1)
+        .map((c) => ({ fingerprint: c.fingerprint, id: 'OMN-42' })),
+      capGuardTripped: false,
+    }),
+  );
+
+  // We need to know what fingerprint runDiagnosis will assign to the omnifocus_sd cluster.
+  // The fingerprint is derived from tool+normalizedError in clustering.ts. To keep the test
+  // stable, we instead verify that the filer was called with exactly one cluster whose
+  // classification is SCHEMA_DRIFT, and that the ledger records a linearIssueId matching
+  // the fingerprint returned in the filer's created array.
+  await runDiagnosis({
+    records: [
+      ...makeRecords('omnifocus_sd', 'Required field mode is missing'),
+      ...makeRecords('omnifocus_cm', 'Expected number, received string'),
+    ],
+    registry: [SCHEMA_DRIFT_ENTRY, COERCION_MISSING_ENTRY],
+    ledgerPath,
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    linearFiler: filer,
+    createIssues: true,
+  });
+
+  // Filer called exactly once
+  expect(filer).toHaveBeenCalledTimes(1);
+  // Only SCHEMA_DRIFT cluster passed to filer (not COERCION_MISSING)
+  const [passedClusters] = filer.mock.calls[0] as [Array<{ classification: string }>];
+  expect(passedClusters).toHaveLength(1);
+  expect(passedClusters[0].classification).toBe('SCHEMA_DRIFT');
+
+  // Ledger entry for the fingerprint returned by filer carries the issue ID
+  const ledger = loadLedger(ledgerPath);
+  const sdEntry = Object.values(ledger.entries).find((e) => e.linearIssueId === 'OMN-42');
+  expect(sdEntry).toBeDefined();
+  expect(sdEntry?.linearIssueId).toBe('OMN-42');
+});
+
+it('appends CAP_GUARD_TRIPPED row to triage doc when filer returns capGuardTripped', async () => {
+  // NON-VACUOUS analysis:
+  // The static legend in renderTriageDoc already contains a "| CAP_GUARD_TRIPPED | ..." line, so
+  // checking for that line alone would be vacuously true even before any Phase-4 wiring.
+  // To make this test bite, we verify:
+  //   (a) the filer is called (fails if createIssues wiring is missing)
+  //   (b) the triage doc data-section (everything before "## Legend") contains a CAP_GUARD_TRIPPED
+  //       occurrence — that occurrence CANNOT come from the legend since we check before it.
+  //
+  // If the CAP_GUARD_TRIPPED-append logic is removed from runDiagnosis:
+  //   — The filer IS still called (a passes), but the data section has no CAP_GUARD_TRIPPED line → (b) fails.
+  // If the createIssues wiring is missing entirely:
+  //   — The filer is never called → (a) fails immediately.
+  const sink = vi.fn();
+  const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15c-')), 'ledger.json');
+
+  const filer = vi.fn().mockResolvedValue({ created: [], capGuardTripped: true });
+
+  await runDiagnosis({
+    records: makeRecords('omnifocus_sd', 'Required field mode is missing'),
+    registry: [SCHEMA_DRIFT_ENTRY],
+    ledgerPath,
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    linearFiler: filer,
+    createIssues: true,
+  });
+
+  // (a) Filer must have been called — fails if wiring is absent
+  expect(filer).toHaveBeenCalledOnce();
+
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+
+  // (b) The data-section (before "## Legend") must contain CAP_GUARD_TRIPPED.
+  //     The legend is AFTER this section, so any match here cannot be the legend.
+  const dataSectionEnd = md.indexOf('## Legend');
+  const dataSection = dataSectionEnd >= 0 ? md.slice(0, dataSectionEnd) : md;
+  expect(dataSection, `expected CAP_GUARD_TRIPPED in the data table (before legend) of:\n${md}`).toContain(
+    'CAP_GUARD_TRIPPED',
+  );
 });

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -117,6 +117,44 @@ it('does NOT invoke linearFiler when createIssues is false (default)', async () 
   expect(sink).toHaveBeenCalledOnce();
 });
 
+it('handles createIssues=true with NO linearFiler (the standalone-CLI path) without throwing', async () => {
+  // This is the exact state the standalone CLI puts runDiagnosis in: --create-issues was
+  // passed (createIssues===true) but there is no linearFiler available in a plain Node
+  // process (MCP graphql action is Claude-runtime-only). runDiagnosis MUST treat the
+  // absent filer as a safe no-op: no throw, no filing attempt, triage doc still written.
+  //
+  // NON-VACUOUS: the records produce a real SCHEMA_DRIFT cluster (omnifocus_sd: advertised
+  // 'mode' required vs Zod optional → REQUIRED_MISMATCH → SCHEMA_DRIFT). If runDiagnosis
+  // were changed to assume/require a filer whenever createIssues is true (e.g.
+  // `await linearFiler(...)` guarded only by `if (createIssues)`), this call would throw
+  // "linearFiler is not a function" on that cluster and the assertions below would fail.
+  // The SCHEMA_DRIFT cluster is what makes the filer-would-have-been-invoked path live.
+  const sink = vi.fn();
+  const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15d-')), 'ledger.json');
+
+  await expect(
+    runDiagnosis({
+      records: makeRecords('omnifocus_sd', 'Required field mode is missing'),
+      registry: [SCHEMA_DRIFT_ENTRY],
+      ledgerPath,
+      now: new Date('2026-05-18T12:00:00Z'),
+      thresholds: { minOccurrences: 3, minSpanDays: 2 },
+      writeTriageDoc: sink,
+      createIssues: true,
+      // linearFiler intentionally undefined — mirrors the standalone CLI runtime
+    }),
+  ).resolves.toBeUndefined();
+
+  // Triage doc still written despite createIssues with no filer
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+  // The SCHEMA_DRIFT row is present (proves a fileable cluster existed — non-vacuous),
+  // and NO CAP_GUARD_TRIPPED row was appended (filer never ran, so no cap result).
+  expect(md).toContain('SCHEMA_DRIFT');
+  const dataSection = md.slice(0, md.indexOf('## Legend') >= 0 ? md.indexOf('## Legend') : md.length);
+  expect(dataSection).not.toContain('CAP_GUARD_TRIPPED');
+});
+
 it('passes ONLY SCHEMA_DRIFT clusters to filer, writes returned issue ID to ledger', async () => {
   // NON-VACUOUS proof:
   // — If the class filter in runDiagnosis were removed, the filer would also receive the

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -10,9 +10,20 @@ it('deterministically classifies a coercion-gap cluster without invoking the age
   const agentRunner = vi.fn();
   const sink = vi.fn();
   await runDiagnosis({
-    records: [
-      /* 3x omnifocus_x failures whose inputShape includes a numeric field the Zod rejects as string */
-    ],
+    records: (() => {
+      const base = {
+        tool: 'omnifocus_x',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'Expected number, received string',
+        inputArgs: { limit: '5' },
+        schemaDescription: 'test',
+      };
+      return [
+        { ...base, timestamp: '2026-05-16T10:00:00.000Z' },
+        { ...base, timestamp: '2026-05-17T10:00:00.000Z' },
+        { ...base, timestamp: '2026-05-18T10:00:00.000Z' },
+      ];
+    })(),
     registry: [
       {
         name: 'omnifocus_x',
@@ -26,8 +37,19 @@ it('deterministically classifies a coercion-gap cluster without invoking the age
     writeTriageDoc: sink,
     agentRunner,
   });
-  expect(agentRunner).not.toHaveBeenCalled(); // deterministic class → no LLM
+  // The agent is bypassed because the cluster was resolved DETERMINISTICALLY
+  // (advertised limit:number vs Zod z.number() rejecting the string '5' → COERCION_GAP),
+  // not because there was nothing to classify.
+  expect(agentRunner).not.toHaveBeenCalled();
   expect(sink).toHaveBeenCalledOnce();
   const md = sink.mock.calls[0][0] as string;
-  expect(md).toContain('COERCION');
+
+  // Assert the actual classified table row is present — NOT the static legend.
+  // The legend line for COERCION_MISSING does not contain the tool name, so a line
+  // carrying BOTH 'omnifocus_x' and 'COERCION_MISSING' can only be the data row.
+  const classifiedRow = md
+    .split('\n')
+    .find((line) => line.includes('omnifocus_x') && line.includes('COERCION_MISSING'));
+  expect(classifiedRow, `expected a triage table row classifying omnifocus_x as COERCION_MISSING\n${md}`).toBeDefined();
+  expect(classifiedRow).toMatch(/^\|.*\|.*\|/); // it is a markdown table row
 });

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -1,0 +1,33 @@
+// tests/unit/diagnostics/diagnose-driver.test.ts
+import { it, expect, vi } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runDiagnosis } from '../../../scripts/diagnose-failures.js';
+import { z } from 'zod';
+
+it('deterministically classifies a coercion-gap cluster without invoking the agent', async () => {
+  const agentRunner = vi.fn();
+  const sink = vi.fn();
+  await runDiagnosis({
+    records: [
+      /* 3x omnifocus_x failures whose inputShape includes a numeric field the Zod rejects as string */
+    ],
+    registry: [
+      {
+        name: 'omnifocus_x',
+        getInputSchema: () => ({ type: 'object', properties: { limit: { type: 'number' } } }),
+        zodSchema: z.object({ limit: z.number() }),
+      },
+    ],
+    ledgerPath: join(mkdtempSync(join(tmpdir(), 'omn37-drv-')), 'ledger.json'),
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    agentRunner,
+  });
+  expect(agentRunner).not.toHaveBeenCalled(); // deterministic class → no LLM
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+  expect(md).toContain('COERCION');
+});

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -98,7 +98,7 @@ it('does NOT invoke linearFiler when createIssues is false (default)', async () 
   // NON-VACUOUS: the cluster would be SCHEMA_DRIFT-classified (the filer should handle it if wired),
   // but createIssues is not set, so the filer must never be called. Removing the createIssues
   // guard from runDiagnosis would cause this test to FAIL (filer would be called once).
-  const filer = vi.fn().mockResolvedValue({ created: [], capGuardTripped: false });
+  const filer = vi.fn().mockResolvedValue({ created: [], failed: [], capGuardTripped: false });
   const sink = vi.fn();
   const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15a-')), 'ledger.json');
 
@@ -171,6 +171,7 @@ it('passes ONLY SCHEMA_DRIFT clusters to filer, writes returned issue ID to ledg
         .filter((c) => c.classification === 'SCHEMA_DRIFT')
         .slice(0, 1)
         .map((c) => ({ fingerprint: c.fingerprint, id: 'OMN-42' })),
+      failed: [],
       capGuardTripped: false,
     }),
   );
@@ -208,6 +209,59 @@ it('passes ONLY SCHEMA_DRIFT clusters to filer, writes returned issue ID to ledg
   expect(sdEntry?.linearIssueId).toBe('OMN-42');
 });
 
+it('partial filer failure: still ledgers the success, appends a FILE_FAILED triage row', async () => {
+  // Two distinct SCHEMA_DRIFT clusters. The filer "creates" the first and "fails" the second.
+  //
+  // NON-VACUOUS: the filer returns BOTH created:[1 entry] AND failed:[1 entry]. If runDiagnosis
+  // skipped the ledger update whenever failed[] is non-empty (the silent-divergence bug this fix
+  // prevents), the ledger assertion would find no linearIssueId → fail. If the FILE_FAILED append
+  // were missing, the triage-doc assertion (data section, before the legend) would fail. The
+  // success-fingerprint is taken from the clusters runDiagnosis actually passes, so it is a real
+  // ledger key, not a hardcoded guess.
+  const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15e-')), 'ledger.json');
+  const sink = vi.fn();
+
+  const SECOND_SD_ENTRY = {
+    name: 'omnifocus_sd2',
+    getInputSchema: () => ({ type: 'object', required: ['mode'], properties: { mode: { type: 'string' } } }),
+    zodSchema: z.object({ mode: z.string().optional() }),
+  };
+
+  const filer = vi.fn().mockImplementation((clusters: Array<{ fingerprint: string; classification: string }>) => {
+    const sd = clusters.filter((c) => c.classification === 'SCHEMA_DRIFT');
+    return Promise.resolve({
+      created: sd.slice(0, 1).map((c) => ({ fingerprint: c.fingerprint, id: 'OMN-77' })),
+      failed: sd.slice(1, 2).map((c) => ({ fingerprint: c.fingerprint, error: 'Linear 503 unavailable' })),
+      capGuardTripped: false,
+    });
+  });
+
+  await runDiagnosis({
+    records: [
+      ...makeRecords('omnifocus_sd', 'Required field mode is missing'),
+      ...makeRecords('omnifocus_sd2', 'Required field mode is missing'),
+    ],
+    registry: [SCHEMA_DRIFT_ENTRY, SECOND_SD_ENTRY],
+    ledgerPath,
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    linearFiler: filer,
+    createIssues: true,
+  });
+
+  // The successfully-created issue id IS in the ledger despite a sibling failure
+  const ledger = loadLedger(ledgerPath);
+  const success = Object.values(ledger.entries).find((e) => e.linearIssueId === 'OMN-77');
+  expect(success, 'success must be ledgered even when another cluster failed to file').toBeDefined();
+
+  // A FILE_FAILED row is present in the data section (before the legend — not the legend entry)
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+  const dataSection = md.slice(0, md.indexOf('## Legend') >= 0 ? md.indexOf('## Legend') : md.length);
+  expect(dataSection, `expected a FILE_FAILED row in the data section of:\n${md}`).toContain('FILE_FAILED');
+});
+
 it('appends CAP_GUARD_TRIPPED row to triage doc when filer returns capGuardTripped', async () => {
   // NON-VACUOUS analysis:
   // The static legend in renderTriageDoc already contains a "| CAP_GUARD_TRIPPED | ..." line, so
@@ -224,7 +278,7 @@ it('appends CAP_GUARD_TRIPPED row to triage doc when filer returns capGuardTripp
   const sink = vi.fn();
   const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-t15c-')), 'ledger.json');
 
-  const filer = vi.fn().mockResolvedValue({ created: [], capGuardTripped: true });
+  const filer = vi.fn().mockResolvedValue({ created: [], failed: [], capGuardTripped: true });
 
   await runDiagnosis({
     records: makeRecords('omnifocus_sd', 'Required field mode is missing'),

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -262,6 +262,54 @@ it('partial filer failure: still ledgers the success, appends a FILE_FAILED tria
   expect(dataSection, `expected a FILE_FAILED row in the data section of:\n${md}`).toContain('FILE_FAILED');
 });
 
+it('warns (does not silently drop) when filer returns a created id for an unknown fingerprint', async () => {
+  // Invariant violation: filer reports creating an issue for a fingerprint that has NO ledger
+  // entry. Cannot happen via the single in-repo call site, but the injected linearFiler seam
+  // makes a rogue/future filer able to reach it. runDiagnosis must surface it loudly, not drop it.
+  //
+  // NON-VACUOUS: the orphan fingerprint 'ghost-fp-not-a-cluster' is deliberately NOT among the
+  // input clusters, so it will never be a ledger key. The assertion requires console.warn to
+  // have been called with a message containing that exact orphan fingerprint — if the `else`
+  // branch were removed (silent drop), warn is never called and the test fails.
+  const ledgerPath = join(mkdtempSync(join(tmpdir(), 'omn37-orphan-')), 'ledger.json');
+  const sink = vi.fn();
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  const filer = vi.fn().mockResolvedValue({
+    created: [{ fingerprint: 'ghost-fp-not-a-cluster', id: 'OMN-999' }],
+    failed: [],
+    capGuardTripped: false,
+  });
+
+  try {
+    await expect(
+      runDiagnosis({
+        records: makeRecords('omnifocus_sd', 'Required field mode is missing'),
+        registry: [SCHEMA_DRIFT_ENTRY],
+        ledgerPath,
+        now: new Date('2026-05-18T12:00:00Z'),
+        thresholds: { minOccurrences: 3, minSpanDays: 2 },
+        writeTriageDoc: sink,
+        linearFiler: filer,
+        createIssues: true,
+      }),
+    ).resolves.toBeUndefined(); // still resolves — the anomaly does not abort the run
+
+    // The orphan id was NOT recorded against any ledger entry
+    const ledger = loadLedger(ledgerPath);
+    const orphan = Object.values(ledger.entries).find((e) => e.linearIssueId === 'OMN-999');
+    expect(orphan, 'orphan issue id must NOT be associated to any ledger entry').toBeUndefined();
+
+    // ...but it was surfaced loudly with the orphan fingerprint (and id) in the message
+    expect(warnSpy).toHaveBeenCalled();
+    const warnMsg = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warnMsg).toContain('ghost-fp-not-a-cluster');
+    expect(warnMsg).toContain('OMN-999');
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+
 it('appends CAP_GUARD_TRIPPED row to triage doc when filer returns capGuardTripped', async () => {
   // NON-VACUOUS analysis:
   // The static legend in renderTriageDoc already contains a "| CAP_GUARD_TRIPPED | ..." line, so

--- a/tests/unit/diagnostics/diagnose-driver.test.ts
+++ b/tests/unit/diagnostics/diagnose-driver.test.ts
@@ -353,3 +353,78 @@ it('appends CAP_GUARD_TRIPPED row to triage doc when filer returns capGuardTripp
     'CAP_GUARD_TRIPPED',
   );
 });
+
+// ---------------------------------------------------------------------------
+// FIELD_MISSING deviation — pins the deliberate v1 carve-out documented in PR #24
+// (deterministicClassification filters `f.kind !== 'FIELD_MISSING'`, so a
+// FIELD_MISSING-only cluster is NOT classified inline / NOT auto-filed; it goes
+// to the LLM agent, falling back to NEEDS_LLM when no agent is configured).
+// ---------------------------------------------------------------------------
+
+/** Registry entry that yields FIELD_MISSING ONLY: advertised exposes a field Zod never
+ *  validates → diffSchemas emits exactly one FIELD_MISSING finding, no ENUM/REQUIRED/
+ *  COERCION. With FIELD_MISSING excluded from the deterministic path this cluster has
+ *  NO deterministic classification. */
+const FIELD_MISSING_ENTRY = {
+  name: 'omnifocus_fm',
+  getInputSchema: () => ({ type: 'object', properties: { phantom: { type: 'string' } } }),
+  zodSchema: z.object({}),
+};
+
+it('FIELD_MISSING-only cluster is NOT deterministically classified — routes to the LLM agent', async () => {
+  // NON-VACUOUS: if the `f.kind !== 'FIELD_MISSING'` filter were removed from
+  // deterministicClassification (i.e. FIELD_MISSING treated as a blocking finding),
+  // this cluster would resolve INLINE as SCHEMA_DRIFT and the agent would be bypassed —
+  // so `expect(agentRunner).toHaveBeenCalledOnce()` would fail. The agent being invoked
+  // is therefore proof the FIELD_MISSING carve-out is in effect, not that nothing classified.
+  const agentRunner = vi.fn().mockResolvedValue({
+    classification: 'DESCRIPTION_GAP',
+    suggestedFix: 'agent judgement',
+  });
+  const sink = vi.fn();
+
+  await runDiagnosis({
+    records: makeRecords('omnifocus_fm', 'unexpected field phantom'),
+    registry: [FIELD_MISSING_ENTRY],
+    ledgerPath: join(mkdtempSync(join(tmpdir(), 'omn37-fm-a-')), 'ledger.json'),
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    agentRunner,
+  });
+
+  expect(agentRunner).toHaveBeenCalledOnce();
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+  // The data row carries BOTH the tool name and the agent's classification — a legend
+  // line never contains the tool name, so this can only be the classified table row.
+  const row = md.split('\n').find((l) => l.includes('omnifocus_fm') && l.includes('DESCRIPTION_GAP'));
+  expect(row, `expected an agent-classified row for omnifocus_fm\n${md}`).toBeDefined();
+});
+
+it('FIELD_MISSING-only cluster falls back to NEEDS_LLM when no agent is configured (never SCHEMA_DRIFT)', async () => {
+  // NON-VACUOUS: with FIELD_MISSING excluded from the deterministic path AND no
+  // agentRunner injected, the only correct classification is NEEDS_LLM. If the
+  // FIELD_MISSING carve-out were dropped, this same cluster would instead surface
+  // as a deterministic SCHEMA_DRIFT row (and become auto-fileable) — so the
+  // assertions below (NEEDS_LLM present, SCHEMA_DRIFT absent for this tool) would fail.
+  const sink = vi.fn();
+
+  await runDiagnosis({
+    records: makeRecords('omnifocus_fm', 'unexpected field phantom'),
+    registry: [FIELD_MISSING_ENTRY],
+    ledgerPath: join(mkdtempSync(join(tmpdir(), 'omn37-fm-b-')), 'ledger.json'),
+    now: new Date('2026-05-18T12:00:00Z'),
+    thresholds: { minOccurrences: 3, minSpanDays: 2 },
+    writeTriageDoc: sink,
+    // agentRunner intentionally omitted — exercises the no-agent fallback branch
+  });
+
+  expect(sink).toHaveBeenCalledOnce();
+  const md = sink.mock.calls[0][0] as string;
+  const needsLlmRow = md.split('\n').find((l) => l.includes('omnifocus_fm') && l.includes('NEEDS_LLM'));
+  expect(needsLlmRow, `expected a NEEDS_LLM row for omnifocus_fm\n${md}`).toBeDefined();
+  // And it must NOT have been deterministically classified as fileable SCHEMA_DRIFT.
+  const driftRow = md.split('\n').find((l) => l.includes('omnifocus_fm') && l.includes('SCHEMA_DRIFT'));
+  expect(driftRow, `omnifocus_fm must NOT be classified SCHEMA_DRIFT (FIELD_MISSING carve-out)\n${md}`).toBeUndefined();
+});

--- a/tests/unit/diagnostics/diagnoser-agent.test.ts
+++ b/tests/unit/diagnostics/diagnoser-agent.test.ts
@@ -1,0 +1,14 @@
+// tests/unit/diagnostics/diagnoser-agent.test.ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('mcp-failure-diagnoser agent', () => {
+  it('has frontmatter name/description and enumerates the five classifications', () => {
+    const md = readFileSync(join(process.cwd(), '.claude/agents/mcp-failure-diagnoser.md'), 'utf-8');
+    expect(md).toMatch(/^---[\s\S]*name:\s*mcp-failure-diagnoser[\s\S]*---/);
+    for (const k of ['SCHEMA_DRIFT', 'DESCRIPTION_GAP', 'COERCION_MISSING', 'LLM_EXPLORATION', 'DATA_ERROR']) {
+      expect(md).toContain(k);
+    }
+  });
+});

--- a/tests/unit/diagnostics/failure-log.test.ts
+++ b/tests/unit/diagnostics/failure-log.test.ts
@@ -1,0 +1,46 @@
+// tests/unit/diagnostics/failure-log.test.ts
+import { describe, it, expect } from 'vitest';
+import { parseFailureLog } from '../../../src/diagnostics/failure-log.js';
+
+describe('parseFailureLog', () => {
+  it('parses valid JSONL lines into FailureRecord[]', () => {
+    const jsonl = [
+      JSON.stringify({
+        timestamp: '2026-05-18T10:00:00.000Z',
+        tool: 'omnifocus_write',
+        errorType: 'VALIDATION_ERROR',
+        errorMessage: 'name: Required',
+        inputArgs: { x: 1 },
+        schemaDescription: 'd',
+      }),
+      JSON.stringify({
+        timestamp: '2026-05-18T10:01:00.000Z',
+        tool: 'omnifocus_read',
+        errorType: 'EXECUTION_ERROR',
+        errorMessage: 'boom',
+        inputArgs: {},
+        schemaDescription: 'd',
+        categorization: { errorType: 'INVALID_ID', severity: 'low', recoverable: true },
+      }),
+    ].join('\n');
+    const recs = parseFailureLog(jsonl);
+    expect(recs).toHaveLength(2);
+    expect(recs[0].tool).toBe('omnifocus_write');
+    expect(recs[1].categorization?.errorType).toBe('INVALID_ID');
+  });
+
+  it('skips malformed lines and blank lines without throwing', () => {
+    const jsonl =
+      'not json\n\n' +
+      JSON.stringify({
+        timestamp: '2026-05-18T10:00:00.000Z',
+        tool: 't',
+        errorType: 'EXECUTION_ERROR',
+        errorMessage: 'e',
+        inputArgs: {},
+        schemaDescription: 'd',
+      });
+    const recs = parseFailureLog(jsonl);
+    expect(recs).toHaveLength(1);
+  });
+});

--- a/tests/unit/diagnostics/ledger.test.ts
+++ b/tests/unit/diagnostics/ledger.test.ts
@@ -18,4 +18,34 @@ describe('seen-patterns ledger', () => {
     expect(isKnown(loadLedger(path), 'fp1')).toBe(true);
     expect(loadLedger(path).entries['fp1'].linearIssueId).toBe('OMN-99');
   });
+
+  it('preserves the original diagnosedAt across a later update (linearIssueId attach)', () => {
+    // diagnosedAt = "when first diagnosed"; a subsequent update (e.g. attaching a
+    // linearIssueId after auto-filing) must NOT reset it to the update-run time.
+    // NON-VACUOUS: the second recordDiagnosis is called with a LATER `now`. Under the old
+    // unconditional `diagnosedAt: now.toISOString()` behavior this assertion fails (the
+    // timestamp would advance to the second `now`); it only holds because recordDiagnosis
+    // now honors an already-present diagnosedAt.
+    const path = join(mkdtempSync(join(tmpdir(), 'omn37led2-')), 'diagnosed-patterns.json');
+    const firstNow = new Date('2026-05-10T08:00:00.000Z');
+    const laterNow = new Date('2026-05-18T17:30:00.000Z');
+
+    let ledger = recordDiagnosis(
+      loadLedger(path),
+      path,
+      { fingerprint: 'fpX', classification: 'SCHEMA_DRIFT' },
+      firstNow,
+    );
+    const firstStamp = loadLedger(path).entries['fpX'].diagnosedAt;
+    expect(firstStamp).toBe(firstNow.toISOString());
+
+    // Simulate the Phase-4 update path: spread the existing entry (carries diagnosedAt) + add issue id.
+    const existing = ledger.entries['fpX'];
+    ledger = recordDiagnosis(ledger, path, { ...existing, linearIssueId: 'OMN-77' }, laterNow);
+
+    const updated = loadLedger(path).entries['fpX'];
+    expect(updated.linearIssueId).toBe('OMN-77'); // update applied
+    expect(updated.diagnosedAt).toBe(firstStamp); // ...but original timestamp preserved
+    expect(updated.diagnosedAt).not.toBe(laterNow.toISOString());
+  });
 });

--- a/tests/unit/diagnostics/ledger.test.ts
+++ b/tests/unit/diagnostics/ledger.test.ts
@@ -1,0 +1,21 @@
+// tests/unit/diagnostics/ledger.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadLedger, recordDiagnosis, isKnown } from '../../../src/diagnostics/ledger.js';
+
+describe('seen-patterns ledger', () => {
+  it('round-trips and recognizes a known fingerprint', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'omn37led-')), 'diagnosed-patterns.json');
+    let ledger = loadLedger(path); // missing file → empty
+    expect(isKnown(ledger, 'fp1')).toBe(false);
+    ledger = recordDiagnosis(ledger, path, {
+      fingerprint: 'fp1',
+      classification: 'SCHEMA_DRIFT',
+      linearIssueId: 'OMN-99',
+    });
+    expect(isKnown(loadLedger(path), 'fp1')).toBe(true);
+    expect(loadLedger(path).entries['fp1'].linearIssueId).toBe('OMN-99');
+  });
+});

--- a/tests/unit/diagnostics/linear-filer.test.ts
+++ b/tests/unit/diagnostics/linear-filer.test.ts
@@ -44,6 +44,10 @@ it('dedups against an existing issue with the same fingerprint in body', async (
   };
   await fileDriftIssues([cluster('dup', 'SCHEMA_DRIFT')], { client, perRunLimit: 3, capThreshold: 230 });
   expect(client.createIssue).not.toHaveBeenCalled();
+  // Assert the dedup search actually ran with the right label + fingerprint. Without this,
+  // a bug that skips searchByLabelAndBody entirely (treating dedup as always-true) would
+  // pass silently — createIssue would also not be called for the wrong reason.
+  expect(client.searchByLabelAndBody).toHaveBeenCalledWith('omn-37-auto', 'dup');
 });
 
 it('caps creations at perRunLimit', async () => {
@@ -62,4 +66,51 @@ it('caps creations at perRunLimit', async () => {
     { client, perRunLimit: 3, capThreshold: 230 },
   );
   expect(client.createIssue).toHaveBeenCalledTimes(3);
+});
+
+it('isolates a mid-loop createIssue failure: records it in failed[], continues, does NOT throw', async () => {
+  // 3 eligible SCHEMA_DRIFT clusters, perRunLimit high enough for all 3. createIssue resolves
+  // for cluster 1, REJECTS for cluster 2, resolves for cluster 3.
+  //
+  // NON-VACUOUS: if the per-cluster try/catch were removed, the cluster-2 rejection would
+  // propagate out of fileDriftIssues — the `await expect(...).resolves` below would fail
+  // (it would reject), cluster 3's createIssue would never be attempted (call count 2 not 3),
+  // and `created` would never be returned to the caller (silent loss of cluster 1). Each of
+  // the three assertions independently bites if the isolation is gone.
+  const createIssue = vi
+    .fn()
+    .mockResolvedValueOnce('OMN-101') // cluster 1 ok
+    .mockRejectedValueOnce(new Error('Linear 500: rate limited')) // cluster 2 fails
+    .mockResolvedValueOnce('OMN-103'); // cluster 3 ok (proves loop continued past the failure)
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue([]),
+    createIssue,
+  };
+
+  const result = await fileDriftIssues(
+    [cluster('c1', 'SCHEMA_DRIFT'), cluster('c2', 'SCHEMA_DRIFT'), cluster('c3', 'SCHEMA_DRIFT')],
+    { client, perRunLimit: 5, capThreshold: 230 },
+  );
+
+  // Did NOT throw (we got a result) and cluster 3 WAS still attempted after cluster 2 failed
+  expect(createIssue).toHaveBeenCalledTimes(3);
+  // Successes carry their fingerprints
+  expect(result.created).toEqual([
+    { fingerprint: 'c1', id: 'OMN-101' },
+    { fingerprint: 'c3', id: 'OMN-103' },
+  ]);
+  // The failed cluster is recorded with its error message — caller can surface FILE_FAILED
+  expect(result.failed).toEqual([{ fingerprint: 'c2', error: 'Linear 500: rate limited' }]);
+  expect(result.capGuardTripped).toBe(false);
+});
+
+it('returns failed:[] when nothing fails (always present)', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue([]),
+    createIssue: vi.fn().mockResolvedValue('OMN-1'),
+  };
+  const r = await fileDriftIssues([cluster('a', 'SCHEMA_DRIFT')], { client, perRunLimit: 3, capThreshold: 230 });
+  expect(r.failed).toEqual([]);
 });

--- a/tests/unit/diagnostics/linear-filer.test.ts
+++ b/tests/unit/diagnostics/linear-filer.test.ts
@@ -1,0 +1,65 @@
+// tests/unit/diagnostics/linear-filer.test.ts
+import { it, expect, vi } from 'vitest';
+import { fileDriftIssues } from '../../../src/diagnostics/linear-filer.js';
+
+const cluster = (fp: string, cls: string) => ({
+  fingerprint: fp,
+  tool: 't',
+  classification: cls,
+  suggestedFix: 'fix',
+  firstSeen: '',
+  lastSeen: '',
+  count: 5,
+});
+
+it('files ONLY SCHEMA_DRIFT, never judgment/no-op classes', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue([]),
+    createIssue: vi.fn().mockResolvedValue('OMN-1'),
+  };
+  await fileDriftIssues(
+    [cluster('a', 'SCHEMA_DRIFT'), cluster('b', 'DESCRIPTION_GAP'), cluster('c', 'COERCION_MISSING')],
+    { client, perRunLimit: 3, capThreshold: 230 },
+  );
+  expect(client.createIssue).toHaveBeenCalledTimes(1);
+});
+
+it('trips the cap guard at >= capThreshold and creates nothing', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(230),
+    searchByLabelAndBody: vi.fn(),
+    createIssue: vi.fn(),
+  };
+  const r = await fileDriftIssues([cluster('a', 'SCHEMA_DRIFT')], { client, perRunLimit: 3, capThreshold: 230 });
+  expect(client.createIssue).not.toHaveBeenCalled();
+  expect(r.capGuardTripped).toBe(true);
+});
+
+it('dedups against an existing issue with the same fingerprint in body', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue(['OMN-7']),
+    createIssue: vi.fn(),
+  };
+  await fileDriftIssues([cluster('dup', 'SCHEMA_DRIFT')], { client, perRunLimit: 3, capThreshold: 230 });
+  expect(client.createIssue).not.toHaveBeenCalled();
+});
+
+it('caps creations at perRunLimit', async () => {
+  const client = {
+    openIssueCount: vi.fn().mockResolvedValue(10),
+    searchByLabelAndBody: vi.fn().mockResolvedValue([]),
+    createIssue: vi.fn().mockResolvedValue('OMN-X'),
+  };
+  await fileDriftIssues(
+    [
+      cluster('a', 'SCHEMA_DRIFT'),
+      cluster('b', 'SCHEMA_DRIFT'),
+      cluster('c', 'SCHEMA_DRIFT'),
+      cluster('d', 'SCHEMA_DRIFT'),
+    ],
+    { client, perRunLimit: 3, capThreshold: 230 },
+  );
+  expect(client.createIssue).toHaveBeenCalledTimes(3);
+});

--- a/tests/unit/diagnostics/marker-script.test.ts
+++ b/tests/unit/diagnostics/marker-script.test.ts
@@ -1,8 +1,11 @@
 // tests/unit/diagnostics/marker-script.test.ts
 //
 // Verifies that scripts/mcp-failure-marker.sh:
-//  1. Appends exactly one ISO8601<TAB>tool line per invocation.
-//  2. Does NOT contain `claude -p` (must never spawn an agent).
+//  1. Reads tool_name from the stdin JSON payload (the way Claude Code's
+//     command-type hook runner actually invokes it — NOT a positional arg).
+//  2. Appends exactly one ISO8601<TAB>tool line per invocation.
+//  3. Never spawns an agent (`claude -p` absent from the script source).
+//  4. Fails silently (exit 0, no throw) on empty / non-JSON stdin.
 //
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
@@ -12,19 +15,25 @@ import { join, resolve } from 'path';
 
 const SCRIPT = resolve(process.cwd(), 'scripts/mcp-failure-marker.sh');
 
+// Drive the script the way the real hook runner does: JSON piped to stdin.
+function runHook(payload: object, markerFile: string): void {
+  execFileSync('bash', [SCRIPT], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, OMN37_MARKER: markerFile },
+  });
+}
+
 describe('mcp-failure-marker.sh', () => {
   it('does NOT contain `claude -p` (must never spawn an agent)', () => {
     const src = readFileSync(SCRIPT, 'utf-8');
     expect(src).not.toMatch(/claude\s+-p/);
   });
 
-  it('appends exactly one ISO8601<TAB>tool line per invocation', () => {
+  it('reads tool_name from stdin JSON and appends one ISO8601<TAB>tool line', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'omn37-marker-'));
     const markerFile = join(tmpDir, 'fresh-failures.tsv');
 
-    execFileSync('bash', [SCRIPT, 'omnifocus_read'], {
-      env: { ...process.env, OMN37_MARKER: markerFile },
-    });
+    runHook({ hook_event_name: 'PostToolUse', tool_name: 'mcp__omnifocus__omnifocus_read' }, markerFile);
 
     expect(existsSync(markerFile)).toBe(true);
     const lines = readFileSync(markerFile, 'utf-8')
@@ -32,28 +41,57 @@ describe('mcp-failure-marker.sh', () => {
       .filter((l) => l.trim() !== '');
     expect(lines).toHaveLength(1);
 
-    // Each line must be ISO8601<TAB>tool
     const [ts, tool] = lines[0].split('\t');
     expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
-    expect(tool).toBe('omnifocus_read');
+    expect(tool).toBe('mcp__omnifocus__omnifocus_read');
   });
 
   it('appends a second line on the second call (never overwrites)', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'omn37-marker2-'));
     const markerFile = join(tmpDir, 'fresh-failures.tsv');
 
-    execFileSync('bash', [SCRIPT, 'omnifocus_write'], {
-      env: { ...process.env, OMN37_MARKER: markerFile },
-    });
-    execFileSync('bash', [SCRIPT, 'omnifocus_analyze'], {
-      env: { ...process.env, OMN37_MARKER: markerFile },
-    });
+    runHook({ hook_event_name: 'PostToolUse', tool_name: 'mcp__omnifocus__omnifocus_write' }, markerFile);
+    runHook({ hook_event_name: 'PostToolUse', tool_name: 'mcp__omnifocus__omnifocus_analyze' }, markerFile);
 
     const lines = readFileSync(markerFile, 'utf-8')
       .split('\n')
       .filter((l) => l.trim() !== '');
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toContain('omnifocus_write');
-    expect(lines[1]).toContain('omnifocus_analyze');
+    expect(lines[0]).toContain('mcp__omnifocus__omnifocus_write');
+    expect(lines[1]).toContain('mcp__omnifocus__omnifocus_analyze');
+  });
+
+  it('fails silently on empty stdin: exits 0, appends an empty tool field, does not throw', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omn37-marker-empty-'));
+    const markerFile = join(tmpDir, 'fresh-failures.tsv');
+
+    // Empty stdin — must not throw (execFileSync throws on non-zero exit).
+    expect(() =>
+      execFileSync('bash', [SCRIPT], {
+        input: '',
+        env: { ...process.env, OMN37_MARKER: markerFile },
+      }),
+    ).not.toThrow();
+
+    const lines = readFileSync(markerFile, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(1);
+    // Timestamp present, tool field empty (script appends the row, does not skip).
+    const [ts, tool] = lines[0].split('\t');
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(tool ?? '').toBe('');
+  });
+
+  it('fails silently on non-JSON stdin: exits 0, does not throw', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omn37-marker-junk-'));
+    const markerFile = join(tmpDir, 'fresh-failures.tsv');
+
+    expect(() =>
+      execFileSync('bash', [SCRIPT], {
+        input: 'this is not json {{{',
+        env: { ...process.env, OMN37_MARKER: markerFile },
+      }),
+    ).not.toThrow();
   });
 });

--- a/tests/unit/diagnostics/marker-script.test.ts
+++ b/tests/unit/diagnostics/marker-script.test.ts
@@ -1,0 +1,59 @@
+// tests/unit/diagnostics/marker-script.test.ts
+//
+// Verifies that scripts/mcp-failure-marker.sh:
+//  1. Appends exactly one ISO8601<TAB>tool line per invocation.
+//  2. Does NOT contain `claude -p` (must never spawn an agent).
+//
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const SCRIPT = resolve(process.cwd(), 'scripts/mcp-failure-marker.sh');
+
+describe('mcp-failure-marker.sh', () => {
+  it('does NOT contain `claude -p` (must never spawn an agent)', () => {
+    const src = readFileSync(SCRIPT, 'utf-8');
+    expect(src).not.toMatch(/claude\s+-p/);
+  });
+
+  it('appends exactly one ISO8601<TAB>tool line per invocation', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omn37-marker-'));
+    const markerFile = join(tmpDir, 'fresh-failures.tsv');
+
+    execFileSync('bash', [SCRIPT, 'omnifocus_read'], {
+      env: { ...process.env, OMN37_MARKER: markerFile },
+    });
+
+    expect(existsSync(markerFile)).toBe(true);
+    const lines = readFileSync(markerFile, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(1);
+
+    // Each line must be ISO8601<TAB>tool
+    const [ts, tool] = lines[0].split('\t');
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(tool).toBe('omnifocus_read');
+  });
+
+  it('appends a second line on the second call (never overwrites)', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omn37-marker2-'));
+    const markerFile = join(tmpDir, 'fresh-failures.tsv');
+
+    execFileSync('bash', [SCRIPT, 'omnifocus_write'], {
+      env: { ...process.env, OMN37_MARKER: markerFile },
+    });
+    execFileSync('bash', [SCRIPT, 'omnifocus_analyze'], {
+      env: { ...process.env, OMN37_MARKER: markerFile },
+    });
+
+    const lines = readFileSync(markerFile, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('omnifocus_write');
+    expect(lines[1]).toContain('omnifocus_analyze');
+  });
+});

--- a/tests/unit/diagnostics/normalize.test.ts
+++ b/tests/unit/diagnostics/normalize.test.ts
@@ -1,0 +1,21 @@
+// tests/unit/diagnostics/normalize.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeErrorMessage, normalizeInputShape } from '../../../src/diagnostics/normalize.js';
+
+describe('normalizeErrorMessage', () => {
+  it('replaces hex IDs and ISO dates with placeholders and truncates to 100 chars', () => {
+    expect(normalizeErrorMessage('task a1b2c3d4e5 not found on 2026-05-18')).toBe('task ID not found on DATE');
+    expect(normalizeErrorMessage('x'.repeat(200)).length).toBe(100);
+  });
+});
+
+describe('normalizeInputShape', () => {
+  it('produces a stable shape string keyed by sorted top-level keys, not values', () => {
+    expect(normalizeInputShape({ b: 2, a: 'hello' })).toBe(normalizeInputShape({ a: 'world', b: 99 }));
+    expect(normalizeInputShape({ a: 1 })).not.toBe(normalizeInputShape({ a: 1, c: 2 }));
+  });
+  it('handles non-object inputs', () => {
+    expect(normalizeInputShape(null)).toBe('<non-object>');
+    expect(normalizeInputShape('str')).toBe('<non-object>');
+  });
+});

--- a/tests/unit/diagnostics/schema-drift-tools.test.ts
+++ b/tests/unit/diagnostics/schema-drift-tools.test.ts
@@ -1,0 +1,19 @@
+// tests/unit/diagnostics/schema-drift-tools.test.ts
+import { describe, it, expect } from 'vitest';
+import { TOOL_SCHEMA_REGISTRY } from '../../../src/diagnostics/tool-schema-registry.js';
+import { canonicalizeInputSchema, canonicalizeZodSchema, diffSchemas } from '../../../src/diagnostics/schema-drift.js';
+
+describe('inputSchema <-> Zod drift gate (fails CI on drift)', () => {
+  for (const entry of TOOL_SCHEMA_REGISTRY) {
+    it(`${entry.name}: advertised schema matches Zod validation`, () => {
+      const findings = diffSchemas(
+        canonicalizeInputSchema(entry.getInputSchema(), entry.wrapperKey),
+        canonicalizeZodSchema(entry.zodSchema, entry.wrapperKey),
+      );
+      // Some advertised-vs-validated asymmetry is intentional (compact advertised schema).
+      // The gate fails ONLY on the high-signal kinds: enum/required/coercion drift.
+      const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');
+      expect(blocking, `${entry.name} drift: ${JSON.stringify(findings, null, 2)}`).toEqual([]);
+    });
+  }
+});

--- a/tests/unit/diagnostics/schema-drift-tools.test.ts
+++ b/tests/unit/diagnostics/schema-drift-tools.test.ts
@@ -3,13 +3,39 @@ import { describe, it, expect } from 'vitest';
 import { TOOL_SCHEMA_REGISTRY } from '../../../src/diagnostics/tool-schema-registry.js';
 import { canonicalizeInputSchema, canonicalizeZodSchema, diffSchemas } from '../../../src/diagnostics/schema-drift.js';
 
+// Non-vacuity floor (verified against commit 2ce9255). The gate's blocking-findings
+// assertion is satisfied trivially if BOTH canonicalizers collapse to {} — e.g. a Zod
+// major upgrade renaming `_def.typeName` so `unwrap`/`membersOf` return [] →
+// `mergeShapes` → {} → `diffSchemas({}, {})` → []. These exact lower bounds make that
+// silent shrink a HARD FAIL (the OMN-65 vacuous-green lesson, applied to the gate itself).
+const EXPECTED_MIN_FIELDS: Record<string, number> = {
+  system: 4,
+  omnifocus_read: 17,
+  omnifocus_write: 19,
+  omnifocus_analyze: 3,
+};
+
 describe('inputSchema <-> Zod drift gate (fails CI on drift)', () => {
   for (const entry of TOOL_SCHEMA_REGISTRY) {
     it(`${entry.name}: advertised schema matches Zod validation`, () => {
-      const findings = diffSchemas(
-        canonicalizeInputSchema(entry.getInputSchema(), entry.wrapperKey),
-        canonicalizeZodSchema(entry.zodSchema, entry.wrapperKey),
-      );
+      const advertised = canonicalizeInputSchema(entry.getInputSchema(), entry.wrapperKey);
+      const zod = canonicalizeZodSchema(entry.zodSchema, entry.wrapperKey);
+
+      // Non-vacuity guard FIRST: both sides must canonicalize to a sane field count.
+      // If this fires, the blocking-findings check below is meaningless — fix the
+      // canonicalizer (likely `_def` internals; see schema-drift.ts breadcrumb) before
+      // trusting a green gate.
+      const expectedMin = EXPECTED_MIN_FIELDS[entry.name];
+      expect(
+        Object.keys(zod).length,
+        `${entry.name}: Zod canonicalization collapsed — _def internals may have changed`,
+      ).toBeGreaterThanOrEqual(expectedMin);
+      expect(
+        Object.keys(advertised).length,
+        `${entry.name}: advertised canonicalization collapsed — inputSchema shape may have changed`,
+      ).toBeGreaterThanOrEqual(expectedMin);
+
+      const findings = diffSchemas(advertised, zod);
       // Some advertised-vs-validated asymmetry is intentional (compact advertised schema).
       // The gate fails ONLY on the high-signal kinds: enum/required/coercion drift.
       const blocking = findings.filter((f) => f.kind !== 'FIELD_MISSING');

--- a/tests/unit/diagnostics/schema-drift.test.ts
+++ b/tests/unit/diagnostics/schema-drift.test.ts
@@ -82,13 +82,19 @@ describe('diffSchemas', () => {
   it('reports FIELD_MISSING, ENUM_MISMATCH, REQUIRED_MISMATCH, COERCION_GAP', () => {
     const advertised = canonicalizeInputSchema({
       type: 'object',
-      properties: { mode: { type: 'string', enum: ['a', 'b'] }, limit: { type: 'number' }, ghost: { type: 'string' } },
-      required: ['mode'],
+      properties: {
+        mode: { type: 'string', enum: ['a', 'b'] },
+        limit: { type: 'number' },
+        ghost: { type: 'string' },
+        requiredHere: { type: 'string' }, // required in advertised, optional in Zod -> REQUIRED_MISMATCH
+      },
+      required: ['mode', 'requiredHere'],
     });
     const zod = canonicalizeZodSchema(
       z.object({
         mode: z.enum(['a']), // ENUM_MISMATCH (b advertised, not validated)
         limit: z.number(), // COERCION_GAP (advertised numeric, not coercible)
+        requiredHere: z.string().optional(), // REQUIRED_MISMATCH (advertised required, Zod optional)
         extra: z.string(), // advertised-missing (validated field never advertised)
       }),
     );
@@ -97,6 +103,7 @@ describe('diffSchemas', () => {
     expect(kinds).toContain('FIELD_MISSING'); // ghost advertised, not validated
     expect(kinds).toContain('FIELD_MISSING'); // extra validated, not advertised
     expect(kinds).toContain('ENUM_MISMATCH');
+    expect(kinds).toContain('REQUIRED_MISMATCH');
     expect(kinds).toContain('COERCION_GAP');
   });
 

--- a/tests/unit/diagnostics/schema-drift.test.ts
+++ b/tests/unit/diagnostics/schema-drift.test.ts
@@ -1,6 +1,7 @@
 // tests/unit/diagnostics/schema-drift.test.ts
 import { describe, it, expect } from 'vitest';
-import { canonicalizeInputSchema } from '../../../src/diagnostics/schema-drift.js';
+import { z } from 'zod';
+import { canonicalizeInputSchema, canonicalizeZodSchema } from '../../../src/diagnostics/schema-drift.js';
 
 describe('canonicalizeInputSchema', () => {
   it('flattens a flat advertised JSON schema (system tool — no wrapper)', () => {
@@ -34,5 +35,45 @@ describe('canonicalizeInputSchema', () => {
     expect(c.type).toEqual({ type: 'string', required: true, enum: ['tasks', 'projects'] });
     expect(c.limit).toEqual({ type: 'number', required: false, enum: undefined });
     expect(c.query).toBeUndefined(); // the wrapper itself is not a field
+  });
+});
+
+describe('canonicalizeZodSchema', () => {
+  it('marks z.coerce.number() fields coercible and bare z.number() non-coercible (behavioral probe, not syntactic)', () => {
+    const schema = z.object({
+      a: z.coerce.number(),
+      b: z.number(),
+      mode: z.enum(['x', 'y']),
+      note: z.string().optional(),
+    });
+    const c = canonicalizeZodSchema(schema);
+    // NOTE: `coercible` is only meaningful for NUMERIC fields. A non-numeric optional like
+    // `note` also probes coercible=true (z.string().optional().safeParse('5') succeeds); that
+    // is harmless because diffSchemas only consults `coercible` when advertised type==='number'.
+    expect(c.a.coercible).toBe(true); // z.coerce.number().safeParse('5') succeeds
+    expect(c.b.coercible).toBe(false); // z.number().safeParse('5') fails
+    expect(c.mode.enum).toEqual(['x', 'y']);
+    expect(c.note.required).toBe(false);
+  });
+
+  it('descends a single wrapper key whose inner is z.preprocess(...) over a discriminatedUnion (the real read/write/analyze shape)', () => {
+    // Mirrors ReadSchema = z.object({ query: coerceObject(QuerySchema) }),
+    // QuerySchema = z.discriminatedUnion('type', [...]). coerceObject = z.preprocess(fn, inner).
+    const coerceObject = <T extends z.ZodTypeAny>(s: T) => z.preprocess((v) => v, s);
+    const QuerySchema = z.discriminatedUnion('type', [
+      z.object({ type: z.literal('tasks'), limit: z.coerce.number().optional(), flagged: z.boolean().optional() }),
+      z.object({ type: z.literal('projects'), limit: z.coerce.number().optional() }),
+    ]);
+    const ReadSchema = z.object({ query: coerceObject(QuerySchema) });
+
+    const c = canonicalizeZodSchema(ReadSchema, 'query');
+    // Discriminator: union of member literal values.
+    expect(c.type.enum?.sort()).toEqual(['projects', 'tasks']);
+    expect(c.type.required).toBe(true); // required in every member
+    // limit present in all members -> required iff required in all (it's optional -> not required), and coercible.
+    expect(c.limit.coercible).toBe(true);
+    expect(c.limit.required).toBe(false);
+    // flagged present in only ONE member -> not required (absent from a member counts as not-required).
+    expect(c.flagged.required).toBe(false);
   });
 });

--- a/tests/unit/diagnostics/schema-drift.test.ts
+++ b/tests/unit/diagnostics/schema-drift.test.ts
@@ -1,0 +1,38 @@
+// tests/unit/diagnostics/schema-drift.test.ts
+import { describe, it, expect } from 'vitest';
+import { canonicalizeInputSchema } from '../../../src/diagnostics/schema-drift.js';
+
+describe('canonicalizeInputSchema', () => {
+  it('flattens a flat advertised JSON schema (system tool — no wrapper)', () => {
+    const adv = {
+      type: 'object',
+      properties: {
+        operation: { type: 'string', enum: ['version', 'cache'] },
+        limit: { type: 'number' },
+      },
+      required: ['operation'],
+    };
+    const c = canonicalizeInputSchema(adv); // wrapperKey omitted
+    expect(c.operation).toEqual({ type: 'string', required: true, enum: ['version', 'cache'] });
+    expect(c.limit).toEqual({ type: 'number', required: false, enum: undefined });
+  });
+
+  it('descends into a single wrapper key (read/write/analyze nest real fields under query/mutation/analysis)', () => {
+    // Mirrors OmniFocusReadTool.inputSchema: { properties: { query: { properties: {...}, required: ['type'] } } }
+    const adv = {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'object',
+          properties: { type: { type: 'string', enum: ['tasks', 'projects'] }, limit: { type: 'number' } },
+          required: ['type'],
+        },
+      },
+      required: ['query'],
+    };
+    const c = canonicalizeInputSchema(adv, 'query');
+    expect(c.type).toEqual({ type: 'string', required: true, enum: ['tasks', 'projects'] });
+    expect(c.limit).toEqual({ type: 'number', required: false, enum: undefined });
+    expect(c.query).toBeUndefined(); // the wrapper itself is not a field
+  });
+});

--- a/tests/unit/diagnostics/schema-drift.test.ts
+++ b/tests/unit/diagnostics/schema-drift.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/diagnostics/schema-drift.test.ts
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
-import { canonicalizeInputSchema, canonicalizeZodSchema } from '../../../src/diagnostics/schema-drift.js';
+import { canonicalizeInputSchema, canonicalizeZodSchema, diffSchemas } from '../../../src/diagnostics/schema-drift.js';
 
 describe('canonicalizeInputSchema', () => {
   it('flattens a flat advertised JSON schema (system tool — no wrapper)', () => {
@@ -75,5 +75,38 @@ describe('canonicalizeZodSchema', () => {
     expect(c.limit.required).toBe(false);
     // flagged present in only ONE member -> not required (absent from a member counts as not-required).
     expect(c.flagged.required).toBe(false);
+  });
+});
+
+describe('diffSchemas', () => {
+  it('reports FIELD_MISSING, ENUM_MISMATCH, REQUIRED_MISMATCH, COERCION_GAP', () => {
+    const advertised = canonicalizeInputSchema({
+      type: 'object',
+      properties: { mode: { type: 'string', enum: ['a', 'b'] }, limit: { type: 'number' }, ghost: { type: 'string' } },
+      required: ['mode'],
+    });
+    const zod = canonicalizeZodSchema(
+      z.object({
+        mode: z.enum(['a']), // ENUM_MISMATCH (b advertised, not validated)
+        limit: z.number(), // COERCION_GAP (advertised numeric, not coercible)
+        extra: z.string(), // advertised-missing (validated field never advertised)
+      }),
+    );
+    const findings = diffSchemas(advertised, zod);
+    const kinds = findings.map((f) => f.kind).sort();
+    expect(kinds).toContain('FIELD_MISSING'); // ghost advertised, not validated
+    expect(kinds).toContain('FIELD_MISSING'); // extra validated, not advertised
+    expect(kinds).toContain('ENUM_MISMATCH');
+    expect(kinds).toContain('COERCION_GAP');
+  });
+
+  it('returns [] for an aligned schema (no false positives on coerced numerics)', () => {
+    const advertised = canonicalizeInputSchema({
+      type: 'object',
+      properties: { limit: { type: 'number' } },
+      required: [],
+    });
+    const zod = canonicalizeZodSchema(z.object({ limit: z.coerce.number().optional() }));
+    expect(diffSchemas(advertised, zod)).toEqual([]);
   });
 });

--- a/tests/unit/diagnostics/triage-doc.test.ts
+++ b/tests/unit/diagnostics/triage-doc.test.ts
@@ -22,5 +22,66 @@ describe('renderTriageDoc', () => {
     expect(md).toContain('| Fingerprint | Tool | Classification |');
     expect(md).toContain('| abc123 | omnifocus_write | SCHEMA_DRIFT |');
     expect(md).toContain('CAP_GUARD'); // legend documents the sentinel even when unused
+    expect(md).toContain('NEEDS_LLM'); // legend documents the agent-unconfigured sentinel
+  });
+
+  it('sorts rows by count desc, then fingerprint asc (deterministic), tie-break included', () => {
+    // Deliberately wrong input order: low count first, and two equal-count rows out of
+    // fingerprint order so the tie-break is actually exercised.
+    const md = renderTriageDoc(
+      [
+        {
+          fingerprint: 'ddd',
+          tool: 't',
+          classification: 'SCHEMA_DRIFT',
+          suggestedFix: 'f',
+          firstSeen: '',
+          lastSeen: '',
+          count: 2,
+        }, // lowest count
+        {
+          fingerprint: 'bbb',
+          tool: 't',
+          classification: 'SCHEMA_DRIFT',
+          suggestedFix: 'f',
+          firstSeen: '',
+          lastSeen: '',
+          count: 9,
+        }, // tie count=9, fp 'bbb'
+        {
+          fingerprint: 'aaa',
+          tool: 't',
+          classification: 'SCHEMA_DRIFT',
+          suggestedFix: 'f',
+          firstSeen: '',
+          lastSeen: '',
+          count: 9,
+        }, // tie count=9, fp 'aaa'
+        {
+          fingerprint: 'ccc',
+          tool: 't',
+          classification: 'SCHEMA_DRIFT',
+          suggestedFix: 'f',
+          firstSeen: '',
+          lastSeen: '',
+          count: 5,
+        }, // middle count
+      ],
+      new Date('2026-05-18T12:00:00Z'),
+    );
+    // Expected render order: count desc → [9,9,5,2]; within the count=9 tie, fingerprint asc → aaa before bbb.
+    // So: aaa (9), bbb (9), ccc (5), ddd (2).
+    const iAaa = md.indexOf('| aaa |');
+    const iBbb = md.indexOf('| bbb |');
+    const iCcc = md.indexOf('| ccc |');
+    const iDdd = md.indexOf('| ddd |');
+    expect(iAaa).toBeGreaterThan(-1);
+    expect(iBbb).toBeGreaterThan(-1);
+    expect(iCcc).toBeGreaterThan(-1);
+    expect(iDdd).toBeGreaterThan(-1);
+    // Monotonic increasing position == correct sorted order.
+    expect(iAaa).toBeLessThan(iBbb); // count tie broken by fingerprint asc
+    expect(iBbb).toBeLessThan(iCcc); // count 9 before count 5
+    expect(iCcc).toBeLessThan(iDdd); // count 5 before count 2
   });
 });

--- a/tests/unit/diagnostics/triage-doc.test.ts
+++ b/tests/unit/diagnostics/triage-doc.test.ts
@@ -1,0 +1,26 @@
+// tests/unit/diagnostics/triage-doc.test.ts
+import { describe, it, expect } from 'vitest';
+import { renderTriageDoc } from '../../../src/diagnostics/triage-doc.js';
+
+describe('renderTriageDoc', () => {
+  it('renders a tables-over-prose markdown doc, one row per pattern, with fingerprint', () => {
+    const md = renderTriageDoc(
+      [
+        {
+          fingerprint: 'abc123',
+          tool: 'omnifocus_write',
+          classification: 'SCHEMA_DRIFT',
+          suggestedFix: 'add coerceNumber to limit',
+          firstSeen: '2026-05-10',
+          lastSeen: '2026-05-18',
+          count: 7,
+        },
+      ],
+      new Date('2026-05-18T12:00:00Z'),
+    );
+    expect(md).toContain('# MCP Failure Triage');
+    expect(md).toContain('| Fingerprint | Tool | Classification |');
+    expect(md).toContain('| abc123 | omnifocus_write | SCHEMA_DRIFT |');
+    expect(md).toContain('CAP_GUARD'); // legend documents the sentinel even when unused
+  });
+});


### PR DESCRIPTION
## Summary

Turns the already-captured MCP tool-failure JSONL stream into automated, deduplicated, classified triage — and adds a CI gate that fails on `inputSchema`↔Zod drift before it compounds. Resolves **OMN-37**.

Five independently-shippable phases (full spec→plan→TDD pipeline; per-phase spec + code-quality review gates; whole-implementation review returned **SAFE TO MERGE**):

- **P1 — clustering module** (`src/diagnostics/{failure-log,normalize,clustering}.ts`): tolerant JSONL parse → normalize → cluster (≥3 occ OR ≥2-day span) → coarse-classify + ignore-set. `scripts/analyze-tool-failures.ts` refactored onto it, golden-test behavior-preserving.
- **P2 — schema-drift CI gate** (`schema-drift.ts`, `tool-schema-registry.ts`): canonicalizes advertised `inputSchema` vs the real Zod schema (wrapper-key descent + discriminated-union member-merge; **behavioral** coercibility probe, not source pattern-matching), `diffSchemas`, and a CI test that **fails on enum/required/coercion drift** for all 4 tools — with a non-vacuity floor so a future Zod-internals change can't make the gate silently pass empty.
- **P3 — diagnoser + Tier-1 driver** (`ledger.ts`, `triage-doc.ts`, `.claude/agents/mcp-failure-diagnoser.md`, `scripts/diagnose-failures.ts`): deterministic SCHEMA_DRIFT/COERCION classified inline; residual → optional LLM agent; seen-patterns ledger dedup; committed `docs/dev/mcp-failure-triage.md`.
- **P4 — guardrailed auto-Linear** (`linear-filer.ts`): class allowlist → cap-guard (≥230 OMN+GATE → create nothing) → per-run limit → fingerprint dedup → create; per-cluster failure isolation; **opt-in, default off**.
- **P5 — Tier-2 hook + docs**: `scripts/mcp-failure-marker.sh` (reads `tool_name` from stdin JSON per the Claude Code hook contract; cheap, agent-free, silent-fail), gitignored `settings.local.json` entry, operator doc + untracked `~/bin` scheduling recipe.

## Notable review catches (all fixed + mutation-verified)

- P2 gate had no non-vacuity assertion (would pass empty on a Zod major bump) — added per-tool field-count floor.
- P3 Task-13 test was vacuous (empty records placeholder) — replaced with a real coercion-gap cluster; flip-Zod-to-coerce → fail → restore proven.
- P5 hook read `$TOOL_NAME` env var but Claude Code delivers JSON on **stdin** — would have logged empty tool names in prod; tests passed only because they bypassed the real hook invocation path. Fixed + driven across the seam as production does.
- Ledger `diagnosedAt` was reset on issue-id write; orphan filed-issue ids were silently dropped — both fixed.

## Deliberate v1 deviations (documented)

Both are safer-than-spec; behavior is final for v1.

**1 — `--create-issues` does not auto-file from the standalone CLI.** `npm run diagnose-failures --create-issues` is **recognized but does not auto-file**. The concrete `LinearClient` uses the Linear MCP `graphql` action, callable only from Claude's runtime — never from a standalone `tsx` script. Filing is wired and fully tested at the injection seam; the CLI prints an actionable message rather than introducing an unspecified `LINEAR_API_KEY` secret surface.

**2 — `FIELD_MISSING` drift is excluded from deterministic classification (and therefore from auto-filing).** Spec §2 lists `FIELD_MISSING` as a first-class `DriftKind` and §3/§4 treat deterministic `SCHEMA_DRIFT` as the inline-classified, auto-fileable class — a literal reading would auto-file `FIELD_MISSING`. `deterministicClassification()` instead filters it out (`f.kind !== 'FIELD_MISSING'`), so a `FIELD_MISSING`-only cluster routes to the LLM agent (residual path), falls back to `NEEDS_LLM` when no agent is configured, and is never auto-filed. **Rationale:** `FIELD_MISSING` is bidirectional and, in this dual-schema codebase, dominated by *intentional* asymmetry — CLAUDE.md mandates compact hand-crafted `inputSchema` overrides that deliberately omit recursive Zod internals, so "validated by Zod but never advertised" fires on by-design structure, not drift. Auto-filing it would manufacture false-positive Linear issues against the workspace-wide 250-issue cap — exactly the §4 risk the guardrails exist to contain. **Accepted cost:** this also defers the genuinely-actionable "advertised to LLM but not validated by Zod" direction to the agent rather than catching it inline. Behavior is pinned by two non-vacuous tests in `tests/unit/diagnostics/diagnose-driver.test.ts` (mutation-verified: removing the carve-out flips them red) and a rationale block in `deterministicClassification()`. The remaining open question — split `FIELD_MISSING` by direction so the advertised-but-unvalidated half classifies deterministically as `SCHEMA_DRIFT` — is a tracked decision, not an undone task.

## Test plan

- [x] `npm run test:unit` — 90 files / 1907 tests green (incl. the non-vacuous drift gate, golden CLI snapshot, guardrail tests, + 2 new FIELD_MISSING-deviation tests)
- [x] `npm run build` — clean (tsc, 0 errors)
- [x] `npm run lint` — 0 errors, 6 non-blocking warnings (see follow-ups)
- [x] `HOME=$(mktemp -d) npm run diagnose-failures` — graceful no-logs path, triage doc written, no agent spawn
- [x] marker hook driven with piped JSON → records real tool name; empty stdin → exit 0
- [ ] Reviewer SAFE/Yes verdict gate before merge (per repo norm) — whole-impl review already SAFE TO MERGE

## Tracked post-merge follow-ups (none blocking)

- `runDiagnosis` cognitive-complexity warn (29/20) → extract per-cluster classification helper
- Decision (deferred, non-blocking): split `FIELD_MISSING` by direction so the advertised-but-unvalidated half classifies deterministically as `SCHEMA_DRIFT` — rationale + behavior now documented in code/tests and Deliberate v1 deviation #2; only the direction-split decision remains open
- Replace hardcoded `/Users/kip/` with `/Users/YOUR_USERNAME/` in the launchd plist example
- (If filing is ever CLI-activated) wire a real LinearClient transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
