### PR TITLE
docs(OMN-13): drop hardcoded v3.0.0 + remove dead doc links in prompts

### DIFF
--- a/src/prompts/README.md
+++ b/src/prompts/README.md
@@ -9,7 +9,6 @@ These prompts are available through the MCP protocol and can be called programma
 - **[Manual Templates](../../prompts/README.md)** - Copy/paste prompts for testing and workflows
 - **[API Documentation](../../docs/)** - Tool references and implementation guides
 - **[Improvement Roadmap](../../docs/IMPROVEMENT_ROADMAP.md)** - Future enhancements including prompt discovery CLI
-- **[Real LLM Testing](../../docs/REAL_LLM_TESTING.md)** - How to test prompts with actual AI models
 
 ## Architecture
 
@@ -39,7 +38,7 @@ These prompts are available through the MCP protocol and can be called programma
 | `eisenhower_matrix_inbox` | Prioritize by urgency/importance | "Use the eisenhower_matrix_inbox prompt" |
 | `quick_reference`         | Essential commands               | "Use the quick_reference prompt"         |
 
-**🎉 Available Now:** [`npm run prompts:list`](../../docs/PROMPT_DISCOVERY.md) CLI command for prompt discovery
+**🎉 Available Now:** `npm run prompts:list` CLI command for prompt discovery
 
 #### GTD Workflow Prompts (`gtd/`)
 
@@ -152,5 +151,5 @@ Potential improvements identified in the **[Improvement Roadmap](../../docs/IMPR
 - **Dynamic prompt composition** - Combine multiple prompts for complex scenarios
 - **Usage analytics** - Track which prompts are most valuable
 
-**✅ Implemented:** The [`npm run prompts:list`](../../docs/PROMPT_DISCOVERY.md) CLI tool bridges the gap between manual
-and programmatic approaches with unified discovery, validation, and multiple output formats.
+**✅ Implemented:** The `npm run prompts:list` CLI tool bridges the gap between manual and programmatic approaches with
+unified discovery, validation, and multiple output formats.

--- a/src/prompts/reference/QuickReferencePrompt.ts
+++ b/src/prompts/reference/QuickReferencePrompt.ts
@@ -4,7 +4,7 @@ import { PromptMessage } from '@modelcontextprotocol/sdk/types.js';
 const QUICK_REFERENCE = `
 # OmniFocus MCP Quick Reference
 
-## Unified API (v3.0.0)
+## Unified API
 
 Four tools: \`omnifocus_read\`, \`omnifocus_write\`, \`omnifocus_analyze\`, \`system\`
 


### PR DESCRIPTION
## Summary

The three mechanical residuals the OMN-13 🔁 re-verification identified, now shipped. Substantive v3 unified-API migration landed in earlier PRs (`7a196ae`, `558fa81`, `c6677da`); this is the leftover ~15-30 min hygiene pass.

| Edit | What |
|---|---|
| `src/prompts/reference/QuickReferencePrompt.ts:7` | Drop `(v3.0.0)` from `## Unified API` heading per CLAUDE.md's "don't hardcode current version in prose" rule. |
| `src/prompts/README.md:12` | Remove dead `[Real LLM Testing](.../REAL_LLM_TESTING.md)` bullet — file never existed in git history. |
| `src/prompts/README.md:42, 155` | Drop broken `PROMPT_DISCOVERY.md` link in both places; keep `npm run prompts:list` as inline code since `scripts/list-prompts.ts` IS the real feature, just no separate doc page. The existing line-148 link to `IMPROVEMENT_ROADMAP.md#prompt-discovery-cli-tool` already carries design context. |

## Verification
- `npm run build`: 0 errors
- `npm run test:unit`: **1945/1945**
- `tests/unit/docs/claude-md-paths.test.ts` (CLAUDE.md path guard): 8/8
- Grep verified zero residual `REAL_LLM_TESTING` / `PROMPT_DISCOVERY` / `(v3.0.0)` refs in `src/prompts/`
- All still-referenced docs paths (`IMPROVEMENT_ROADMAP.md`, `DOCS_MAP.md`, `../../prompts/*`, root `README.md`) resolve on disk
- Pre-merge code-standards review: **APPROVED / SAFE** (reviewer independently confirmed both removed files genuinely never existed in git, no downstream anchors depend on the removed heading)

Closes OMN-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)