### PR TITLE
fix(OMN-80): parseProjects preserves explicit null dates (was collapsing to undefined)

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -677,6 +677,17 @@ PERFORMANCE:
 
   /**
    * Parse raw project data, converting date strings to Date objects.
+   *
+   * OMN-80: collapse missing-or-null to `null`, NOT `undefined`. An explicit
+   * `null` from the OmniJS projection (project.dueDate is null) must remain
+   * distinguishable from "field not requested" (which the field-projection
+   * step strips entirely, producing an absent key). Consumers that
+   * truthy-check (`if (proj.dueDate)`) are unaffected — `null` and
+   * `undefined` are both falsy. (parseTasks has the same anti-pattern across
+   * 6 date fields and is tracked as a separate follow-up — OMN-82 — to keep
+   * this PR scoped per the OMN-80 ticket. OMN-81 tracks a separate defect:
+   * `ProjectFieldEnum` advertises `completedDate` while source/parser emit
+   * `completionDate`, so the projection layer strips that field regardless.)
    */
   private parseProjects(projects: unknown): unknown[] {
     if (!Array.isArray(projects)) return [];
@@ -685,10 +696,10 @@ PERFORMANCE:
       const projectRecord = project as Record<string, unknown>;
       return {
         ...projectRecord,
-        dueDate: projectRecord.dueDate ? new Date(projectRecord.dueDate as string) : undefined,
-        completionDate: projectRecord.completionDate ? new Date(projectRecord.completionDate as string) : undefined,
-        nextReviewDate: projectRecord.nextReviewDate ? new Date(projectRecord.nextReviewDate as string) : undefined,
-        lastReviewDate: projectRecord.lastReviewDate ? new Date(projectRecord.lastReviewDate as string) : undefined,
+        dueDate: projectRecord.dueDate ? new Date(projectRecord.dueDate as string) : null,
+        completionDate: projectRecord.completionDate ? new Date(projectRecord.completionDate as string) : null,
+        nextReviewDate: projectRecord.nextReviewDate ? new Date(projectRecord.nextReviewDate as string) : null,
+        lastReviewDate: projectRecord.lastReviewDate ? new Date(projectRecord.lastReviewDate as string) : null,
       };
     });
   }

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -260,8 +260,40 @@ describe('OmniFocusReadTool', () => {
       // Dates should be parsed into Date objects
       expect(proj.dueDate).toBeInstanceOf(Date);
       expect(proj.nextReviewDate).toBeInstanceOf(Date);
-      // Null dates remain undefined
+      // NOTE: completionDate is undefined here NOT because of the
+      // null-collapse bug (that's fixed by OMN-80, see next test), but
+      // because of a SEPARATE defect — `projectFieldsOnResult` strips it.
+      // The source field name is `completionDate` (what parseProjects
+      // writes) but ProjectFieldEnum only knows `completedDate` (a stale
+      // name from earlier API revisions). The projection layer filters by
+      // the enum and removes the unrecognized key. Tracked as a follow-up
+      // ticket. Until that's fixed, completionDate cannot survive the
+      // projection layer regardless of source value, so the right
+      // assertion here is "field stripped by projection" = undefined.
       expect(proj.completionDate).toBeUndefined();
+    });
+
+    // OMN-80: regression — null dueDate from the script must NOT be silently
+    // converted to undefined. The pre-fix bug at parseProjects() lines 688-691
+    // (`x ? new Date(x) : undefined`) lost the explicit-null signal; fixed to
+    // preserve it (`x ? new Date(x) : null`).
+    it('OMN-80: explicit null dueDate survives parsing as null (not undefined)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [{ id: 'p_nulldue', name: 'No Due Date Project', dueDate: null, lastReviewDate: null }],
+          metadata: { total_available: 1 },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', details: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      const proj = result.data.projects[0];
+      expect(proj.dueDate).toBeNull();
+      expect(proj.lastReviewDate).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Bug 6 split from OMN-35. 4-line behavior change to `parseProjects`: the falsy-branch of the 4 project date fields (`dueDate`/`completionDate`/`nextReviewDate`/`lastReviewDate`) flips from `: undefined` to `: null`. An explicit `null` from the OmniJS projection now survives end-to-end, so consumers (LLMs in particular) can distinguish "field absent in response" from "field present with no value."

## Why this is safe

Truthy-check downstream consumers (`if (proj.dueDate)`) are unaffected — `null` and `undefined` are both falsy. Grep across `src/` and `tests/` for `=== undefined` strict checks against any of the 4 fields → **zero hits**. The OmniJS API type declarations already declare these fields as `Date | null`, so the fix brings `parseProjects` into alignment with the canonical types.

## TDD trace

Tests first, watched fail (2 RED — `expected undefined to be null`), minimal impl to green. 1 new regression test added using `dueDate` and `lastReviewDate` (source-name-matches-enum so projection doesn't strip).

## Two follow-up tickets filed during execution

| Ticket | Defect |
|---|---|
| **OMN-81** | `ProjectFieldEnum` advertises `completedDate` but source data + `parseProjects` emit `completionDate`. `projectFieldsOnResult` strips the unrecognized key, so the project completion date is unreachable via the projects API regardless of source value. The pre-existing `OmniFocusReadTool.test.ts` `toBeUndefined()` assertion on `completionDate` was passing for THIS reason (projection strip), not for the OMN-80 null-collapse reason the OMN-35 🔁 attributed. Annotated the test with a forward reference + kept assertion as-is pending OMN-81's alias-vs-rename decision. |
| **OMN-82** | `parseTasks` (`src/tools/tasks/task-query-pipeline.ts:182-187`) has the same null-collapse anti-pattern across 6 task date fields. Filed per OMN-80's acceptance criterion ("scan parseTasks; file a separate ticket if yes"). |

## Verification

- `npm run test:unit`: **1975/1975** (+1)
- `npm run build`: clean (tsc exit 0)
- `eslint` clean on touched code
- Pre-merge code-standards review: **APPROVED / SAFE** (one ticket-number typo in the JSDoc — OMN-81 → OMN-82 — fixed before push)

Closes OMN-80. Follow-ups: OMN-81, OMN-82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)