### PR TITLE
fix(OMN-82): parseTasks preserves explicit null dates (symmetric to OMN-80)

### DIFF
--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -165,13 +165,17 @@ export function parseTasks(tasks: unknown[]): OmniFocusTask[] {
     return [];
   }
   return tasks.map((task) => {
+    // OMN-82: date fields include `null` after this PR — the OmniJS
+    // projection emits null for "explicitly unset" task dates, and
+    // parseTasks now preserves it (was collapsing to undefined). The truthy
+    // guards below narrow it out, so this only documents the input shape.
     const t = task as {
-      dueDate?: string | Date;
-      deferDate?: string | Date;
-      completionDate?: string | Date;
-      added?: string | Date;
-      modified?: string | Date;
-      dropDate?: string | Date;
+      dueDate?: string | Date | null;
+      deferDate?: string | Date | null;
+      completionDate?: string | Date | null;
+      added?: string | Date | null;
+      modified?: string | Date | null;
+      dropDate?: string | Date | null;
       parentTaskId?: string;
       parentTaskName?: string;
       inInbox?: boolean;
@@ -179,12 +183,19 @@ export function parseTasks(tasks: unknown[]): OmniFocusTask[] {
     };
     return {
       ...t,
-      dueDate: t.dueDate ? new Date(t.dueDate) : undefined,
-      deferDate: t.deferDate ? new Date(t.deferDate) : undefined,
-      completionDate: t.completionDate ? new Date(t.completionDate) : undefined,
-      added: t.added ? new Date(t.added) : undefined,
-      modified: t.modified ? new Date(t.modified) : undefined,
-      dropDate: t.dropDate ? new Date(t.dropDate) : undefined,
+      // OMN-82 (symmetric to OMN-80 for parseProjects): collapse missing-or-null
+      // to `null`, NOT `undefined`. Explicit `null` from the OmniJS projection
+      // (e.g. task.dueDate is null) must remain distinguishable from "field
+      // not requested" (which the field-projection step strips entirely,
+      // producing an absent key). Truthy-check consumers (`if (t.dueDate)`)
+      // are unaffected — both null and undefined are falsy. Aligns with the
+      // canonical OmniJS API types which declare these as `Date | null`.
+      dueDate: t.dueDate ? new Date(t.dueDate) : null,
+      deferDate: t.deferDate ? new Date(t.deferDate) : null,
+      completionDate: t.completionDate ? new Date(t.completionDate) : null,
+      added: t.added ? new Date(t.added) : null,
+      modified: t.modified ? new Date(t.modified) : null,
+      dropDate: t.dropDate ? new Date(t.dropDate) : null,
       parentTaskId: t.parentTaskId,
       parentTaskName: t.parentTaskName,
       inInbox: t.inInbox,

--- a/tests/unit/tools/tasks/task-query-pipeline.test.ts
+++ b/tests/unit/tools/tasks/task-query-pipeline.test.ts
@@ -353,8 +353,13 @@ describe('parseTasks', () => {
   it('handles missing date fields gracefully', () => {
     const raw = [{ id: '1', name: 'Test', completed: false, flagged: false, blocked: false }];
     const result = parseTasks(raw);
-    expect(result[0].dueDate).toBeUndefined();
-    expect(result[0].deferDate).toBeUndefined();
+    // OMN-82: parseTasks now collapses missing-or-null dates to `null`, not
+    // `undefined`, so explicit null from the OmniJS projection survives and
+    // is distinguishable from "field not requested." Aligns with the
+    // canonical `Date | null` typing in the OmniJS API declarations and
+    // matches the OMN-80 fix for parseProjects.
+    expect(result[0].dueDate).toBeNull();
+    expect(result[0].deferDate).toBeNull();
   });
 
   it('converts deferDate strings to Date objects', () => {

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1457,4 +1457,70 @@ describe('OmniFocusReadTool', () => {
       expect(tasksCacheCalls).toHaveLength(0);
     });
   });
+
+  // OMN-82: symmetric to OMN-80 (which fixed parseProjects). parseTasks had
+  // the same `x ? new Date(x) : undefined` anti-pattern across 6 task date
+  // fields (dueDate, deferDate, completionDate, added, modified, dropDate).
+  // Explicit `null` from the OmniJS projection must survive end-to-end as
+  // `null`, distinguishable from "field absent from projection." Unlike the
+  // projects path, TaskFieldEnum uses the same names as the source, so the
+  // projection-stripping bug OMN-81 doesn't confound this test — fields with
+  // null source values survive end-to-end with the right value.
+  describe('parseTasks preserves explicit null dates (OMN-82)', () => {
+    it('explicit null dueDate / deferDate / completionDate survive as null (not undefined)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [
+            {
+              id: 't_nulls',
+              name: 'No Dates Task',
+              completed: false,
+              flagged: false,
+              blocked: false,
+              dueDate: null,
+              deferDate: null,
+              completionDate: null,
+            },
+          ],
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', details: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      const task = result.data.tasks[0];
+      expect(task.dueDate).toBeNull();
+      expect(task.deferDate).toBeNull();
+      expect(task.completionDate).toBeNull();
+    });
+
+    it('non-null date strings still convert to Date instances (back-compat)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [
+            {
+              id: 't_dated',
+              name: 'Has Due Date',
+              completed: false,
+              flagged: false,
+              blocked: false,
+              dueDate: '2026-12-31T17:00:00.000Z',
+            },
+          ],
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', details: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      const task = result.data.tasks[0];
+      expect(task.dueDate).toBeInstanceOf(Date);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Symmetric counterpart to OMN-80 (#31). Same null-collapse anti-pattern, but in `parseTasks` (read path for tasks). 6-line behavior fix across `dueDate` / `deferDate` / `completionDate` / `added` / `modified` / `dropDate` — falsy branch flips from `: undefined` to `: null`. Explicit `null` from the OmniJS projection now survives end-to-end so consumers (LLMs in particular) can distinguish "field absent from projection" from "field present with no value."

## Why this is safe

- Truthy-check consumers (`if (t.dueDate)`) unaffected — `null` and `undefined` are both falsy.
- `sortTasks` (the main task-result consumer) already handles `null || undefined` explicitly at line 247 (pushes nulls last).
- `response-format.ts` truthy guards + `isValidDateValue` (returns `false` for `null`) — identical behavior to the prior `undefined`.
- `task-sanitizer` (the write-path consumer) already explicitly handles `value === null` (`task-sanitizer.ts:49-51` — "Allow explicit null to clear the date"), so read→write null round-trip is well-defined.
- Grep across `src/` + `tests/` for `=== undefined` strict checks on any of the 6 fields → **zero hits**.
- Canonical OmniJS API declarations already type these fields as `Date | null` — fix brings parseTasks into alignment.

## TDD trace

Tests first, watched fail (1 RED — `expected undefined to be null` on the 3 explicit-null assertions; back-compat test passed pre-fix as expected), minimal impl to green. Plus 1 pre-existing bug-baked assertion flipped from `toBeUndefined()` → `toBeNull()` (in `task-query-pipeline.test.ts` — the test calls `parseTasks` directly, no projection-layer indirection, so unlike OMN-80 the flip is clean with no OMN-81-style hidden defect underneath).

## Bonus type-honesty fix

Local cast type at `task-query-pipeline.ts:169-177` now declares the 6 date fields as `string | Date | null` (was `string | Date`). The outer `as unknown as OmniFocusTask` cast already bypassed the type system, so this is cosmetic but documents the actual input shape now that null is a possible runtime value.

## Verification

- `npm run test:unit`: **1977/1977** (+2 new + 1 flipped pre-existing assertion)
- `npm run build`: clean (tsc exit 0)
- `eslint` clean on touched code (pre-existing warnings unchanged)
- Pre-merge code-standards review: **APPROVED / SAFE** (all 6 verification points confirmed, including mutation-verify)

## Out of scope (acknowledged)

`OmniFocusTask` in `src/omnifocus/types.ts` still declares dates as `string | undefined` — a pre-existing type lie that the `as unknown as` casts in both parseProjects + parseTasks have always suppressed. Updating the type and removing the casts would be a separate cleanup ticket if anyone wants the type system to be useful for these fields again.

Closes OMN-82. Same family as OMN-80. OMN-81 (projects-only projection-strip enum name mismatch) remains its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)