### PR TITLE
fix(OMN-81): rename completedDate→completionDate across project read path (silent total failure fix)

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -144,7 +144,19 @@ export const MINIMAL_PROJECT_FIELDS = ['id', 'name', 'status', 'flagged', 'dueDa
  * but surface ONLY when explicitly requested via `fields`, never on a bare
  * `details:true` — keeps the detailed response token-cheap and shape-stable.
  */
-export const DETAIL_PROJECT_FIELDS = ['note', 'folderPath', 'sequential', 'lastReviewDate', 'nextReviewDate'];
+// OMN-81: completionDate added — was effectively unavailable on all responses
+// (script emitted null for every project due to the completedDate/completionDate
+// rename bug); now that the script emits real values, surface it on details:true
+// so completed-project responses carry the date without an explicit fields:[...]
+// request.
+export const DETAIL_PROJECT_FIELDS = [
+  'note',
+  'folderPath',
+  'sequential',
+  'lastReviewDate',
+  'nextReviewDate',
+  'completionDate',
+];
 
 /**
  * Resolve effective task fields based on user input and details flag.
@@ -1122,8 +1134,13 @@ function generateProjectFieldProjection(fields: string[], context?: { noteTrunca
           'reviewInterval: project.reviewInterval ? { unit: project.reviewInterval.unit, steps: project.reviewInterval.steps } : null',
         );
         break;
-      case 'completedDate':
-        projections.push('completedDate: project.completedDate ? project.completedDate.toISOString() : null');
+      case 'completionDate':
+        // OMN-81: was 'completedDate' reading `project.completedDate` — the
+        // OmniJS Project class has no such property (canonical name is
+        // `completionDate`, per the .d.ts at OmniFocus-4.8.x), so the script
+        // emitted null for EVERY project regardless of completion state.
+        // Aligned with the canonical API + the rest of the codebase.
+        projections.push('completionDate: project.completionDate ? project.completionDate.toISOString() : null');
         break;
       case 'defaultSingletonActionHolder':
         projections.push('defaultSingletonActionHolder: project.defaultSingletonActionHolder || false');

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -185,7 +185,7 @@ RESPONSE CONTROL:
 - ID lookup always returns all fields with full notes
 - fields are type-specific; requesting a field of the other type (e.g. reviewInterval on tasks) returns a guided error
 - fields (tasks): id, name, completed, flagged, blocked, available, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox
-- fields (projects): id, name, status, flagged, note, dueDate, deferDate, completedDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder, tags, plannedDate
+- fields (projects): id, name, status, flagged, note, dueDate, deferDate, completionDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder, tags, plannedDate
 - sort: [{ field: "dueDate", direction: "asc" }]
 - limit/offset: Pagination (default limit: 25, max: 500)
 - countOnly: true returns only count (33x faster for "how many" questions) — tasks only
@@ -683,11 +683,11 @@ PERFORMANCE:
    * distinguishable from "field not requested" (which the field-projection
    * step strips entirely, producing an absent key). Consumers that
    * truthy-check (`if (proj.dueDate)`) are unaffected — `null` and
-   * `undefined` are both falsy. (parseTasks has the same anti-pattern across
-   * 6 date fields and is tracked as a separate follow-up — OMN-82 — to keep
-   * this PR scoped per the OMN-80 ticket. OMN-81 tracks a separate defect:
-   * `ProjectFieldEnum` advertises `completedDate` while source/parser emit
-   * `completionDate`, so the projection layer strips that field regardless.)
+   * `undefined` are both falsy. (parseTasks had the same anti-pattern across
+   * 6 date fields, fixed in OMN-82. OMN-81 resolved the related
+   * `completedDate`/`completionDate` projection-strip bug by renaming the
+   * enum/script-builder to use `completionDate` consistently; this override
+   * is now the canonical key for that field.)
    */
   private parseProjects(projects: unknown): unknown[] {
     if (!Array.isArray(projects)) return [];

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -140,7 +140,7 @@ const PROJECT_FIELDS = [
   'note',
   'dueDate',
   'deferDate',
-  'completedDate',
+  'completionDate', // OMN-81: was completedDate (stale name, no OmniJS Project property of that name → silent total failure); aligned with OmniJS Project.completionDate + filterFields.completionDate + task side
   'folder',
   'folderPath',
   'folderId',

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -260,17 +260,13 @@ describe('OmniFocusReadTool', () => {
       // Dates should be parsed into Date objects
       expect(proj.dueDate).toBeInstanceOf(Date);
       expect(proj.nextReviewDate).toBeInstanceOf(Date);
-      // NOTE: completionDate is undefined here NOT because of the
-      // null-collapse bug (that's fixed by OMN-80, see next test), but
-      // because of a SEPARATE defect — `projectFieldsOnResult` strips it.
-      // The source field name is `completionDate` (what parseProjects
-      // writes) but ProjectFieldEnum only knows `completedDate` (a stale
-      // name from earlier API revisions). The projection layer filters by
-      // the enum and removes the unrecognized key. Tracked as a follow-up
-      // ticket. Until that's fixed, completionDate cannot survive the
-      // projection layer regardless of source value, so the right
-      // assertion here is "field stripped by projection" = undefined.
-      expect(proj.completionDate).toBeUndefined();
+      // OMN-81: completionDate now survives projection (was previously stripped
+      // because ProjectFieldEnum erroneously had `completedDate`, a name with
+      // no OmniJS Project property, causing silent total failure). After the
+      // rename, completionDate is in the enum + DETAIL_PROJECT_FIELDS, so
+      // details:true includes it; OMN-80's null-preservation now applies to
+      // the consumer-visible field.
+      expect(proj.completionDate).toBeNull();
     });
 
     // OMN-80: regression — null dueDate from the script must NOT be silently
@@ -294,6 +290,47 @@ describe('OmniFocusReadTool', () => {
       const proj = result.data.projects[0];
       expect(proj.dueDate).toBeNull();
       expect(proj.lastReviewDate).toBeNull();
+    });
+
+    // OMN-81: completionDate is now the canonical name (was completedDate,
+    // which the OmniJS Project class doesn't have → script always emitted
+    // null → user-facing silent total failure). After the rename + adding
+    // completionDate to DETAIL_PROJECT_FIELDS, completed projects' dates
+    // survive end-to-end.
+    it('OMN-81: explicit fields:["completionDate"] returns the parsed Date', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [{ id: 'p_done', name: 'Done Project', completionDate: '2026-04-01T17:00:00.000Z' }],
+          metadata: { total_available: 1 },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', fields: ['completionDate'] },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      const proj = result.data.projects[0];
+      expect(proj.completionDate).toBeInstanceOf(Date);
+    });
+
+    it('OMN-81: completionDate is included in details:true output', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [{ id: 'p_done', name: 'Done Project', completionDate: '2026-04-01T17:00:00.000Z' }],
+          metadata: { total_available: 1 },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', details: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      const proj = result.data.projects[0];
+      expect(proj.completionDate).toBeInstanceOf(Date);
     });
   });
 

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -439,7 +439,7 @@ describe('ReadSchema', () => {
         'note',
         'dueDate',
         'deferDate',
-        'completedDate',
+        'completionDate', // OMN-81: renamed from completedDate to match OmniJS canonical API
         'folder',
         'folderPath',
         'folderId',
@@ -453,6 +453,18 @@ describe('ReadSchema', () => {
         query: { type: 'projects', fields: allProjectFields },
       };
       const result = ReadSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    // OMN-81: completionDate is the canonical name (matches OmniJS Project class
+    // + filterFields.completionDate + parseProjects' override key). Was
+    // erroneously named completedDate in the enum and script-builder, causing
+    // silent total failure (script always emitted null because the OmniJS
+    // Project class has no .completedDate property).
+    it('OMN-81: accepts fields:["completionDate"] on a projects query', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'projects', fields: ['completionDate'] },
+      });
       expect(result.success).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

Completes the OMN-80/82/81 trilogy. Original ticket framed this as a cosmetic name-mismatch; investigation revealed **silent total failure** — no user could get project completion dates through `omnifocus_read`. Live MCP probe confirmed on 3 known-completed projects pre-fix (all returned without `completedDate` in the response).

## Root cause

`ProjectFieldEnum` + script-builder used `completedDate`, but the OmniJS `Project` class has **no such property** (canonical name is `completionDate` per `src/omnifocus/api/OmniFocus-4.8.6-d.ts:591`). `project.completedDate.toISOString()` at script-builder line 1126 always read undefined → ternary fell through to `null` → script emitted `completedDate: null` for every project regardless of completion state.

## Global rename across 4 production files

| File | Change |
|---|---|
| `src/tools/unified/schemas/read-schema.ts:143` | ProjectFieldEnum `'completedDate'` → `'completionDate'` |
| `src/contracts/ast/script-builder.ts:1131` | case `'completionDate'` reading `project.completionDate` (canonical OmniJS API) |
| `src/contracts/ast/script-builder.ts:147` | DETAIL_PROJECT_FIELDS gains `'completionDate'` so `details:true` returns it |
| `src/tools/unified/OmniFocusReadTool.ts:188` | Description field list reflects rename |

Plus the OMN-80 JSDoc forward-reference (which mentioned OMN-81 as a future ticket) is updated to past tense — now resolved.

Aligns the project read path with: OmniJS canonical API + the task side (`task.completionDate` everywhere) + `filterFields.completionDate` (which was already correct).

## Tests (5 RED→GREEN)

- read-schema.test.ts: "all 16 project fields" — `completedDate` → `completionDate`; new `OMN-81: accepts fields:['completionDate']` regression.
- OmniFocusReadTool.test.ts: flipped OMN-80-annotated `toBeUndefined()` → `toBeNull()` (forward-ref comment removed); two new it() cases — explicit `fields:['completionDate']` returns a Date; `details:true` includes it.

RED #4 was illuminating: the OMN-73 cross-type errorMap correctly identified `completionDate` as a tasks-only field under pre-rename enums, proving the cross-type guardrail works as designed.

## Breaking-change blast radius: conceptual only

Pre-fix: nobody got real values from `fields:['completedDate']`. Post-fix: that exact request hits a clear schema error guiding to valid project fields (via the OMN-73 errorMap) instead of silently returning nothing. **Strict improvement** for all callers.

## Verification

- `npm run test:unit`: **1980/1980** (+3)
- `npm run build`: clean (tsc exit 0)
- `eslint` clean on touched code
- Residual `completedDate` grep across `src/` + `tests/` → all hits are in comments (documentation of the rename), zero in code/strings
- Pre-merge code-standards review: **APPROVED / SAFE** (7-of-7 verification points confirmed)

Closes OMN-81. Completes the OMN-80/82/81 trilogy on project/task date-field handling.

## Live-state note

This is the third behavior-change PR in the trilogy (after OMN-80 #31 and OMN-82 #32). The bug-fix won't reach actual consumers until the prod MCP server (`~/omnifocus-mcp`) is redeployed and `/mcp` reconnected. Three behavior-change PRs accumulate for the redeploy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)