### PR TITLE
fix(OMN-79): clear 7 ESLint errors in mcp-test-client.ts (drop --no-verify gate-bypass)

### DIFF
--- a/tests/integration/helpers/mcp-test-client.ts
+++ b/tests/integration/helpers/mcp-test-client.ts
@@ -76,7 +76,7 @@ export class MCPTestClient {
     // server child inherited it by accident if (and only if) the parent had already
     // imported sandbox-manager before the spawn. Tests that didn't import it could
     // silently bypass the guard and write to live DB. Explicit-set closes the bypass.
-    const env: NodeJS.ProcessEnv = {
+    const env: Record<string, string | undefined> = {
       ...process.env,
       NODE_ENV: 'test',
       OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
@@ -107,8 +107,7 @@ export class MCPTestClient {
       try {
         const response: MCPResponse = JSON.parse(line);
         this.handleResponse(response);
-      } catch (error: unknown) {
-        // Critical Issue #1: Proper error typing
+      } catch {
         // Ignore non-JSON output (logging lines, etc.)
       }
     });
@@ -233,8 +232,7 @@ export class MCPTestClient {
       if (first.type === 'json') return first.json;
       if (first.type === 'text') return JSON.parse(first.text);
       return response.result;
-    } catch (error: unknown) {
-      // Critical Issue #1: Proper error typing
+    } catch {
       return response.result;
     }
   }
@@ -457,8 +455,7 @@ export class MCPTestClient {
     if (this.server && !this.server.killed) {
       try {
         this.server.stdin?.end();
-      } catch (error: unknown) {
-        // Critical Issue #1: Proper error typing
+      } catch {
         // Ignore errors during stdin close
       }
 


### PR DESCRIPTION
## Summary

- Resolves [OMN-79](https://linear.app/omnifocus-mcp/issue/OMN-79). Clears 7 pre-existing ESLint errors in `tests/integration/helpers/mcp-test-client.ts`. Edits to this helper no longer force `--no-verify` on commit.
- L79 `NodeJS.ProcessEnv` → `Record<string, string | undefined>` (no-undef on `NodeJS` global). Same alias OMN-77 used in `src/diagnostics/failure-log-gate.ts`; `env` is local and passes through to `spawn({env})` which accepts the same shape — no behavioral widening.
- Three `catch (error: unknown) { /* swallow */ }` → ES2019 optional binding `catch { /* swallow */ }`. Kills both `no-unused-vars` and `sonarjs/no-ignored-exceptions` at all three sites. Swallow intent preserved (non-JSON stdout, result-extraction fallback, stdin close race) — comments retained.
- No new `eslint-disable` directives.

## Why this matters

Per `feedback_pipeline_gates_load_bearing`: any path that forces `--no-verify` silently disables lint/format on the entire commit — exactly the gate-bypass class to keep closed. This file was the last forcing site that surfaced during OMN-77 / PR #25.

## Test plan

- [x] `npx eslint tests/integration/helpers/mcp-test-client.ts` → **0 errors, 0 warnings**
- [x] `npm run build` → clean
- [x] `npm run test:unit` → **1988/1988 passing**
- [x] Pre-commit hook ran cleanly on this commit with no `--no-verify` (i.e. the fix self-validates against its own acceptance criterion)
- [x] code-standards-reviewer subagent: SAFE/APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)