### PR TITLE
fix(OMN-66): sanitize filterDescription comment on list-tasks-ast path

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -366,7 +366,7 @@ function generateWarningsMetadata(hasProjectPreamble: boolean): string {
 function generateMatchesFilterBlock(ctx: ScriptBuildContext): string {
   return `${ctx.filterCode.preamble ? ctx.filterCode.preamble + '\n' : ''}
   // AST-generated filter predicate
-  // Filter: ${ctx.filterDescription}
+  // Filter: ${sanitizeForScriptComment(ctx.filterDescription)}
   function matchesFilter(task) {
     const taskTags = task.tags ? task.tags.map(t => t.name) : [];
     return ${ctx.filterCode.predicate};
@@ -784,7 +784,7 @@ export function buildRecurringTasksScript(options: RecurringTasksOptions = {}): 
 
   ${filterCode.preamble ? filterCode.preamble + '\n' : ''}
   // AST-generated filter predicate
-  // Filter: ${filterDescription}
+  // Filter: ${sanitizeForScriptComment(filterDescription)}
   function matchesFilter(task) {
     const taskTags = task.tags ? task.tags.map(t => t.name) : [];
     return ${filterCode.predicate};

--- a/tests/unit/contracts/ast/bridge-injection.test.ts
+++ b/tests/unit/contracts/ast/bridge-injection.test.ts
@@ -6,6 +6,7 @@ import {
   buildFilteredFoldersScript,
   buildTaskCountScript,
 } from '../../../../src/contracts/ast/script-builder.js';
+import { buildListTasksScriptV4 } from '../../../../src/omnifocus/scripts/tasks/list-tasks-ast.js';
 
 const NL = String.fromCharCode(10); // a real newline
 const BS = 'a\\b'; // literal single backslash: the 3-char string a \ b
@@ -62,5 +63,24 @@ describe('OMN-65: bridge builders survive hostile filter strings', () => {
     it(`buildFilteredFoldersScript search=${tag}`, () =>
       assertSafe(buildFilteredFoldersScript({ search: v }).script, v));
     it(`buildProjectByIdScript projectId=${tag}`, () => assertSafe(buildProjectByIdScript(v).script, v));
+  }
+});
+
+// OMN-66: the list-tasks-ast.ts path was scoped OUT of OMN-65 because its
+// backtick/${ vectors are already neutralized by the whole-source
+// escapeTemplateString wrap at list-tasks-ast.ts:89. But that wrap
+// deliberately does NOT touch CR/LF/control chars — so a raw newline in
+// the user `text` filter could still split the `// Filter:` comment line.
+// Exercise the production entry point (buildListTasksScriptV4) so the test
+// runs against the wrapped form OmniFocus actually executes, not the
+// inner unwrapped builder output. Covers both the general-filter and
+// inbox routes since they share generateMatchesFilterBlock.
+describe('OMN-66: list-tasks-ast comment channel survives hostile filter strings', () => {
+  for (const v of [...HOSTILE, 'benign_abc']) {
+    const tag = JSON.stringify(v);
+    it(`buildListTasksScriptV4 general filter text=${tag}`, () =>
+      assertSafe(buildListTasksScriptV4({ filter: { text: v } }), v));
+    it(`buildListTasksScriptV4 inbox mode text=${tag}`, () =>
+      assertSafe(buildListTasksScriptV4({ filter: { text: v }, mode: 'inbox' }), v));
   }
 });


### PR DESCRIPTION
## Summary

- Resolves [OMN-66](https://linear.app/omnifocus-mcp/issue/OMN-66). Closes the residual comment-channel newline-injection gap that OMN-65 / PR #20 deliberately scoped out for the list-tasks-ast.ts path.
- Apply existing `sanitizeForScriptComment` helper (in `src/contracts/ast/bridge-escape.ts`) to `filterDescription` before its interpolation into the `// Filter:` comment line, at both call sites in `src/contracts/ast/script-builder.ts`.

## Background — why this is residual, not new severity

OMN-65 centralized bridge-template escaping for the 5 wrap-aware builders. The list-tasks-ast.ts path was scoped OUT of OMN-65 because its dangerous backtick / `${` vectors are already neutralized by the pre-existing whole-source `escapeTemplateString` wrap at `src/omnifocus/scripts/tasks/list-tasks-ast.ts:89`.

The gap that survived: `escapeTemplateString` deliberately does NOT touch CR/LF/control chars (those are harmless inside a normal template literal). A user `text` filter with a raw newline could therefore still split the `// Filter:` comment line, breaking the OmniJS parse downstream.

**Severity:** comment-only, newline-only, **no code execution.** Strictly lower than OMN-65 class.

## Production-reachable scope

`src/contracts/ast/script-builder.ts:369` — `generateMatchesFilterBlock`. Called by `buildFilteredTasksScript` and `buildInboxScript`; both routed through `buildListTasksScriptV4` in `src/omnifocus/scripts/tasks/list-tasks-ast.ts`.

## Out-of-production fix included for symmetry

`src/contracts/ast/script-builder.ts:787` — `buildRecurringTasksScript`. This builder is **not currently production-reachable** (the actual production analytics path lives in `src/omnifocus/scripts/recurring/analyze-recurring-tasks-ast.ts`, whose `filterDescription` has no user-controllable text — verified separately). The mechanical fix is applied so the two parallel implementations don't diverge if anyone wires this version up later.

## Tests

New `OMN-66` describe block in `tests/unit/contracts/ast/bridge-injection.test.ts`. Drives `buildListTasksScriptV4` (production-wrapped entry, NOT the inner unwrapped builder output) for both general and inbox modes across the same OMN-65 HOSTILE vector array.

**Mutation-verified RED→GREEN:** reverting the L369 sanitizer makes the newline-payload general-filter test fail (raw `a<LF>b` survives into the script); restoring it passes. The inbox-mode test is a defensive regression check — the current inbox builder has no `// Filter:` comment, so it stays green either way; documents the safe state.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **1998/1998 passing** (10 new from this PR)
- [x] Mutation-verified: revert L369 → newline-payload test fails → restore L369 → passes
- [x] code-standards-reviewer subagent: **SAFE/APPROVED** (per `feedback_pipeline_gates_load_bearing` — tests driven through production seam, not wrong-invocation-seam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)