### PR TITLE
feat(OMN-54): meta-check for ESLint rule monitored-identifier dead-set

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -23,6 +23,10 @@ function enclosingFunction(node) {
 // `StandardResponse` must still match the longer `StandardResponseV2` (no word
 // boundary exists between `...Response` and `V2`); a trailing \b would silently
 // stop enforcing the ~8 methods annotated StandardResponseV2<...> checked today.
+// MONITORS: StandardResponseV2, SystemResponse
+// (The regex matches the `StandardResponse` prefix — by design (see above) —
+// so it covers `StandardResponseV2` too. The MONITORS annotation lists the
+// actual identifiers live in src/, which is what the meta-check verifies.)
 const RESPONSE_CONTRACT_TYPES = /\b(StandardResponse|SystemResponse)/;
 
 const plugin = {
@@ -109,6 +113,9 @@ const plugin = {
         const filename = context.filename;
         if (!filename.includes('/tools/') || !filename.endsWith('Tool.ts')) return {};
 
+        // MONITORS: handleErrorV2, createErrorResponseV2
+        // (`throw` is a JS keyword — always present; not a renamable identifier
+        // and excluded from the meta-check.)
         const VALID_SINK = /\bthis\.handleError(V2)?\b|\bcreateErrorResponse(V2)?\b|\bthrow\b/;
 
         return {
@@ -141,17 +148,19 @@ const plugin = {
         },
       },
       create(context) {
-        // Per-builder metadata-arg index. Signatures are not uniform:
-        //   V1 (legacy, no longer called in src/): metadata is the 3rd arg.
+        // Per-builder metadata-arg index. V1 builders were retired in PR #3
+        // (commit f2d04e8) and have zero non-import occurrences in src/ —
+        // their entries here were dead. Removed so the meta-check
+        // (tests/unit/eslint-rules/monitored-identifiers-live.test.ts) stays
+        // green and so this list reflects what's actually in production.
+        // Signatures are not uniform:
         //   createSuccessResponseV2(op, data, summary?, metadata?)   — 4th arg.
         //   createListResponseV2   (op, items, itemType, metadata?)  — 4th arg.
         //   createErrorResponseV2  (op, code, msg, suggestion?, details?, metadata?) — 6th arg.
         //   createTaskResponseV2   (op, tasks, metadata?)            — 3rd arg.
         //   createAnalyticsResponseV2 (op, data, analysisType, keyFindings, metadata?) — 5th arg.
+        // MONITORS: createSuccessResponseV2, createErrorResponseV2, createListResponseV2, createTaskResponseV2, createAnalyticsResponseV2
         const METADATA_ARG_INDEX = {
-          createSuccessResponse: 2,
-          createErrorResponse: 2,
-          createListResponse: 2,
           createSuccessResponseV2: 3,
           createErrorResponseV2: 5,
           createListResponseV2: 3,

--- a/tests/unit/eslint-rules/monitored-identifiers-live.test.ts
+++ b/tests/unit/eslint-rules/monitored-identifiers-live.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// OMN-54 meta-check: every identifier annotated with `// MONITORS: ...` in
+// eslint-rules/index.js must have at least one non-import occurrence in src/.
+//
+// A monitored identifier with zero src/ occurrences means either the rule is
+// dead (codebase migrated away — rule silently produces zero diagnostics) or
+// the symbol was renamed/removed without the rule being updated. Either way,
+// the lint rule is enforcing nothing real. This test fails loudly when that
+// happens. Precedent: PR #3 / commit f2d04e8 (metadata-snake-case listed only
+// V1 builder names while the codebase was fully on V2; rule produced zero
+// diagnostics until V2 names were added).
+//
+// AST-parsing the rule file was rejected in favor of explicit annotations —
+// authors of new rules opt in by adding a `// MONITORS:` comment next to the
+// monitored Set/RegExp/Map. The convention is documented in eslint-rules/index.js.
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '../../../..');
+const RULE_FILE = join(REPO_ROOT, 'eslint-rules/index.js');
+const SRC_DIR = join(REPO_ROOT, 'src');
+
+function extractMonitoredIdentifiers(ruleFileContents: string): string[] {
+  const out: string[] = [];
+  const re = /\/\/\s*MONITORS:\s*(.+)$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(ruleFileContents)) !== null) {
+    for (const raw of m[1].split(',')) {
+      const id = raw.trim();
+      if (id) out.push(id);
+    }
+  }
+  return out;
+}
+
+function* walkTypescriptFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkTypescriptFiles(full);
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      yield full;
+    }
+  }
+}
+
+// Lines whose trimmed form matches this pattern are interior members of a
+// multi-line `import { … } from …` or `export { … } from …` block, e.g.:
+//   import {
+//     createErrorResponseV2,            // ← matches
+//     type StandardResponseV2,          // ← matches
+//     createSuccessResponseV2 as alias, // ← matches
+//   } from '../../utils/response-format.js';
+// Real usages never look like a bare identifier on its own line — they
+// involve `=`, `(`, `.`, `:`, `<`, `extends`, etc.
+const BARE_IMPORT_MEMBER = /^(?:type\s+)?[\w$]+(?:\s+as\s+[\w$]+)?\s*,?\s*(?:\/\/.*)?$/;
+
+function hasNonImportOccurrence(identifier: string, srcDir: string): boolean {
+  const re = new RegExp(`\\b${identifier}\\b`);
+  for (const file of walkTypescriptFiles(srcDir)) {
+    const contents = readFileSync(file, 'utf8');
+    if (!re.test(contents)) continue;
+    for (const line of contents.split('\n')) {
+      if (!re.test(line)) continue;
+      const trimmed = line.trim();
+      // Skip ES module import/re-export headers, `from '…'` continuations,
+      // and bare-identifier interior lines of multi-line import/export braces.
+      // None of these represent real usage; the rule is dead even if a stray
+      // import lingers.
+      if (
+        trimmed.startsWith('import ') ||
+        trimmed.startsWith('export {') ||
+        trimmed.startsWith('export * ') ||
+        trimmed.startsWith('export type {') ||
+        trimmed.startsWith('} from ') ||
+        trimmed.startsWith('from ') ||
+        BARE_IMPORT_MEMBER.test(trimmed)
+      ) {
+        continue;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+describe('OMN-54: eslint-rules monitored-identifier meta-check', () => {
+  const ruleSource = readFileSync(RULE_FILE, 'utf8');
+  const monitored = extractMonitoredIdentifiers(ruleSource);
+
+  it('rule file declares at least one MONITORS annotation', () => {
+    // Sanity guard: if every annotation gets accidentally deleted, the test
+    // would otherwise pass with zero work — vacuous green. Require ≥1 so the
+    // check can't disappear silently. Today there are 3 monitored sets in
+    // eslint-rules/index.js (RESPONSE_CONTRACT_TYPES, VALID_SINK,
+    // METADATA_ARG_INDEX); 9 identifiers total.
+    expect(monitored.length).toBeGreaterThan(0);
+  });
+
+  for (const id of monitored) {
+    it(`monitored identifier "${id}" has at least one non-import occurrence in src/`, () => {
+      const live = hasNonImportOccurrence(id, SRC_DIR);
+      if (!live) {
+        throw new Error(
+          `Monitored ESLint-rule identifier "${id}" has zero non-import occurrences in src/. ` +
+            'Either the rule is dead (codebase migrated away — rule produces zero diagnostics) ' +
+            'or the symbol was renamed/removed without updating eslint-rules/index.js. ' +
+            'Update or remove the // MONITORS: annotation in eslint-rules/index.js.',
+        );
+      }
+      expect(live).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Resolves [OMN-54](https://linear.app/omnifocus-mcp/issue/OMN-54). When an ESLint rule in `eslint-rules/index.js` hardcodes a set of callee names or identifiers and the codebase migrates away from those identifiers, the rule silently produces zero diagnostics and lint stays green. This is the **PR #3 / commit f2d04e8** anti-pattern: `metadata-snake-case` listed only V1 builder names while the codebase was fully on V2 helpers; the rule was inert.

This PR adds a meta-check that fails when any monitored ESLint-rule identifier has zero non-import occurrences in `src/`. Authors of new rules opt in by annotating monitored Sets / RegExps / Maps with `// MONITORS: <comma-separated list>`.

## Changes

### `eslint-rules/index.js`
- Add `// MONITORS:` annotations next to the three monitored sets:
  - `RESPONSE_CONTRACT_TYPES` regex → `StandardResponseV2, SystemResponse`. (The regex intentionally matches the `StandardResponse` prefix; the annotation lists the actual live form.)
  - `VALID_SINK` regex → `handleErrorV2, createErrorResponseV2`. (`throw` is a JS keyword, intentionally excluded.)
  - `METADATA_ARG_INDEX` map → all five V2 builder names.
- **Drop 3 dead V1 entries** from `METADATA_ARG_INDEX` (`createSuccessResponse`, `createErrorResponse`, `createListResponse`). Verified zero non-import occurrences in `src/` — PR #3 / commit f2d04e8 retired them; their entries here were ballast.

### `tests/unit/eslint-rules/monitored-identifiers-live.test.ts` (NEW)
- Reads `eslint-rules/index.js`; extracts `// MONITORS:` annotations.
- For each identifier, walks `src/**/*.ts` recursively and looks for a non-import occurrence. "Non-import" skips import / re-export headers, `from …` continuations, **and** bare-identifier interior lines of multi-line import braces (e.g. `createErrorResponseV2,` alone, with optional `type` prefix or `as` rename) — closes a false-positive path the reviewer flagged.
- Sanity guard: requires ≥1 monitored identifier so accidentally deleting all `MONITORS` annotations doesn't vacuous-green the check.

## Mutation verification (RED → GREEN)

- Add fake identifier `createDeadResponseV9` to a `MONITORS` line → test fails with that exact name and the diagnostic message.
- Remove it → test passes.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **2008/2008 passing** (10 new from this PR; existing `metadata-snake-case` test still green — V1 removal didn't break anything)
- [x] `npm run lint` → 0 errors, 7 pre-existing warnings (unrelated)
- [x] Mutation-verified RED → GREEN on a fake-identifier addition
- [x] Pre-commit hook ran cleanly with no `--no-verify` (OMN-79 stays paid down)
- [x] code-standards-reviewer subagent: **APPROVED** (one minor false-positive path flagged — multi-line import bodies — fixed in this PR's `BARE_IMPORT_MEMBER` guard before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)