### PR TITLE
fix(OMN-76): close diagnose-failures blind spot — CreateDataSchema rejects unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **`omnifocus_write` create rejects unknown fields** (OMN-76) — Unknown keys on `operation: create` (e.g. `subtasks`,
+  `context`, `priority`, `estimate`) were silently dropped — the call returned `success: true` and the fields vanished,
+  invisible to the failure-log/diagnose-failures pipeline. Create now hard-rejects unknown fields with a Zod validation
+  error, matching the existing strict behavior on `operation: update`. Callers that were relying on the silent drop will
+  now get a clear error naming the offending key. Use `estimatedMinutes` instead of `estimate`.
 - **OmniFocus 4.7+ repetition rules** — Reading tasks with repetition rules works again on current OmniFocus versions;
   deprecated fields have been replaced with the modern API. Older tasks missing `catchUpAutomatically` no longer throw.
 - **`reviewInterval` accepts the `{ steps, unit }` object form** (OMN-38), matching what OmniFocus returns when reading

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -172,7 +172,9 @@ SAFETY:
    *
    * This flat schema advertises all operations and fields without branch
    * duplication. Server-side Zod validation (WriteSchema) still enforces
-   * the full discriminated union with strict field types.
+   * the full discriminated union with strict field types — both
+   * CreateDataSchema and UpdateChangesSchema reject unknown fields (OMN-76),
+   * which is what surfaces caller mistakes through the failure-log pipeline.
    */
   override get inputSchema(): Record<string, unknown> {
     return {

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -87,28 +87,38 @@ const DATE_FORMAT_MSG = 'Date format: YYYY-MM-DD or YYYY-MM-DD HH:mm';
 // Create data schema — single source of truth for task/project creation fields.
 // Both the unified write tool and batch-schemas derive from this.
 // Exported for OMN-61 write-side parity testing (settable field ↔ builder).
-export const CreateDataSchema = z.object({
-  name: z.string().min(1),
-  note: z.string().optional(),
-  project: z.union([z.string(), z.null()]).optional(),
-  parentTaskId: z.string().optional(), // Bug #17: Enable subtask creation
-  tags: z.array(z.string()).optional(),
-  dueDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
-  deferDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
-  plannedDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
-  flagged: coerceBoolean().optional(),
-  estimatedMinutes: z
-    .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
-    .pipe(z.number())
-    .optional(),
-  repetitionRule: RepetitionRuleSchema.optional(),
+//
+// OMN-76: `.strict()` parity with UpdateChangesSchema. Without it, unknown
+// fields the caller passes (e.g. `subtasks`, `context`, `priority`, `estimate`)
+// were silently dropped on create — the call returned `success:true`, the
+// fields vanished, and the OMN-37 failure-log/diagnose-failures pipeline never
+// saw them (it only records Zod rejects + execution errors). Strictness turns
+// silent data loss into a loud Zod rejection that `logToolFailure` records,
+// closing the diagnose-pipeline blind spot.
+export const CreateDataSchema = z
+  .object({
+    name: z.string().min(1),
+    note: z.string().optional(),
+    project: z.union([z.string(), z.null()]).optional(),
+    parentTaskId: z.string().optional(), // Bug #17: Enable subtask creation
+    tags: z.array(z.string()).optional(),
+    dueDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
+    deferDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
+    plannedDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
+    flagged: coerceBoolean().optional(),
+    estimatedMinutes: z
+      .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
+      .pipe(z.number())
+      .optional(),
+    repetitionRule: RepetitionRuleSchema.optional(),
 
-  // Project-specific
-  folder: z.string().optional(),
-  sequential: coerceBoolean().optional(),
-  status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
-  reviewInterval: ReviewIntervalSchema.optional(),
-});
+    // Project-specific
+    folder: z.string().optional(),
+    sequential: coerceBoolean().optional(),
+    status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
+    reviewInterval: ReviewIntervalSchema.optional(),
+  })
+  .strict();
 
 // Update changes schema
 // Exported for OMN-61 write-side parity testing (settable field ↔ builder).

--- a/tests/unit/tools/unified/schemas/write-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/write-schema.test.ts
@@ -817,4 +817,120 @@ describe('WriteSchema', () => {
       }
     });
   });
+
+  // OMN-76: create-input must reject unknown fields, matching update's strict
+  // behavior. Silently dropping unknown create-input fields is the worst class
+  // of bug (silent data loss + invisible to the failure-log diagnose pipeline).
+  // After this fix all four empirically-observed silent-drop fields
+  // (subtasks, context, priority, estimate) become loud Zod rejects, which
+  // the `logToolFailure` ZodError branch already records.
+  describe('create-input strictness (OMN-76)', () => {
+    it('rejects unknown field `subtasks` on create task (was silently dropped)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: { name: 'x', subtasks: [] },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field `context` on create task (was silently dropped — asymmetric vs update which rejected)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: { name: 'x', context: 'home' },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field `priority` on create task (was silently dropped)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: { name: 'x', priority: 1 },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field `estimate` on create task (was silently dropped — use `estimatedMinutes`)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: { name: 'x', estimate: 30 },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown field on create project', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'project',
+          data: { name: 'p', bogusField: 'x' },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts the documented create surface (no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: {
+            name: 'Real task',
+            note: 'desc',
+            tags: ['work'],
+            dueDate: '2026-06-01',
+            deferDate: '2026-05-25',
+            flagged: true,
+            estimatedMinutes: 30,
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('still accepts the documented batch-create item surface (no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          operations: [
+            {
+              operation: 'create',
+              target: 'task',
+              data: { name: 'A', tempId: 't1', flagged: true },
+            },
+          ],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects unknown field nested in a batch-create item (closes the batch back-door)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          operations: [
+            {
+              operation: 'create',
+              target: 'task',
+              data: { name: 'A', subtasks: [] },
+            },
+          ],
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves [OMN-76](https://linear.app/omnifocus-mcp/issue/OMN-76). Unknown keys on `omnifocus_write` `operation: create` (e.g. `subtasks`, `context`, `priority`, `estimate`) were **silently dropped** — the call returned `success: true`, the fields vanished on read-back, and the OMN-37 failure-log / `diagnose-failures` pipeline (which only records Zod rejects + execution errors) never saw them. This was a structural blind spot in the weekly triage job: the most damaging class — silent data loss — was unobservable through it.

The asymmetry was also user-visible: `context` was **silently dropped on create** but **hard-rejected on update** (`Unrecognized key(s) in object: 'context'`). Same field, two opposite behaviors depending on operation.

## Why

The OMN-37 pipeline can only see what fails. Silent successes are invisible. Making create strict converts silent data loss into a loud Zod rejection that `logToolFailure`'s `ZodError` branch already records (`src/tools/base.ts` `VALIDATION_ERROR`), so future silent-drop bugs surface in the next weekly `diagnose-failures` pass instead of accumulating undetected.

This is the v1 the ticket explicitly recommends: "Make the create input schema `.strict()` so unknown fields reject like update already does. Cheapest; converts silent loss → loud reject (which then logs and becomes diagnosable)."

## Changes

### `src/tools/unified/schemas/write-schema.ts`
- Wrap `CreateDataSchema` in `.strict()` (parity with `UpdateChangesSchema`, which has been `.strict()` already).
- The `BatchItemDataSchema = CreateDataSchema.extend({...})` path inherits the strict catchall (Zod v3 behavior), so the batch back-door closes in the same change.
- Multi-line block comment documents *why* strictness is load-bearing (it's not for type-safety — it's for the diagnose-failures pipeline).

### `src/tools/unified/OmniFocusWriteTool.ts`
- Comment-only update to the `inputSchema` docstring to make the strict-on-unknown invariant explicit so a future contributor doesn't loosen it.
- No structural change to the advertised JSON schema (the inputSchema already doesn't enumerate `data` object field names, so there's no shape to keep in sync).

### `tests/unit/tools/unified/schemas/write-schema.test.ts` (8 new tests)
A new `describe('create-input strictness (OMN-76)')` block:
- Four named-field rejection tests, one per empirically-observed silent-drop field: `subtasks`, `context`, `priority`, `estimate`.
- One generic `bogusField` rejection on create project.
- Two no-regression tests: the full documented create surface + the documented batch-create-item surface (`tempId`, `flagged`, etc.) — these passed before the fix too; explicit guard.
- One nested-batch-item rejection — closes the back-door through `BatchItemDataSchema`.

All tests drive through `WriteSchema.safeParse` — the same seam `BaseTool.handler()` validates production input through. No helper-seam bypass.

### `CHANGELOG.md`
One-liner in the Unreleased / Fixed section flagging the behavior change for callers.

## Mutation verification (RED → GREEN)

- `git stash push src/tools/unified/schemas/write-schema.ts` → re-run `npm run test:unit -- write-schema.test.ts` → **6 of 8 new tests fail** (all 4 named fields + project + nested batch). The 2 still-passing are the explicit no-regression checks. This is the **empirical confirmation of the ticket's silent-drop claim**.
- `git stash pop` → all **2016 unit tests pass**.

Not vacuous-green: every rejection test asserts on a specific empirically-observed key, and the schema-impl-parity gate (`tests/unit/architecture/schema-impl-parity.test.ts`) that iterates `CreateDataSchema.shape` continues to pass (strict() doesn't change the shape).

## Behavior change

Callers passing unknown keys on create will now get a clear Zod schema error naming the offending key, instead of a misleading `success: true` with the field absent on read-back. Empirically the only known caller exercising this surface (the LLM through MCP) was already getting rejected on update for the same keys — the asymmetry was the source of the confusion, not the strictness.

`estimate` callers: use `estimatedMinutes` (the documented field).

## Out of scope (deferred)

The `completionDate` natural-language → `INTERNAL_ERROR` inconsistency mentioned in OMN-76 (NL `dueDate`/`deferDate` on create return a clean date-format error; NL `completionDate` on complete throws uncategorized `INTERNAL_ERROR`) is **related, lower-priority**, and will be filed as a follow-up Linear ticket — not addressed here.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **2016/2016 passing** (8 new from this PR)
- [x] `npm run lint` → 0 errors, 7 pre-existing warnings (unrelated; same baseline as #35/#36/#37)
- [x] Mutation-verified RED → GREEN on schema revert (6 of 8 new fail without the `.strict()`, all pass with)
- [x] Pre-commit hook ran cleanly with no `--no-verify`
- [x] Inline code-standards review against `superpowers:requesting-code-review` template → **APPROVED** with one minor (CHANGELOG entry), fixed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)