### PR TITLE
fix(OMN-85): apply DATE_REGEX to direct-path completionDate on complete

### DIFF
--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -198,7 +198,11 @@ SAFETY:
             minimalResponse: { type: 'boolean' },
 
             // complete
-            completionDate: { type: 'string' },
+            // OMN-85: format must match the Zod regex (YYYY-MM-DD optionally
+            // followed by HH:mm or HH:mm:ss). NL strings like "tomorrow" are
+            // now rejected with a clean Zod schema error rather than producing
+            // an uncategorized INTERNAL_ERROR downstream.
+            completionDate: { type: 'string', description: 'YYYY-MM-DD or YYYY-MM-DD HH:mm' },
 
             // batch
             operations: {
@@ -211,7 +215,8 @@ SAFETY:
                   data: { type: 'object' },
                   changes: { type: 'object' },
                   id: { type: 'string' },
-                  completionDate: { type: 'string' },
+                  // OMN-85: same DATE_REGEX rejection as the top-level complete path.
+                  completionDate: { type: 'string', description: 'YYYY-MM-DD or YYYY-MM-DD HH:mm' },
                 },
                 required: ['operation', 'target'],
               },

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -238,7 +238,12 @@ const MutationSchema = z.discriminatedUnion('operation', [
     operation: z.literal('complete'),
     target: z.enum(['task', 'project']).default('task'), // OMN-75: model often omits target
     id: z.string(),
-    completionDate: z.string().optional(), // Bug #20: Allow custom completion date
+    // Bug #20: allows a custom completion timestamp. OMN-85: the regex
+    // matches the dueDate/deferDate validation elsewhere on the write path
+    // (and the batch-complete sibling at L187) — without it NL input
+    // ("tomorrow") slipped through Zod and surfaced as uncategorized
+    // INTERNAL_ERROR downstream instead of a clean VALIDATION_ERROR.
+    completionDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
     minimalResponse: z.boolean().optional(), // Bug #21: Reduce response size
   }),
   // Delete operation

--- a/tests/unit/tools/unified/schemas/write-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/write-schema.test.ts
@@ -818,6 +818,64 @@ describe('WriteSchema', () => {
     });
   });
 
+  // OMN-85: NL completionDate ("tomorrow", "in 3 days", etc.) used to bypass
+  // the schema and surface downstream as an uncategorized INTERNAL_ERROR —
+  // unlike NL dueDate/deferDate on create/update, which already returned a
+  // clean Zod schema error via the matching DATE_REGEX. Apply the same regex
+  // on the `complete` operation so the failure shape is symmetric across the
+  // three date-input channels and the diagnose-failures pipeline categorizes
+  // it (VALIDATION_ERROR) instead of dropping it as a server-side crash.
+  describe('completionDate format validation on complete (OMN-85)', () => {
+    it('accepts YYYY-MM-DD completionDate', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'complete', target: 'task', id: 'x', completionDate: '2026-05-20' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts YYYY-MM-DD HH:mm completionDate', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'complete', target: 'task', id: 'x', completionDate: '2026-05-20 14:30' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects natural-language completionDate "tomorrow" as a clean Zod error', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'complete', target: 'task', id: 'x', completionDate: 'tomorrow' },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const completionDateIssue = result.error.issues.find((i) => i.path.includes('completionDate'));
+        expect(completionDateIssue).toBeDefined();
+        expect(completionDateIssue?.message).toMatch(/Date format/i);
+      }
+    });
+
+    it('rejects natural-language completionDate "in 3 days" as a clean Zod error', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'complete', target: 'task', id: 'x', completionDate: 'in 3 days' },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const completionDateIssue = result.error.issues.find((i) => i.path.includes('completionDate'));
+        expect(completionDateIssue).toBeDefined();
+      }
+    });
+
+    it('rejects ISO-8601-with-Z completionDate (matches dueDate/deferDate behavior)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'complete',
+          target: 'task',
+          id: 'x',
+          completionDate: '2026-05-20T14:30:00Z',
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
   // OMN-76: create-input must reject unknown fields, matching update's strict
   // behavior. Silently dropping unknown create-input fields is the worst class
   // of bug (silent data loss + invisible to the failure-log diagnose pipeline).


### PR DESCRIPTION
## Summary

Resolves [OMN-85](https://linear.app/omnifocus-mcp/issue/OMN-85). NL `completionDate` (`"tomorrow"`, `"in 3 days"`) on the top-level `complete` operation used to slip past Zod and surface downstream as uncategorized `INTERNAL_ERROR` (severity high, recoverable: false). The `BatchOperationSchema`'s sibling `complete` arm at L187 already had `.regex(DATE_REGEX, DATE_FORMAT_MSG)`; the top-level `MutationSchema`'s `complete` arm at L241 did not. This one-line schema change closes the gap.

The diagnose-failures pipeline (OMN-37 / OMN-76) was classifying these as server-side crashes instead of validation errors — they now feed the failure log via the normal `VALIDATION_ERROR` branch alongside `dueDate` / `deferDate` format violations.

## Changes

- `src/tools/unified/schemas/write-schema.ts`: `completionDate: z.string().optional()` → `+.regex(DATE_REGEX, DATE_FORMAT_MSG)`. Block-comment above the field documents the why (Bug #20 history + OMN-85 rationale).
- `src/tools/unified/OmniFocusWriteTool.ts`: dual-schema update — added `description: 'YYYY-MM-DD or YYYY-MM-DD HH:mm'` to both `completionDate` declarations (top-level and batch-item) per CLAUDE.md so MCP clients see the format constraint.
- `tests/unit/tools/unified/schemas/write-schema.test.ts`: new `completionDate format validation on complete (OMN-85)` describe block — 5 cases driven through `WriteSchema.safeParse` (production seam): accept `YYYY-MM-DD`, accept `YYYY-MM-DD HH:mm`, reject NL `"tomorrow"` with completionDate-path Zod issue + "Date format" message, reject NL `"in 3 days"`, reject ISO-8601-with-Z.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **2064/2064** (5 new from this PR)
- [x] **Mutation-verified RED→GREEN**: pre-fix run showed 3 reject tests failing (proving the bug); post-fix all 5 pass
- [x] Pre-commit hook ran clean (no `--no-verify`)
- [x] code-standards-reviewer subagent: **SAFE/APPROVED** with one minor (long inline comment) — refactored to block comment before commit
- [x] Reviewer-flagged batch-complete gap concern verified unfounded — `BatchOperationSchema:187` was already strict; no parallel fix needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)