### PR TITLE
test(OMN-86): align cleared-dueDate assertion with the OMN-82 contract

### DIFF
--- a/tests/integration/validation/update-operations.test.ts
+++ b/tests/integration/validation/update-operations.test.ts
@@ -171,9 +171,13 @@ describe('Update Operations - Read-Back Validation', () => {
       updateResult = await updateTask(taskId, { clearDueDate: true });
       expectOk(updateResult, 'clear dueDate');
 
-      // Verify dueDate was cleared
+      // Verify dueDate was cleared.
+      // OMN-86: OMN-82 (commit 7e5a97d) changed `parseTasks` to emit `null`
+      // for cleared dates (was collapsing to `undefined`). Test was written
+      // pre-OMN-82 and still expected `undefined`; aligning with the new
+      // contract.
       task = await readTask(taskId);
-      expect(task.dueDate).toBeUndefined();
+      expect(task.dueDate).toBeNull();
       expect(task.deferDate.split('T')[0]).toBe('2025-12-20'); // Still set
     }, 120000);
 


### PR DESCRIPTION
## Summary

Resolves [OMN-86](https://linear.app/omnifocus-mcp/issue/OMN-86). **The test was stale, not the code.** OMN-82 (commit `7e5a97d`, merged 2026-05-20T00:52:55Z) intentionally changed `parseTasks` to emit `null` for cleared dates instead of collapsing them to `undefined`. The integration test at `tests/integration/validation/update-operations.test.ts:176` was written before OMN-82 and still expected `undefined`.

The agent who filed OMN-86 yesterday misread the failure as a code regression in the OMN-80/-82 family because they hadn't traced the contract back. A `git log -S "toBeUndefined" -- tests/integration/validation/update-operations.test.ts` would have surfaced the gap.

## Changes

One assertion:
- `expect(task.dueDate).toBeUndefined()` → `expect(task.dueDate).toBeNull()`
- Multi-line OMN-86 / OMN-82 contract-citation comment above the assertion so future-me doesn't re-debug.

## Note on OMN-82 contract precision (separate follow-up)

The code-standards-reviewer flagged that the OMN-82 commit message claims "absent (field not requested) is distinguishable from cleared (explicit null)" — but the implementation actually spreads `...t` then overrides `dueDate`, so an absent input key gets re-added as `null` regardless of whether the field was requested. The first draft of my inline comment propagated that documentation imprecision; tightened to just describe the user-visible change (`undefined` → `null`) without overclaiming the distinction.

Filing the `parseTasks` contract-vs-implementation gap as a separate Linear ticket — it doesn't affect the test fix and is out of scope here.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **2059/2059** (this is an integration test; unit count unchanged)
- [x] Pre-commit hook ran clean
- [x] code-standards-reviewer subagent: **APPROVED** — premise verified against `src/tools/tasks/task-query-pipeline.ts:163-204`, all downstream consumers use truthy-check patterns (none would silently mishandle the `null` contract), test drives the production seam (full MCP read pipeline via `readTask()`)
- [ ] Integration smoke for the affected test — not run in this session (requires Mac + OmniFocus + ~4 min). The next `test:integration` sweep will confirm RED→GREEN on this assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)