### PR TITLE
feat(OMN-87): single-source OmniJS sweep predicate + parity test

### DIFF
--- a/tests/integration/helpers/sandbox-manager.ts
+++ b/tests/integration/helpers/sandbox-manager.ts
@@ -300,6 +300,57 @@ export function isFixtureProjectByName(projectName: string, parentFolderName: st
 }
 
 /**
+ * OMN-87: shared OmniJS-side predicate source.
+ *
+ * The deletion / scan sweeps run inside OmniFocus's OmniJS context — they
+ * can't import the TypeScript predicates above. Pre-OMN-87 each sweep
+ * inlined the predicate logic, creating three independently-maintained
+ * copies of the OMN-83 contract. A future edit to one copy (e.g. someone
+ * "I'll just be permissive here" reintroducing substring matching) would
+ * silently diverge — the 23 TS-predicate regression tests would stay
+ * green, the sweep would behave differently. Same drift-risk shape as
+ * OMN-46 / OMN-47.
+ *
+ * This constant is the SINGLE source for the OmniJS-side predicate
+ * functions. Each sweep interpolates it as a preamble and calls
+ * `isFixtureTask` / `isFixtureProject` instead of inlining. The
+ * characterization test at
+ * `tests/unit/integration-helpers/sandbox-manager-omnijs-predicate-parity.test.ts`
+ * evaluates this string via `new Function` and verifies it produces the
+ * same results as the TypeScript predicates on the OMN-83 fixture
+ * corpus — closing the drift gap.
+ *
+ * The functions take their prefix/sandbox constants as arguments rather
+ * than closing over module-level values: this keeps the source pure
+ * (`new Function`-able) and decouples it from how the constants are
+ * interpolated into each call site (which still happens via the
+ * `${TEST_INBOX_PREFIX}` template-literal interpolation in each script).
+ *
+ * Do NOT add backticks, template-literal interpolation, or top-level
+ * mutable state to this string — it must remain interpolatable into a
+ * JXA → OmniJS double-backtick context AND evaluatable in Node via
+ * `new Function`.
+ */
+export const OMNIJS_FIXTURE_PREDICATES_SOURCE = `
+function isFixtureTask(name, tagNames, namePrefix, tagPrefix) {
+  if (!name) return false;
+  if (name.startsWith(namePrefix)) return true;
+  if (tagNames) {
+    for (var i = 0; i < tagNames.length; i++) {
+      if (tagNames[i] && tagNames[i].startsWith(tagPrefix)) return true;
+    }
+  }
+  return false;
+}
+function isFixtureProject(name, parentFolderName, namePrefix, sandboxName) {
+  if (!name) return false;
+  if (name.startsWith(namePrefix)) return true;
+  if (parentFolderName === sandboxName) return true;
+  return false;
+}
+`;
+
+/**
  * Delete orphaned test projects that escaped the sandbox folder.
  * Uses OmniJS deleteObject() — the correct API for project deletion.
  *
@@ -312,23 +363,24 @@ async function deleteOrphanedProjects(): Promise<{ deleted: number; errors: stri
   const script = `
     const result = app.evaluateJavascript(\`
       (() => {
+        ${OMNIJS_FIXTURE_PREDICATES_SOURCE}
+
         let deleted = 0;
         const errors = [];
-        const prefix = '${TEST_INBOX_PREFIX}';
+        const namePrefix = '${TEST_INBOX_PREFIX}';
         const sandboxName = '${SANDBOX_FOLDER_NAME}';
 
-        // Collect orphaned projects (__TEST__ prefix, NOT in sandbox)
+        // Collect orphaned projects (__TEST__ prefix, NOT in sandbox).
+        // OMN-87: isFixtureProject covers prefix OR sandbox; filter sandbox
+        // here so deleteSandboxProjects handles those.
         const toDelete = [];
         for (const project of flattenedProjects) {
           try {
             const name = project.name;
-            if (!name) continue;
-            if (!name.startsWith(prefix)) continue;
-
-            // Skip projects in sandbox (handled by deleteSandboxProjects)
             const folder = project.parentFolder;
-            if (folder && folder.name === sandboxName) continue;
-
+            const folderName = folder ? folder.name : null;
+            if (!isFixtureProject(name, folderName, namePrefix, sandboxName)) continue;
+            if (folderName === sandboxName) continue;
             toDelete.push(project);
           } catch (e) {}
         }
@@ -369,33 +421,28 @@ async function deleteTestTasksEverywhere(): Promise<{ deleted: number; errors: s
   const script = `
     const result = app.evaluateJavascript(\`
       (() => {
+        ${OMNIJS_FIXTURE_PREDICATES_SOURCE}
+
         let deleted = 0;
         const errors = [];
         const namePrefix = '${TEST_INBOX_PREFIX}';
         const tagPrefix = '${TEST_TAG_PREFIX}';
 
-        // Collect tasks to delete first (avoid modifying while iterating)
+        // OMN-87: collect tasks to delete via the shared OmniJS predicate.
+        // isFixtureTask encodes the OMN-83 contract (__TEST__ name prefix OR
+        // any tag with __test- prefix). Sweep collects first, deletes second
+        // to avoid modifying the collection while iterating.
         const toDelete = [];
         for (const task of flattenedTasks) {
           try {
             const name = task.name;
-            if (!name) continue;
-
-            // Predicate: name carries __TEST__ prefix OR any tag with __test- prefix.
-            // No substring matching, no project-location heuristic — the prefix /
-            // tag-prefix IS the test-fixture contract.
-            if (name.startsWith(namePrefix)) {
-              toDelete.push(task);
-              continue;
-            }
-
-            const tags = task.tags;
+            const tags = task.tags || [];
+            const tagNames = [];
             for (let i = 0; i < tags.length; i++) {
-              const tagName = tags[i].name;
-              if (tagName && tagName.startsWith(tagPrefix)) {
-                toDelete.push(task);
-                break;
-              }
+              tagNames.push(tags[i] ? tags[i].name : null);
+            }
+            if (isFixtureTask(name, tagNames, namePrefix, tagPrefix)) {
+              toDelete.push(task);
             }
           } catch (e) {
             // Skip invalid/dropped tasks
@@ -725,6 +772,8 @@ export async function scanForFixtures(): Promise<FixtureScanReport> {
   const script = `
     const result = app.evaluateJavascript(\`
       (() => {
+        ${OMNIJS_FIXTURE_PREDICATES_SOURCE}
+
         const inboxPrefix = '${TEST_INBOX_PREFIX}';
         const tagPrefix = '${TEST_TAG_PREFIX}';
         const sandboxName = '${SANDBOX_FOLDER_NAME}';
@@ -738,24 +787,17 @@ export async function scanForFixtures(): Promise<FixtureScanReport> {
           testTags: [],
         };
 
-        // Tasks: __TEST__ name prefix OR membership of a __test- tag
+        // OMN-87: classify tasks via the shared isFixtureTask predicate;
+        // bucket by containing-project name (Inbox vs other).
         for (const task of flattenedTasks) {
           try {
             const name = task.name;
-            if (!name) continue;
-
-            let isFixture = name.startsWith(inboxPrefix);
-            if (!isFixture) {
-              const tags = task.tags;
-              for (let i = 0; i < tags.length; i++) {
-                const tagName = tags[i].name;
-                if (tagName && tagName.startsWith(tagPrefix)) {
-                  isFixture = true;
-                  break;
-                }
-              }
+            const tags = task.tags || [];
+            const tagNames = [];
+            for (let i = 0; i < tags.length; i++) {
+              tagNames.push(tags[i] ? tags[i].name : null);
             }
-            if (!isFixture) continue;
+            if (!isFixtureTask(name, tagNames, inboxPrefix, tagPrefix)) continue;
 
             const proj = task.containingProject;
             const where = proj ? proj.name : 'Inbox';
@@ -767,17 +809,20 @@ export async function scanForFixtures(): Promise<FixtureScanReport> {
           } catch (e) {}
         }
 
-        // Projects: anything inside sandbox folder OR __TEST__ prefix outside
+        // OMN-87: classify projects via the shared isFixtureProject
+        // predicate; bucket by sandbox vs orphan based on parent folder.
+        // Predicate covers prefix-or-sandbox; the bucketing decides which
+        // cleanup function will handle each.
         for (const project of flattenedProjects) {
           try {
             const name = project.name;
-            if (!name) continue;
             const folder = project.parentFolder;
-            const folderName = folder ? folder.name : '(no folder)';
-            if (folder && folder.name === sandboxName) {
+            const folderName = folder ? folder.name : null;
+            if (!isFixtureProject(name, folderName, inboxPrefix, sandboxName)) continue;
+            if (folderName === sandboxName) {
               out.sandboxProjects.push({ id: project.id.primaryKey, name, location: sandboxName });
-            } else if (name.startsWith(inboxPrefix)) {
-              out.orphanProjects.push({ id: project.id.primaryKey, name, location: folderName });
+            } else {
+              out.orphanProjects.push({ id: project.id.primaryKey, name, location: folderName || '(no folder)' });
             }
           } catch (e) {}
         }

--- a/tests/unit/integration-helpers/sandbox-manager-omnijs-predicate-parity.test.ts
+++ b/tests/unit/integration-helpers/sandbox-manager-omnijs-predicate-parity.test.ts
@@ -1,0 +1,164 @@
+/**
+ * OMN-87 — OmniJS-side predicate parity with the TypeScript predicates.
+ *
+ * The sandbox-manager has two equivalent predicate implementations:
+ *
+ *   1. TypeScript: `isFixtureTaskByName` / `isFixtureProjectByName` — used by
+ *      unit-level callers and pinned by the 23 tests in
+ *      `sandbox-manager-predicate.test.ts`.
+ *   2. OmniJS source: `OMNIJS_FIXTURE_PREDICATES_SOURCE` — interpolated into
+ *      every deletion / scan sweep that runs inside OmniFocus's JS context
+ *      (`deleteTestTasksEverywhere`, `deleteOrphanedProjects`,
+ *      `scanForFixtures`). The TS predicates are unreachable from there;
+ *      this string is the single source for what those sweeps enforce.
+ *
+ * Pre-OMN-87 the OmniJS side was three independently-maintained copies of
+ * the predicate logic. A future edit to one copy (e.g. reintroducing
+ * substring matching) would silently diverge — TS regression tests would
+ * stay green, the sweep would behave differently. Same drift-risk shape as
+ * OMN-46 / OMN-47.
+ *
+ * This test loads the OmniJS source via `new Function` (the source is pure
+ * — no template-literal interpolation, no closure over module state) and
+ * verifies it produces the same answers as the TypeScript predicates on
+ * the OMN-83 fixture corpus. Any divergence — in either direction — fails
+ * loudly here.
+ *
+ * Drives the production seam: extracts the EXACT string that gets
+ * interpolated into the OmniJS scripts. A mutation that flips a `.startsWith`
+ * to `.includes` in the OmniJS source would fail this test (mutation-verified
+ * — see PR body).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  OMNIJS_FIXTURE_PREDICATES_SOURCE,
+  isFixtureTaskByName,
+  isFixtureProjectByName,
+  SANDBOX_FOLDER_NAME,
+  TEST_INBOX_PREFIX,
+  TEST_TAG_PREFIX,
+} from '../../integration/helpers/sandbox-manager.js';
+
+type OmniJsTaskFn = (
+  name: string | null | undefined,
+  tagNames: ReadonlyArray<string | null | undefined> | null,
+  namePrefix: string,
+  tagPrefix: string,
+) => boolean;
+
+type OmniJsProjectFn = (
+  name: string | null | undefined,
+  parentFolderName: string | null,
+  namePrefix: string,
+  sandboxName: string,
+) => boolean;
+
+function instantiate(): { task: OmniJsTaskFn; project: OmniJsProjectFn } {
+  // The source defines `isFixtureTask` and `isFixtureProject` as plain JS
+  // function declarations. Wrap in an IIFE-style Function body and pull
+  // them out as values. `new Function` is safe here — the source is a
+  // module-level constant in this repo, not user input.
+  const factory = new Function(
+    `${OMNIJS_FIXTURE_PREDICATES_SOURCE}\nreturn { isFixtureTask: isFixtureTask, isFixtureProject: isFixtureProject };`,
+  ) as () => { isFixtureTask: OmniJsTaskFn; isFixtureProject: OmniJsProjectFn };
+  const { isFixtureTask, isFixtureProject } = factory();
+  return { task: isFixtureTask, project: isFixtureProject };
+}
+
+describe('OMN-87: OmniJS predicate source parity with TS predicates', () => {
+  const { task: omniTask, project: omniProject } = instantiate();
+
+  describe('isFixtureTask parity', () => {
+    type TaskCase = { label: string; name: string; tagNames?: ReadonlyArray<string> };
+    const cases: ReadonlyArray<TaskCase> = [
+      // Fixtures.
+      { label: '__TEST__ prefix with space', name: `${TEST_INBOX_PREFIX} Protocol test task` },
+      { label: '__TEST__ prefix no space', name: `${TEST_INBOX_PREFIX}Direct` },
+      { label: 'task with __test- tag', name: 'Plan summer vacation 2025', tagNames: [`${TEST_TAG_PREFIX}travel`] },
+      {
+        label: 'task with one matching tag among many',
+        name: 'Buy groceries',
+        tagNames: ['urgent', `${TEST_TAG_PREFIX}batch`, 'home'],
+      },
+      // Non-fixtures (OMN-83 regression corpus — real user task names).
+      { label: 'Test fire alarm', name: 'Test fire alarm' },
+      { label: 'Test the new espresso machine', name: 'Test the new espresso machine' },
+      { label: 'Quick Test of the projector', name: 'Quick Test of the projector' },
+      { label: 'Performance Test results for Q1 report', name: 'Performance Test results for Q1 report' },
+      { label: 'Completed 1 lap of pool', name: 'Completed 1 lap of pool' },
+      { label: 'Velocity Test Task to evaluate sprint pace', name: 'Velocity Test Task to evaluate sprint pace' },
+      { label: 'empty name no tags', name: '' },
+      { label: 'task with only non-prefixed tags', name: 'Important meeting', tagNames: ['work', 'q1', 'review'] },
+      { label: 'task with no tags array', name: 'Random task name' },
+      { label: '__TEST__ as substring in middle', name: `Notes about ${TEST_INBOX_PREFIX} from yesterday` },
+      {
+        label: 'tag prefix as substring in middle of tag',
+        name: 'Some task',
+        tagNames: [`important-${TEST_TAG_PREFIX}lookalike`],
+      },
+    ];
+
+    for (const c of cases) {
+      it(`agrees on: ${c.label}`, () => {
+        const tsResult = isFixtureTaskByName(c.name, c.tagNames);
+        const omniResult = omniTask(c.name, c.tagNames ?? [], TEST_INBOX_PREFIX, TEST_TAG_PREFIX);
+        expect(omniResult).toBe(tsResult);
+      });
+    }
+  });
+
+  describe('isFixtureProject parity', () => {
+    type ProjectCase = { label: string; name: string; parent: string | null };
+    const cases: ReadonlyArray<ProjectCase> = [
+      // Fixtures.
+      {
+        label: '__TEST__ prefix in a normal folder',
+        name: `${TEST_INBOX_PREFIX} TestBatch_Mapping_123`,
+        parent: 'Work',
+      },
+      { label: '__TEST__ prefix at root', name: `${TEST_INBOX_PREFIX} TestBatch_Simple_456`, parent: null },
+      { label: 'no prefix but inside sandbox folder', name: 'Plan Summer Vacation 2025', parent: SANDBOX_FOLDER_NAME },
+      // Non-fixtures (real user projects).
+      {
+        label: 'Test Migration to Postgres outside sandbox',
+        name: 'Test Migration to Postgres',
+        parent: 'Engineering',
+      },
+      { label: 'TestBatch_NewProcess outside sandbox', name: 'TestBatch_NewProcess', parent: 'Ops' },
+      {
+        label: '__TEST__ in middle, real user project',
+        name: `Notes on ${TEST_INBOX_PREFIX} debugging`,
+        parent: 'Reference',
+      },
+      { label: 'real user project at root', name: 'Annual Review 2026', parent: null },
+      { label: 'similarly-named-but-not-sandbox folder', name: 'My Project', parent: '__MCP_TEST_SANDBOX_OLD__' },
+    ];
+
+    for (const c of cases) {
+      it(`agrees on: ${c.label}`, () => {
+        const tsResult = isFixtureProjectByName(c.name, c.parent);
+        const omniResult = omniProject(c.name, c.parent, TEST_INBOX_PREFIX, SANDBOX_FOLDER_NAME);
+        expect(omniResult).toBe(tsResult);
+      });
+    }
+  });
+
+  describe('OmniJS source preconditions', () => {
+    it('source does not contain backticks (would break JXA → OmniJS interpolation)', () => {
+      // The source is interpolated into a JXA template literal that
+      // itself contains an inner OmniJS backtick block. A backtick in
+      // the source would terminate the inner block prematurely.
+      expect(OMNIJS_FIXTURE_PREDICATES_SOURCE.includes('`')).toBe(false);
+    });
+
+    it('source declares both predicate functions by name', () => {
+      // Sanity guard: if a refactor renames or removes one of these,
+      // the deletion / scan sweeps will fail to find the symbol at
+      // OmniJS-eval time — a runtime error inside OmniFocus that
+      // bypasses TypeScript. Catch it at unit-test time instead.
+      expect(OMNIJS_FIXTURE_PREDICATES_SOURCE).toMatch(/function\s+isFixtureTask\s*\(/);
+      expect(OMNIJS_FIXTURE_PREDICATES_SOURCE).toMatch(/function\s+isFixtureProject\s*\(/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves [OMN-87](https://linear.app/omnifocus-mcp/issue/OMN-87). The three OmniJS-embedded sweep predicate sites in `tests/integration/helpers/sandbox-manager.ts` — `deleteOrphanedProjects`, `deleteTestTasksEverywhere`, `scanForFixtures` — were three independently-maintained copies of the OMN-83 fixture-identity logic. The TypeScript exports were pinned by 23 unit tests, but the OmniJS-side duplicates had no test coverage. Surfaced by the post-merge code-standards review on OMN-83 (PR #39): a future edit to one copy (e.g. reintroducing `.includes` substring matching) would silently diverge — TS regression tests would stay green, the sweep would behave differently.

This PR implements **both** Option 1 (single-source) and Option 2 (characterization test) from the ticket.

## Changes

### `tests/integration/helpers/sandbox-manager.ts`

- New exported `OMNIJS_FIXTURE_PREDICATES_SOURCE` — a pure template literal containing two JS function declarations (`isFixtureTask`, `isFixtureProject`) that take their prefix / sandbox constants as args. The source is `new Function`-able (no template-literal interpolation, no closure over module state) so the parity test can verify it directly.
- All three OmniJS-embedding sites now interpolate the constant as a preamble and call `isFixtureTask(name, tagNames, ...)` / `isFixtureProject(name, folderName, ...)` instead of inlining.
- `scanForFixtures` project bucketing rewritten to call `isFixtureProject` first then bucket by `folderName === sandboxName`. Behaviorally equivalent — the orphan set is still exactly `name.startsWith(inboxPrefix) AND folderName !== sandboxName` (verified by reviewer); the `'(no folder)'` sentinel for the null-parent location output is preserved.

### `tests/unit/integration-helpers/sandbox-manager-omnijs-predicate-parity.test.ts` (NEW)

- Loads `OMNIJS_FIXTURE_PREDICATES_SOURCE` via `new Function`, extracts both predicate functions.
- Drives a 15-case task corpus + 8-case project corpus (derived from the existing 23-test OMN-83 regression suite) through BOTH the TS predicates AND the OmniJS predicates. Asserts `omniResult === tsResult` for every case.
- Two preconditions: source contains no backticks (would break JXA → OmniJS interpolation); source declares both function names (so a refactor that renames a function fails at unit-test time instead of at OmniJS-eval runtime inside OmniFocus).

## Mutation verification (RED → GREEN)

Temporarily flipped `.startsWith` → `.includes` in `OMNIJS_FIXTURE_PREDICATES_SOURCE`. The `"__TEST__ as substring in middle"` parity case failed exactly as expected. Restored to `.startsWith`, all 25 pass.

## Out of scope but flagged

The reviewer identified two additional inline-predicate sites NOT named in the OMN-87 ticket: `isTaskInSandbox` (per-task lookup) and `deleteTestInboxTasks` (inbox-only sweep). Both use `name.startsWith(TEST_INBOX_PREFIX)` inline. Filing as a follow-up rather than scope-creeping — they're the same drift-risk shape but have narrower contracts.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **2089/2089** (25 new from this PR)
- [x] Mutation-verified RED → GREEN on the OmniJS source
- [x] Pre-commit hook ran clean (no `--no-verify`)
- [x] code-standards-reviewer subagent: **APPROVED** — verified all six points (single-sourcing complete for the three sites, parity test drives the exported constant, `scanForFixtures` rewrite is semantically equivalent, `'(no folder)'` sentinel preserved, `new Function` safe, no vacuous-green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)