### PR TITLE
fix(OMN-88): parseTasks/parseProjects preserve absent vs cleared distinction

### DIFF
--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -160,46 +160,38 @@ export function getDefaultSort(mode: TaskQueryMode | undefined): SortOption[] | 
  * Parse raw script output into typed OmniFocusTask objects.
  * Converts date strings to Date objects for date fields.
  */
+// OMN-88: date fields the OmniJS field-projection step emits.
+// Pre-OMN-88 parseTasks spread the input then unconditionally overrode each
+// of these with `t.k ? Date : null`, so ABSENT input keys came back as
+// `null` — defeating field-projection's payload reduction and silently
+// breaking the "absent (not requested) vs null (explicitly cleared)"
+// distinction the OMN-80/-82 comments claimed. We now only set a key when
+// it was present in the input.
+const TASK_DATE_FIELDS = ['dueDate', 'deferDate', 'completionDate', 'added', 'modified', 'dropDate'] as const;
+
 export function parseTasks(tasks: unknown[]): OmniFocusTask[] {
   if (!tasks || !Array.isArray(tasks)) {
     return [];
   }
   return tasks.map((task) => {
-    // OMN-82: date fields include `null` after this PR — the OmniJS
-    // projection emits null for "explicitly unset" task dates, and
-    // parseTasks now preserves it (was collapsing to undefined). The truthy
-    // guards below narrow it out, so this only documents the input shape.
-    const t = task as {
-      dueDate?: string | Date | null;
-      deferDate?: string | Date | null;
-      completionDate?: string | Date | null;
-      added?: string | Date | null;
-      modified?: string | Date | null;
-      dropDate?: string | Date | null;
-      parentTaskId?: string;
-      parentTaskName?: string;
-      inInbox?: boolean;
-      [key: string]: unknown;
-    };
-    return {
-      ...t,
-      // OMN-82 (symmetric to OMN-80 for parseProjects): collapse missing-or-null
-      // to `null`, NOT `undefined`. Explicit `null` from the OmniJS projection
-      // (e.g. task.dueDate is null) must remain distinguishable from "field
-      // not requested" (which the field-projection step strips entirely,
-      // producing an absent key). Truthy-check consumers (`if (t.dueDate)`)
-      // are unaffected — both null and undefined are falsy. Aligns with the
-      // canonical OmniJS API types which declare these as `Date | null`.
-      dueDate: t.dueDate ? new Date(t.dueDate) : null,
-      deferDate: t.deferDate ? new Date(t.deferDate) : null,
-      completionDate: t.completionDate ? new Date(t.completionDate) : null,
-      added: t.added ? new Date(t.added) : null,
-      modified: t.modified ? new Date(t.modified) : null,
-      dropDate: t.dropDate ? new Date(t.dropDate) : null,
-      parentTaskId: t.parentTaskId,
-      parentTaskName: t.parentTaskName,
-      inInbox: t.inInbox,
-    } as unknown as OmniFocusTask;
+    // OMN-82 / OMN-88: date fields come through as `string | null` from the
+    // OmniJS projection. `null` means "explicitly cleared in OmniFocus"; an
+    // absent key means "field not requested by the script." parseTasks now
+    // honors both: strings convert to Date objects, nulls pass through as
+    // nulls, absent keys stay absent. Truthy-check consumers
+    // (`if (t.dueDate)`) are unaffected.
+    const t = task as Record<string, unknown>;
+    const result: Record<string, unknown> = { ...t };
+    for (const field of TASK_DATE_FIELDS) {
+      if (field in t) {
+        const raw = t[field];
+        // Strict null/undefined check (not truthy): the input type is
+        // `string | null`, but a defensive `=== null` aligns with the
+        // documented contract — strings → Date, nulls → null.
+        result[field] = raw === null || raw === undefined ? null : new Date(raw as string);
+      }
+    }
+    return result as unknown as OmniFocusTask;
   });
 }
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -148,6 +148,10 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
   return { script, filter, mode, scriptFields, limit, sortedInScript: !isInboxPath && !!userSort, fieldsMode };
 }
 
+// OMN-88: date fields parseProjects converts string → Date. Mirrors the
+// TASK_DATE_FIELDS contract in `src/tools/tasks/task-query-pipeline.ts`.
+const PROJECT_DATE_FIELDS = ['dueDate', 'completionDate', 'nextReviewDate', 'lastReviewDate'] as const;
+
 export class OmniFocusReadTool extends BaseTool<typeof ReadSchema, unknown> {
   name = 'omnifocus_read';
   description = `Query OmniFocus data with flexible filtering. Returns tasks, projects, tags, perspectives, folders, or exports.
@@ -678,29 +682,37 @@ PERFORMANCE:
   /**
    * Parse raw project data, converting date strings to Date objects.
    *
-   * OMN-80: collapse missing-or-null to `null`, NOT `undefined`. An explicit
-   * `null` from the OmniJS projection (project.dueDate is null) must remain
-   * distinguishable from "field not requested" (which the field-projection
-   * step strips entirely, producing an absent key). Consumers that
-   * truthy-check (`if (proj.dueDate)`) are unaffected — `null` and
-   * `undefined` are both falsy. (parseTasks had the same anti-pattern across
-   * 6 date fields, fixed in OMN-82. OMN-81 resolved the related
-   * `completedDate`/`completionDate` projection-strip bug by renaming the
-   * enum/script-builder to use `completionDate` consistently; this override
-   * is now the canonical key for that field.)
+   * OMN-80 / OMN-88: date fields come through as `string | null` from the
+   * OmniJS projection. `null` means "explicitly cleared in OmniFocus"; an
+   * absent key means "field not requested by the script." parseProjects
+   * honors all three:
+   *   absent input  → absent output key
+   *   null input    → null output
+   *   string input  → Date object output
+   * Truthy-check consumers (`if (proj.dueDate)`) are unaffected — both
+   * null and absent are falsy. The observable win is that field-projection's
+   * payload reduction is no longer defeated by parseProjects resurrecting
+   * null date keys.
+   *
+   * OMN-81 resolved the related `completedDate`/`completionDate`
+   * projection-strip bug by renaming the enum/script-builder to use
+   * `completionDate` consistently; this override is now the canonical key
+   * for that field.
    */
   private parseProjects(projects: unknown): unknown[] {
     if (!Array.isArray(projects)) return [];
 
     return projects.map((project: unknown) => {
       const projectRecord = project as Record<string, unknown>;
-      return {
-        ...projectRecord,
-        dueDate: projectRecord.dueDate ? new Date(projectRecord.dueDate as string) : null,
-        completionDate: projectRecord.completionDate ? new Date(projectRecord.completionDate as string) : null,
-        nextReviewDate: projectRecord.nextReviewDate ? new Date(projectRecord.nextReviewDate as string) : null,
-        lastReviewDate: projectRecord.lastReviewDate ? new Date(projectRecord.lastReviewDate as string) : null,
-      };
+      const result: Record<string, unknown> = { ...projectRecord };
+      for (const field of PROJECT_DATE_FIELDS) {
+        if (field in projectRecord) {
+          const raw = projectRecord[field];
+          // Strict null/undefined check (see parseTasks for rationale).
+          result[field] = raw === null || raw === undefined ? null : new Date(raw as string);
+        }
+      }
+      return result;
     });
   }
 

--- a/tests/unit/tools/tasks/task-query-pipeline.test.ts
+++ b/tests/unit/tools/tasks/task-query-pipeline.test.ts
@@ -350,16 +350,71 @@ describe('parseTasks', () => {
     expect(result[0].inInbox).toBe(true);
   });
 
-  it('handles missing date fields gracefully', () => {
-    const raw = [{ id: '1', name: 'Test', completed: false, flagged: false, blocked: false }];
-    const result = parseTasks(raw);
-    // OMN-82: parseTasks now collapses missing-or-null dates to `null`, not
-    // `undefined`, so explicit null from the OmniJS projection survives and
-    // is distinguishable from "field not requested." Aligns with the
-    // canonical `Date | null` typing in the OmniJS API declarations and
-    // matches the OMN-80 fix for parseProjects.
-    expect(result[0].dueDate).toBeNull();
-    expect(result[0].deferDate).toBeNull();
+  // OMN-88: the OMN-82 commit message claimed `null` (explicitly cleared)
+  // was distinguishable from "field not requested" (absent key). The old
+  // implementation didn't honor that — it spread the input then unconditionally
+  // overrode every date field with `t.dueDate ? Date : null`, so absent
+  // input keys came back as `null`. OMN-88 fixes parseTasks to only set a
+  // date key when it was present in the input. The three cases now
+  // distinguish:
+  //   absent input  → absent output key   (field not requested by the script)
+  //   null input    → null output         (explicitly cleared in OmniJS)
+  //   string input  → Date object output  (value present)
+  // Truthy-check consumers (`if (t.dueDate)`) are unchanged — both null and
+  // absent are falsy. The observable win is that field-projection's payload
+  // reduction (the OmniJS-side `fields:['name']` projection) is no longer
+  // defeated by parseTasks resurrecting null date keys.
+  describe('absent vs cleared vs present (OMN-88)', () => {
+    it('leaves absent date keys absent in output (not null)', () => {
+      const raw = [{ id: '1', name: 'Test', completed: false, flagged: false, blocked: false }];
+      const result = parseTasks(raw);
+      expect('dueDate' in result[0]).toBe(false);
+      expect('deferDate' in result[0]).toBe(false);
+      expect('completionDate' in result[0]).toBe(false);
+      expect('added' in result[0]).toBe(false);
+      expect('modified' in result[0]).toBe(false);
+      expect('dropDate' in result[0]).toBe(false);
+      expect(result[0].dueDate).toBeUndefined();
+    });
+
+    it('preserves explicit null dates as null (OMN-82 cleared case still works)', () => {
+      const raw = [
+        {
+          id: '1',
+          name: 'Test',
+          completed: false,
+          flagged: false,
+          blocked: false,
+          dueDate: null,
+          deferDate: null,
+        },
+      ];
+      const result = parseTasks(raw);
+      // Key IS present in output (input had it explicitly), value is null.
+      expect('dueDate' in result[0]).toBe(true);
+      expect(result[0].dueDate).toBeNull();
+      expect('deferDate' in result[0]).toBe(true);
+      expect(result[0].deferDate).toBeNull();
+    });
+
+    it('mixed: absent dueDate + null deferDate + string completionDate all distinguishable', () => {
+      const raw = [
+        {
+          id: '1',
+          name: 'Test',
+          completed: false,
+          flagged: false,
+          blocked: false,
+          // dueDate intentionally absent
+          deferDate: null, // explicitly cleared
+          completionDate: '2026-05-20T12:00:00.000Z', // present
+        },
+      ];
+      const result = parseTasks(raw);
+      expect('dueDate' in result[0]).toBe(false);
+      expect(result[0].deferDate).toBeNull();
+      expect(result[0].completionDate).toBeInstanceOf(Date);
+    });
   });
 
   it('converts deferDate strings to Date objects', () => {


### PR DESCRIPTION
## Summary

Resolves [OMN-88](https://linear.app/omnifocus-mcp/issue/OMN-88). The OMN-82 commit (`7e5a97d`) claimed `parseTasks` made explicit `null` (cleared in OmniFocus) distinguishable from an absent key ("field not requested by the script"). The implementation didn't honor that — it spread `...t` then unconditionally overrode each date field with `t.dueDate ? Date : null`, so absent input keys came back as `null`. `parseProjects` (OMN-80) had the same shape. Surfaced by the post-merge review on OMN-86.

## Two observable consequences of the old behavior

1. **Field-projection's payload reduction was defeated.** A `fields: ["name"]` request still received `dueDate: null, deferDate: null, completionDate: null, added: null, modified: null, dropDate: null` for every task in the response.
2. The OMN-82-documented three-state contract was unobservable downstream — absent and cleared both came back as `null`.

## Implements Option 1 from OMN-88 (tighten the impl to match the docs)

Three-state contract now actually distinguishes:
- **Absent input** → absent output key (field not requested)
- **Null input** → null output (explicitly cleared in OmniFocus)
- **String input** → Date object output (value present)

Truthy-check consumers (`if (task.dueDate)`) are unaffected — both null and absent are falsy. Audit of `src/` confirms every parsed-date consumer uses truthy checks.

## Changes

- `src/tools/tasks/task-query-pipeline.ts`: refactored `parseTasks` to gate each date conversion on `field in t`. Introduced `TASK_DATE_FIELDS` module-private constant listing the 6 date keys. The old explicit `parentTaskId: t.parentTaskId` etc. lines were redundant with `...t` spread — removed.
- `src/tools/unified/OmniFocusReadTool.ts`: symmetric fix for `parseProjects`. `PROJECT_DATE_FIELDS = ['dueDate', 'completionDate', 'nextReviewDate', 'lastReviewDate']`.
- Both sites use strict `raw === null || raw === undefined` check rather than `raw ?` truthy check — defensive given the constrained input type, and aligns with the documented contract.
- `tests/unit/tools/tasks/task-query-pipeline.test.ts`: removed the old "handles missing date fields gracefully" test (which pinned the buggy "absent → null" behavior). Added a new `absent vs cleared vs present (OMN-88)` describe block with 3 cases.

## Mutation verification (RED → GREEN)

Pre-fix, the two absent-key cases failed (proving the bug). Post-fix, all 3 OMN-88 cases pass + the existing OMN-80 explicit-null test for `parseProjects` (which mocks `dueDate: null` explicitly) still passes because the explicit-null code path is preserved.

## Test plan

- [x] `npm run build` → clean
- [x] `npm run test:unit` → **2091/2091** (net +2 from this PR: 3 new OMN-88 cases, 1 old test removed)
- [x] Mutation-verified RED → GREEN
- [x] Pre-commit hook ran clean (no `--no-verify`)
- [x] code-standards-reviewer subagent: **APPROVED**. Minor (truthy vs strict null check) addressed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)