### PR TITLE
chore(OMN-25): audit "legacy" labels — remove dead _OMNI_SCRIPT twins, disambiguate back-compat from debt

### DIFF
--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -173,9 +173,14 @@ export interface TaskFilter {
    */
   orBranches?: TaskFilter[];
 
-  // --- Legacy (PUBLIC API deprecation) ---
+  // --- Compat alias (intentional PUBLIC API boundary — do NOT remove in "legacy" sweeps) ---
   /**
    * @deprecated PUBLIC API ONLY - Use `completed: true` instead
+   *
+   * AUDIT NOTE (OMN-25, 2026-05-21): The `@deprecated` tag here is a
+   * PUBLIC API hint, not a removal signal. Re-flagging this in "legacy
+   * code" audits is incorrect — the dual naming is a permanent boundary.
+   * See the design note below for the full rationale.
    *
    * INTERNAL DESIGN NOTE: The codebase intentionally uses dual naming:
    * - PUBLIC API: `completed` (what users should use)

--- a/src/omnifocus/OmniAutomation.ts
+++ b/src/omnifocus/OmniAutomation.ts
@@ -68,7 +68,7 @@ export class OmniAutomation {
     try {
       const result = await this.execute<unknown>(script);
 
-      // Handle raw script errors (legacy shape)
+      // Handle raw script errors (back-compat shape from pre-envelope scripts)
       const isObj = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object';
       if (isObj(result) && 'error' in result && (result as Record<string, unknown>).error === true) {
         const obj = result as Record<string, unknown>;
@@ -118,7 +118,7 @@ export class OmniAutomation {
     try {
       env = JxaEnvelopeSchema.parse(raw);
     } catch {
-      // Fallback for legacy scripts: normalize legacy shapes to envelope
+      // Fallback for back-compat scripts: normalize pre-envelope shapes to envelope
       env = normalizeToEnvelope(raw);
     }
     if (env.ok === false) {

--- a/src/omnifocus/scripts/tasks.ts
+++ b/src/omnifocus/scripts/tasks.ts
@@ -12,9 +12,9 @@
 // Re-export the modularized scripts
 // Note: CREATE_TASK_SCRIPT archived 2025-12-18, replaced by AST builder
 // Note: GET_TASK_COUNT_SCRIPT archived 2025-12-19, replaced by buildTaskCountScript in script-builder.ts
-export { COMPLETE_TASK_SCRIPT, COMPLETE_TASK_OMNI_SCRIPT } from './tasks/complete-task.js';
+export { COMPLETE_TASK_SCRIPT } from './tasks/complete-task.js';
 export { buildBulkCompleteTasksScript } from './tasks/complete-tasks-bulk.js';
-export { DELETE_TASK_SCRIPT, DELETE_TASK_OMNI_SCRIPT } from './tasks/delete-task.js';
+export { DELETE_TASK_SCRIPT } from './tasks/delete-task.js';
 export { BULK_DELETE_TASKS_SCRIPT } from './tasks/delete-tasks-bulk.js';
 // Note: TODAYS_AGENDA_SCRIPT archived 2026-02-09, replaced by AST builder (todayMode in buildAST)
 
@@ -23,6 +23,3 @@ export { BULK_DELETE_TASKS_SCRIPT } from './tasks/delete-tasks-bulk.js';
 // - mutations: buildCreateTaskScript, buildUpdateTaskScript from mutation-script-builder.ts
 // Old templates archived: list-tasks-omnijs.ts, update-task-v3.ts
 export { buildListTasksScriptV4 } from './tasks/list-tasks-ast.js';
-
-// Legacy helper export
-// Note: legacy SAFE_UTILITIES_SCRIPT re-export removed. Import directly from './shared/helpers.js' if needed.

--- a/src/omnifocus/scripts/tasks/complete-task.ts
+++ b/src/omnifocus/scripts/tasks/complete-task.ts
@@ -60,25 +60,3 @@ export const COMPLETE_TASK_SCRIPT = `
     }
   })();
 `;
-
-/**
- * Script to complete a task using OmniAutomation (URL scheme fallback)
- */
-export const COMPLETE_TASK_OMNI_SCRIPT = `
-  (() => {
-    const taskId = {{taskId}};
-    const task = Task.byIdentifier(taskId);
-    
-    if (!task) {
-      throw new Error('Task not found: ' + taskId);
-    }
-    
-    task.markComplete();
-    
-    return {
-      id: taskId,
-      completed: true,
-      message: 'Task completed successfully'
-    };
-  })()
-`;

--- a/src/omnifocus/scripts/tasks/delete-task.ts
+++ b/src/omnifocus/scripts/tasks/delete-task.ts
@@ -49,27 +49,3 @@ export const DELETE_TASK_SCRIPT = `
     }
   })();
 `;
-
-/**
- * Script to delete a task using OmniAutomation (URL scheme fallback)
- */
-export const DELETE_TASK_OMNI_SCRIPT = `
-  (() => {
-    const taskId = {{taskId}};
-    const task = Task.byIdentifier(taskId);
-    
-    if (!task) {
-      throw new Error('Task not found: ' + taskId);
-    }
-    
-    const taskName = task.name;
-    deleteObject(task);
-    
-    return {
-      id: taskId,
-      name: taskName,
-      deleted: true,
-      message: 'Task deleted successfully'
-    };
-  })()
-`;

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -42,8 +42,11 @@ interface RawOmniFocusData {
 }
 
 /**
- * Legacy error format from older OmniFocus scripts.
- * Some scripts return { error: true, message: "..." } instead of ScriptResult.
+ * Back-compat error shape from older OmniFocus scripts that pre-date the
+ * ScriptResult envelope. The `Legacy*` symbol names are retained because they
+ * appear in wire-observable error categories (e.g. `'Legacy script error'`)
+ * that MCP clients may match on. "Legacy" here means "older wire shape we
+ * still parse," not "deprecated and scheduled for removal."
  */
 interface LegacyScriptError {
   error?: boolean | string;
@@ -53,7 +56,7 @@ interface LegacyScriptError {
 }
 
 /**
- * Type guard: checks if an unknown value is a legacy script error object.
+ * Type guard: checks if an unknown value is a back-compat script error object.
  * Matches objects with error flags (true/'true') or explicit success: false.
  */
 export function isLegacyScriptError(value: unknown): value is LegacyScriptError {
@@ -65,7 +68,7 @@ export function isLegacyScriptError(value: unknown): value is LegacyScriptError 
 }
 
 /**
- * Safely extract error message from a legacy error object.
+ * Safely extract error message from a back-compat error object.
  */
 export function getLegacyErrorMessage(error: LegacyScriptError): string {
   return typeof error.message === 'string' ? error.message : 'Script execution failed';
@@ -101,6 +104,7 @@ function parseStringResult<T>(res: string): ScriptResult<T> {
 
     if (isLegacyScriptError(parsed)) {
       const details = parsed.details !== undefined ? parsed.details : parsed;
+      // 'Legacy script error' is wire-observable; preserve verbatim for client back-compat.
       return createScriptError(getLegacyErrorMessage(parsed), 'Legacy script error', details);
     }
 


### PR DESCRIPTION
## Summary

Closes [OMN-25](https://linear.app/omnifocus-mcp/issue/OMN-25/audit-legacy-code-labels-determine-whats-actually-legacy-vs-active).

The "legacy" label was overloaded in this codebase:

1. Genuinely superseded code scheduled for removal (the ticket's intended meaning), **and**
2. Back-compat wire-protocol surfaces that are intentionally permanent.

This audit separates the two:

- **Removes** dead code that was sitting orphaned behind a barrel re-export.
- **Renames** the back-compat surfaces' descriptive comments from "legacy" to "back-compat" to disambiguate them from the AST-migration sense of "legacy."
- **Annotates** the public/internal `includeCompleted` boundary so future "legacy → remove" sweeps stop re-flagging it.

Behavior-preserving. No wire-observable strings changed.

## Changes

| File | Change |
|------|--------|
| `src/omnifocus/scripts/tasks/delete-task.ts` | Delete `DELETE_TASK_OMNI_SCRIPT` (zero non-barrel consumers; the JXA twin `DELETE_TASK_SCRIPT` remains the actively-consumed path) |
| `src/omnifocus/scripts/tasks/complete-task.ts` | Delete `COMPLETE_TASK_OMNI_SCRIPT` (same as above; JXA twin `COMPLETE_TASK_SCRIPT` is what `OmniFocusWriteTool` consumes) |
| `src/omnifocus/scripts/tasks.ts` | Drop both `_OMNI_SCRIPT` re-exports from the barrel + trim the now-empty "Legacy helper export" header |
| `src/omnifocus/OmniAutomation.ts` | Reword two comments: raw-error parse path + envelope fallback. Both handle older wire shapes, not deprecated debt |
| `src/tools/base.ts` | Reword `LegacyScriptError` docstrings to clarify the symbol name is preserved for wire-observability (the `'Legacy script error'` category string is unchanged). Add explanatory comment at the `createScriptError` call site |
| `src/contracts/filters.ts` | Reword `// --- Legacy ---` section header to `// --- Compat alias ---` and add an AUDIT NOTE banner on the `@deprecated includeCompleted` block so the deliberate public/internal API boundary isn't re-flagged in future sweeps |

## What was deliberately NOT changed

- **Wire-observable strings.** `'Legacy script error'` (the 3rd-arg category in three `createScriptError` calls) is preserved verbatim because MCP clients may match on it.
- **The `LegacyScriptError` type name and `isLegacyScriptError` / `getLegacyErrorMessage` exports.** Renaming the symbol would touch every call site for purely cosmetic gain.
- **`safe-io.ts`'s `v: 'legacy-1'`.** That's a wire version tag, not a deprecation label.
- **History-note comments** like "Replaces the legacy X" describe completed migrations correctly.

## Verification

- ✅ `npm run build` — clean
- ✅ `npm run test:unit` — 2117/2117 (97 test files)
- ✅ `grep -rn 'DELETE_TASK_OMNI_SCRIPT\|COMPLETE_TASK_OMNI_SCRIPT' src/ tests/` — zero remaining references after deletion
- ✅ Pre-commit hook (prettier + eslint) — clean
- ✅ Pre-push hook (full unit suite) — re-ran 2117/2117

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [x] No orphan references to deleted symbols
- [x] `CLAUDE.md` path-resolution guard test passes (no broken `src/` references introduced)
- [ ] Code-reviewer subagent gate (running next, per repo workflow norm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)