### PR TITLE
refactor(OMN-32): migrate 5 mutation scripts from {{placeholder}} templates to typed builders

### DIFF
--- a/src/omnifocus/scripts/reviews.ts
+++ b/src/omnifocus/scripts/reviews.ts
@@ -1,4 +1,4 @@
 // Review-related scripts for GTD project review workflows
 
-export { MARK_PROJECT_REVIEWED_SCRIPT } from './reviews/mark-project-reviewed.js';
+export { buildMarkProjectReviewedScript, type MarkProjectReviewedParams } from './reviews/mark-project-reviewed.js';
 export { SET_REVIEW_SCHEDULE_SCRIPT } from './reviews/set-review-schedule.js';

--- a/src/omnifocus/scripts/reviews.ts
+++ b/src/omnifocus/scripts/reviews.ts
@@ -1,4 +1,8 @@
 // Review-related scripts for GTD project review workflows
 
 export { buildMarkProjectReviewedScript, type MarkProjectReviewedParams } from './reviews/mark-project-reviewed.js';
-export { SET_REVIEW_SCHEDULE_SCRIPT } from './reviews/set-review-schedule.js';
+export {
+  buildSetReviewScheduleScript,
+  type SetReviewScheduleParams,
+  type ReviewIntervalSpec,
+} from './reviews/set-review-schedule.js';

--- a/src/omnifocus/scripts/reviews/mark-project-reviewed.ts
+++ b/src/omnifocus/scripts/reviews/mark-project-reviewed.ts
@@ -9,7 +9,21 @@
  * - Handle projects with and without review intervals
  * - Proper error handling for missing projects
  */
-export const MARK_PROJECT_REVIEWED_SCRIPT = `
+
+export interface MarkProjectReviewedParams {
+  projectId: string | null;
+  reviewDate: string;
+  updateNextReviewDate: boolean;
+}
+
+export function buildMarkProjectReviewedScript(params: MarkProjectReviewedParams): string {
+  const serialized = JSON.stringify({
+    projectId: params.projectId ?? null,
+    reviewDate: params.reviewDate,
+    updateNextReviewDate: params.updateNextReviewDate,
+  });
+
+  return `
   // MARK_PROJECT_REVIEWED - OmniJS-first pattern
   (() => {
     const app = Application('OmniFocus');
@@ -17,9 +31,10 @@ export const MARK_PROJECT_REVIEWED_SCRIPT = `
     try {
       const omniJsScript = \`
         (() => {
-          const projectId = {{projectId}};
-          const reviewDate = {{reviewDate}};
-          const updateNextReviewDate = {{updateNextReviewDate}};
+          const __params = ${serialized};
+          const projectId = __params.projectId;
+          const reviewDate = __params.reviewDate;
+          const updateNextReviewDate = __params.updateNextReviewDate;
 
           // Helper function to calculate next review date
           function calculateNextReviewDate(reviewInterval, fromDate) {
@@ -120,3 +135,4 @@ export const MARK_PROJECT_REVIEWED_SCRIPT = `
     }
   })();
 `;
+}

--- a/src/omnifocus/scripts/reviews/set-review-schedule.ts
+++ b/src/omnifocus/scripts/reviews/set-review-schedule.ts
@@ -9,7 +9,26 @@
  * - Handle projects that don't exist
  * - Detailed reporting of changes made
  */
-export const SET_REVIEW_SCHEDULE_SCRIPT = `
+
+export interface ReviewIntervalSpec {
+  unit: string;
+  steps: number;
+}
+
+export interface SetReviewScheduleParams {
+  projectIds: string[];
+  reviewInterval: ReviewIntervalSpec | null;
+  nextReviewDate: string | null;
+}
+
+export function buildSetReviewScheduleScript(params: SetReviewScheduleParams): string {
+  const serialized = JSON.stringify({
+    projectIds: params.projectIds,
+    reviewInterval: params.reviewInterval ?? null,
+    nextReviewDate: params.nextReviewDate ?? null,
+  });
+
+  return `
   // SET_REVIEW_SCHEDULE - OmniJS-first pattern
   (() => {
     const app = Application('OmniFocus');
@@ -17,9 +36,10 @@ export const SET_REVIEW_SCHEDULE_SCRIPT = `
     try {
       const omniJsScript = \`
         (() => {
-          const projectIds = {{projectIds}};
-          const reviewInterval = {{reviewInterval}};
-          const nextReviewDateParam = {{nextReviewDate}};
+          const __params = ${serialized};
+          const projectIds = __params.projectIds;
+          const reviewInterval = __params.reviewInterval;
+          const nextReviewDateParam = __params.nextReviewDate;
 
           // Helper function to calculate next review date from now
           function calculateNextReviewDate(interval, baseDate = null) {
@@ -188,3 +208,4 @@ export const SET_REVIEW_SCHEDULE_SCRIPT = `
     }
   })();
 `;
+}

--- a/src/omnifocus/scripts/tasks.ts
+++ b/src/omnifocus/scripts/tasks.ts
@@ -15,7 +15,7 @@
 export { buildCompleteTaskScript, type CompleteTaskParams } from './tasks/complete-task.js';
 export { buildBulkCompleteTasksScript } from './tasks/complete-tasks-bulk.js';
 export { buildDeleteTaskScript, type DeleteTaskParams } from './tasks/delete-task.js';
-export { BULK_DELETE_TASKS_SCRIPT } from './tasks/delete-tasks-bulk.js';
+export { buildBulkDeleteTasksScript, type BulkDeleteTasksParams } from './tasks/delete-tasks-bulk.js';
 // Note: TODAYS_AGENDA_SCRIPT archived 2026-02-09, replaced by AST builder (todayMode in buildAST)
 
 // AST-powered scripts (Phase 1-2 migration complete 2025-12-17):

--- a/src/omnifocus/scripts/tasks.ts
+++ b/src/omnifocus/scripts/tasks.ts
@@ -12,7 +12,7 @@
 // Re-export the modularized scripts
 // Note: CREATE_TASK_SCRIPT archived 2025-12-18, replaced by AST builder
 // Note: GET_TASK_COUNT_SCRIPT archived 2025-12-19, replaced by buildTaskCountScript in script-builder.ts
-export { COMPLETE_TASK_SCRIPT } from './tasks/complete-task.js';
+export { buildCompleteTaskScript, type CompleteTaskParams } from './tasks/complete-task.js';
 export { buildBulkCompleteTasksScript } from './tasks/complete-tasks-bulk.js';
 export { DELETE_TASK_SCRIPT } from './tasks/delete-task.js';
 export { BULK_DELETE_TASKS_SCRIPT } from './tasks/delete-tasks-bulk.js';

--- a/src/omnifocus/scripts/tasks.ts
+++ b/src/omnifocus/scripts/tasks.ts
@@ -14,7 +14,7 @@
 // Note: GET_TASK_COUNT_SCRIPT archived 2025-12-19, replaced by buildTaskCountScript in script-builder.ts
 export { buildCompleteTaskScript, type CompleteTaskParams } from './tasks/complete-task.js';
 export { buildBulkCompleteTasksScript } from './tasks/complete-tasks-bulk.js';
-export { DELETE_TASK_SCRIPT } from './tasks/delete-task.js';
+export { buildDeleteTaskScript, type DeleteTaskParams } from './tasks/delete-task.js';
 export { BULK_DELETE_TASKS_SCRIPT } from './tasks/delete-tasks-bulk.js';
 // Note: TODAYS_AGENDA_SCRIPT archived 2026-02-09, replaced by AST builder (todayMode in buildAST)
 

--- a/src/omnifocus/scripts/tasks/complete-task.ts
+++ b/src/omnifocus/scripts/tasks/complete-task.ts
@@ -8,13 +8,26 @@ import { getUnifiedHelpers } from '../shared/helpers.js';
  * - New approach: OmniJS bridge for fast ID lookup - sub-second execution
  * - Performance: ~1000x faster due to OmniJS bulk property access vs JXA per-property calls
  */
-export const COMPLETE_TASK_SCRIPT = `
+
+export interface CompleteTaskParams {
+  taskId: string;
+  completionDate?: string | null;
+}
+
+export function buildCompleteTaskScript(params: CompleteTaskParams): string {
+  const serialized = JSON.stringify({
+    taskId: params.taskId,
+    completionDate: params.completionDate ?? null,
+  });
+
+  return `
   ${getUnifiedHelpers()}
 
   (() => {
     const app = Application('OmniFocus');
-    const taskId = {{taskId}};
-    const completionDateStr = {{completionDate}};
+    const __params = ${serialized};
+    const taskId = __params.taskId;
+    const completionDateStr = __params.completionDate;
 
     try {
       // Use OmniJS bridge for fast task lookup and completion
@@ -60,3 +73,4 @@ export const COMPLETE_TASK_SCRIPT = `
     }
   })();
 `;
+}

--- a/src/omnifocus/scripts/tasks/delete-task.ts
+++ b/src/omnifocus/scripts/tasks/delete-task.ts
@@ -8,12 +8,21 @@ import { getUnifiedHelpers } from '../shared/helpers.js';
  * - New approach: O(1) lookup using Task.byIdentifier() + deleteObject() in single OmniJS call
  * - Performance: ~1000x faster (sub-second vs 27 seconds)
  */
-export const DELETE_TASK_SCRIPT = `
+
+export interface DeleteTaskParams {
+  taskId: string;
+}
+
+export function buildDeleteTaskScript(params: DeleteTaskParams): string {
+  const serialized = JSON.stringify({ taskId: params.taskId });
+
+  return `
   ${getUnifiedHelpers()}
 
   (() => {
     const app = Application('OmniFocus');
-    const taskId = {{taskId}};
+    const __params = ${serialized};
+    const taskId = __params.taskId;
 
     try {
       // Use pure OmniJS for O(1) lookup AND deletion in single bridge call
@@ -49,3 +58,4 @@ export const DELETE_TASK_SCRIPT = `
     }
   })();
 `;
+}

--- a/src/omnifocus/scripts/tasks/delete-tasks-bulk.ts
+++ b/src/omnifocus/scripts/tasks/delete-tasks-bulk.ts
@@ -10,12 +10,21 @@ import { getUnifiedHelpers } from '../shared/helpers.js';
  *
  * Accepts array of task IDs and deletes them all using OmniJS bridge
  */
-export const BULK_DELETE_TASKS_SCRIPT = `
+
+export interface BulkDeleteTasksParams {
+  taskIds: string[];
+}
+
+export function buildBulkDeleteTasksScript(params: BulkDeleteTasksParams): string {
+  const serialized = JSON.stringify({ taskIds: params.taskIds });
+
+  return `
   ${getUnifiedHelpers()}
 
   (() => {
     const app = Application('OmniFocus');
-    const taskIds = {{taskIds}};
+    const __params = ${serialized};
+    const taskIds = __params.taskIds;
 
     if (!Array.isArray(taskIds) || taskIds.length === 0) {
       return JSON.stringify({
@@ -67,3 +76,4 @@ export const BULK_DELETE_TASKS_SCRIPT = `
     }
   })();
 `;
+}

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -20,7 +20,7 @@ import { ANALYZE_OVERDUE_V3 as ANALYZE_OVERDUE_SCRIPT } from '../../omnifocus/sc
 import { WORKFLOW_ANALYSIS_V3 } from '../../omnifocus/scripts/analytics/workflow-analysis-v3.js';
 import { GET_RECURRING_PATTERNS_SCRIPT } from '../../omnifocus/scripts/recurring.js';
 import { buildRecurringTasksScript } from '../../omnifocus/scripts/recurring/analyze-recurring-tasks-ast.js';
-import { buildMarkProjectReviewedScript, SET_REVIEW_SCHEDULE_SCRIPT } from '../../omnifocus/scripts/reviews.js';
+import { buildMarkProjectReviewedScript, buildSetReviewScheduleScript } from '../../omnifocus/scripts/reviews.js';
 import { buildProjectsForReviewScript } from '../../omnifocus/scripts/reviews/projects-for-review.js';
 
 // Pure-JS analyzer imports (for pattern analysis)
@@ -2939,10 +2939,10 @@ SCOPE FILTERING:
     const projectId = compiled.params?.projectId;
     const brandedProjectIds = projectId ? [convertToProjectId(projectId)] : [];
 
-    const script = this.omniAutomation.buildScript(SET_REVIEW_SCHEDULE_SCRIPT, {
+    // OMN-60: pass the requested interval through (was hardcoded null, which
+    // made the entire reviewInterval path dead code).
+    const script = buildSetReviewScheduleScript({
       projectIds: brandedProjectIds,
-      // OMN-60: pass the requested interval through (was hardcoded null, which
-      // made the entire reviewInterval path dead code).
       reviewInterval: compiled.params?.reviewInterval ?? null,
       nextReviewDate: compiled.params?.reviewDate ?? null,
     });
@@ -2981,7 +2981,7 @@ SCOPE FILTERING:
     const projectId = compiled.params?.projectId;
     const brandedProjectIds = projectId ? [convertToProjectId(projectId)] : [];
 
-    const script = this.omniAutomation.buildScript(SET_REVIEW_SCHEDULE_SCRIPT, {
+    const script = buildSetReviewScheduleScript({
       projectIds: brandedProjectIds,
       reviewInterval: null,
       nextReviewDate: null,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -20,7 +20,7 @@ import { ANALYZE_OVERDUE_V3 as ANALYZE_OVERDUE_SCRIPT } from '../../omnifocus/sc
 import { WORKFLOW_ANALYSIS_V3 } from '../../omnifocus/scripts/analytics/workflow-analysis-v3.js';
 import { GET_RECURRING_PATTERNS_SCRIPT } from '../../omnifocus/scripts/recurring.js';
 import { buildRecurringTasksScript } from '../../omnifocus/scripts/recurring/analyze-recurring-tasks-ast.js';
-import { MARK_PROJECT_REVIEWED_SCRIPT, SET_REVIEW_SCHEDULE_SCRIPT } from '../../omnifocus/scripts/reviews.js';
+import { buildMarkProjectReviewedScript, SET_REVIEW_SCHEDULE_SCRIPT } from '../../omnifocus/scripts/reviews.js';
 import { buildProjectsForReviewScript } from '../../omnifocus/scripts/reviews/projects-for-review.js';
 
 // Pure-JS analyzer imports (for pattern analysis)
@@ -2897,8 +2897,8 @@ SCOPE FILTERING:
     const reviewDate = compiled.params?.reviewDate || new Date().toISOString();
     const brandedProjectId = projectId ? convertToProjectId(projectId) : undefined;
 
-    const script = this.omniAutomation.buildScript(MARK_PROJECT_REVIEWED_SCRIPT, {
-      projectId: brandedProjectId,
+    const script = buildMarkProjectReviewedScript({
+      projectId: brandedProjectId ?? null,
       reviewDate,
       updateNextReviewDate: true,
     });

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -45,7 +45,7 @@ import type { ScriptExecutionResult, TaskCreationArgs } from '../../omnifocus/sc
 import type { TaskOperationDataV2 } from '../response-types-v2.js';
 import {
   buildCompleteTaskScript,
-  DELETE_TASK_SCRIPT,
+  buildDeleteTaskScript,
   BULK_DELETE_TASKS_SCRIPT,
 } from '../../omnifocus/scripts/tasks.js';
 import { localToUTC } from '../../utils/timezone.js';
@@ -899,9 +899,7 @@ SAFETY:
     }
 
     try {
-      const deleteScript = this.omniAutomation.buildScript(DELETE_TASK_SCRIPT, {
-        taskId,
-      } as unknown as Record<string, unknown>);
+      const deleteScript = buildDeleteTaskScript({ taskId });
       const res = await this.execJson(deleteScript);
       const deleteResult =
         res && typeof res === 'object' && 'success' in res

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -44,9 +44,9 @@ import { isScriptError, isScriptSuccess } from '../../omnifocus/script-result-ty
 import type { ScriptExecutionResult, TaskCreationArgs } from '../../omnifocus/script-response-types.js';
 import type { TaskOperationDataV2 } from '../response-types-v2.js';
 import {
+  buildBulkDeleteTasksScript,
   buildCompleteTaskScript,
   buildDeleteTaskScript,
-  BULK_DELETE_TASKS_SCRIPT,
 } from '../../omnifocus/scripts/tasks.js';
 import { localToUTC } from '../../utils/timezone.js';
 import { parsingError, formatErrorWithRecovery, invalidDateError } from '../../utils/error-messages.js';
@@ -1009,7 +1009,7 @@ SAFETY:
     const errors: unknown[] = [];
 
     try {
-      const script = this.omniAutomation.buildScript(BULK_DELETE_TASKS_SCRIPT, {
+      const script = buildBulkDeleteTasksScript({
         taskIds: taskIds.map((id) => id as string),
       });
       const result = await this.execJson(script);

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -43,7 +43,11 @@ import type {
 import { isScriptError, isScriptSuccess } from '../../omnifocus/script-result-types.js';
 import type { ScriptExecutionResult, TaskCreationArgs } from '../../omnifocus/script-response-types.js';
 import type { TaskOperationDataV2 } from '../response-types-v2.js';
-import { COMPLETE_TASK_SCRIPT, DELETE_TASK_SCRIPT, BULK_DELETE_TASKS_SCRIPT } from '../../omnifocus/scripts/tasks.js';
+import {
+  buildCompleteTaskScript,
+  DELETE_TASK_SCRIPT,
+  BULK_DELETE_TASKS_SCRIPT,
+} from '../../omnifocus/scripts/tasks.js';
 import { localToUTC } from '../../utils/timezone.js';
 import { parsingError, formatErrorWithRecovery, invalidDateError } from '../../utils/error-messages.js';
 import { sanitizeTaskUpdates } from './utils/task-sanitizer.js';
@@ -822,17 +826,11 @@ SAFETY:
       );
     }
 
-    // Convert completionDate if provided
-    const processedArgs = {
-      taskId,
-      completionDate: compiled.completionDate ? localToUTC(compiled.completionDate, 'completion') : undefined,
-    };
-
     try {
-      const completeScript = this.omniAutomation.buildScript(
-        COMPLETE_TASK_SCRIPT,
-        processedArgs as unknown as Record<string, unknown>,
-      );
+      const completeScript = buildCompleteTaskScript({
+        taskId,
+        completionDate: compiled.completionDate ? localToUTC(compiled.completionDate, 'completion') : null,
+      });
       const res = await this.execJson(completeScript);
       const completeResult =
         res && typeof res === 'object' && 'success' in res

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -124,7 +124,7 @@ const AnalysisSchema = z.discriminatedUnion('type', [
           projectId: z.string().optional(),
           reviewDate: z.string().optional(),
           // OMN-60: review interval for set_schedule. Object shape — passed
-          // through to SET_REVIEW_SCHEDULE_SCRIPT, which expects { unit, steps }.
+          // through to buildSetReviewScheduleScript(), which expects { unit, steps }.
           reviewInterval: z
             .object({
               unit: z.enum(['day', 'week', 'month', 'year']),

--- a/tests/unit/omnifocus/scripts/reviews/mark-project-reviewed.test.ts
+++ b/tests/unit/omnifocus/scripts/reviews/mark-project-reviewed.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildMarkProjectReviewedScript } from '../../../../../src/omnifocus/scripts/reviews/mark-project-reviewed';
+
+describe('buildMarkProjectReviewedScript', () => {
+  it('serializes all three params into the script body', () => {
+    const script = buildMarkProjectReviewedScript({
+      projectId: 'proj-xyz',
+      reviewDate: '2026-05-21T17:00:00',
+      updateNextReviewDate: true,
+    });
+    expect(script).toContain('"projectId":"proj-xyz"');
+    expect(script).toContain('"reviewDate":"2026-05-21T17:00:00"');
+    expect(script).toContain('"updateNextReviewDate":true');
+  });
+
+  it('normalizes null projectId (e.g. missing param) explicitly', () => {
+    const script = buildMarkProjectReviewedScript({
+      projectId: null,
+      reviewDate: '2026-05-21',
+      updateNextReviewDate: false,
+    });
+    expect(script).toContain('"projectId":null');
+    expect(script).toContain('"updateNextReviewDate":false');
+  });
+
+  it('emits a JXA IIFE that calls evaluateJavascript with the OmniJS body', () => {
+    const script = buildMarkProjectReviewedScript({
+      projectId: 'p',
+      reviewDate: '2026-05-21',
+      updateNextReviewDate: true,
+    });
+    expect(script).toMatch(/Application\('OmniFocus'\)/);
+    expect(script).toContain('app.evaluateJavascript(omniJsScript)');
+    expect(script).toContain('Project.byIdentifier(projectId)');
+    expect(script).toContain("operation: 'mark_project_reviewed'");
+  });
+
+  it('escapes quote characters in projectId via JSON.stringify', () => {
+    const script = buildMarkProjectReviewedScript({
+      projectId: 'has"quote',
+      reviewDate: '2026-05-21',
+      updateNextReviewDate: true,
+    });
+    expect(script).toContain('"projectId":"has\\"quote"');
+  });
+});

--- a/tests/unit/omnifocus/scripts/reviews/set-review-schedule.test.ts
+++ b/tests/unit/omnifocus/scripts/reviews/set-review-schedule.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildSetReviewScheduleScript } from '../../../../../src/omnifocus/scripts/reviews/set-review-schedule';
+
+describe('buildSetReviewScheduleScript', () => {
+  it('serializes all three params (set-interval call site shape)', () => {
+    const script = buildSetReviewScheduleScript({
+      projectIds: ['p1', 'p2'],
+      reviewInterval: { unit: 'week', steps: 2 },
+      nextReviewDate: '2026-05-21T17:00:00',
+    });
+    expect(script).toContain('"projectIds":["p1","p2"]');
+    expect(script).toContain('"reviewInterval":{"unit":"week","steps":2}');
+    expect(script).toContain('"nextReviewDate":"2026-05-21T17:00:00"');
+  });
+
+  it('serializes the clear-schedule call site (both nullable fields explicit)', () => {
+    const script = buildSetReviewScheduleScript({
+      projectIds: ['p1'],
+      reviewInterval: null,
+      nextReviewDate: null,
+    });
+    expect(script).toContain('"projectIds":["p1"]');
+    expect(script).toContain('"reviewInterval":null');
+    expect(script).toContain('"nextReviewDate":null');
+  });
+
+  it('handles empty projectIds (returns the early no-IDs error in JXA)', () => {
+    const script = buildSetReviewScheduleScript({
+      projectIds: [],
+      reviewInterval: null,
+      nextReviewDate: null,
+    });
+    expect(script).toContain('"projectIds":[]');
+    expect(script).toContain('"No project IDs provided"');
+  });
+
+  it('emits a JXA IIFE with Project.byIdentifier + OMN-58/60 setter pattern', () => {
+    const script = buildSetReviewScheduleScript({
+      projectIds: ['p'],
+      reviewInterval: { unit: 'month', steps: 1 },
+      nextReviewDate: null,
+    });
+    expect(script).toMatch(/Application\('OmniFocus'\)/);
+    expect(script).toContain('app.evaluateJavascript(omniJsScript)');
+    expect(script).toContain('Project.byIdentifier(projectId)');
+    expect(script).toContain('targetProject.reviewInterval = ri;');
+    expect(script).toContain("operation: 'set_review_schedule'");
+  });
+
+  it('escapes quote characters in projectIds via JSON.stringify', () => {
+    const script = buildSetReviewScheduleScript({
+      projectIds: ['has"quote'],
+      reviewInterval: null,
+      nextReviewDate: null,
+    });
+    expect(script).toContain('"projectIds":["has\\"quote"]');
+  });
+});

--- a/tests/unit/omnifocus/scripts/tasks/complete-task.test.ts
+++ b/tests/unit/omnifocus/scripts/tasks/complete-task.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildCompleteTaskScript } from '../../../../../src/omnifocus/scripts/tasks/complete-task';
+
+describe('buildCompleteTaskScript', () => {
+  it('serializes taskId into the script body', () => {
+    const script = buildCompleteTaskScript({ taskId: 'abc-123' });
+    expect(script).toContain('"taskId":"abc-123"');
+  });
+
+  it('normalizes missing completionDate to null', () => {
+    const script = buildCompleteTaskScript({ taskId: 'abc-123' });
+    expect(script).toContain('"completionDate":null');
+  });
+
+  it('passes completionDate string through verbatim when provided', () => {
+    const script = buildCompleteTaskScript({
+      taskId: 'abc-123',
+      completionDate: '2026-05-21T17:00:00',
+    });
+    expect(script).toContain('"completionDate":"2026-05-21T17:00:00"');
+  });
+
+  it('emits a JXA IIFE that calls evaluateJavascript', () => {
+    const script = buildCompleteTaskScript({ taskId: 'x' });
+    expect(script).toMatch(/Application\('OmniFocus'\)/);
+    expect(script).toContain('app.evaluateJavascript(omniScript)');
+    expect(script).toContain("formatError(error, 'complete_task')");
+  });
+
+  it('escapes taskId values that contain quotes safely via JSON.stringify', () => {
+    const script = buildCompleteTaskScript({ taskId: 'has"quote' });
+    expect(script).toContain('"taskId":"has\\"quote"');
+  });
+});

--- a/tests/unit/omnifocus/scripts/tasks/delete-task.test.ts
+++ b/tests/unit/omnifocus/scripts/tasks/delete-task.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { buildDeleteTaskScript } from '../../../../../src/omnifocus/scripts/tasks/delete-task';
+
+describe('buildDeleteTaskScript', () => {
+  it('serializes taskId into the script body', () => {
+    const script = buildDeleteTaskScript({ taskId: 'abc-123' });
+    expect(script).toContain('"taskId":"abc-123"');
+  });
+
+  it('emits a JXA IIFE that calls evaluateJavascript with the Task.byIdentifier lookup', () => {
+    const script = buildDeleteTaskScript({ taskId: 'x' });
+    expect(script).toMatch(/Application\('OmniFocus'\)/);
+    expect(script).toContain('Task.byIdentifier(targetId)');
+    expect(script).toContain('deleteObject(task)');
+    expect(script).toContain('app.evaluateJavascript(deleteScript)');
+    expect(script).toContain("formatError(error, 'delete_task')");
+  });
+
+  it('escapes taskId values with quotes safely via JSON.stringify', () => {
+    const script = buildDeleteTaskScript({ taskId: 'has"quote' });
+    expect(script).toContain('"taskId":"has\\"quote"');
+  });
+});

--- a/tests/unit/omnifocus/scripts/tasks/delete-tasks-bulk.test.ts
+++ b/tests/unit/omnifocus/scripts/tasks/delete-tasks-bulk.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildBulkDeleteTasksScript } from '../../../../../src/omnifocus/scripts/tasks/delete-tasks-bulk';
+
+describe('buildBulkDeleteTasksScript', () => {
+  it('serializes taskIds array into the script body', () => {
+    const script = buildBulkDeleteTasksScript({ taskIds: ['id1', 'id2', 'id3'] });
+    expect(script).toContain('"taskIds":["id1","id2","id3"]');
+  });
+
+  it('handles an empty taskIds array (returns the empty-input fast path in JXA)', () => {
+    const script = buildBulkDeleteTasksScript({ taskIds: [] });
+    expect(script).toContain('"taskIds":[]');
+    expect(script).toContain("'No task IDs provided'");
+  });
+
+  it('emits a JXA IIFE with Task.byIdentifier + deleteObject', () => {
+    const script = buildBulkDeleteTasksScript({ taskIds: ['x'] });
+    expect(script).toMatch(/Application\('OmniFocus'\)/);
+    expect(script).toContain('Task.byIdentifier(id)');
+    expect(script).toContain('deleteObject(task)');
+    expect(script).toContain("formatError(error, 'bulk_delete_tasks')");
+  });
+
+  it('escapes IDs that contain quotes safely via JSON.stringify', () => {
+    const script = buildBulkDeleteTasksScript({ taskIds: ['has"quote', 'plain'] });
+    expect(script).toContain('"taskIds":["has\\"quote","plain"]');
+  });
+});

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -702,11 +702,16 @@ describe('OmniFocusAnalyzeTool', () => {
 
   // ==========================================================================
   // manage_reviews set_schedule — reviewInterval wiring (OMN-60)
+  //
+  // Post-OMN-32: SET_REVIEW_SCHEDULE_SCRIPT template was replaced by
+  // buildSetReviewScheduleScript(). The OMN-60 invariant — "the requested
+  // reviewInterval ends up in the generated script, not hardcoded null" — is
+  // now verified by inspecting the script string passed to executeJson, since
+  // the builder JSON-serializes the params and bakes them into the OmniJS body.
   // ==========================================================================
   describe('manage_reviews set_schedule reviewInterval wiring (OMN-60)', () => {
     it('passes the requested reviewInterval through to the script (not hardcoded null)', async () => {
       mockCache.get.mockReturnValue(null);
-      mockOmni.buildScript.mockReturnValue('script');
       mockOmni.executeJson.mockResolvedValue({
         success: true,
         data: { results: { successful: [], failed: [], summary: { successful_count: 0, failed_count: 0 } } },
@@ -723,15 +728,13 @@ describe('OmniFocusAnalyzeTool', () => {
         },
       });
 
-      expect(mockOmni.buildScript).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ reviewInterval: { unit: 'week', steps: 2 } }),
-      );
+      expect(mockOmni.executeJson).toHaveBeenCalledTimes(1);
+      const generatedScript = mockOmni.executeJson.mock.calls[0][0] as string;
+      expect(generatedScript).toContain('"reviewInterval":{"unit":"week","steps":2}');
     });
 
     it('passes reviewInterval: null when none is supplied (back-compat)', async () => {
       mockCache.get.mockReturnValue(null);
-      mockOmni.buildScript.mockReturnValue('script');
       mockOmni.executeJson.mockResolvedValue({
         success: true,
         data: { results: { successful: [], failed: [], summary: { successful_count: 0, failed_count: 0 } } },
@@ -744,10 +747,9 @@ describe('OmniFocusAnalyzeTool', () => {
         },
       });
 
-      expect(mockOmni.buildScript).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ reviewInterval: null }),
-      );
+      expect(mockOmni.executeJson).toHaveBeenCalledTimes(1);
+      const generatedScript = mockOmni.executeJson.mock.calls[0][0] as string;
+      expect(generatedScript).toContain('"reviewInterval":null');
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes [OMN-32](https://linear.app/omnifocus-mcp/issue/OMN-32/migrate-remaining-template-scripts-to-builder-pattern), per the **re-scoped** plan in its 🔁 comment (2026-05-16).

The original ticket framed migrating "13 active templates" with the end-goal of deleting `omniAutomation.buildScript()`. The 🔁 audit found 8 of those templates are intentionally **legacy-staying** per the AST migration tracker — analytics (productivity/velocity/overdue/workflow), `get-recurring-patterns`, the two `warm-*-cache` scripts, and `list-perspectives`. `buildScript()` therefore cannot be deleted under this ticket, and this PR scopes itself to the 5 **genuine simple-mutation candidates** the 🔁 identified:

| Wave | Script | Consumer | Sites |
|------|--------|----------|-------|
| A1 | `COMPLETE_TASK_SCRIPT` → `buildCompleteTaskScript` | OmniFocusWriteTool | 1 |
| A2 | `DELETE_TASK_SCRIPT` → `buildDeleteTaskScript` | OmniFocusWriteTool | 1 |
| A3 | `BULK_DELETE_TASKS_SCRIPT` → `buildBulkDeleteTasksScript` | OmniFocusWriteTool | 1 |
| B1 | `MARK_PROJECT_REVIEWED_SCRIPT` → `buildMarkProjectReviewedScript` | OmniFocusAnalyzeTool | 1 |
| B2 | `SET_REVIEW_SCHEDULE_SCRIPT` → `buildSetReviewScheduleScript` | OmniFocusAnalyzeTool | 2 |

After this PR:
- **OmniFocusWriteTool** no longer uses `omniAutomation.buildScript()` for any task mutation.
- **OmniFocusAnalyzeTool** no longer uses `omniAutomation.buildScript()` for either review-mutation path.
- **`omniAutomation.buildScript()` remains** with 9 call sites across 7 legacy-staying scripts (the analytics + recurring + export + list-perspectives surfaces) — confirmed by grep.

## Pattern

Every builder follows the reference pattern from `buildProjectsForReviewScript` / `buildBulkCompleteTasksScript`: JSON.stringify the whole typed params object once, interpolate as a JS literal at the outermost JXA (or innermost OmniJS) scope. Optional params are normalized with `?? null` **before** JSON.stringify so that `JSON.stringify({x: undefined}) === '{}'` doesn't silently drop a key (the old `formatValue()` path converted `undefined → 'null'`).

```typescript
export interface CompleteTaskParams {
  taskId: string;
  completionDate?: string | null;
}

export function buildCompleteTaskScript(params: CompleteTaskParams): string {
  const serialized = JSON.stringify({
    taskId: params.taskId,
    completionDate: params.completionDate ?? null,
  });
  return `
    (() => {
      const __params = ${serialized};
      ...
    })();
  `;
}
```

## OMN-60 regression test update

`OmniFocusAnalyzeTool.test.ts` had two regression guards for the OMN-60 fix ("don't hardcode `reviewInterval` to null") that asserted on `mockOmni.buildScript.toHaveBeenCalledWith(...)`. That mock is no longer invoked. Rewrote the tests to inspect the script string passed to `mockOmni.executeJson` and assert on the baked-in serialization — `"reviewInterval":{"unit":"week","steps":2}` is now directly visible in the generated OmniJS body, which is arguably a **stronger** invariant than checking what got passed to a helper function.

## Verification

- ✅ `npm run build` — clean
- ✅ `npm run test:unit` — **2138/2138** across 102 test files (was 2117/97 pre-PR; +21 new tests across 5 new builder test files)
- ✅ `grep 'omniAutomation.buildScript' src/` — exactly the 9 expected surviving call sites; none reference any migrated template
- ✅ Pre-commit hooks (prettier + eslint) clean on all 5 commits
- ✅ Pre-push hook ran full unit suite again

## Out-of-scope discovery (not addressed here)

While verifying `buildScript()`'s surviving call sites, found that **`GET_PROJECT_STATS_SCRIPT`** in `src/omnifocus/scripts/projects/get-project-stats.ts` is exported but has **zero non-definer consumers** — it's an orphan, structurally identical to the `_OMNI_SCRIPT` twins that OMN-25 deleted. Not deleting here (PR is already 5 commits + 5 test files); flagging for a follow-up ticket.

## Test plan

- [x] Build passes
- [x] Unit tests pass (2138/2138)
- [x] `buildScript()` correctly survives for the 8 legacy-staying scripts
- [x] OMN-60 regression invariant verified via new assertion shape
- [x] No wire-observable behavior change (the generated OmniJS bodies are equivalent — both old and new bake the same JSON literals at the same scopes)
- [ ] Code-reviewer subagent gate (running next)

## Commits

```
8bf7dbc refactor(OMN-32): migrate COMPLETE_TASK_SCRIPT to typed buildCompleteTaskScript
10c4c23 refactor(OMN-32): migrate DELETE_TASK_SCRIPT to typed buildDeleteTaskScript
cf8eb4f refactor(OMN-32): migrate BULK_DELETE_TASKS_SCRIPT to typed buildBulkDeleteTasksScript
9bb3a3c refactor(OMN-32): migrate MARK_PROJECT_REVIEWED_SCRIPT to typed builder
5cab244 refactor(OMN-32): migrate SET_REVIEW_SCHEDULE_SCRIPT to typed builder
```

Each commit is independently green; squash on merge will collapse them into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)