### PR TITLE
chore(OMN-94): Cat B batch 1 — delete 5 truly-unused helpers/schemas + flag closed-loop insights subtree

### DIFF
--- a/src/contracts/analytics-types.ts
+++ b/src/contracts/analytics-types.ts
@@ -244,22 +244,6 @@ export function generateRecommendations(metrics: AnalysisMetrics, configs: Recom
 // =============================================================================
 
 /**
- * Calculate a percentage safely (handles division by zero)
- */
-export function safePercentage(numerator: number, denominator: number, decimals: number = 1): number {
-  if (denominator === 0) return 0;
-  return Number(((numerator / denominator) * 100).toFixed(decimals));
-}
-
-/**
- * Calculate a rate (items per day)
- */
-export function calculateRate(count: number, days: number, decimals: number = 2): number {
-  if (days === 0) return 0;
-  return Number((count / days).toFixed(decimals));
-}
-
-/**
  * Create empty metrics (useful for initialization)
  */
 export function createEmptyMetrics(): AnalysisMetrics {

--- a/src/omnifocus/script-result-types.ts
+++ b/src/omnifocus/script-result-types.ts
@@ -5,8 +5,6 @@
  * scattered error checking and improve type safety across the codebase.
  */
 
-import { z } from 'zod';
-
 /**
  * Discriminated union for script execution results
  * Replaces manual checking of result.error/result.success patterns
@@ -36,38 +34,6 @@ export function isScriptSuccess<T>(result: ScriptResult<T>): result is ScriptSuc
 export function isScriptError<T>(result: ScriptResult<T>): result is ScriptError {
   return result.success === false;
 }
-
-/**
- * Common JXA script result patterns for OmniFocus operations
- * These provide validation for the most frequent script response shapes
- */
-
-// Schema for task/project list results
-export const ListResultSchema = z.object({
-  items: z.array(z.unknown()), // Will be tasks or projects
-  summary: z
-    .object({
-      total: z.number(),
-      insights: z.array(z.string()).optional(),
-    })
-    .optional(),
-  metadata: z.record(z.unknown()).optional(),
-});
-
-// Schema for analytics results
-export const AnalyticsResultSchema = z.object({
-  summary: z.record(z.unknown()),
-  data: z.record(z.unknown()).optional(),
-  insights: z.array(z.string()).optional(),
-  metadata: z.record(z.unknown()).optional(),
-});
-
-// Schema for simple success/error operations
-export const SimpleOperationResultSchema = z.object({
-  success: z.boolean(),
-  message: z.string().optional(),
-  data: z.unknown().optional(),
-});
 
 /**
  * Helpers to create ScriptResult instances


### PR DESCRIPTION
## Summary

Second sub-PR of the [OMN-94](https://linear.app/omnifocus-mcp/issue/OMN-94) audit epic. Targets **Cat B (post-migration leftovers)** — 5 items where verification confirmed zero consumers anywhere.

But ALSO surfaces a **major out-of-scope audit finding**: an entire dead subsystem (`src/contracts/ast/insights/`) that was masking 3 other ts-prune-flagged orphans. Flagged for OMN-94 Cat-D escalation, NOT addressed here (needs your decision on intentional WIP vs stillborn experiment).

2 files changed, -50 lines, no test changes.

## Items removed (5)

| File:line | Symbol | Why orphan |
|-----------|--------|------------|
| `src/contracts/analytics-types.ts:249` | `safePercentage` (utility helper) | Zero consumers anywhere |
| `src/contracts/analytics-types.ts:257` | `calculateRate` (utility helper) | Zero consumers anywhere |
| `src/omnifocus/script-result-types.ts:46` | `ListResultSchema` (Zod) | Zero consumers |
| `src/omnifocus/script-result-types.ts:58` | `AnalyticsResultSchema` (Zod) | Zero consumers |
| `src/omnifocus/script-result-types.ts:66` | `SimpleOperationResultSchema` (Zod) | Zero consumers |
| `src/omnifocus/script-result-types.ts:8` | `import { z } from 'zod'` | Now-dead after the 3 schemas removed (only Zod usage in the file) |

`script-result-types.ts` still exports the live API: `ScriptResult` discriminated union, `ScriptSuccess`/`ScriptError` interfaces, `isScriptSuccess`/`isScriptError` type guards, `createScriptSuccess`/`createScriptError` factories — all heavily consumed.

## Items NOT removed (kept on Cat B roster as judgment calls)

From the original Cat B audit list, 3 items were *also* in `analytics-types.ts`: `generateInsights`, `generateRecommendations`, `createEmptyMetrics`. **All three have real consumers** — found by grep:

- `generateInsights`: consumed by `src/contracts/ast/insights/index.ts` + `src/contracts/ast/insights/presets/workflow-insights.ts` + `tests/unit/contracts/ast/insights/workflow-insights.test.ts`
- `generateRecommendations`: consumed by `src/contracts/ast/insights/index.ts` + the test
- `createEmptyMetrics`: consumed by the test

Per [[feedback_verify_premise_before_agreeing]] / [[feedback_rule_premise_audit]]: ts-prune's flagging here is **misleading** — these items aren't dead, they're held alive by a chain that ts-prune fails to fully trace. Kept them in this PR.

## MAJOR audit finding (out of scope for this PR — needs your decision)

While verifying the above, discovered `src/contracts/ast/insights/` is a **closed-loop dead subtree**:

```
src/contracts/ast/insights/
├── index.ts                      ← barrel, 12 orphans per ts-prune
└── presets/
    └── workflow-insights.ts      ← uses generateInsights/etc.

tests/unit/contracts/ast/insights/
└── workflow-insights.test.ts     ← tests the preset
```

**Zero `src/` consumers outside this subtree boundary** (verified: `grep -rln "from.*contracts/ast/insights" src/ tests/ | grep -v 'src/contracts/ast/insights/'` returns only the test file). The insights API is tested but never wired into any production code path. Same shape as the OMN-93 `buildRecurringSummaryScript` cascading-discovery, but much bigger — a whole subsystem rather than a single function.

**Decisions needed for the OMN-94 Cat-D follow-up:**

1. Is this subtree intentional WIP (you plan to wire it in someday)?
2. Or is it stillborn experiment debris that can be deleted entirely?

If (2), the follow-up PR would delete:
- `src/contracts/ast/insights/` (2 files)
- `tests/unit/contracts/ast/insights/` (1+ files)
- `generateInsights`, `generateRecommendations`, `createEmptyMetrics` from `analytics-types.ts` (no longer needed)
- The supporting types `Insight`, `Recommendation`, `InsightConfig`, `RecommendationConfig`, `InsightPriority`, `InsightCategory` (only used by those functions)
- Possibly `AnalysisMetrics` / `TaskMetrics` / `ProjectMetrics` / etc. if they're only used by the deleted functions

Rough total: ~300+ lines, multiple files, potential cascading discoveries. Worth a dedicated PR with explicit confirmation.

## ts-prune verification

| Snapshot | Impl-file orphan count |
|----------|-----------------------|
| Pre-PR (post-Cat-A.iii at `34afd1d`) | 89 |
| Post (this commit) | **84** (-5 net) |

**Zero true cascading discoveries** (the diff shows a `createEmptyMetrics` line-number-shift artifact, but it's the same orphan at a new file line after the file shrank — not a new finding). Consistent with the cascading-vs-leaf rule from prior sub-PRs.

**Cumulative session ts-prune impact: 103 → 84 = -19 impl-orphan exports.**

## Verification

- ✅ `npm run build` clean
- ✅ `npm run test:unit` 2138/2138
- ✅ ts-prune impl-orphan count: 89 → 84 (-5, no cascades)
- ✅ Worktree fresh from `origin/main` at `34afd1d`

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [x] Zero consumers of all 5 deleted symbols (re-verified just before deletion)
- [x] `script-result-types.ts` live exports (`ScriptResult` etc.) still consumed correctly
- [x] No remaining `z` references in `script-result-types.ts` after removing the import
- [ ] Code-reviewer gate (running next, with [[feedback_subagent_mutation_verify_carveout]])

🤖 Generated with [Claude Code](https://claude.com/claude-code)