### PR TITLE
docs(OMN-94): park insights subtree pending OMN-95 (Phase 4C completion)

### DIFF
--- a/src/contracts/ast/insights/index.ts
+++ b/src/contracts/ast/insights/index.ts
@@ -1,12 +1,29 @@
 /**
  * Insights Module - Configurable insight and recommendation generation
  *
+ * ⏸ PARKED — Phase 4C is half-built (OMN-95).
+ * ─────────────────────────────────────────────────────────────────────────
+ * This subtree (the typed insight preset system) was added in commit
+ * `addd9bb` as Phase 4C of the AST consolidation. The DATA layer is
+ * complete; the WIRING layer was never built. As of 2026-05-21, nothing
+ * in `src/tools/` calls `generateInsights()` / `generateRecommendations()`
+ * — the live `workflow_analysis` capability in `OmniFocusAnalyzeTool`
+ * still uses the script-side `WORKFLOW_ANALYSIS_V3` insight pipeline.
+ *
+ * **Do NOT delete this subtree in "unused export" audits** — it is
+ * intentional WIP, not stillborn code. Completion is tracked in
+ * [OMN-95](https://linear.app/omnifocus-mcp/issue/OMN-95).
+ *
+ * When OMN-95 lands, remove this banner. Until then, ts-prune will flag
+ * everything below as orphan; that is correct-but-known.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
  * This module provides:
  * - Pre-defined insight configurations for workflow analysis
  * - Pre-defined recommendation configurations
  * - Utilities for filtering and sorting insights
  *
- * Usage:
+ * Usage (once OMN-95 wires it in):
  * ```typescript
  * import {
  *   ALL_WORKFLOW_INSIGHTS,


### PR DESCRIPTION
## Summary

Closes the [OMN-94](https://linear.app/omnifocus-mcp/issue/OMN-94) Cat E (subsystem-scale) escalation surfaced in PR #52.

**Comment-only change.** Adds a parking banner to `src/contracts/ast/insights/index.ts` documenting:

1. The subtree is **intentional Phase 4C AST-consolidation WIP** (added in commit `addd9bb`), not stillborn code.
2. The DATA layer (typed insight/recommendation presets) is complete; the WIRING layer (`OmniFocusAnalyzeTool.workflow_analysis` integration) was never built.
3. ts-prune will continue to flag everything inside as orphan — that's correct-but-known until OMN-95 lands.
4. The completion work is tracked in [OMN-95](https://linear.app/omnifocus-mcp/issue/OMN-95) — filed earlier in this session with full integration scope (refactor `WORKFLOW_ANALYSIS_V3` to emit raw metrics, wire `generateInsights()` into the AnalyzeTool, preserve wire-observable shape).
5. The banner instructs future contributors to remove it once OMN-95 lands.

## Why park instead of delete?

This came from a Kip-side challenge to my earlier "stillborn experiment" framing — turned out wrong. The subtree:

- Has a clear intent (typed, configurable GTD workflow insights — 6 preset categories)
- Was added in a commit with planning-doc references (`docs/plans/snug-foraging-sloth.md`, since deleted)
- Is consumed today only inside its own closed loop — but the design clearly maps onto the existing `workflow_analysis` capability's response shape
- Would take a real feature-PR (~M-L effort) to finish, not a cleanup-PR

Deleting it would discard ~300+ lines of genuinely useful scaffolding. Parking documents the intent so future audit passes don't re-flag it, and OMN-95 carries the completion as proper feature work.

## Verification

- ✅ `npm run build` clean (comment-only edit, no behavior change)
- ✅ `npm run test:unit` 2138/2138 (unchanged)
- ✅ No ts-prune impact (the subtree was already flagged as orphan; banner doesn't change that — just documents WHY)
- ✅ Pre-commit hook clean (prettier + eslint)

## Test plan

- [x] Build passes
- [x] Tests pass
- [x] Banner cleanly references commit `addd9bb` (Phase 4C origin) + OMN-95 (completion ticket) + a "remove this banner when OMN-95 lands" sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)