### PR TITLE
chore(ops): commit diagnose-failures launchd wrapper + deploy script

### DIFF
--- a/docs/dev/mcp-failure-diagnosis.md
+++ b/docs/dev/mcp-failure-diagnosis.md
@@ -139,78 +139,53 @@ Auto-filing guards (enforced by `src/diagnostics/linear-filer.ts`):
 
 ---
 
-## Scheduling: `~/bin/of-mcp-diagnose` (NOT committed — machine-specific)
+## Scheduling: weekly launchd job
 
-> This recipe is **not committed to the repo**. It is a local ops script, following the same convention as
-> `~/bin/of-mcp-redeploy`.
+The wrapper and launchd plist are **committed** under `scripts/ops/` and deployed by a script — the runtime locations
+(`~/bin`, `~/Library/LaunchAgents`) are install targets, not the source of truth. Edit the canonical files and re-run
+the installer; never hand-edit the deployed copies.
 
-Create `~/bin/of-mcp-diagnose`:
+| Committed source                                        | Deployed to                                               | Role                                          |
+| ------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
+| `scripts/ops/of-mcp-diagnose`                           | `~/bin/of-mcp-diagnose`                                   | cron/launchd wrapper for `diagnose-failures`. |
+| `scripts/ops/com.omnifocus-mcp.diagnose.plist.template` | `~/Library/LaunchAgents/com.omnifocus-mcp.diagnose.plist` | launchd job definition (paths substituted).   |
+| `scripts/ops/install-diagnose-schedule.sh`              | —                                                         | Installs both, (re)loads the job.             |
 
-```bash
-#!/usr/bin/env bash
-# ~/bin/of-mcp-diagnose — local cron/launchd wrapper for diagnose-failures
-# NOT committed; machine-specific. See docs/dev/mcp-failure-diagnosis.md.
-set -euo pipefail
-
-REPO_DIR="$HOME/omnifocus-mcp"
-LOG="$HOME/.omnifocus-mcp/diagnose-failures.log"
-
-cd "$REPO_DIR"
-npm run diagnose-failures -- --days=90 >> "$LOG" 2>&1
-```
-
-Make it executable:
+### Deploy
 
 ```bash
-chmod +x ~/bin/of-mcp-diagnose
+scripts/ops/install-diagnose-schedule.sh            # install / reload
+scripts/ops/install-diagnose-schedule.sh --verify   # also kickstart + assert exit 0
+scripts/ops/install-diagnose-schedule.sh --uninstall # bootout + remove the plist
 ```
 
-### launchd plist (weekly, Sunday 09:00)
+The installer is idempotent: it copies the wrapper to `~/bin`, generates the plist from the template (substituting
+absolute paths — launchd does NOT expand `$HOME`/`~`), validates it with `plutil`, and reloads via
+`launchctl bootout`/`bootstrap`. Schedule is weekly, **Sunday 09:00**.
 
-> launchd does NOT expand `$HOME` or `~` in `ProgramArguments` — substitute your own absolute username path (replace
-> `/Users/kip/...` below). The cron alternative further down uses `$HOME` and is fine as-is.
+Env overrides: `OF_MCP_BIN_DIR` (default `~/bin`), `OF_MCP_REPO_DIR` (default `~/omnifocus-mcp`, the prod checkout the
+job runs against).
 
-Save as `~/Library/LaunchAgents/com.omnifocus-mcp.diagnose.plist`:
+### The PATH gotcha (why the plist sets `EnvironmentVariables`)
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>com.omnifocus-mcp.diagnose</string>
-    <key>ProgramArguments</key>
-    <array>
-      <string>/bin/bash</string>
-      <string>/Users/kip/bin/of-mcp-diagnose</string>
-    </array>
-    <key>StartCalendarInterval</key>
-    <dict>
-      <key>Weekday</key>
-      <integer>0</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <key>RunAtLoad</key>
-    <false/>
-    <key>StandardOutPath</key>
-    <string>/Users/kip/.omnifocus-mcp/diagnose-failures-launchd.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/kip/.omnifocus-mcp/diagnose-failures-launchd.log</string>
-  </dict>
-</plist>
-```
+launchd and cron run with a minimal `PATH=/usr/bin:/bin:/usr/sbin:/sbin` that omits Homebrew. With Node installed via
+Homebrew, `npm`/`node`/`npx` are not found and the job **dies at exit 127** — a wrapper that works by hand fails
+silently when scheduled. Two layers guard this:
 
-Load it:
+1. The installer detects the Homebrew bin dir (`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel) and
+   bakes it into the plist's `EnvironmentVariables` → `PATH`.
+2. The wrapper itself prepends the same dirs at runtime, so a manual or cron invocation is robust regardless of the
+   caller's environment.
 
-```bash
-launchctl load ~/Library/LaunchAgents/com.omnifocus-mcp.diagnose.plist
-```
+**Diagnosing a broken job:** `launchctl list | grep diagnose` — the middle column is the **last exit code** (127 =
+command-not-found / PATH bug; 0 = healthy). A stale triage-doc mtime means a scheduled run never regenerated it.
+**Verify a fix through launchd, not your shell:** `launchctl kickstart -p gui/$(id -u)/com.omnifocus-mcp.diagnose` runs
+the job with the plist's environment applied (`--verify` does this for you). Note `launchctl print` does NOT echo
+per-job `EnvironmentVariables`, so don't use it to confirm the PATH took — confirm via a successful kickstart.
 
 ### cron alternative (weekly, Sunday 09:00)
+
+The wrapper is cron-safe (it sets its own PATH), so launchd is optional:
 
 ```cron
 0 9 * * 0 $HOME/bin/of-mcp-diagnose

--- a/scripts/ops/com.omnifocus-mcp.diagnose.plist.template
+++ b/scripts/ops/com.omnifocus-mcp.diagnose.plist.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated from scripts/ops/com.omnifocus-mcp.diagnose.plist.template by
+     install-diagnose-schedule.sh, which substitutes absolute paths and a
+     Homebrew-aware PATH (launchd does NOT expand $HOME or ~). Re-run the
+     installer to update; do not hand-edit the deployed copy. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.omnifocus-mcp.diagnose</string>
+    <!-- launchd's default PATH omits Homebrew → npm not found → exit 127. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>__PATH_VALUE__</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>__WRAPPER_PATH__</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Weekday</key>
+      <integer>0</integer>
+      <key>Hour</key>
+      <integer>9</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__LAUNCHD_LOG__</string>
+    <key>StandardErrorPath</key>
+    <string>__LAUNCHD_LOG__</string>
+  </dict>
+</plist>

--- a/scripts/ops/install-diagnose-schedule.sh
+++ b/scripts/ops/install-diagnose-schedule.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# install-diagnose-schedule.sh — deploy the weekly diagnose-failures launchd job.
+#
+# Installs the canonical wrapper (scripts/ops/of-mcp-diagnose) to ~/bin and a
+# launchd plist (generated from the .template) to ~/Library/LaunchAgents, then
+# (re)loads the job. Idempotent: safe to re-run after editing the canonical
+# sources. See docs/dev/mcp-failure-diagnosis.md § Scheduling.
+#
+# Usage:
+#   scripts/ops/install-diagnose-schedule.sh            # install / reload
+#   scripts/ops/install-diagnose-schedule.sh --verify   # also kickstart + check
+#   scripts/ops/install-diagnose-schedule.sh --uninstall # bootout + remove plist
+#
+# Env overrides:
+#   OF_MCP_BIN_DIR   (default ~/bin)             where the wrapper is installed
+#   OF_MCP_REPO_DIR  (default ~/omnifocus-mcp)   prod checkout the job runs against
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LABEL="com.omnifocus-mcp.diagnose"
+PLIST_NAME="$LABEL.plist"
+TEMPLATE="$SCRIPT_DIR/$PLIST_NAME.template"
+WRAPPER_SRC="$SCRIPT_DIR/of-mcp-diagnose"
+
+BIN_DIR="${OF_MCP_BIN_DIR:-$HOME/bin}"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+PLIST_DEST="$LAUNCH_AGENTS/$PLIST_NAME"
+WRAPPER_DEST="$BIN_DIR/of-mcp-diagnose"
+LAUNCHD_LOG="$HOME/.omnifocus-mcp/diagnose-failures-launchd.log"
+GUI="gui/$(id -u)"
+
+uninstall() {
+  echo "Unloading $LABEL ..."
+  launchctl bootout "$GUI/$LABEL" 2>/dev/null || echo "  (was not loaded)"
+  rm -f "$PLIST_DEST" && echo "Removed $PLIST_DEST"
+  echo "Wrapper left in place at $WRAPPER_DEST (delete manually if desired)."
+  exit 0
+}
+
+[ "${1:-}" = "--uninstall" ] && uninstall
+
+# --- Detect Homebrew bin dir so the baked PATH finds npm/node/npx -------------
+BREW_BIN=""
+for d in /opt/homebrew/bin /usr/local/bin; do
+  if [ -x "$d/npm" ]; then BREW_BIN="$d"; break; fi
+done
+if [ -z "$BREW_BIN" ]; then
+  echo "ERROR: npm not found in /opt/homebrew/bin or /usr/local/bin." >&2
+  echo "       Install Node via Homebrew, or edit the PATH detection above." >&2
+  exit 1
+fi
+PATH_VALUE="$BREW_BIN:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# --- 1. Install the wrapper ---------------------------------------------------
+mkdir -p "$BIN_DIR"
+install -m 0755 "$WRAPPER_SRC" "$WRAPPER_DEST"
+echo "Installed wrapper → $WRAPPER_DEST"
+
+# --- 2. Generate the plist from the template ----------------------------------
+mkdir -p "$LAUNCH_AGENTS" "$(dirname "$LAUNCHD_LOG")"
+sed -e "s|__WRAPPER_PATH__|$WRAPPER_DEST|g" \
+    -e "s|__LAUNCHD_LOG__|$LAUNCHD_LOG|g" \
+    -e "s|__PATH_VALUE__|$PATH_VALUE|g" \
+    "$TEMPLATE" > "$PLIST_DEST"
+plutil -lint "$PLIST_DEST" >/dev/null
+echo "Installed plist   → $PLIST_DEST"
+echo "  PATH = $PATH_VALUE"
+
+# --- 3. (Re)load the job ------------------------------------------------------
+launchctl bootout "$GUI/$LABEL" 2>/dev/null || true
+launchctl bootstrap "$GUI" "$PLIST_DEST"
+echo "Loaded job $LABEL (weekly, Sunday 09:00)."
+
+# --- 4. Optional verification -------------------------------------------------
+if [ "${1:-}" = "--verify" ]; then
+  echo "Verifying via kickstart (runs the job now through launchd) ..."
+  before="$(date +%s)"
+  launchctl kickstart -p "$GUI/$LABEL"
+  # Wait for the run to finish (triage doc regeneration), up to ~30s.
+  for _ in $(seq 1 30); do
+    sleep 1
+    rc="$(launchctl list | awk -v l="$LABEL" '$3==l {print $2}')"
+    [ "${rc:-}" = "0" ] && break
+  done
+  rc="$(launchctl list | awk -v l="$LABEL" '$3==l {print $2}')"
+  echo "  last exit code = ${rc:-unknown} (0 = success; 127 = command not found / PATH bug)"
+  if [ "${rc:-}" != "0" ]; then
+    echo "  VERIFY FAILED — check $LAUNCHD_LOG and ~/.omnifocus-mcp/diagnose-failures.log" >&2
+    exit 1
+  fi
+  echo "  OK."
+  unset before
+fi
+
+echo
+echo "Done. Inspect status:  launchctl list | grep diagnose"
+echo "Manual run:            launchctl kickstart -p $GUI/$LABEL"
+echo "Durable log:           ~/.omnifocus-mcp/diagnose-failures.log"

--- a/scripts/ops/install-diagnose-schedule.sh
+++ b/scripts/ops/install-diagnose-schedule.sh
@@ -37,19 +37,31 @@ uninstall() {
   exit 0
 }
 
-[ "${1:-}" = "--uninstall" ] && uninstall
+# Explicit arg dispatch — reject unknowns so a typo (e.g. --verfiy) can't
+# silently skip verification and exit 0 (the silent-success class this fixes).
+MODE="install"
+case "${1:-}" in
+  "")          MODE="install" ;;
+  --verify)    MODE="verify" ;;
+  --uninstall) uninstall ;;
+  *) echo "Unknown argument: $1" >&2
+     echo "Usage: $(basename "$0") [--verify | --uninstall]" >&2
+     exit 2 ;;
+esac
 
-# --- Detect Homebrew bin dir so the baked PATH finds npm/node/npx -------------
-BREW_BIN=""
+# --- Detect Homebrew bin dir(s) so the baked PATH finds npm/node/npx ----------
+# Include every prefix that actually has npm, /opt/homebrew first — same order
+# as the wrapper's runtime PATH prepend, so scheduled and manual runs agree.
+brew_dirs=()
 for d in /opt/homebrew/bin /usr/local/bin; do
-  if [ -x "$d/npm" ]; then BREW_BIN="$d"; break; fi
+  [ -x "$d/npm" ] && brew_dirs+=("$d")
 done
-if [ -z "$BREW_BIN" ]; then
+if [ ${#brew_dirs[@]} -eq 0 ]; then
   echo "ERROR: npm not found in /opt/homebrew/bin or /usr/local/bin." >&2
   echo "       Install Node via Homebrew, or edit the PATH detection above." >&2
   exit 1
 fi
-PATH_VALUE="$BREW_BIN:/usr/bin:/bin:/usr/sbin:/sbin"
+PATH_VALUE="$(IFS=:; printf '%s' "${brew_dirs[*]}"):/usr/bin:/bin:/usr/sbin:/sbin"
 
 # --- 1. Install the wrapper ---------------------------------------------------
 mkdir -p "$BIN_DIR"
@@ -58,6 +70,10 @@ echo "Installed wrapper → $WRAPPER_DEST"
 
 # --- 2. Generate the plist from the template ----------------------------------
 mkdir -p "$LAUNCH_AGENTS" "$(dirname "$LAUNCHD_LOG")"
+# Substituted values are all $HOME-rooted absolute paths and a PATH string of
+# the same — none can contain '|' (the sed delimiter), '&', or newlines on
+# macOS, so these s||| replacements are safe. Re-check if a less-controlled
+# value (e.g. a user-supplied label) is ever substituted here.
 sed -e "s|__WRAPPER_PATH__|$WRAPPER_DEST|g" \
     -e "s|__LAUNCHD_LOG__|$LAUNCHD_LOG|g" \
     -e "s|__PATH_VALUE__|$PATH_VALUE|g" \
@@ -67,29 +83,49 @@ echo "Installed plist   → $PLIST_DEST"
 echo "  PATH = $PATH_VALUE"
 
 # --- 3. (Re)load the job ------------------------------------------------------
+# bootout is async; bootstrap can race it and fail ("already bootstrapped" /
+# I/O error). Poll until the old instance is gone, then bootstrap with one retry
+# so a transient launchd hiccup doesn't abort an otherwise-idempotent install.
 launchctl bootout "$GUI/$LABEL" 2>/dev/null || true
-launchctl bootstrap "$GUI" "$PLIST_DEST"
+for _ in $(seq 1 10); do
+  launchctl print "$GUI/$LABEL" >/dev/null 2>&1 || break
+  sleep 0.5
+done
+launchctl bootstrap "$GUI" "$PLIST_DEST" || { sleep 1; launchctl bootstrap "$GUI" "$PLIST_DEST"; }
 echo "Loaded job $LABEL (weekly, Sunday 09:00)."
 
 # --- 4. Optional verification -------------------------------------------------
-if [ "${1:-}" = "--verify" ]; then
+if [ "$MODE" = "verify" ]; then
   echo "Verifying via kickstart (runs the job now through launchd) ..."
-  before="$(date +%s)"
-  launchctl kickstart -p "$GUI/$LABEL"
-  # Wait for the run to finish (triage doc regeneration), up to ~30s.
-  for _ in $(seq 1 30); do
+  triage="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}/docs/dev/mcp-failure-triage.md"
+  before_mtime="$(stat -f %m "$triage" 2>/dev/null || echo 0)"
+
+  launchctl kickstart -k "$GUI/$LABEL"
+  # kickstart returns once the job is SPAWNED, not when it exits — and launchd's
+  # "last exit code" persists from the PRIOR run until this one ends. So reading
+  # the exit code immediately would latch onto a stale value (e.g. a stale 0,
+  # masking the very 127 PATH bug --verify exists to catch). Wait for the
+  # spawned instance to disappear, then read the exit code.
+  pid="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/^[[:space:]]*pid =/{print $NF; exit}')"
+  for _ in $(seq 1 60); do
+    { [ -n "${pid:-}" ] && kill -0 "$pid" 2>/dev/null; } || break
     sleep 1
-    rc="$(launchctl list | awk -v l="$LABEL" '$3==l {print $2}')"
-    [ "${rc:-}" = "0" ] && break
   done
-  rc="$(launchctl list | awk -v l="$LABEL" '$3==l {print $2}')"
+
+  rc="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/last exit code/{print $NF; exit}')"
+  after_mtime="$(stat -f %m "$triage" 2>/dev/null || echo 0)"
   echo "  last exit code = ${rc:-unknown} (0 = success; 127 = command not found / PATH bug)"
   if [ "${rc:-}" != "0" ]; then
     echo "  VERIFY FAILED — check $LAUNCHD_LOG and ~/.omnifocus-mcp/diagnose-failures.log" >&2
     exit 1
   fi
-  echo "  OK."
-  unset before
+  # Corroborate: a real run regenerates the triage doc. exit 0 with an unchanged
+  # doc means nothing actually executed (stale exit code) — treat as a failure.
+  if [ "$after_mtime" = "$before_mtime" ]; then
+    echo "  VERIFY FAILED — exit 0 but triage doc unchanged ($triage); run did not execute." >&2
+    exit 1
+  fi
+  echo "  OK (job exited 0 and regenerated the triage doc)."
 fi
 
 echo

--- a/scripts/ops/of-mcp-diagnose
+++ b/scripts/ops/of-mcp-diagnose
@@ -18,9 +18,15 @@ set -euo pipefail
 # /usr/local). The launchd plist sets PATH too; this keeps a manual or cron
 # invocation robust regardless of the caller's environment. (Probes fixed dirs
 # rather than calling `brew`, which would itself be off the minimal PATH.)
+# Order matches install-diagnose-schedule.sh: /opt/homebrew first, so both the
+# scheduled and manual runs resolve npm/node to the same prefix.
+brew_dirs=()
 for d in /opt/homebrew/bin /usr/local/bin; do
-  [ -d "$d" ] && PATH="$d:$PATH"
+  [ -d "$d" ] && brew_dirs+=("$d")
 done
+if [ ${#brew_dirs[@]} -gt 0 ]; then
+  PATH="$(IFS=:; printf '%s' "${brew_dirs[*]}"):$PATH"
+fi
 export PATH
 
 REPO_DIR="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}"
@@ -28,6 +34,6 @@ LOG="${OF_MCP_DIAGNOSE_LOG:-$HOME/.omnifocus-mcp/diagnose-failures.log}"
 DAYS="${OF_MCP_DIAGNOSE_DAYS:-90}"
 
 mkdir -p "$(dirname "$LOG")"
-cd "$REPO_DIR"
+cd "$REPO_DIR" || { echo "of-mcp-diagnose: repo dir not found: $REPO_DIR" >&2; exit 1; }
 echo "===== run $(date '+%Y-%m-%d %H:%M:%S %Z') =====" >> "$LOG"
 npm run diagnose-failures -- --days="$DAYS" >> "$LOG" 2>&1

--- a/scripts/ops/of-mcp-diagnose
+++ b/scripts/ops/of-mcp-diagnose
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# of-mcp-diagnose — cron/launchd wrapper for `npm run diagnose-failures`.
+#
+# Canonical source: scripts/ops/of-mcp-diagnose in the omnifocus-mcp repo.
+# Deploy with scripts/ops/install-diagnose-schedule.sh, which copies this file
+# to ~/bin and installs the launchd plist. Do NOT hand-edit the deployed copy —
+# edit here and re-run the installer, or the next deploy will clobber your change.
+#
+# Runs against the PROD checkout ($OF_MCP_REPO_DIR, default ~/omnifocus-mcp) and
+# regenerates its tracked docs/dev/mcp-failure-triage.md; ~/bin/of-mcp-redeploy
+# discards that churn before its `git pull --rebase`. The durable record is $LOG,
+# not the in-repo .md (which is regenerated scratch on the prod checkout).
+set -euo pipefail
+
+# launchd and cron run with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that
+# omits Homebrew, so npm/node/npx are not found and the job dies at exit 127.
+# Prepend Homebrew's bin dir if present (Apple Silicon: /opt/homebrew, Intel:
+# /usr/local). The launchd plist sets PATH too; this keeps a manual or cron
+# invocation robust regardless of the caller's environment. (Probes fixed dirs
+# rather than calling `brew`, which would itself be off the minimal PATH.)
+for d in /opt/homebrew/bin /usr/local/bin; do
+  [ -d "$d" ] && PATH="$d:$PATH"
+done
+export PATH
+
+REPO_DIR="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}"
+LOG="${OF_MCP_DIAGNOSE_LOG:-$HOME/.omnifocus-mcp/diagnose-failures.log}"
+DAYS="${OF_MCP_DIAGNOSE_DAYS:-90}"
+
+mkdir -p "$(dirname "$LOG")"
+cd "$REPO_DIR"
+echo "===== run $(date '+%Y-%m-%d %H:%M:%S %Z') =====" >> "$LOG"
+npm run diagnose-failures -- --days="$DAYS" >> "$LOG" 2>&1


### PR DESCRIPTION
## What

Promotes the weekly `diagnose-failures` scheduling glue from untracked machine-local `~/bin` scripts to **committed, portable ops tooling** under `scripts/ops/`, and **fixes the launchd PATH bug** that silently failed the scheduled job.

## Why

The Sunday 2026-05-24 09:00 launchd run fired on schedule but **died at exit 127** (`npm: command not found`): launchd execs with a minimal `PATH=/usr/bin:/bin:/usr/sbin:/sbin` that omits Homebrew's `/opt/homebrew/bin`, where `npm`/`node`/`npx` live. The wrapper worked when run by hand, so the failure was silent — the triage doc just stopped updating. The recipe in `docs/dev/mcp-failure-diagnosis.md` was the (uncommitted, PATH-unaware) source of the bug.

## Changes

| File | Role |
|------|------|
| `scripts/ops/of-mcp-diagnose` | Wrapper; prepends Homebrew bin (`/opt/homebrew` on Apple Silicon, `/usr/local` on Intel) so manual/cron runs are robust. Env-overridable `OF_MCP_REPO_DIR`/`OF_MCP_DIAGNOSE_LOG`/`OF_MCP_DIAGNOSE_DAYS`. |
| `scripts/ops/com.omnifocus-mcp.diagnose.plist.template` | launchd job with an `EnvironmentVariables` PATH; absolute paths substituted at install time (launchd does not expand `$HOME`/`~`). |
| `scripts/ops/install-diagnose-schedule.sh` | Idempotent installer: detects brew prefix, generates+`plutil`-validates the plist, installs the wrapper to `~/bin`, reloads via `bootout`/`bootstrap`. `--verify` kickstarts and asserts exit 0; `--uninstall` removes the job. |
| `docs/dev/mcp-failure-diagnosis.md` | Replaces the "NOT committed" recipe with deploy-script docs + the PATH/exit-127 gotcha and the kickstart verification technique. |

## Verification

`scripts/ops/install-diagnose-schedule.sh --verify` deploys both artifacts and kickstarts the job **through launchd** — last exit code `0` (was `127`). Confirmed the generated plist carries the substituted Homebrew PATH and the deployed copy has an accurate (non-"template") banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)