### PR TITLE
feat(OMN-96): accept folder:null on projects queries as "top-level only"

### DIFF
--- a/src/contracts/ast/filter-generator.ts
+++ b/src/contracts/ast/filter-generator.ts
@@ -306,6 +306,11 @@ export function generateProjectFilterCode(filter: ProjectFilter): string {
     );
   }
 
+  // OMN-96: top-level projects only — no containing folder.
+  if (filter.topLevelOnly) {
+    conditions.push('!project.parentFolder');
+  }
+
   // Return 'true' if no conditions (match all projects)
   return conditions.length > 0 ? conditions.join(' && ') : 'true';
 }
@@ -320,7 +325,8 @@ export function isEmptyProjectFilter(filter: ProjectFilter): boolean {
     filter.needsReview === undefined &&
     !filter.text &&
     !filter.folderId &&
-    !filter.folderName
+    !filter.folderName &&
+    !filter.topLevelOnly // OMN-96
   );
 }
 
@@ -347,6 +353,9 @@ export function describeProjectFilter(filter: ProjectFilter): string {
   }
   if (filter.folderName) {
     conditions.push(`folder name contains "${filter.folderName}"`);
+  }
+  if (filter.topLevelOnly) {
+    conditions.push('top-level only (no folder)'); // OMN-96
   }
 
   if (conditions.length === 0) {

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -157,6 +157,8 @@ export interface TaskFilter {
 
   // --- Folder (for project filtering) ---
   folder?: string; // Filter projects by folder name
+  // OMN-96: `folder: null` (top-level projects only) compiles to this flag.
+  folderTopLevel?: boolean;
 
   // --- Pagination ---
   limit?: number;
@@ -245,6 +247,11 @@ export interface ProjectFilter {
    * Filter by folder name (case-insensitive substring match)
    */
   folderName?: string;
+  /**
+   * OMN-96: match only top-level projects (no containing folder).
+   * Set when the read query passes `folder: null`.
+   */
+  topLevelOnly?: boolean;
 
   // --- Pagination ---
   limit?: number;
@@ -262,6 +269,7 @@ export const PROJECT_FILTER_PROPERTY_NAMES = [
   'text',
   'folderId',
   'folderName',
+  'topLevelOnly', // OMN-96
   'limit',
   'offset',
 ] as const;
@@ -363,6 +371,7 @@ export const FILTER_PROPERTY_NAMES = [
   'search',
   'projectStatus',
   'folder',
+  'folderTopLevel', // OMN-96
   'limit',
   'offset',
   'mode',

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -180,6 +180,7 @@ FILTER OPERATORS:
 - dates (dueDate, deferDate, plannedDate, added): { before: "YYYY-MM-DD" }, { after: "..." }, { between: ["...", "..."] }
 - text: { contains: "..." }, { matches: "regex" }
 - boolean: flagged, blocked, available, inInbox
+- folder (projects queries): "<name>" matches folder-name substring; null = top-level projects only (no containing folder)
 - logic: { OR: [...] }, { AND: [...] }, { NOT: {...} }
 
 RESPONSE CONTROL:
@@ -608,7 +609,11 @@ PERFORMANCE:
     if (compiled.filters.projectStatus) {
       projectFilter.status = compiled.filters.projectStatus;
     }
-    if (compiled.filters.folder) {
+    // OMN-96: `folder: null` compiled to folderTopLevel → top-level projects
+    // only (no containing folder). A folder string is a name substring filter.
+    if (compiled.filters.folderTopLevel) {
+      projectFilter.topLevelOnly = true;
+    } else if (compiled.filters.folder) {
       projectFilter.folderName = compiled.filters.folder;
     }
     if (compiled.filters.search) {

--- a/src/tools/unified/compilers/QueryCompiler.ts
+++ b/src/tools/unified/compilers/QueryCompiler.ts
@@ -118,7 +118,15 @@ export class QueryCompiler {
 
     // ID/folder passthrough
     if (input.id) result.id = input.id;
-    if (input.folder) result.folder = input.folder;
+    // OMN-96: `folder: null` means "top-level projects only" (the model's
+    // natural guess); a string is a folder-name substring filter. Distinguish
+    // them explicitly — `null` is falsy, so the old `if (input.folder)` truthy
+    // check silently dropped it. See the decision record in read-schema.ts.
+    if (input.folder === null) {
+      result.folderTopLevel = true;
+    } else if (typeof input.folder === 'string') {
+      result.folder = input.folder;
+    }
 
     // Safety net: warn on unknown properties that survived schema validation
     const unknownProps = validateFilterProperties(result as Record<string, unknown>);

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -66,7 +66,32 @@ const filterFields = {
   text: TextFilterSchema.optional(),
   estimatedMinutes: NumberFilterSchema.optional(), // Task duration
   name: TextFilterSchema.optional(), // Project/Task name filter
-  folder: z.string().optional(), // Project filters
+  // OMN-96 DECISION RECORD — `folder: null` = "top-level projects only".
+  //
+  // The model repeatedly sent `filters.folder: null` on projects queries,
+  // expecting it to mean "top-level projects with no containing folder"
+  // (failures-2026-03-05 and -2026-05-21, 2.5 months apart). The old schema
+  // typed folder as a bare string and hard-rejected null. We chose to MOLD THE
+  // SERVER TO THE MODEL'S NATURAL GUESS: accept null and treat it as the
+  // top-level filter. A string still means "folder name contains <string>".
+  //
+  // Alternatives considered and NOT taken (recorded so a future revisit is
+  // cheap — pick a different row here and re-thread):
+  //   1. Explicit boolean `topLevelOnly: true`. Self-documenting, but the model
+  //      doesn't reach for it unprompted; `folder: null` is what it actually
+  //      emits, so accepting null closes the real gap with zero new vocabulary.
+  //   2. Structured `folder: { exists: false }`. More expressive (room for
+  //      `{ exists: true }`, name/id sub-filters later) but heavier schema and
+  //      still not the model's first guess.
+  //   3. Keep rejecting, but make the error actionable ("to list top-level
+  //      projects, use …"). Lowest effort, but leaves a capability gap — the
+  //      model has no working way to express a common, legitimate intent.
+  //
+  // The internal representation is the boolean flag `folderTopLevel`
+  // (TaskFilter) → `topLevelOnly` (ProjectFilter); null never reaches the
+  // emitter as a folder *name*. See QueryCompiler.transformFilters and
+  // generateProjectFilterCode.
+  folder: z.union([z.string(), z.null()]).optional(), // Project filters; null = top-level only (OMN-96)
 };
 
 // Flat filter: base fields only, no logical operators.

--- a/tests/unit/ast-phase3-builders.test.ts
+++ b/tests/unit/ast-phase3-builders.test.ts
@@ -13,10 +13,7 @@ import {
   isEmptyProjectFilter,
   describeProjectFilter,
 } from '../../src/contracts/ast/filter-generator.js';
-import {
-  buildFilteredProjectsScript,
-  buildProjectByIdScript,
-} from '../../src/contracts/ast/script-builder.js';
+import { buildFilteredProjectsScript, buildProjectByIdScript } from '../../src/contracts/ast/script-builder.js';
 import { buildTagsScript, buildActiveTagsScript } from '../../src/contracts/ast/tag-script-builder.js';
 import type { ProjectFilter } from '../../src/contracts/filters.js';
 import type { TagQueryOptions } from '../../src/contracts/tag-options.js';
@@ -70,6 +67,13 @@ describe('Phase 3 AST Builders', () => {
       expect(code).toContain('toLowerCase()');
     });
 
+    // OMN-96: top-level-only means "no containing folder" → !project.parentFolder
+    it('should generate top-level-only filter', () => {
+      const filter: ProjectFilter = { topLevelOnly: true };
+      const code = generateProjectFilterCode(filter);
+      expect(code).toContain('!project.parentFolder');
+    });
+
     it('should combine multiple filters with AND', () => {
       const filter: ProjectFilter = { status: ['active'], flagged: true };
       const code = generateProjectFilterCode(filter);
@@ -93,6 +97,11 @@ describe('Phase 3 AST Builders', () => {
     it('should return false for filter with flagged', () => {
       expect(isEmptyProjectFilter({ flagged: true })).toBe(false);
     });
+
+    // OMN-96: topLevelOnly is a real constraint, so the filter isn't empty
+    it('should return false for filter with topLevelOnly', () => {
+      expect(isEmptyProjectFilter({ topLevelOnly: true })).toBe(false);
+    });
   });
 
   describe('describeProjectFilter', () => {
@@ -110,6 +119,12 @@ describe('Phase 3 AST Builders', () => {
       expect(desc).toContain('status');
       expect(desc).toContain('flagged');
       expect(desc).toContain('AND');
+    });
+
+    // OMN-96
+    it('should describe top-level-only filter', () => {
+      const desc = describeProjectFilter({ topLevelOnly: true });
+      expect(desc).toContain('top-level');
     });
   });
 

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -706,6 +706,21 @@ describe('QueryCompiler', () => {
         const result = compiler.transformFilters({ folder: 'Work' });
         expect(result.folder).toBe('Work');
       });
+
+      // OMN-96: `folder: null` is the model's natural guess for "top-level
+      // projects, no containing folder." Map it to the internal folderTopLevel
+      // flag (NOT result.folder, which does substring matching on the folder
+      // name and would never match a null).
+      it('input.folder: null maps to folderTopLevel and not result.folder', () => {
+        const result = compiler.transformFilters({ folder: null });
+        expect(result.folderTopLevel).toBe(true);
+        expect(result.folder).toBeUndefined();
+      });
+
+      it('a folder name does not set folderTopLevel', () => {
+        const result = compiler.transformFilters({ folder: 'Work' });
+        expect(result.folderTopLevel).toBeUndefined();
+      });
     });
 
     describe('compile() export passthrough', () => {

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -192,6 +192,33 @@ describe('ReadSchema', () => {
     });
   });
 
+  // OMN-96: `folder: null` means "top-level projects only" (no containing
+  // folder). We mold the schema to the model's natural guess for that intent —
+  // see the decision record in read-schema.ts at the `folder` field.
+  describe('folder: null → top-level only (OMN-96)', () => {
+    it('should accept folder: null on projects queries', () => {
+      const input = {
+        query: {
+          type: 'projects',
+          filters: { folder: null },
+        },
+      };
+      const result = ReadSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('should still accept a folder name string', () => {
+      const input = {
+        query: {
+          type: 'projects',
+          filters: { folder: 'Work' },
+        },
+      };
+      const result = ReadSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
   // OMN-43: explicit projectId filter key. Previously the only project-related
   // filter was `project` (string-or-null), which routed string values through a
   // name-resolution path that failed with SCRIPT_ERROR for ambiguous or unmatched


### PR DESCRIPTION
## What

`omnifocus_read` projects queries now accept `filters.folder: null`, meaning **"top-level projects only"** (no containing folder). Previously the Zod schema typed `folder` as a bare string and hard-rejected `null`.

## Why

The weekly `diagnose-failures` run surfaced the model repeatedly sending `filters.folder: null` on projects queries, expecting it to mean top-level/no-folder — two identical failures **2.5 months apart** (`failures-2026-03-05` and `-2026-05-21`, fingerprint `066ca0a17c883d02`). There was no working way to express that common intent.

Per grooming, we chose **option 1: mold the server to the model's natural guess** — accept `null` rather than introduce new vocabulary the model doesn't reach for. The rejected alternatives (explicit `topLevelOnly` boolean / structured `folder: {exists:false}` / actionable-error-only) are recorded as a **decision record** at the schema's `folder` field, so a future revisit is a cheap "pick a different row."

## How it threads

`folder: null` → compiler sets internal `folderTopLevel` flag → `ProjectFilter.topLevelOnly` → emitted predicate `!project.parentFolder`. A folder *string* still means name-substring matching (unchanged). `null` is converted to a boolean at the compiler boundary and never reaches the emitter as a folder name.

| Layer | File |
|---|---|
| Schema (accept null + decision record) | `read-schema.ts` |
| Compiler (`null`→`folderTopLevel`, string→`folder`) | `QueryCompiler.ts` |
| Compiled + project filter types (+ known-prop lists) | `filters.ts` |
| Routing (`folderTopLevel`→`topLevelOnly`) | `OmniFocusReadTool.ts` |
| Emitter (`!project.parentFolder`) | `filter-generator.ts` |

Dual-schema: tool description documents the null semantics. `inputSchema.filters` is intentionally a bare `{type:'object'}`, so no field-level inputSchema sync is owed.

## Testing

- TDD: schema accepts null, compiler maps null→flag (not folder), generator emits `!project.parentFolder`; `isEmpty`/`describe` updated.
- **2145/2145 unit tests pass**, clean `tsc` build.
- Code-review gate: **APPROVED / SAFE** with load-bearing mutation-verify (reverting the compiler mapping and the emitter predicate each failed the right test, then restored).

Closes OMN-96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)