### PR TITLE
feat(OMN-97): propagate .strict() across write mutation tree + actionable redirects

### DIFF
--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -106,6 +106,11 @@ OPERATIONS:
 - bulk_delete: Delete multiple items by IDs
 - tag_manage: Manage tag hierarchy (create, rename, delete, merge, nest, unnest, reparent)
 
+FIELD PLACEMENT (fields go INSIDE data/changes, not beside them):
+- Unknown or misplaced keys are rejected (not silently dropped). Common fixes:
+  estimate → estimatedMinutes; context → tags (no contexts in OF3+);
+  priority → flagged (no priority levels); subtasks → a batch op with parentTempId.
+
 FOLDER CREATION:
 - operation: "create_folder"
 - data.name: Folder name (required)
@@ -181,6 +186,37 @@ SAFETY:
    * which is what surfaces caller mistakes through the failure-log pipeline.
    */
   override get inputSchema(): Record<string, unknown> {
+    // OMN-97: advertise the supported fields of `data`/`changes` so MCP clients
+    // get field-level guidance and misplace fewer keys. Mirrors CreateDataSchema /
+    // UpdateChangesSchema in write-schema.ts — keep in sync (dual-schema rule).
+    // (Plain `type: string` for enum-bearing fields like `status` to avoid
+    // advertising an enum the inputSchema↔Zod parity test would police.)
+    const createDataProperties: Record<string, unknown> = {
+      name: { type: 'string' },
+      note: { type: 'string' },
+      project: { type: 'string', description: 'name or ID; omit/null = inbox' },
+      parentTaskId: { type: 'string', description: 'create as subtask of this ID' },
+      tags: { type: 'array', items: { type: 'string' }, description: 'no contexts in OF3+ — use tags' },
+      dueDate: { type: 'string', description: 'YYYY-MM-DD [HH:mm]' },
+      deferDate: { type: 'string', description: 'YYYY-MM-DD [HH:mm]' },
+      plannedDate: { type: 'string', description: 'YYYY-MM-DD [HH:mm]' },
+      flagged: { type: 'boolean', description: 'no priority levels — use flagged' },
+      estimatedMinutes: { type: 'number', description: 'minutes (not "estimate")' },
+      repetitionRule: { type: 'object' },
+      folder: { type: 'string', description: 'project-only' },
+      sequential: { type: 'boolean', description: 'project-only' },
+      status: { type: 'string', description: 'project-only: active|on_hold|completed|dropped' },
+      reviewInterval: { description: 'project-only: days or {steps,unit}' },
+    };
+    const updateChangesProperties: Record<string, unknown> = {
+      ...createDataProperties,
+      addTags: { type: 'array', items: { type: 'string' } },
+      removeTags: { type: 'array', items: { type: 'string' } },
+      clearDueDate: { type: 'boolean' },
+      clearDeferDate: { type: 'boolean' },
+      clearPlannedDate: { type: 'boolean' },
+      clearEstimatedMinutes: { type: 'boolean' },
+    };
     return {
       type: 'object',
       properties: {
@@ -194,9 +230,10 @@ SAFETY:
             },
             target: { type: 'string', enum: ['task', 'project'] },
 
-            // create/update shared
-            data: { type: 'object' },
-            changes: { type: 'object' },
+            // create/update shared — OMN-97: field-level guidance; misplaced
+            // siblings (e.g. `flagged` outside `data`) are now hard-rejected.
+            data: { type: 'object', properties: createDataProperties },
+            changes: { type: 'object', properties: updateChangesProperties },
             id: { type: 'string' },
             target_id: { type: 'string', description: 'Alias for id, accepted on delete (pairs with target)' },
             minimalResponse: { type: 'boolean' },
@@ -216,6 +253,10 @@ SAFETY:
                 properties: {
                   operation: { type: 'string', enum: ['create', 'update', 'complete', 'delete'] },
                   target: { type: 'string', enum: ['task', 'project'] },
+                  // OMN-97: kept bare to bound advertised-schema size — the
+                  // top-level data/changes carry the field guidance, and Zod
+                  // (BatchItemDataSchema/UpdateChangesSchema) still hard-rejects
+                  // misplaced keys inside batch entries regardless.
                   data: { type: 'object' },
                   changes: { type: 'object' },
                   id: { type: 'string' },

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -84,6 +84,41 @@ const ReviewIntervalSchema = z
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?)?$/;
 const DATE_FORMAT_MSG = 'Date format: YYYY-MM-DD or YYYY-MM-DD HH:mm';
 
+// ── OMN-97: strict everywhere + actionable redirects ─────────────────
+// `.strict()` does NOT propagate through discriminatedUnion/union (prior art
+// OMN-90 on the read path), so every object literal in the mutation tree needs
+// its own — otherwise a key at the wrong nesting level (e.g. `flagged` as a
+// sibling of `data`) is silently stripped and the caller believes it was set.
+//
+// `.strict()`'s generic "Unrecognized key(s)" error is unhelpful for the
+// handful of fields LLMs reach for that OmniFocus simply doesn't have (or
+// names differently). We attach an errorMap that turns those into a loud error
+// that ALSO names the supported alternative. Empirically the errorMap fires
+// for unrecognized_keys at every depth — leaf `data`, member sibling, wrapper.
+const WRITE_FIELD_REDIRECTS: Record<string, string> = {
+  estimate: "use 'estimatedMinutes' (duration in minutes as a number)",
+  context: "OmniFocus 3+ has no contexts — use 'tags'",
+  priority: "OmniFocus has no priority levels — use 'flagged: true'",
+  subtasks: "create children via a batch op with 'parentTempId' (or set 'parentTaskId' on create)",
+};
+
+const writeAliasErrorMap: z.ZodErrorMap = (issue, ctx) => {
+  if (issue.code === z.ZodIssueCode.unrecognized_keys) {
+    const hints = issue.keys.filter((k) => k in WRITE_FIELD_REDIRECTS).map((k) => `${k} → ${WRITE_FIELD_REDIRECTS[k]}`);
+    if (hints.length > 0) {
+      return { message: `${ctx.defaultError}. ${hints.join('; ')}` };
+    }
+  }
+  return { message: ctx.defaultError };
+};
+
+/**
+ * Strict object literal with the write-path alias errorMap attached. Use for
+ * EVERY object in the mutation tree so unknown keys are rejected (not stripped)
+ * and the four known misplaced/aliased fields get an actionable message.
+ */
+const strictObj = <T extends z.ZodRawShape>(shape: T) => z.object(shape, { errorMap: writeAliasErrorMap }).strict();
+
 // Create data schema — single source of truth for task/project creation fields.
 // Both the unified write tool and batch-schemas derive from this.
 // Exported for OMN-61 write-side parity testing (settable field ↔ builder).
@@ -96,66 +131,73 @@ const DATE_FORMAT_MSG = 'Date format: YYYY-MM-DD or YYYY-MM-DD HH:mm';
 // silent data loss into a loud Zod rejection that `logToolFailure` records,
 // closing the diagnose-pipeline blind spot.
 export const CreateDataSchema = z
-  .object({
-    name: z.string().min(1),
-    note: z.string().optional(),
-    project: z.union([z.string(), z.null()]).optional(),
-    parentTaskId: z.string().optional(), // Bug #17: Enable subtask creation
-    tags: z.array(z.string()).optional(),
-    dueDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
-    deferDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
-    plannedDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
-    flagged: coerceBoolean().optional(),
-    estimatedMinutes: z
-      .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
-      .pipe(z.number())
-      .optional(),
-    repetitionRule: RepetitionRuleSchema.optional(),
+  .object(
+    {
+      name: z.string().min(1),
+      note: z.string().optional(),
+      project: z.union([z.string(), z.null()]).optional(),
+      parentTaskId: z.string().optional(), // Bug #17: Enable subtask creation
+      tags: z.array(z.string()).optional(),
+      dueDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
+      deferDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
+      plannedDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
+      flagged: coerceBoolean().optional(),
+      estimatedMinutes: z
+        .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
+        .pipe(z.number())
+        .optional(),
+      repetitionRule: RepetitionRuleSchema.optional(),
 
-    // Project-specific
-    folder: z.string().optional(),
-    sequential: coerceBoolean().optional(),
-    status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
-    reviewInterval: ReviewIntervalSchema.optional(),
-  })
+      // Project-specific
+      folder: z.string().optional(),
+      sequential: coerceBoolean().optional(),
+      status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
+      reviewInterval: ReviewIntervalSchema.optional(),
+    },
+    { errorMap: writeAliasErrorMap },
+  ) // OMN-97: actionable redirects on unknown keys
   .strict();
 
 // Update changes schema
 // Exported for OMN-61 write-side parity testing (settable field ↔ builder).
 export const UpdateChangesSchema = z
-  .object({
-    name: z.string().optional(),
-    note: z.string().optional(),
-    tags: z.array(z.string()).optional(),
-    addTags: z.array(z.string()).optional(),
-    removeTags: z.array(z.string()).optional(),
-    dueDate: z.union([z.string(), z.null()]).optional(),
-    deferDate: z.union([z.string(), z.null()]).optional(),
-    plannedDate: z.union([z.string(), z.null()]).optional(),
-    clearDueDate: coerceBoolean().optional(),
-    clearDeferDate: coerceBoolean().optional(),
-    clearPlannedDate: coerceBoolean().optional(),
-    flagged: coerceBoolean().optional(),
-    // Note: tasks only support 'completed'/'dropped'; projects support all 4.
-    // Task-specific narrowing happens in sanitizer + script builder.
-    status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
-    project: z.union([z.string(), z.null()]).optional(),
-    folder: z.union([z.string(), z.null()]).optional(),
-    parentTaskId: z.union([z.string(), z.null()]).optional(), // Bug OMN-5: Update parent task relationship
-    estimatedMinutes: z
-      .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
-      .pipe(z.number())
-      .optional(),
-    clearEstimatedMinutes: coerceBoolean().optional(), // Bug #18: Clear estimated time
-    repetitionRule: z.union([RepetitionRuleSchema, z.null()]).optional(), // Set (object) or clear (null)
-    // Project-specific update fields
-    sequential: coerceBoolean().optional(),
-    reviewInterval: ReviewIntervalSchema.optional(),
-  })
+  .object(
+    {
+      name: z.string().optional(),
+      note: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      addTags: z.array(z.string()).optional(),
+      removeTags: z.array(z.string()).optional(),
+      dueDate: z.union([z.string(), z.null()]).optional(),
+      deferDate: z.union([z.string(), z.null()]).optional(),
+      plannedDate: z.union([z.string(), z.null()]).optional(),
+      clearDueDate: coerceBoolean().optional(),
+      clearDeferDate: coerceBoolean().optional(),
+      clearPlannedDate: coerceBoolean().optional(),
+      flagged: coerceBoolean().optional(),
+      // Note: tasks only support 'completed'/'dropped'; projects support all 4.
+      // Task-specific narrowing happens in sanitizer + script builder.
+      status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
+      project: z.union([z.string(), z.null()]).optional(),
+      folder: z.union([z.string(), z.null()]).optional(),
+      parentTaskId: z.union([z.string(), z.null()]).optional(), // Bug OMN-5: Update parent task relationship
+      estimatedMinutes: z
+        .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
+        .pipe(z.number())
+        .optional(),
+      clearEstimatedMinutes: coerceBoolean().optional(), // Bug #18: Clear estimated time
+      repetitionRule: z.union([RepetitionRuleSchema, z.null()]).optional(), // Set (object) or clear (null)
+      // Project-specific update fields
+      sequential: coerceBoolean().optional(),
+      reviewInterval: ReviewIntervalSchema.optional(),
+    },
+    { errorMap: writeAliasErrorMap },
+  ) // OMN-97: actionable redirects on unknown keys
   .strict();
 
 // Folder create data schema — minimal: just name + optional parent folder
-const FolderCreateDataSchema = z.object({
+// OMN-97: strict so misplaced keys are rejected, not silently dropped.
+const FolderCreateDataSchema = strictObj({
   name: z.string().min(1),
   parentFolder: z.string().optional(),
 });
@@ -168,25 +210,27 @@ export const BatchItemDataSchema = CreateDataSchema.extend({
 });
 
 // Batch operation schema - discriminated union
+// OMN-97: each member strictObj() so a misplaced sibling of `data`/`changes`
+// inside a batch entry is rejected, not silently stripped.
 const BatchOperationSchema = z.discriminatedUnion('operation', [
-  z.object({
+  strictObj({
     operation: z.literal('create'),
     target: z.enum(['task', 'project']),
     data: BatchItemDataSchema,
   }),
-  z.object({
+  strictObj({
     operation: z.literal('update'),
     target: z.enum(['task', 'project']),
     id: z.string(),
     changes: UpdateChangesSchema,
   }),
-  z.object({
+  strictObj({
     operation: z.literal('complete'),
     target: z.enum(['task', 'project']),
     id: z.string(),
     completionDate: z.string().regex(DATE_REGEX, DATE_FORMAT_MSG).optional(),
   }),
-  z.object({
+  strictObj({
     operation: z.literal('delete'),
     target: z.enum(['task', 'project']),
     id: z.string(),
@@ -207,14 +251,14 @@ const TagActionSchema = z.enum([
 // Mutation schema - discriminated union by operation
 const MutationSchema = z.discriminatedUnion('operation', [
   // Create operation (task/project)
-  z.object({
+  strictObj({
     operation: z.literal('create'),
     target: z.enum(['task', 'project']),
     data: CreateDataSchema,
     minimalResponse: z.boolean().optional(), // Bug #21: Reduce response size
   }),
   // Create folder operation
-  z.object({
+  strictObj({
     operation: z.literal('create_folder'),
     data: FolderCreateDataSchema,
   }),
@@ -225,7 +269,7 @@ const MutationSchema = z.discriminatedUnion('operation', [
   // WriteSchema superRefine enforces exactly-one-present. `target` defaults to
   // 'task' (the model frequently omits it on update/complete); non-breaking
   // since a missing target was previously a hard error.
-  z.object({
+  strictObj({
     operation: z.literal('update'),
     target: z.enum(['task', 'project']).default('task'),
     id: z.string(),
@@ -234,7 +278,7 @@ const MutationSchema = z.discriminatedUnion('operation', [
     minimalResponse: z.boolean().optional(), // Bug #21: Reduce response size
   }),
   // Complete operation
-  z.object({
+  strictObj({
     operation: z.literal('complete'),
     target: z.enum(['task', 'project']).default('task'), // OMN-75: model often omits target
     id: z.string(),
@@ -251,14 +295,14 @@ const MutationSchema = z.discriminatedUnion('operation', [
   // a more consistent shape than `id`. Accept it as a non-breaking alias.
   // Both are optional here; the WriteSchema superRefine enforces exactly-one-
   // present so an empty delete still fails with a clear, schema-level error.
-  z.object({
+  strictObj({
     operation: z.literal('delete'),
     target: z.enum(['task', 'project']),
     id: z.string().optional(),
     target_id: z.string().optional(),
   }),
   // Batch operation with options
-  z.object({
+  strictObj({
     operation: z.literal('batch'),
     target: z.enum(['task', 'project']).optional(),
     operations: z.array(BatchOperationSchema),
@@ -269,14 +313,14 @@ const MutationSchema = z.discriminatedUnion('operation', [
     dryRun: coerceBoolean().optional().default(false), // Preview without executing
   }),
   // Bulk delete operation - for efficient batch deletion
-  z.object({
+  strictObj({
     operation: z.literal('bulk_delete'),
     target: z.enum(['task', 'project']),
     ids: z.array(z.string()).min(1).max(100), // Limit to 100 items for safety
     dryRun: coerceBoolean().optional().default(false), // Preview without executing
   }),
   // Tag management operation
-  z.object({
+  strictObj({
     operation: z.literal('tag_manage'),
     action: TagActionSchema,
     tagName: z.string().min(1).describe('The tag name to operate on'),
@@ -289,9 +333,13 @@ const MutationSchema = z.discriminatedUnion('operation', [
 // Main write schema
 // Note: coerceObject handles JSON string->object conversion from MCP bridge
 export const WriteSchema = z
-  .object({
-    mutation: coerceObject(MutationSchema),
-  })
+  .object(
+    {
+      mutation: coerceObject(MutationSchema),
+    },
+    { errorMap: writeAliasErrorMap }, // OMN-97
+  )
+  .strict() // OMN-97: reject unknown keys at the top-level wrapper (sibling of `mutation`)
   // OMN-71: delete accepts `id` OR its alias `target_id`. The discriminated-
   // union member can't carry a refinement (zod requires ZodObject members),
   // so enforce "exactly one identifier present" at the boundary schema — this

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -799,9 +799,19 @@ describe('OmniFocusWriteTool task operations', () => {
       const schema = tool.inputSchema as any;
       const mutationProps = schema.properties.mutation.properties;
 
-      // data and changes should be loose objects
-      expect(mutationProps.data).toEqual({ type: 'object' });
-      expect(mutationProps.changes).toEqual({ type: 'object' });
+      // OMN-97: data/changes now advertise their supported fields so MCP
+      // clients get field-level guidance and misplace fewer keys.
+      expect(mutationProps.data.type).toBe('object');
+      for (const f of ['name', 'dueDate', 'estimatedMinutes', 'flagged', 'tags', 'status']) {
+        expect(mutationProps.data.properties[f]).toBeDefined();
+      }
+      // changes is a superset (adds addTags/removeTags/clear* fields)
+      expect(mutationProps.changes.properties.addTags).toBeDefined();
+      expect(mutationProps.changes.properties.clearDueDate).toBeDefined();
+
+      // repetitionRule stays shallow — advertised as a loose object, NOT the
+      // deeply-expanded recursive shape (the size blowup this test guards).
+      expect(mutationProps.data.properties.repetitionRule).toEqual({ type: 'object' });
     });
 
     it('should advertise batch control flags as boolean, not string', () => {

--- a/tests/unit/tools/unified/schemas/write-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/write-schema.test.ts
@@ -991,4 +991,105 @@ describe('WriteSchema', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  // OMN-97: OMN-76 made the *leaf* data/changes payloads strict. This block
+  // closes the residual surface — `.strict()` does NOT propagate through
+  // discriminatedUnion/union, so the enclosing members and the top-level
+  // wrapper were still plain z.object and silently stripped misplaced keys.
+  describe('mutation-tree strictness — siblings + wrapper (OMN-97)', () => {
+    // helper: join all issue messages so we can assert actionable hints
+    const messagesOf = (result: ReturnType<typeof WriteSchema.safeParse>): string =>
+      result.success ? '' : result.error.issues.map((i) => i.message).join(' | ');
+
+    it('rejects `flagged` placed as a sibling of data (the canonical misplacement)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: { name: 'X' },
+          flagged: true, // belongs INSIDE data; as a sibling it was silently dropped
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown key at the top-level WriteSchema wrapper (sibling of mutation)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'create', target: 'task', data: { name: 'X' } },
+        bogusTopLevel: true,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown sibling key inside the update member', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'update',
+          target: 'task',
+          id: 'task-1',
+          changes: { flagged: true },
+          bogusSibling: 1,
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown sibling key inside the complete member', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'complete', target: 'task', id: 'task-1', bogus: 1 },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown sibling key on a batch operation entry (sibling of data)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          operations: [{ operation: 'create', target: 'task', data: { name: 'A' }, flagged: true }],
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    // Actionable rejection messages for the four well-known misplaced/aliased fields.
+    it('names `estimatedMinutes` when `estimate` is used inside data', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'create', target: 'task', data: { name: 'X', estimate: 30 } },
+      });
+      expect(result.success).toBe(false);
+      expect(messagesOf(result)).toContain('estimatedMinutes');
+    });
+
+    it('names `tags` when `context` is used inside data', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'create', target: 'task', data: { name: 'X', context: 'home' } },
+      });
+      expect(result.success).toBe(false);
+      expect(messagesOf(result)).toContain('tags');
+    });
+
+    it('names `flagged` when `priority` is used inside data', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'create', target: 'task', data: { name: 'X', priority: 1 } },
+      });
+      expect(result.success).toBe(false);
+      expect(messagesOf(result)).toContain('flagged');
+    });
+
+    it('names the batch/parentTempId path when `subtasks` is used inside data', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'create', target: 'task', data: { name: 'X', subtasks: [] } },
+      });
+      expect(result.success).toBe(false);
+      expect(messagesOf(result)).toContain('parentTempId');
+    });
+
+    it('still accepts a fully valid create (no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: { operation: 'create', target: 'task', data: { name: 'Real', flagged: true } },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What

Closes the residual silent-key-drop surface on the write path. OMN-76 made the **leaf** `data`/`changes` payloads strict, but Zod's `.strict()` does **not** propagate through `discriminatedUnion`/`union` (prior art OMN-90 on the read path). So the enclosing `MutationSchema` members, the `BatchOperationSchema` members, and the top-level `WriteSchema` wrapper were still plain `z.object` and **silently stripped** misplaced keys — e.g. `flagged` placed as a sibling of `data` was dropped while the caller believed it was set (the exact silent-data-loss class, one nesting level up from OMN-76).

## Changes

1. **Strict at every depth.** A `strictObj()` helper (`z.object(shape, { errorMap }).strict()`) applied to all 8 `MutationSchema` members, all 4 `BatchOperationSchema` members, `FolderCreateDataSchema`, and the top-level wrapper. The two leaf schemas keep `.strict()` and gain the errorMap.
2. **Actionable rejection messages** via a write-path `errorMap` that rewrites the `unrecognized_keys` message for the four fields LLMs reach for that OmniFocus lacks or names differently:
   - `estimate` → `estimatedMinutes`
   - `context` → `tags` (no contexts in OF3+)
   - `priority` → `flagged` (no priority levels)
   - `subtasks` → batch op with `parentTempId`

   (errorMap fires at leaf, member-sibling, and wrapper depth — verified end-to-end through the `McpError` message.)
3. **Enriched `inputSchema.data`/`changes`** with field-level `properties` mirroring the Zod schemas, so clients misplace fewer keys. `repetitionRule` kept shallow; batch entries kept bare to bound advertised size (**3835 B < 4 KB budget**; Zod still hard-rejects misplaced batch keys). Tool description gains a FIELD PLACEMENT note.

## Testing

- Strictness at each depth (wrapper, each member, batch entry, leaf), actionable messages for all four aliases, no-regression on the valid surface; inputSchema advertisement test updated to the enriched contract.
- **2155/2155 unit pass**, schema↔impl parity (168) green, clean `tsc`.
- Code-review gate: **APPROVED / SAFE** with load-bearing mutation-verify (reverting a `strictObj` and dropping a redirect entry each failed the right test, then restored).

## Follow-up (out of scope)

`RepetitionRuleSchema` (and its nested `daysOfWeek`) remain non-strict — unknown keys *inside* `data.repetitionRule` are still silently stripped. Pre-existing, not a regression; none of the four aliases land there. Tracked as a separate ticket.

Closes OMN-97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)