### PR TITLE
fix(OMN-98): make RepetitionRuleSchema + nested daysOfWeek strict

### DIFF
--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -15,38 +15,42 @@ type SameKeys<A, B> =
 // Repetition rule schema — derived from RepetitionRule contract via `satisfies`.
 // Constrains output type only (input is `unknown` to allow MCP bridge string coercion).
 // If the contract changes a field type, `satisfies` errors here.
-const RepetitionRuleSchema = z.object({
-  frequency: z.enum(['minutely', 'hourly', 'daily', 'weekly', 'monthly', 'yearly']),
-  interval: z
-    .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
-    .pipe(z.number().min(1))
-    .optional()
-    .default(1),
-  // Fix 1: daysOfWeek must be DayOfWeek[] (object with day + optional position), not number[]
-  daysOfWeek: z
-    .array(
-      z.object({
-        day: z.enum(['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']),
-        position: z.number().optional(),
-      }),
-    )
-    .optional(),
-  // Fix 2: 4 missing fields that contract + script builder already support
-  daysOfMonth: z.array(z.number().min(-31).max(31)).optional(),
-  count: z
-    .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
-    .pipe(z.number().min(1))
-    .optional(),
-  weekStart: z.enum(['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']).optional(),
-  setPositions: z.array(z.number().min(-366).max(366)).optional(),
-  endDate: z.string().optional(),
-  // OmniFocus 4.7+ repetition method control
-  method: z.enum(['fixed', 'due-after-completion', 'defer-after-completion', 'none']).optional(),
-  scheduleType: z.enum(['regularly', 'from-completion', 'none']).optional(),
-  anchorDateKey: z.enum(['due-date', 'defer-date', 'planned-date']).optional(),
-  // Fix 4: coerceBoolean for MCP bridge compatibility (Claude Desktop sends strings)
-  catchUpAutomatically: coerceBoolean().optional(),
-}) satisfies z.ZodType<RepetitionRule, z.ZodTypeDef, unknown>;
+const RepetitionRuleSchema = z
+  .object({
+    frequency: z.enum(['minutely', 'hourly', 'daily', 'weekly', 'monthly', 'yearly']),
+    interval: z
+      .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
+      .pipe(z.number().min(1))
+      .optional()
+      .default(1),
+    // Fix 1: daysOfWeek must be DayOfWeek[] (object with day + optional position), not number[]
+    daysOfWeek: z
+      .array(
+        z
+          .object({
+            day: z.enum(['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']),
+            position: z.number().optional(),
+          })
+          .strict(), // OMN-98: reject unknown keys in a daysOfWeek entry
+      )
+      .optional(),
+    // Fix 2: 4 missing fields that contract + script builder already support
+    daysOfMonth: z.array(z.number().min(-31).max(31)).optional(),
+    count: z
+      .union([z.number(), z.string().transform((v) => parseInt(v, 10))])
+      .pipe(z.number().min(1))
+      .optional(),
+    weekStart: z.enum(['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']).optional(),
+    setPositions: z.array(z.number().min(-366).max(366)).optional(),
+    endDate: z.string().optional(),
+    // OmniFocus 4.7+ repetition method control
+    method: z.enum(['fixed', 'due-after-completion', 'defer-after-completion', 'none']).optional(),
+    scheduleType: z.enum(['regularly', 'from-completion', 'none']).optional(),
+    anchorDateKey: z.enum(['due-date', 'defer-date', 'planned-date']).optional(),
+    // Fix 4: coerceBoolean for MCP bridge compatibility (Claude Desktop sends strings)
+    catchUpAutomatically: coerceBoolean().optional(),
+  })
+  .strict() satisfies z.ZodType<RepetitionRule, z.ZodTypeDef, unknown>; // OMN-98: last non-strict object in the write tree
 
 // Key-set sync: catches missing optional fields (which `satisfies` alone allows through).
 // If RepetitionRule gains or loses a field, `never = true` fails to compile.

--- a/tests/unit/tools/unified/schemas/write-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/write-schema.test.ts
@@ -1092,4 +1092,65 @@ describe('WriteSchema', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  // OMN-98: RepetitionRuleSchema was the last non-strict object in the write
+  // mutation tree after OMN-97 — unknown keys inside data.repetitionRule (and
+  // its nested daysOfWeek entries) were still silently stripped, so a typo like
+  // `freqency` vanished and the rule was created with defaults.
+  describe('repetitionRule strictness (OMN-98)', () => {
+    it('rejects an unknown key inside data.repetitionRule (e.g. the `freqency` typo)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: { name: 'X', repetitionRule: { frequency: 'daily', freqency: 'weekly' } },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown key inside a daysOfWeek entry', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: {
+            name: 'X',
+            repetitionRule: { frequency: 'weekly', daysOfWeek: [{ day: 'MO', bogus: true }] },
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown key inside changes.repetitionRule on update', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'update',
+          target: 'task',
+          id: 'task-1',
+          changes: { repetitionRule: { frequency: 'daily', interva: 2 } },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts a valid repetitionRule with daysOfWeek (no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'task',
+          data: {
+            name: 'X',
+            repetitionRule: {
+              frequency: 'weekly',
+              interval: 1,
+              daysOfWeek: [{ day: 'MO' }, { day: 'WE', position: 1 }],
+            },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What

The last non-strict object literals in the write mutation tree after OMN-97. Unknown keys inside `data.repetitionRule` / `changes.repetitionRule` — and inside a `daysOfWeek` entry — were still silently stripped, so a typo like `freqency` or `interva` vanished and the rule was created with defaults while the caller believed it was set. Same silent-data-loss class OMN-76 (leaf) and OMN-97 (members/wrapper) closed at the levels above.

## How

Add `.strict()` to `RepetitionRuleSchema` and its nested `daysOfWeek` object. The `satisfies`/`SameKeys` type guards are unaffected (`.strict()` doesn't change the inferred output type) — `tsc` is clean. No errorMap attached: repetition rules have no known field aliases, so the generic loud rejection is the fix (the value is catching typos, not redirecting renamed fields).

## Testing

- New: unknown key inside `data.repetitionRule`, inside a `daysOfWeek` entry, and inside `changes.repetitionRule` on update are all rejected; a valid rule with `daysOfWeek` still passes.
- **2159/2159 unit pass**, schema↔impl parity green, clean build.
- Code-review gate: **APPROVED / SAFE** with load-bearing mutation-verify (removing either `.strict()` independently flips the matching test to silent-strip; restored).

## Follow-up (out of scope)

The review flagged `ReviewIntervalObjectSchema` (the `{steps, unit}` object reachable via `reviewInterval`) as the one remaining non-strict object on the mutation path — same class. Tracked separately; after it lands the write tree is fully strict.

Closes OMN-98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)