### PR TITLE
fix(OMN-99): make ReviewIntervalObjectSchema strict — last non-strict write-path object

### DIFF
--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -75,6 +75,12 @@ const ReviewIntervalObjectSchema = z
     steps: z.union([z.number(), z.string().transform((v) => parseInt(v, 10))]).pipe(z.number().min(1)),
     unit: z.string(),
   })
+  // OMN-99: .strict() rejects unknown keys (e.g. a typo'd `bogu`) instead of
+  // silently stripping them — same data-loss class as OMN-76/97/98. Must chain
+  // BEFORE .transform(): .strict() is a ZodObject method; .transform() returns
+  // ZodEffects, which has none. This was the last non-strict object on the
+  // write mutation tree.
+  .strict()
   .transform((obj) => {
     const multiplier = UNIT_TO_DAYS[obj.unit.toLowerCase()] ?? 1;
     return obj.steps * multiplier;

--- a/tests/unit/tools/unified/schemas/write-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/write-schema.test.ts
@@ -1153,4 +1153,70 @@ describe('WriteSchema', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  // OMN-99: ReviewIntervalObjectSchema (the { steps, unit } form) was the last
+  // non-strict object reachable on the write mutation tree after OMN-98 — an
+  // unknown key inside reviewInterval (e.g. `bogu`) was silently stripped. The
+  // object carries a .transform() (steps→days), so .strict() must be chained
+  // BEFORE .transform() (.strict() is a ZodObject method; .transform() yields
+  // ZodEffects, which has none).
+  describe('reviewInterval object strictness (OMN-99)', () => {
+    it('rejects an unknown key inside reviewInterval object on create', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'project',
+          data: { name: 'P', reviewInterval: { steps: 2, unit: 'weeks', bogu: 1 } },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an unknown key inside reviewInterval object on update', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'update',
+          target: 'project',
+          id: 'project-1',
+          changes: { reviewInterval: { steps: 2, unit: 'months', bogu: 1 } },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts a valid reviewInterval object (no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'project',
+          data: { name: 'P', reviewInterval: { steps: 2, unit: 'weeks' } },
+        },
+      });
+      expect(result.success).toBe(true);
+      const data = (result.data!.mutation as { data: { reviewInterval: number } }).data;
+      expect(data.reviewInterval).toBe(14);
+    });
+
+    it('still accepts the bare-number reviewInterval form (no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'project',
+          data: { name: 'P', reviewInterval: 14 },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('still accepts the string reviewInterval form (MCP bridge, no regression)', () => {
+      const result = WriteSchema.safeParse({
+        mutation: {
+          operation: 'create',
+          target: 'project',
+          data: { name: 'P', reviewInterval: '7' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`ReviewIntervalObjectSchema` in `src/tools/unified/schemas/write-schema.ts` (the `{ steps, unit }` form, reachable via `reviewInterval` in both `CreateDataSchema` and `UpdateChangesSchema`) was plain `z.object`, so unknown keys were **silently stripped** — same silent-data-loss class as OMN-76 / OMN-97 / OMN-98.

```json
{ "mutation": { "operation": "create", "target": "project",
  "data": { "name": "P", "reviewInterval": { "steps": 2, "unit": "weeks", "bogu": 1 } } } }
```

Pre-fix, `bogu` vanished and the call reported success.

## Fix

One line: chain `.strict()` **before** `.transform()`. The object carries a `.transform()` (`{steps, unit}` → days); `.strict()` is a `ZodObject` method while `.transform()` returns `ZodEffects` (which has no `.strict()`), so order matters.

This closes the lineage: OMN-76 → OMN-90 (read) → OMN-97 → OMN-98 → **OMN-99**. After this, the write mutation tree has **no remaining non-strict objects**.

## Tests

New `reviewInterval object strictness (OMN-99)` block, 5 cases:
- rejects unknown key inside `reviewInterval` object on **create**
- rejects unknown key inside `reviewInterval` object on **update**
- still accepts valid `{steps, unit}` object (→ correct day count, no regression)
- still accepts bare-number form (no regression)
- still accepts string form / MCP bridge coercion (no regression)

Mutation-verified red→green (the 2 rejection cases fail without the fix). Full unit suite: 2164 passing. `tsc` build clean.

## Out of scope

Reject-not-strip only; no new capabilities, no `inputSchema` change (strictness is server-side validation, not an advertised field — consistent with OMN-97/98).

Closes OMN-99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)