### PR TITLE
OMN-114 + OMN-115: read-side ergonomics — parentTaskId filter + real fastSearch

### DIFF
--- a/src/contracts/ast/builder.ts
+++ b/src/contracts/ast/builder.ts
@@ -143,7 +143,13 @@ export const FILTER_DEFS: readonly FilterDef[] = [
       const searchTerm = f.text ?? f.search;
       if (searchTerm === undefined) return null;
       const operator = f.textOperator === 'MATCHES' ? 'matches' : 'includes';
-      return or(comparison('task.name', operator, searchTerm), comparison('task.note', operator, searchTerm));
+      const nameMatch = comparison('task.name', operator, searchTerm);
+      // OMN-115: fastSearch restricts matching to the task NAME only, skipping
+      // the note body — the documented "Name search" fast path. Reading fewer
+      // properties per task is the only avoidable cost in an otherwise
+      // bridge-bound full scan.
+      if (f.fastSearch) return nameMatch;
+      return or(nameMatch, comparison('task.note', operator, searchTerm));
     },
   },
 

--- a/src/contracts/ast/builder.ts
+++ b/src/contracts/ast/builder.ts
@@ -183,6 +183,13 @@ export const FILTER_DEFS: readonly FilterDef[] = [
     },
   },
 
+  // --- Parent task filter (OMN-114) ---
+  // Direct children of a given task id — read-side mirror of write's parentTaskId.
+  {
+    fields: ['task.parentTaskId'],
+    build: (f) => (f.parentTaskId !== undefined ? comparison('task.parentTaskId', '==', f.parentTaskId) : null),
+  },
+
   // --- Estimated minutes (numeric) filter (OMN-49) ---
   {
     fields: ['task.estimatedMinutes'],

--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -163,10 +163,26 @@ function emitOmniJSTagStatusValid(operator: ComparisonOperator, value: unknown):
 }
 
 /**
+ * OMN-114: parentTaskId filter. Compares the task's parent id, guarding against
+ * a null parent before reading `.id.primaryKey` (top-level tasks have no parent).
+ */
+function emitOmniJSParentTaskId(operator: ComparisonOperator, value: unknown): string {
+  const id = JSON.stringify(value as string);
+  if (operator === '==') {
+    return `(task.parent && task.parent.id.primaryKey === ${id})`;
+  }
+  if (operator === '!=') {
+    return `(!task.parent || task.parent.id.primaryKey !== ${id})`;
+  }
+  throw new Error(`Unsupported parentTaskId operator: ${operator}`);
+}
+
+/**
  * Registry of synthetic fields and their emitter functions.
  * Adding a new synthetic field requires one entry here.
  */
 export const SYNTHETIC_FIELD_DEFS: readonly SyntheticFieldDef[] = [
+  { field: 'task.parentTaskId', omnijs: emitOmniJSParentTaskId },
   { field: 'task.dropped', omnijs: (op, val) => emitOmniJSStatusComparison(op, val, 'Task.Status.Dropped') },
   {
     field: 'task.available',
@@ -201,6 +217,7 @@ export const KNOWN_FIELDS = [
   'task.taskStatus', // TaskStatus enum: active, completed, dropped
   'task.dropped', // Synthetic: taskStatus === Task.Status.Dropped (computed in emitter)
   'task.tagStatusValid', // Synthetic: has active/on-hold tag or untagged (computed in emitter)
+  'task.parentTaskId', // OMN-114 synthetic: task.parent.id.primaryKey === <id> (null-guarded, computed in emitter)
 
   // Date properties
   'task.dueDate',

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -152,6 +152,14 @@ export interface TaskFilter {
   // --- Search (for name/note search) ---
   search?: string; // Search term for name/note content
 
+  /**
+   * OMN-115: fast search restricts text matching to the task NAME only,
+   * skipping the note body. Fulfils the documented "Name search → fastSearch:
+   * true" fast path (QuickReferencePrompt). When undefined/false, search
+   * matches both name and note.
+   */
+  fastSearch?: boolean;
+
   // --- Project Status (preserved for project queries) ---
   projectStatus?: ProjectStatus[];
 
@@ -369,6 +377,7 @@ export const FILTER_PROPERTY_NAMES = [
   'projectId',
   'project',
   'search',
+  'fastSearch', // OMN-115: name-only fast search
   'projectStatus',
   'folder',
   'folderTopLevel', // OMN-96

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -149,6 +149,14 @@ export interface TaskFilter {
   projectId?: string; // Filter by project ID (from advanced filters)
   project?: string | null; // Filter by project (simple param, null = inbox)
 
+  // --- Parent task (OMN-114) ---
+  /**
+   * Filter to direct children of the given task ID — the read-side mirror of
+   * `data.parentTaskId` on write, which writes already accept and reads already
+   * project. Matches `task.parent.id.primaryKey === parentTaskId` (null-guarded).
+   */
+  parentTaskId?: string;
+
   // --- Search (for name/note search) ---
   search?: string; // Search term for name/note content
 
@@ -376,6 +384,7 @@ export const FILTER_PROPERTY_NAMES = [
   'dueSoonDays',
   'projectId',
   'project',
+  'parentTaskId', // OMN-114: direct children of a task
   'search',
   'fastSearch', // OMN-115: name-only fast search
   'projectStatus',

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -159,6 +159,7 @@ export class OmniFocusReadTool extends BaseTool<typeof ReadSchema, unknown> {
 COMMON QUERIES:
 - Inbox: { query: { type: "tasks", filters: { project: null } } }
 - Tasks in a specific project (by ID, fast): { query: { type: "tasks", filters: { projectId: "<id>" } } }
+- Direct children of a task (subtasks): { query: { type: "tasks", filters: { parentTaskId: "<id>" } } }
 - Overdue: { query: { type: "tasks", mode: "overdue" } }
 - Today perspective: { query: { type: "tasks", mode: "today" } }
 - Flagged: { query: { type: "tasks", mode: "flagged" } }

--- a/src/tools/unified/compilers/QueryCompiler.ts
+++ b/src/tools/unified/compilers/QueryCompiler.ts
@@ -49,6 +49,13 @@ export class QueryCompiler {
 
     // Transform filters from API schema to internal contract, then normalize
     const rawFilters: TaskFilter = query.filters ? this.transformFilters(query.filters) : {};
+    // OMN-115: fastSearch is a query-level param, but the AST search builder only
+    // sees the filter object. Thread it onto the filter so `fastSearch: true`
+    // emits a name-only predicate (skips the note body) per the documented
+    // "Name search" fast path.
+    if ('fastSearch' in query && query.fastSearch !== undefined) {
+      rawFilters.fastSearch = query.fastSearch;
+    }
     const filters = normalizeFilter(rawFilters);
     const taskMode = 'mode' in query && query.mode ? query.mode : 'all';
 

--- a/src/tools/unified/compilers/QueryCompiler.ts
+++ b/src/tools/unified/compilers/QueryCompiler.ts
@@ -123,6 +123,11 @@ export class QueryCompiler {
       result.projectId = input.project;
     }
 
+    // OMN-114: parentTaskId — direct children of a task. Unambiguous id match.
+    if (typeof input.parentTaskId === 'string') {
+      result.parentTaskId = input.parentTaskId;
+    }
+
     // ID/folder passthrough
     if (input.id) result.id = input.id;
     // OMN-96: `folder: null` means "top-level projects only" (the model's

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -54,6 +54,10 @@ const filterFields = {
   // ambiguous when multiple projects share a name. `projectId` is unambiguous and
   // takes the fast path through Project.byIdentifier().
   projectId: z.string().optional(),
+  // OMN-114: filter to direct children of a task. Read-side mirror of write's
+  // `data.parentTaskId` (writes accept it, reads project it). Unambiguous id
+  // match via task.parent.id.primaryKey.
+  parentTaskId: z.string().optional(),
   dueDate: DateFilterSchema.optional(),
   deferDate: DateFilterSchema.optional(),
   plannedDate: DateFilterSchema.optional(),

--- a/tests/unit/architecture/schema-impl-parity.test.ts
+++ b/tests/unit/architecture/schema-impl-parity.test.ts
@@ -77,6 +77,8 @@ const FILTER_SAMPLES: Record<string, unknown> = {
   tags: { any: ['@home'] },
   project: 'sample-project-id',
   projectId: 'sample-project-id',
+  parentTaskId: 'sample-parent-task-id', // OMN-114
+
   dueDate: { before: '2026-12-31' },
   deferDate: { before: '2026-12-31' },
   plannedDate: { before: '2026-12-31' },

--- a/tests/unit/contracts/ast/builder.test.ts
+++ b/tests/unit/contracts/ast/builder.test.ts
@@ -240,6 +240,55 @@ describe('buildAST', () => {
         ],
       });
     });
+
+    it('OMN-115: fastSearch:true matches name only (skips note) for text', () => {
+      const filter: TaskFilter = { text: 'review', fastSearch: true };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'includes',
+        value: 'review',
+      });
+    });
+
+    it('OMN-115: fastSearch:true honors MATCHES operator, still name only', () => {
+      const filter: TaskFilter = { text: '^review.*', textOperator: 'MATCHES', fastSearch: true };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'matches',
+        value: '^review.*',
+      });
+    });
+
+    it('OMN-115: fastSearch:true matches name only for the search alias', () => {
+      const filter: TaskFilter = { search: 'meeting notes', fastSearch: true };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'includes',
+        value: 'meeting notes',
+      });
+    });
+
+    it('OMN-115: fastSearch:false still matches both name and note', () => {
+      const filter: TaskFilter = { text: 'review', fastSearch: false };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'or',
+        children: [
+          { type: 'comparison', field: 'task.name', operator: 'includes', value: 'review' },
+          { type: 'comparison', field: 'task.note', operator: 'includes', value: 'review' },
+        ],
+      });
+    });
   });
 
   describe('date filters', () => {

--- a/tests/unit/contracts/ast/builder.test.ts
+++ b/tests/unit/contracts/ast/builder.test.ts
@@ -291,6 +291,27 @@ describe('buildAST', () => {
     });
   });
 
+  describe('parent task filter (OMN-114)', () => {
+    it('transforms parentTaskId to a synthetic comparison node', () => {
+      const filter: TaskFilter = { parentTaskId: 'abc123' };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.parentTaskId',
+        operator: '==',
+        value: 'abc123',
+      });
+    });
+
+    it('omits the parent filter when parentTaskId is undefined', () => {
+      const filter: TaskFilter = {};
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({ type: 'literal', value: true });
+    });
+  });
+
   describe('date filters', () => {
     it('transforms dueBefore', () => {
       const filter: TaskFilter = { dueBefore: '2025-12-31' };

--- a/tests/unit/contracts/ast/filter-generator.test.ts
+++ b/tests/unit/contracts/ast/filter-generator.test.ts
@@ -56,6 +56,14 @@ describe('generateFilterCode', () => {
       expect(result.predicate).toContain('task.note');
     });
 
+    it('OMN-114: parentTaskId emits a null-guarded parent id comparison', () => {
+      const filter: TaskFilter = { parentTaskId: 'abc123' };
+      const result = generateFilterCode(filter, 'omnijs');
+
+      // Must guard against null parent before reading .id.primaryKey.
+      expect(result.predicate).toBe('(task.parent && task.parent.id.primaryKey === "abc123")');
+    });
+
     it('generateFilterCode returns EmitResult with preamble and predicate', () => {
       const filter = { completed: false, flagged: true };
       const result = generateFilterCode(filter);

--- a/tests/unit/contracts/ast/filter-generator.test.ts
+++ b/tests/unit/contracts/ast/filter-generator.test.ts
@@ -40,6 +40,22 @@ describe('generateFilterCode', () => {
       expect(result.predicate).toBe('true');
     });
 
+    it('OMN-115: fastSearch emits a name-only predicate (no task.note read)', () => {
+      const filter: TaskFilter = { search: 'review', fastSearch: true };
+      const result = generateFilterCode(filter, 'omnijs');
+
+      expect(result.predicate).toContain('task.name');
+      expect(result.predicate).not.toContain('task.note');
+    });
+
+    it('OMN-115: default search still reads task.note', () => {
+      const filter: TaskFilter = { search: 'review' };
+      const result = generateFilterCode(filter, 'omnijs');
+
+      expect(result.predicate).toContain('task.name');
+      expect(result.predicate).toContain('task.note');
+    });
+
     it('generateFilterCode returns EmitResult with preamble and predicate', () => {
       const filter = { completed: false, flagged: true };
       const result = generateFilterCode(filter);

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -61,6 +61,19 @@ describe('QueryCompiler', () => {
       expect(compiled.filters.fastSearch).toBeUndefined();
     });
 
+    it('OMN-114: passes parentTaskId filter through to the compiled filter', () => {
+      const input: ReadInput = {
+        query: {
+          type: 'tasks',
+          filters: { parentTaskId: 'abc123' },
+        },
+      };
+
+      const compiled = compiler.compile(input);
+
+      expect(compiled.filters.parentTaskId).toBe('abc123');
+    });
+
     it('should compile smart_suggest mode', () => {
       const input: ReadInput = {
         query: {

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -30,6 +30,37 @@ describe('QueryCompiler', () => {
       expect(compiled.limit).toBe(25);
     });
 
+    it('OMN-115: threads query-level fastSearch onto the compiled filter', () => {
+      const input: ReadInput = {
+        query: {
+          type: 'tasks',
+          mode: 'search',
+          filters: { text: { contains: 'review' } },
+          fastSearch: true,
+        },
+      };
+
+      const compiled = compiler.compile(input);
+
+      expect(compiled.fastSearch).toBe(true);
+      // Must also reach the filter object so the AST search builder emits name-only.
+      expect(compiled.filters.fastSearch).toBe(true);
+    });
+
+    it('OMN-115: omits fastSearch from the filter when not requested', () => {
+      const input: ReadInput = {
+        query: {
+          type: 'tasks',
+          mode: 'search',
+          filters: { text: { contains: 'review' } },
+        },
+      };
+
+      const compiled = compiler.compile(input);
+
+      expect(compiled.filters.fastSearch).toBeUndefined();
+    });
+
     it('should compile smart_suggest mode', () => {
       const input: ReadInput = {
         query: {


### PR DESCRIPTION
Two read-side ergonomics fixes from the 2026-05-31 latency/ergonomics handoff. Both are unit-tested, zero live dependencies. (Handoff's P1 batch-write perf = OMN-113, planned separately — see below.)

## OMN-115 — make `fastSearch` real (was a no-op)
`fastSearch` was advertised in `inputSchema`, documented in `QuickReferencePrompt` as the "Name search" fast path, accepted by the Zod schema, and compiled into the query object — but **nothing downstream read the compiled value**. Passing `fastSearch: true` gave the identical name+note full scan.

- Search `FilterDef` (`builder.ts`) emits a **name-only** predicate when `f.fastSearch` (skips `task.note`); default still ORs name + note.
- `QueryCompiler` threads the query-level `fastSearch` onto the filter object so the AST search builder sees it.
- `fastSearch` added to `TaskFilter` + `FILTER_PROPERTY_NAMES`.

Scope: makes the *matching* name-only per the documented contract. Field-projection narrowing left out of scope.

## OMN-114 — accept `parentTaskId` as a tasks read filter (API symmetry)
`parentTaskId` was settable on write (`data.parentTaskId`) and projected on read results, but the strict tasks filter schema **rejected it as a read filter** (`-32602 Unrecognized key parentTaskId`) — so "children of task X" required slow name-substring search.

- New synthetic AST field `task.parentTaskId` emitting a **null-guarded** compare: `(task.parent && task.parent.id.primaryKey === "<id>")` — identical null-handling to the existing read projection.
- `builder.ts` FilterDef, `TaskFilter.parentTaskId`, `read-schema` filterFields, `QueryCompiler` passthrough, `KNOWN_FIELDS`, `FILTER_PROPERTY_NAMES`, parity-test sample, tool description.
- Scoped string-only (mirrors `projectId`); `parentTaskId: null` = "top-level only" deferred (OMN-96 `folder:null` precedent exists if wanted).

## Verification
- Full unit suite **2177 passing**; `tsc` clean; ESLint clean on changed files.
- TDD throughout (RED→GREEN at AST, emitter, compiler, and schema-parity layers).
- Code-review subagent verdict: **SAFE TO MERGE** (no blockers/should-fix).

## Not in this PR — OMN-113 (batch-write perf)
Verified root cause: `executeBatchCreates` spawns **one `osascript` process per create** (`createBatchTask` → `execJson` per item). The fix (single-process batch) is a larger, correctness-critical rewrite with **zero `new Task()` OmniJS precedent** in the codebase, and its integration oracle currently leaks into the real inbox via the OMN-111 teardown bug. Planned as a focused, integration-validated follow-up — details on OMN-113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)