### PR TITLE
fix(OMN-111): stray backtick broke integration teardown → inbox leak

### DIFF
--- a/tests/integration/helpers/sandbox-manager.ts
+++ b/tests/integration/helpers/sandbox-manager.ts
@@ -200,9 +200,21 @@ export async function isProjectInSandbox(projectId: string): Promise<boolean> {
  * so it matches the broader sweep's contract exactly — strict superset
  * of the pre-OMN-89 name-prefix-only behavior.
  */
-async function deleteTestInboxTasks(): Promise<{ deleted: number; errors: string[] }> {
-  // Use pure OmniJS to iterate inbox directly - very fast even with large databases
-  const script = `
+/**
+ * OmniJS inbox-fixture deletion script.
+ *
+ * Exported for the parse-safety guard in
+ * `tests/unit/integration-helpers/sandbox-manager-script-parse.test.ts`.
+ *
+ * OMN-111: comments inside the `app.evaluateJavascript(\`...\`)` template MUST
+ * NOT contain backticks. A stray backtick (e.g. markdown-style `` `inbox` ``)
+ * terminates the inner template literal early — the JS engine then parses the
+ * following identifier as a bare token in the argument list and the entire
+ * sweep dies with "Unexpected identifier … Expected ')'", silently leaking
+ * every fixture the sweep should have deleted.
+ */
+export function buildDeleteTestInboxFixturesScript(): string {
+  return `
     const result = app.evaluateJavascript(\`
       (() => {
         ${OMNIJS_FIXTURE_PREDICATES_SOURCE}
@@ -214,7 +226,7 @@ async function deleteTestInboxTasks(): Promise<{ deleted: number; errors: string
 
         // OMN-89: classify via the shared isFixtureTask predicate (the
         // single source covered by sandbox-manager-omnijs-predicate-parity).
-        // Iterating \`inbox\` directly (OmniJS global) keeps this O(inbox.length),
+        // Iterating the inbox global directly keeps this O(inbox.length),
         // not O(flattenedTasks) — inbox tasks rarely carry tags but checking
         // both legs of the contract costs nothing.
         for (const task of inbox) {
@@ -238,7 +250,11 @@ async function deleteTestInboxTasks(): Promise<{ deleted: number; errors: string
     \`);
     return result;
   `;
-  return executeJXA<{ deleted: number; errors: string[] }>(script);
+}
+
+async function deleteTestInboxTasks(): Promise<{ deleted: number; errors: string[] }> {
+  // Use pure OmniJS to iterate inbox directly - very fast even with large databases
+  return executeJXA<{ deleted: number; errors: string[] }>(buildDeleteTestInboxFixturesScript());
 }
 
 /**

--- a/tests/unit/integration-helpers/sandbox-manager-script-parse.test.ts
+++ b/tests/unit/integration-helpers/sandbox-manager-script-parse.test.ts
@@ -1,0 +1,60 @@
+/**
+ * OMN-111 — parse-safety guard for the sandbox-manager OmniJS sweep scripts.
+ *
+ * The cleanup sweeps embed an OmniJS program inside a JXA
+ * `app.evaluateJavascript(`...`)` backtick template. A stray backtick anywhere
+ * in that inner program (most insidiously a markdown-style `` `word` `` in a
+ * comment) terminates the template literal early. The JS engine then parses the
+ * next identifier as a bare token in the call's argument list and the WHOLE
+ * sweep dies at parse time with "Unexpected identifier … Expected ')'". Because
+ * the sweep is teardown code whose result is logged-not-asserted, the failure is
+ * silent: every fixture the sweep should have deleted leaks into the real DB
+ * (the OMN-111 inbox leak).
+ *
+ * Two complementary invariants pin the hazard: (1) the script PARSES — we wrap
+ * it exactly as `executeJXA` does and hand it to `new Function` (same parse
+ * pattern the OMN-87 predicate-parity test already uses); a template-termination
+ * bug is a SyntaxError at parse time. (2) the script holds EXACTLY the two
+ * delimiter backticks of its single `evaluateJavascript(\`…\`)` template — any
+ * extra backtick is a body backtick, i.e. the bug. (An even-count or
+ * balanced-pair check would be fooled by a stray `` `word` `` pair; an exact
+ * count of two is not.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDeleteTestInboxFixturesScript } from '../../integration/helpers/sandbox-manager.js';
+
+/**
+ * Mirror of the JXA wrapper in `executeJXA` (sandbox-manager.ts). We only need
+ * the structure that affects parsing — `app`/`doc` are never invoked here, so
+ * referencing them is fine; `new Function` checks syntax, not runtime.
+ */
+function wrapLikeExecuteJXA(script: string): string {
+  return `
+    (() => {
+      const app = Application('OmniFocus');
+      app.includeStandardAdditions = true;
+      const doc = app.defaultDocument();
+      ${script}
+    })()
+  `;
+}
+
+describe('OMN-111: sandbox-manager OmniJS sweep scripts are parse-safe', () => {
+  it('inbox-fixture deletion script parses (no stray backtick terminating the inner template)', () => {
+    const wrapped = wrapLikeExecuteJXA(buildDeleteTestInboxFixturesScript());
+
+    // A stray backtick in the inner app.evaluateJavascript(`...`) template
+    // would split it and make this throw a SyntaxError.
+    expect(() => new Function(wrapped)).not.toThrow();
+  });
+
+  it('inner evaluateJavascript template contains no unescaped backticks in its body', () => {
+    // The script holds the intended template delimiters as a single backtick
+    // pair. Anything beyond those two delimiter backticks is a body backtick —
+    // the exact OMN-111 hazard. Assert there are exactly two backticks total
+    // (the open + close of the single evaluateJavascript template).
+    const backticks = (buildDeleteTestInboxFixturesScript().match(/`/g) || []).length;
+    expect(backticks).toBe(2);
+  });
+});


### PR DESCRIPTION
## Bug
`deleteTestInboxTasks` (integration teardown) embeds an OmniJS program inside a JXA `app.evaluateJavascript(\`...\`)` backtick template. A comment in that body used markdown-style `` `inbox` `` backticks → **literal backticks** after the TS template evaluates → the inner template literal **terminates early**. JSC then parses the following `inbox` identifier as a bare token in the call's argument list:

```
SyntaxError: Unexpected identifier 'inbox'. Expected ')' to end an argument list.
```

The teardown sweep's result is **logged, not asserted**, so the failure was silent: every `__TEST__` inbox fixture **leaked into the real database** on each integration run (the OMN-111 inbox leak). Only the inbox sweep was affected — it's the sole `evaluateJavascript` body carrying a stray backtick (the other 4 sweeps are clean, verified).

## Fix
- Remove the backticks from the comment (root cause).
- Extract the script into `buildDeleteTestInboxFixturesScript()` and add a parse-safety guard (`sandbox-manager-script-parse.test.ts`) that wraps it like `executeJXA` and asserts it parses via `new Function` (the OMN-87 predicate-parity pattern), plus an exact-backtick-count assertion. A count check **alone** wouldn't catch it — the stray pair is balanced; it splits the intended outer pair, so the guard also parses.

## Verification
- Parse guard: **RED** with the backtick, **GREEN** without (watched both).
- Batch integration teardown now runs **clean** — no SyntaxError, no `"Inbox tasks: JXA execution failed"` (which the pre-fix run emitted).
- Confirmed **0** `__TEST__` inbox leftovers post-run.
- Full unit suite **2179 passing**; `tsc` + ESLint clean.

Unblocks safe integration validation of **OMN-113** (batch-create perf) — its oracle is the batch integration suite, which was leaking via this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)