### PR TITLE
perf(OMN-113): single-script fast path for all-task batch creates

### DIFF
--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -831,6 +831,126 @@ export async function buildCreateTaskScript(data: TaskCreateData): Promise<Gener
 }
 
 /**
+ * OMN-113: one task spec in a single-script batch create. Dates are already
+ * UTC-normalized by the caller (localToUTC). Exactly one container hint applies,
+ * checked in priority order: parentTempId (a task created earlier in THIS batch)
+ * → parentTaskId (existing task id) → projectId (existing project id/name) →
+ * inbox.
+ */
+export interface BatchTaskSpec {
+  tempId: string;
+  name: string;
+  note?: string;
+  flagged?: boolean;
+  tags?: string[];
+  dueDate?: string;
+  deferDate?: string;
+  plannedDate?: string;
+  estimatedMinutes?: number;
+  parentTempId?: string;
+  parentTaskId?: string;
+  projectId?: string;
+}
+
+export function buildBatchCreateTasksScript(
+  specs: BatchTaskSpec[],
+  options: { stopOnError?: boolean } = {},
+): GeneratedMutationScript {
+  const stopOnError = options.stopOnError === true;
+
+  // OMN-111 SAFETY: this OmniJS body carries NO user data and is assembled into
+  // the OmniJS source by string CONCATENATION (not a nested template literal),
+  // so backticks / ${ / newlines in task names, notes, or tags can never break
+  // a template. `specs` is injected at JXA runtime via JSON.stringify (a plain
+  // double-quoted string literal in the generated source — backtick-safe, the
+  // same property the per-item buildCreateTaskScript relies on). The static
+  // body references `specs`, which the concatenation defines just before it.
+  const omniBody = `
+${OMNIJS_PARSE_TAG_PATH}
+${OMNIJS_RESOLVE_OR_CREATE_TAG_PATH}
+const byTempId = {};
+const results = [];
+for (let s = 0; s < specs.length; s++) {
+  const spec = specs[s];
+  try {
+    const task = new Task(spec.name);
+    if (spec.note) task.note = spec.note;
+    if (spec.flagged) task.flagged = true;
+    if (spec.dueDate) task.dueDate = new Date(spec.dueDate);
+    if (spec.deferDate) task.deferDate = new Date(spec.deferDate);
+    if (spec.plannedDate) task.plannedDate = new Date(spec.plannedDate);
+    if (spec.estimatedMinutes) task.estimatedMinutes = spec.estimatedMinutes;
+
+    // Container priority: intra-batch parent -> existing task -> project -> inbox.
+    let container = null;
+    if (spec.parentTempId) {
+      const p = byTempId[spec.parentTempId];
+      if (!p) throw new Error('Parent not created in batch: ' + spec.parentTempId);
+      container = p.ending;
+    } else if (spec.parentTaskId) {
+      const pt = Task.byIdentifier(spec.parentTaskId);
+      if (!pt) throw new Error('Parent task not found: ' + spec.parentTaskId);
+      container = pt.ending;
+    } else if (spec.projectId) {
+      let proj = Project.byIdentifier(spec.projectId);
+      if (!proj) proj = flattenedProjects.find(x => x.name === spec.projectId) || null;
+      if (!proj) throw new Error('Project not found: ' + spec.projectId);
+      container = proj.ending;
+    }
+    if (container) moveTasks([task], container);
+
+    if (spec.tags && spec.tags.length) {
+      for (let t = 0; t < spec.tags.length; t++) {
+        const tagName = spec.tags[t];
+        const segs = parseTagPath(tagName);
+        let tag;
+        if (segs) {
+          tag = resolveOrCreateTagByPath(segs);
+        } else {
+          tag = flattenedTags.find(x => x.name === tagName) || new Tag(tagName, null);
+        }
+        task.addTag(tag);
+      }
+    }
+
+    byTempId[spec.tempId] = task;
+    results.push({ tempId: spec.tempId, taskId: task.id.primaryKey, success: true });
+  } catch (e) {
+    results.push({ tempId: spec.tempId, taskId: null, success: false, error: String(e && e.message ? e.message : e) });
+    if (${stopOnError}) break;
+  }
+}
+return JSON.stringify({ results: results });`;
+
+  const script = `
+(() => {
+  const app = Application('OmniFocus');
+  try {
+    const specs = ${JSON.stringify(specs)};
+    const omniSource =
+      '(() => {' +
+      'const specs = ' + JSON.stringify(specs) + ';' +
+      ${JSON.stringify(omniBody)} +
+      '})()';
+    // Return the OmniJS payload RAW ({results:[...]}). OmniAutomation.executeJson
+    // wraps raw output into a ScriptResult ({success, data}); pre-wrapping here
+    // would double-wrap and hide data.results from callers.
+    return app.evaluateJavascript(omniSource);
+  } catch (e) {
+    return JSON.stringify({ error: true, message: String(e && e.message ? e.message : e), context: 'batch_create_tasks' });
+  }
+})();
+`;
+
+  return {
+    script: script.trim(),
+    operation: 'create',
+    target: 'task',
+    description: `Batch-create ${specs.length} task(s)`,
+  };
+}
+
+/**
  * Build a JXA script for creating a project
  */
 export function buildCreateProjectScript(data: ProjectCreateData): GeneratedMutationScript {

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -29,6 +29,8 @@ import {
   buildCompleteScript,
   buildDeleteScript,
   buildCreateTaskScript,
+  buildBatchCreateTasksScript,
+  type BatchTaskSpec,
   buildUpdateTaskScript,
   markProjectAsValidated,
   markTaskAsValidated,
@@ -1654,14 +1656,22 @@ SAFETY:
     // Step 3: Get creation order (respects dependencies)
     const orderedItems = options.createSequentially ? graph.getCreationOrder() : items;
 
-    // Step 4: Create items in order
-    for (let i = 0; i < orderedItems.length; i++) {
-      const item = orderedItems[i];
-      const result = await this.executeSingleBatchCreate(item, resolver);
-      batchResults.push(result);
+    // Step 4: Create items in order.
+    // OMN-113 fast path: an all-task batch with no repetition rules creates in
+    // ONE osascript round-trip (one process spawn) instead of one spawn per
+    // item — the ~6s/op → near-O(1) win. Mixed project+task batches, repetition
+    // rules, or unordered intra-batch parents fall back to the per-item loop.
+    if (this.isBatchCreateFastPathEligible(orderedItems, options)) {
+      await this.executeBatchCreatesFastPath(orderedItems, resolver, batchResults, options.stopOnError);
+    } else {
+      for (let i = 0; i < orderedItems.length; i++) {
+        const item = orderedItems[i];
+        const result = await this.executeSingleBatchCreate(item, resolver);
+        batchResults.push(result);
 
-      if (!result.success && options.stopOnError) {
-        break;
+        if (!result.success && options.stopOnError) {
+          break;
+        }
       }
     }
 
@@ -1706,6 +1716,87 @@ SAFETY:
     }
 
     return response;
+  }
+
+  /**
+   * OMN-113: a batch qualifies for the single-script fast path when every item
+   * is a task with no repetition rule (repetition is applied via a separate
+   * post-create update, kept on the per-item path). When any item references an
+   * in-batch parent (parentTempId), the items must already be in dependency
+   * order — guaranteed only when createSequentially produced the ordering.
+   */
+  private isBatchCreateFastPathEligible(items: BatchItem[], options: { createSequentially: boolean }): boolean {
+    const allSimpleTasks = items.every((item) => item.type === 'task' && !item.repetitionRule);
+    if (!allSimpleTasks) return false;
+    const hasIntraBatchParent = items.some((item) => Boolean(item.parentTempId));
+    return hasIntraBatchParent ? options.createSequentially : true;
+  }
+
+  /**
+   * OMN-113: create every task in the batch in ONE osascript invocation.
+   * Parents precede children (dependency order), so the script resolves
+   * parentTempId from its own in-script map; real parentTaskId/project ids are
+   * resolved via byIdentifier inside the same OmniJS context. Populates the
+   * resolver + batchResults exactly like the per-item path so the downstream
+   * rollback / cache-invalidation / response steps are unchanged.
+   */
+  private async executeBatchCreatesFastPath(
+    items: BatchItem[],
+    resolver: TempIdResolver,
+    batchResults: BatchItemCreationResult[],
+    stopOnError: boolean,
+  ): Promise<void> {
+    const specs: BatchTaskSpec[] = items.map((item) => {
+      const spec: BatchTaskSpec = { tempId: item.tempId, name: item.name };
+      if (item.note) spec.note = item.note;
+      if (item.flagged) spec.flagged = true;
+      if (item.tags && item.tags.length > 0) spec.tags = item.tags;
+      if (item.dueDate) spec.dueDate = localToUTC(item.dueDate, 'due');
+      if (item.deferDate) spec.deferDate = localToUTC(item.deferDate, 'defer');
+      if (item.plannedDate) spec.plannedDate = localToUTC(item.plannedDate, 'planned');
+      if (item.estimatedMinutes !== undefined) spec.estimatedMinutes = item.estimatedMinutes;
+      // Container priority mirrors resolveBatchTaskParent, but parentTempId is
+      // passed through verbatim — it is resolved inside the script, not here
+      // (the parent has no real id yet at build time).
+      if (item.parentTempId) {
+        spec.parentTempId = item.parentTempId;
+      } else if (item.parentTaskId && typeof item.parentTaskId === 'string') {
+        spec.parentTaskId = item.parentTaskId;
+      } else if (item.project) {
+        spec.projectId = item.project;
+      }
+      return spec;
+    });
+
+    const { script } = buildBatchCreateTasksScript(specs, { stopOnError });
+    const result = await this.execJson(script);
+
+    if (isScriptError(result)) {
+      // Whole-script failure: mark every item failed so atomic rollback / error
+      // reporting behave correctly.
+      for (const item of items) {
+        resolver.markFailed(item.tempId, result.error);
+        batchResults.push({ tempId: item.tempId, realId: null, success: false, error: result.error, type: 'task' });
+      }
+      return;
+    }
+
+    const data = (isScriptSuccess(result) ? result.data : undefined) as
+      | { results?: Array<{ tempId: string; taskId: string | null; success: boolean; error?: string }> }
+      | undefined;
+    const scriptResults = data?.results ?? [];
+
+    for (const r of scriptResults) {
+      if (r.success && r.taskId) {
+        resolver.resolve(r.tempId, r.taskId);
+        markTaskAsValidated(r.taskId);
+        batchResults.push({ tempId: r.tempId, realId: r.taskId, success: true, type: 'task' });
+      } else {
+        const error = r.error || 'Creation failed';
+        resolver.markFailed(r.tempId, error);
+        batchResults.push({ tempId: r.tempId, realId: null, success: false, error, type: 'task' });
+      }
+    }
   }
 
   /**

--- a/tests/integration/batch-operations.test.ts
+++ b/tests/integration/batch-operations.test.ts
@@ -387,6 +387,103 @@ d('Batch Operations Integration (Unified API)', () => {
     expect(errorResults[0].error).toContain('Circular');
   }, 30000);
 
+  it('OMN-113: all-task batch nests via the single-script fast path', async () => {
+    // No project item → the OMN-113 fast path (one osascript round-trip for the
+    // whole batch). Parent in inbox, two subtasks via parentTempId.
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'fp_parent', name: runScopedName(`OMN113_FastParent_${timestamp}`), flagged: true },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'fp_child1',
+              name: runScopedName(`OMN113_FastChild1_${timestamp}`),
+              parentTempId: 'fp_parent',
+              dueDate: '2026-06-04 17:00',
+              tags: [`${TEST_TAG_PREFIX}omn113`],
+            },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'fp_child2',
+              name: runScopedName(`OMN113_FastChild2_${timestamp}`),
+              parentTempId: 'fp_parent',
+            },
+          },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+
+    expect(response).toHaveProperty('success', true);
+    expect(response.data.summary.created).toBe(3);
+    expect(response.data.results.filter((r) => r.operation === 'create')).toHaveLength(3);
+
+    // The first subtask must be nested under the parent (not left in the inbox).
+    const childId = response.data.tempIdMapping?.['fp_child1'];
+    expect(childId).toBeTruthy();
+
+    const readResult = (await client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { id: childId }, details: true },
+    })) as { data?: { tasks?: Array<{ inInbox: boolean; parentTaskName?: string | null; tags?: string[] }> } };
+
+    const task = readResult.data?.tasks?.[0];
+    expect(task).toBeDefined();
+    expect(task!.inInbox).toBe(false);
+  }, 30000);
+
+  it('OMN-113: parentTaskId read filter returns the fast-path subtasks (OMN-114)', async () => {
+    // Build a parent + 3 children via the fast path, then query children by
+    // parentTaskId — exercises OMN-114 against OMN-113-created tasks.
+    const created = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'q_parent', name: runScopedName(`OMN113_QParent_${timestamp}`) },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'q_c1', name: runScopedName(`OMN113_QC1_${timestamp}`), parentTempId: 'q_parent' },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'q_c2', name: runScopedName(`OMN113_QC2_${timestamp}`), parentTempId: 'q_parent' },
+          },
+        ],
+        createSequentially: true,
+        returnMapping: true,
+      },
+    })) as BatchResponse;
+
+    const parentId = created.data.tempIdMapping?.['q_parent'];
+    expect(parentId).toBeTruthy();
+
+    const children = (await client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { parentTaskId: parentId } },
+    })) as { data?: { tasks?: Array<{ id: string }> } };
+
+    expect(children.data?.tasks?.length).toBe(2);
+  }, 30000);
+
   it('should handle tasks with dates and metadata in sandbox', async () => {
     const response = (await client.callTool('omnifocus_write', {
       mutation: {

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -8,6 +8,7 @@ import {
   buildCompleteScript,
   buildDeleteScript,
   buildBatchScript,
+  buildBatchCreateTasksScript,
   buildBulkDeleteScript,
   type GeneratedMutationScript,
 } from '../../../../src/contracts/ast/mutation-script-builder.js';
@@ -1089,5 +1090,65 @@ describe('buildCreateFolderScript', () => {
     });
 
     expect(result.script).toContain('Parent folder not found');
+  });
+});
+
+describe('buildBatchCreateTasksScript (OMN-113)', () => {
+  it('emits ONE evaluateJavascript round-trip creating all tasks with a shared tempId map', () => {
+    const result = buildBatchCreateTasksScript([
+      { tempId: 'p1', name: 'Parent Task' },
+      { tempId: 'c1', name: 'Child Task', parentTempId: 'p1' },
+    ]);
+
+    expect(result.operation).toBe('create');
+    expect(result.target).toBe('task');
+    expect(result.script).toContain("Application('OmniFocus')");
+    expect(result.script).toContain('new Task(');
+    expect(result.script).toContain('moveTasks');
+    expect(result.script).toContain('Parent Task');
+    expect(result.script).toContain('Child Task');
+    expect(result.script).toContain('p1');
+    expect(result.script).toContain('c1');
+    // THE perf invariant: the whole batch is ONE bridge round-trip, not N.
+    expect((result.script.match(/app\.evaluateJavascript\(/g) || []).length).toBe(1);
+  });
+
+  it('produces a parse-safe script across all container + field cases', () => {
+    const result = buildBatchCreateTasksScript([
+      {
+        tempId: 't1',
+        name: "Task with 'quotes' and fields",
+        note: 'multi\nline\nnote',
+        flagged: true,
+        projectId: 'proj123',
+        tags: ['Work : Deep', 'urgent'],
+        dueDate: '2026-06-04 17:00:00',
+        deferDate: '2026-06-01 08:00:00',
+        estimatedMinutes: 30,
+      },
+      { tempId: 't2', name: 'Under existing task', parentTaskId: 'realTask456' },
+      { tempId: 't3', name: 'Inbox task' },
+    ]);
+
+    expect(() => new Function(result.script)).not.toThrow();
+  });
+
+  it('stays parse-safe when names/notes/tags contain backticks or ${ (OMN-111 class)', () => {
+    // Backticks and ${ in user data must NOT break the generated script — the
+    // common dev-GTD case (e.g. "Fix `parseTagPath`") and a literal ${ in notes.
+    const result = buildBatchCreateTasksScript([
+      {
+        tempId: 't1',
+        name: 'Fix `parseTagPath` edge case',
+        note: 'cost is ${total}; run `npm test`\nsecond line',
+        tags: ['proj`tag`', 'Work : ${dyn}'],
+      },
+      { tempId: 't2', name: 'plain child', parentTempId: 't1' },
+    ]);
+
+    expect(() => new Function(result.script)).not.toThrow();
+    // The hazardous characters must survive into the script verbatim (data not lost).
+    expect(result.script).toContain('parseTagPath');
+    expect(result.script).toContain('${total}');
   });
 });

--- a/tests/unit/tools/batch/batch-create-project-field.test.ts
+++ b/tests/unit/tools/batch/batch-create-project-field.test.ts
@@ -22,22 +22,25 @@ class StubCache {
 }
 
 describe('Batch create project field', () => {
-  it('should pass project field to buildCreateTaskScript when provided', async () => {
+  it('should pass project field to the batch-create fast path when provided', async () => {
     const cache = new StubCache();
     const tool = new OmniFocusWriteTool(cache as any);
 
-    // Spy on buildCreateTaskScript to capture the TaskCreateData
-    const spy = vi.spyOn(scriptBuilder, 'buildCreateTaskScript').mockResolvedValue({
+    // OMN-113: an all-task batch takes the single-script fast path, so the
+    // project field flows into buildBatchCreateTasksScript as spec.projectId
+    // (not buildCreateTaskScript). The regression guard — "project must not be
+    // silently dropped" — is unchanged; only the seam moved.
+    const spy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockReturnValue({
       script: 'mock script',
       operation: 'create',
       target: 'task',
       description: 'mock',
     });
 
-    // Mock execJson to return a successful task creation
+    // Mock execJson to return the fast-path result shape.
     vi.spyOn(tool as any, 'execJson').mockResolvedValue({
       success: true,
-      data: { taskId: 'new-task-id-123' },
+      data: { results: [{ tempId: 'task1', taskId: 'new-task-id-123', success: true }] },
     });
 
     await tool.execute({
@@ -58,10 +61,9 @@ describe('Batch create project field', () => {
       },
     });
 
-    // Verify buildCreateTaskScript was called with project in TaskCreateData
     expect(spy).toHaveBeenCalledOnce();
-    const taskCreateData = spy.mock.calls[0][0];
-    expect(taskCreateData).toHaveProperty('project', 'My Existing Project');
+    const specs = spy.mock.calls[0][0];
+    expect(specs[0]).toHaveProperty('projectId', 'My Existing Project');
 
     spy.mockRestore();
   });
@@ -130,11 +132,13 @@ describe('Batch create project field', () => {
     taskSpy.mockRestore();
   });
 
-  it('should pass parentTaskId to buildCreateTaskScript when provided (OMN-31)', async () => {
+  it('should pass parentTaskId to the batch-create fast path when provided (OMN-31)', async () => {
     const cache = new StubCache();
     const tool = new OmniFocusWriteTool(cache as any);
 
-    const spy = vi.spyOn(scriptBuilder, 'buildCreateTaskScript').mockResolvedValue({
+    // OMN-113: all-task batch → single-script fast path; parentTaskId flows in
+    // as spec.parentTaskId (resolved via Task.byIdentifier inside the script).
+    const spy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockReturnValue({
       script: 'mock script',
       operation: 'create',
       target: 'task',
@@ -143,7 +147,7 @@ describe('Batch create project field', () => {
 
     vi.spyOn(tool as any, 'execJson').mockResolvedValue({
       success: true,
-      data: { taskId: 'new-subtask-id' },
+      data: { results: [{ tempId: 'subtask1', taskId: 'new-subtask-id', success: true }] },
     });
 
     await tool.execute({
@@ -165,8 +169,8 @@ describe('Batch create project field', () => {
     });
 
     expect(spy).toHaveBeenCalledOnce();
-    const taskCreateData = spy.mock.calls[0][0];
-    expect(taskCreateData).toHaveProperty('parentTaskId', 'existing-parent-task-id');
+    const specs = spy.mock.calls[0][0];
+    expect(specs[0]).toHaveProperty('parentTaskId', 'existing-parent-task-id');
 
     spy.mockRestore();
   });


### PR DESCRIPTION
## Problem
A batch of N task creates spawned **N osascript processes** — one per item (`executeBatchCreates` looped `execJson` per task), each re-initializing the JXA→OmniFocus bridge and running its own OMN-29 nonce scan. That's the ~6s/op, no-batching-benefit cost the handoff measured (8 ops ≈ 50s).

## Fix
An all-task batch with no repetition rules now creates **every task in ONE `app.evaluateJavascript` round-trip** (`buildBatchCreateTasksScript`). Tasks are created in OmniJS where `new Task` yields a real `id.primaryKey` directly — **no nonce bridge**. A shared in-script map resolves intra-batch `parentTempId`; real `parentTaskId`/`project` ids resolve via `byIdentifier`; positioning reuses the proven `moveTasks(.ending/.beginning)` vocabulary.

Mixed project+task batches, repetition rules, or unordered intra-batch parents **fall back to the unchanged per-item path**. The fast path populates the resolver + batchResults identically, so rollback / cache-invalidation / response building are untouched.

## Safety (both with live-validated tests)
- **OMN-111 class:** the OmniJS body carries **no user data** and is assembled by string **concatenation** (no nested template literal). `specs` is injected as a plain double-quoted JSON literal in JXA — so backticks / `${` / newlines in names, notes, or tags can never break a template (the per-item path relies on the same property). Verified live: a name with `` `parseTagPath` `` and a note with `${total}` + `` `npm test` `` round-trip **verbatim**.
- **Double-wrap:** the script returns **raw** `{results}` (not `{success,data}`) because `OmniAutomation.executeJson` already wraps raw output into a `ScriptResult`.

## Verification
- Unit suite **2182 passing**; `tsc` + ESLint clean. New builder tests assert one round-trip + parse-safety incl. backtick/`${`.
- Live OmniFocus probes (nesting, dates, tags, flagged, backtick/`${` data) — all correct, self-cleaning.
- Full batch **integration suite 10/10 green**, incl. a new all-task fast-path test + an OMN-114 `parentTaskId`-filter test over fast-path subtasks. Existing mixed project+task tests (fallback) unchanged.
- Code-review subagent (incl. adversarial injection retest after the fix): **SAFE / mergeable**.

Depends on #61 (OMN-111 teardown fix) — already merged — for leak-free integration validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)