### PR TITLE
test(OMN-105): fix stale analyze params in analytics-validation integration tests

### DIFF
--- a/tests/integration/validation/analytics-validation.test.ts
+++ b/tests/integration/validation/analytics-validation.test.ts
@@ -90,9 +90,7 @@ describe('Analytics Validation - Actual Calculations', () => {
         analysis: {
           type: 'productivity_stats',
           params: {
-            period: 'week',
-            includeProjectStats: false,
-            includeTagStats: false,
+            groupBy: 'week',
           },
         },
       });
@@ -148,10 +146,6 @@ describe('Analytics Validation - Actual Calculations', () => {
       const result = await client.callTool('omnifocus_analyze', {
         analysis: {
           type: 'overdue_analysis',
-          params: {
-            groupBy: 'project',
-            limit: 100,
-          },
         },
       });
 
@@ -196,9 +190,7 @@ describe('Analytics Validation - Actual Calculations', () => {
         analysis: {
           type: 'task_velocity',
           params: {
-            days: 7,
             groupBy: 'day',
-            includeWeekends: true,
           },
         },
       });
@@ -226,7 +218,7 @@ describe('Analytics Validation - Actual Calculations', () => {
       const productivityResult = await client.callTool('omnifocus_analyze', {
         analysis: {
           type: 'productivity_stats',
-          params: { period: 'week' },
+          params: { groupBy: 'week' },
         },
       });
 
@@ -234,7 +226,7 @@ describe('Analytics Validation - Actual Calculations', () => {
       const velocityResult = await client.callTool('omnifocus_analyze', {
         analysis: {
           type: 'task_velocity',
-          params: { days: 7 },
+          params: { groupBy: 'day' },
         },
       });
 


### PR DESCRIPTION
## What

Replaces 5 stale `analysis.params` blocks in `analytics-validation.test.ts` with schema-valid `groupBy`. Removes dead keys: `period`, `includeProjectStats`, `includeTagStats`, `days`, `includeWeekends`, and `groupBy`/`limit` on `overdue_analysis`.

## Why

Surfaced by the **OMN-105** post-cleanup live test. The integration suite was sending legacy analyze params that the `.strict()` `AnalyzeSchema` (OMN-90, landed **2026-05-20**) correctly rejects with `Unrecognized key(s) ... 'period'`. This caused **4 red tests** in `analytics-validation.test.ts`.

**Not a product regression.** Verified against the handlers:
- `productivity_stats` / `task_velocity` read **only** `params.groupBy` (`OmniFocusAnalyzeTool.ts` — `compiled.params?.groupBy ?? …`). `period`/`days`/`includeWeekends`/`includeProjectStats`/`includeTagStats` were **never consumed**.
- `overdue_analysis` schema is `z.object({})` — accepts no params; the test's `groupBy`/`limit` were silently dropped pre-strict.

Before OMN-90's `.strict()`, the schema used passthrough, so these bogus keys were silently swallowed and the tests passed **for the wrong reason**. Tightening the schema didn't break behavior — it exposed tests that weren't testing what they claimed. The strict change predates this ticket by 8 days, so the recent cleanup work could not have caused these failures.

## Verification

`npx vitest tests/integration/validation/analytics-validation.test.ts --run` → **4 passed** (was 4 failed), live against OmniFocus. `tsc` build clean.

## Follow-ups (not in this PR)

- **OMN-117** (filed): due-date 5PM default-time convention isn't in the write tool's `inputSchema`.
- Minor: `overdue_analysis` handler supports `limit` (`limit || 100`) but its `z.object({})` schema blocks it — cosmetic (default already 100). Surface as a decision: expose `limit` or leave it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)