### PR TITLE
fix(OMN-119): close sandbox-guard bypass on batch create operations

### DIFF
--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -355,6 +355,34 @@ async function validateProjectInSandbox(projectId: string, operation: string): P
 }
 
 /**
+ * Guard batch CREATE operations against the sandbox (test mode only). OMN-119.
+ *
+ * The single-create builders (buildCreateTaskScript / buildCreateProjectScript) embed the
+ * sandbox guard, but batch creates run through a separate execution path
+ * (routeToBatch → executeBatchCreatePhase / buildBatchCreateTasksScript) that did NOT —
+ * so a `batch` envelope could create tasks/projects outside the sandbox during test runs
+ * (the OMN-118 real-inbox leak: a model wrapped an unscoped create in a batch). The batch
+ * orchestrator must call this up front so batch creates honor the same guard as single
+ * creates, independent of the fast/slow create path.
+ *
+ * No-op outside test mode. Throws (message prefixed "TEST GUARD") on the first op that
+ * would write outside the sandbox. Update/complete/delete sub-ops are already guarded —
+ * they dispatch through the single-op handlers — so only creates need this.
+ */
+export async function validateBatchCreateOps(
+  createOps: ReadonlyArray<{ operation?: string; target?: MutationTarget; data: TaskCreateData | ProjectCreateData }>,
+): Promise<void> {
+  if (!isTestMode()) return;
+  for (const op of createOps) {
+    if (op.target === 'project') {
+      validateProjectCreate(op.data as ProjectCreateData);
+    } else {
+      await validateTaskCreate(op.data as TaskCreateData);
+    }
+  }
+}
+
+/**
  * Clear all sandbox caches (for testing)
  */
 export function clearSandboxCache(): void {

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -34,6 +34,7 @@ import {
   buildUpdateTaskScript,
   markProjectAsValidated,
   markTaskAsValidated,
+  validateBatchCreateOps,
 } from '../../contracts/ast/mutation-script-builder.js';
 import type {
   ProjectUpdateData,
@@ -1393,6 +1394,36 @@ SAFETY:
 
   // ─── Batch routing ─────────────────────────────────────────────────
 
+  /**
+   * OMN-119: enforce the sandbox guard on batch CREATE sub-ops (no-op outside test mode).
+   * Returns a SANDBOX_GUARD error response if any create would write outside the sandbox,
+   * else null. Extracted from routeToBatch to keep that orchestrator's complexity in check.
+   */
+  private async guardBatchCreates(
+    createOps: Extract<CompiledMutation, { operation: 'batch' }>['operations'],
+    batchTimer: OperationTimerV2,
+  ): Promise<StandardResponseV2<unknown> | null> {
+    try {
+      await validateBatchCreateOps(
+        createOps.map((op) => ({
+          operation: op.operation,
+          target: op.target,
+          data: (op.data ?? {}) as Parameters<typeof validateBatchCreateOps>[0][number]['data'],
+        })),
+      );
+      return null;
+    } catch (guardError) {
+      return createErrorResponseV2(
+        'omnifocus_write',
+        'SANDBOX_GUARD',
+        guardError instanceof Error ? guardError.message : String(guardError),
+        'Batch creates must stay inside the test sandbox (folder/name/tag scoping).',
+        undefined,
+        batchTimer.toMetadata(),
+      );
+    }
+  }
+
   private async routeToBatch(compiled: Extract<CompiledMutation, { operation: 'batch' }>): Promise<unknown> {
     const batchTimer = new OperationTimerV2();
 
@@ -1401,6 +1432,13 @@ SAFETY:
     const updateOps = compiled.operations.filter((op) => op.operation === 'update');
     const completeOps = compiled.operations.filter((op) => op.operation === 'complete');
     const deleteOps = compiled.operations.filter((op) => op.operation === 'delete');
+
+    // OMN-119: batch creates run through a separate execution path that bypassed the
+    // per-builder sandbox guard. Validate create sub-ops up front (no-op outside test mode)
+    // so a `batch` envelope cannot write outside the sandbox. Update/complete/delete sub-ops
+    // dispatch through the already-guarded single-op handlers.
+    const guardError = await this.guardBatchCreates(createOps, batchTimer);
+    if (guardError) return guardError;
 
     const results: {
       created: unknown[];

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   buildCreateTaskScript,
   buildCreateProjectScript,
@@ -10,6 +10,7 @@ import {
   buildBatchScript,
   buildBatchCreateTasksScript,
   buildBulkDeleteScript,
+  validateBatchCreateOps,
   type GeneratedMutationScript,
 } from '../../../../src/contracts/ast/mutation-script-builder.js';
 
@@ -1150,5 +1151,63 @@ describe('buildBatchCreateTasksScript (OMN-113)', () => {
     // The hazardous characters must survive into the script verbatim (data not lost).
     expect(result.script).toContain('parseTagPath');
     expect(result.script).toContain('${total}');
+  });
+});
+
+describe('validateBatchCreateOps (OMN-119: batch creates must honor the sandbox guard)', () => {
+  // The single-create path guards inside buildCreateTaskScript/buildCreateProjectScript,
+  // but batch creates run through a separate path that bypassed it — letting a model emit
+  // a `batch` envelope to write outside the sandbox (the OMN-118 real-inbox leak).
+  // isTestMode() needs NODE_ENV==='test' (set by vitest) AND SANDBOX_GUARD_ENABLED==='true'.
+  let priorGuard: string | undefined;
+  let priorNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    priorGuard = process.env.SANDBOX_GUARD_ENABLED;
+    priorNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+    process.env.SANDBOX_GUARD_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (priorGuard === undefined) delete process.env.SANDBOX_GUARD_ENABLED;
+    else process.env.SANDBOX_GUARD_ENABLED = priorGuard;
+    if (priorNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = priorNodeEnv;
+  });
+
+  it('rejects an unscoped inbox task create (the OMN-118 leak shape)', async () => {
+    await expect(
+      validateBatchCreateOps([{ operation: 'create', target: 'task', data: { name: 'Test LLM Integration' } }]),
+    ).rejects.toThrow(/TEST GUARD/);
+  });
+
+  it('allows a __TEST__-prefixed inbox task create', async () => {
+    await expect(
+      validateBatchCreateOps([{ operation: 'create', target: 'task', data: { name: '__TEST__-run-Probe' } }]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a project create outside the sandbox folder', async () => {
+    await expect(
+      validateBatchCreateOps([
+        { operation: 'create', target: 'project', data: { name: 'Real Project', folder: 'Personal' } },
+      ]),
+    ).rejects.toThrow(/TEST GUARD/);
+  });
+
+  it('rejects inbox tasks with non-__test- tags even when the name is scoped', async () => {
+    await expect(
+      validateBatchCreateOps([
+        { operation: 'create', target: 'task', data: { name: '__TEST__-run-x', tags: ['real-tag'] } },
+      ]),
+    ).rejects.toThrow(/TEST GUARD/);
+  });
+
+  it('is a no-op when the guard is disabled (production)', async () => {
+    delete process.env.SANDBOX_GUARD_ENABLED;
+    await expect(
+      validateBatchCreateOps([{ operation: 'create', target: 'task', data: { name: 'Unscoped Production Task' } }]),
+    ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes **OMN-119**. Fixes the gap that caused the OMN-118 real-inbox leak.

## Problem
The integration-test sandbox guard (`validateTaskCreate`/`validateProjectCreate`) is embedded inside the **single**-create script builders. Batch creates run through a separate path (`routeToBatch` → `executeBatchCreatePhase` → fast `buildBatchCreateTasksScript` / slow `createBatchTask`/`createBatchProject`) that **never invoked it** — so a `batch` envelope could write tasks/projects outside the sandbox during test runs. This is exactly how OMN-118's real-LLM run leaked an unscoped task into the real inbox: `llama3.1:8b` wrapped its create in a batch envelope and it returned SUCCESS.

## Fix — guard at the orchestration chokepoint, not per-builder
- New exported `validateBatchCreateOps(createOps)` in `mutation-script-builder.ts`, reusing the existing guards. No-op outside test mode (`NODE_ENV=test` AND `SANDBOX_GUARD_ENABLED=true`).
- `routeToBatch` calls it up front (via a small `guardBatchCreates` helper), before any create executes, returning a clean `SANDBOX_GUARD` error on violation. This covers **both** the fast and slow create paths in one place (the reviewer traced every batch-create caller — all converge on `routeToBatch`). Update/complete/delete sub-ops were already guarded (they dispatch through the single-op handlers). `previewBatch` (dryRun) doesn't write, so it's correctly left unguarded.

## Verification
- **TDD**: 5 new unit tests on `validateBatchCreateOps` (inbox-prefix reject incl. the exact OMN-118 leak shape; project-folder reject; tag-prefix reject; prod no-op) — red before, green after.
- Full unit suite **2187 passing**; build clean; lint 0 errors.
- **End-to-end MCP probe**: spawned the built server with the guard active and sent the exact OMN-118 leak shape (`batch` wrapping an unscoped inbox create) → `success:false` / `SANDBOX_GUARD` / "TEST GUARD"; real OmniFocus DB confirmed **0 leaked tasks**. The identical call returned SUCCESS (and leaked) before this fix.
- Code-reviewed (subagent) → **SAFE TO MERGE**.

## Notes
- OMN-119's secondary suggestion (set `NODE_ENV=test` in test spawns) is **unnecessary**: vitest sets `NODE_ENV=test` and the bare `spawn` inherits it, so the guard was already active — the batch bypass was the sole cause.
- Review surfaced a **sibling pre-existing gap**: `bulk_delete` of *tasks* is also unguarded (different builder, `delete-tasks-bulk.ts`). Filed as **OMN-120** (lower severity — requires real task IDs already in hand; not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)