### PR TITLE
feat(OMN-121): LLM conformance probe for local-model (Ollama) support evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "diagnose-failures": "npx tsx scripts/diagnose-failures.ts",
     "analyze-tokens": "npx tsx scripts/analyze-token-usage.ts",
     "setup-real-llm": "npx tsx scripts/setup-real-llm-testing.ts",
+    "conformance": "npm run build && npx tsx scripts/llm-conformance-probe.ts",
     "prompts:list": "npx tsx scripts/list-prompts.ts",
     "benchmark": "npm run build && npx tsx scripts/benchmark-performance.ts",
     "ci:local": "./scripts/ci-local.sh"

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -1,0 +1,427 @@
+#!/usr/bin/env tsx
+/**
+ * LLM Conformance Probe — local-model support evaluation (OMN-121)
+ *
+ * Measures how reliably a given Ollama model can drive the unified MCP tools via NATIVE
+ * tool-calling, with NO fallback substitution and NO execution. This is the "support
+ * contract" tool: a model that scores below the bar is below spec, not a server bug.
+ *
+ * Unlike tests/integration/real-llm-integration.test.ts (which has fallback maps that mask
+ * model failures, and is gated/exploratory), this probe grades the model's RAW tool call:
+ *   1. Present the REAL advertised tool schemas (pulled from the running server's
+ *      tools/list) to the model as Ollama tools.
+ *   2. Capture the model's first tool_call.
+ *   3. Grade: did it call a tool? the RIGHT tool? are the arguments schema-valid against
+ *      the server's strict Zod schema? (Pure validation — no tool execution, no OmniFocus,
+ *      no writes.)
+ *
+ * Because grading is schema validation only, the probe is side-effect-free and does not
+ * need OmniFocus running. It reflects exactly what a real MCP client would send the server.
+ *
+ * Usage:
+ *   npx tsx scripts/llm-conformance-probe.ts llama3.1:8b
+ *   npx tsx scripts/llm-conformance-probe.ts llama3.1:8b qwen2.5:7b qwen2.5:3b phi3.5:3.8b
+ *   REAL_LLM_MODEL=llama3.1:8b npx tsx scripts/llm-conformance-probe.ts
+ *   OLLAMA_HOST=http://host:11434 npx tsx scripts/llm-conformance-probe.ts llama3.1:8b > report.md
+ *
+ * Output: a Markdown conformance report to stdout (redirect to a file), progress to stderr.
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import { Ollama, type Tool, type ToolCall } from 'ollama';
+import type { ZodTypeAny } from 'zod';
+import { ReadSchema } from '../src/tools/unified/schemas/read-schema.js';
+import { WriteSchema } from '../src/tools/unified/schemas/write-schema.js';
+import { AnalyzeSchema } from '../src/tools/unified/schemas/analyze-schema.js';
+import { SystemToolSchema } from '../src/tools/system/SystemTool.js';
+
+// ── Grading config ──────────────────────────────────────────────────────────
+
+/** Map each advertised MCP tool to the strict boundary schema the server validates against. */
+const SCHEMA_BY_TOOL: Record<string, ZodTypeAny> = {
+  omnifocus_read: ReadSchema,
+  omnifocus_write: WriteSchema,
+  omnifocus_analyze: AnalyzeSchema,
+  system: SystemToolSchema,
+};
+
+interface ConformanceCase {
+  id: string;
+  prompt: string;
+  /** Tool name(s) that count as a correct selection for this intent. */
+  expect: string[];
+  note: string;
+}
+
+/**
+ * Representative requests across the tool surface. A handful are deliberately
+ * nesting-stressful (status/date filters, count-only, search-by-name, tags on create) —
+ * those are where small models most often malform the envelope.
+ */
+const CASES: ConformanceCase[] = [
+  { id: 'today', prompt: 'What should I work on today?', expect: ['omnifocus_read'], note: 'today perspective' },
+  {
+    id: 'overdue',
+    prompt: 'Show me my overdue tasks.',
+    expect: ['omnifocus_read', 'omnifocus_analyze'],
+    note: 'overdue read or analysis',
+  },
+  { id: 'flagged', prompt: 'List my flagged tasks.', expect: ['omnifocus_read'], note: 'flagged mode/filter' },
+  { id: 'inbox', prompt: 'What is in my inbox?', expect: ['omnifocus_read'], note: 'inbox (project:null)' },
+  { id: 'projects', prompt: 'List all my projects.', expect: ['omnifocus_read'], note: 'type:projects' },
+  { id: 'tags', prompt: 'Show me all my tags.', expect: ['omnifocus_read'], note: 'type:tags' },
+  {
+    id: 'count-active',
+    prompt: 'How many active tasks do I have?',
+    expect: ['omnifocus_read'],
+    note: 'countOnly + status filter',
+  },
+  {
+    id: 'search-name',
+    prompt: 'Find tasks with "invoice" in the name.',
+    expect: ['omnifocus_read'],
+    note: 'filters.name.contains (nesting)',
+  },
+  {
+    id: 'upcoming',
+    prompt: 'What tasks are due in the next 7 days?',
+    expect: ['omnifocus_read'],
+    note: 'upcoming + daysAhead',
+  },
+  {
+    id: 'due-before',
+    prompt: 'Show tasks due before 2026-07-01.',
+    expect: ['omnifocus_read'],
+    note: 'filters.dueDate.before (nesting)',
+  },
+  {
+    id: 'productivity',
+    prompt: 'How productive was I this week?',
+    expect: ['omnifocus_analyze'],
+    note: 'productivity_stats',
+  },
+  {
+    id: 'overdue-analysis',
+    prompt: 'Analyze why my tasks are piling up overdue.',
+    expect: ['omnifocus_analyze'],
+    note: 'overdue_analysis (params:{})',
+  },
+  {
+    id: 'velocity',
+    prompt: 'What is my task completion velocity over time?',
+    expect: ['omnifocus_analyze'],
+    note: 'task_velocity',
+  },
+  {
+    id: 'create-task',
+    prompt: 'Create a task called "Buy milk".',
+    expect: ['omnifocus_write'],
+    note: 'create task (mutation nesting)',
+  },
+  {
+    id: 'create-task-tags',
+    prompt: 'Add a task "Email Bob" tagged work and urgent.',
+    expect: ['omnifocus_write'],
+    note: 'create with tags array',
+  },
+  {
+    id: 'create-project',
+    prompt: 'Create a new project named "Home Renovation".',
+    expect: ['omnifocus_write'],
+    note: 'create target:project',
+  },
+  {
+    id: 'complete',
+    prompt: 'Mark task with id abc123 as complete.',
+    expect: ['omnifocus_write'],
+    note: 'complete + id',
+  },
+  {
+    id: 'flag-update',
+    prompt: 'Flag the task with id xyz789.',
+    expect: ['omnifocus_write'],
+    note: 'update changes.flagged',
+  },
+  {
+    id: 'version',
+    prompt: 'What version of the OmniFocus server is running?',
+    expect: ['system'],
+    note: 'system version',
+  },
+];
+
+// ── MCP server (tools/list only — no execution) ─────────────────────────────
+
+interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+class McpServer {
+  private proc: ChildProcess;
+  private buf = '';
+  private nextId = 1;
+  private pending = new Map<number, (msg: Record<string, unknown>) => void>();
+
+  constructor() {
+    this.proc = spawn('node', ['dist/index.js'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.proc.stdout?.on('data', (d: Buffer) => {
+      this.buf += d.toString();
+      const lines = this.buf.split('\n');
+      this.buf = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim().startsWith('{')) continue;
+        try {
+          const msg = JSON.parse(line) as { id?: number };
+          if (typeof msg.id === 'number' && this.pending.has(msg.id)) {
+            this.pending.get(msg.id)!(msg as Record<string, unknown>);
+            this.pending.delete(msg.id);
+          }
+        } catch {
+          /* not a complete JSON line yet */
+        }
+      }
+    });
+  }
+
+  private send(method: string, params?: unknown): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      const timer = setTimeout(() => reject(new Error(`MCP ${method} timed out`)), 30000);
+      this.pending.set(id, (msg) => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+      this.proc.stdin?.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    });
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    await this.send('initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'conformance-probe', version: '1.0.0' },
+    });
+    const res = await this.send('tools/list');
+    const result = res.result as { tools: McpTool[] };
+    return result.tools;
+  }
+
+  stop(): void {
+    this.proc.kill();
+  }
+}
+
+// ── Grading ─────────────────────────────────────────────────────────────────
+
+type Outcome = 'pass' | 'no_tool_call' | 'wrong_tool' | 'schema_invalid' | 'model_error';
+
+interface CaseResult {
+  caseId: string;
+  outcome: Outcome;
+  toolCalled?: string;
+  /** Top Zod issues (path + message) when schema_invalid. */
+  issues?: string[];
+  detail?: string;
+}
+
+function gradeToolCall(c: ConformanceCase, call: ToolCall | undefined): CaseResult {
+  if (!call) return { caseId: c.id, outcome: 'no_tool_call' };
+  const name = call.function.name;
+  if (!c.expect.includes(name)) {
+    return { caseId: c.id, outcome: 'wrong_tool', toolCalled: name };
+  }
+  const schema = SCHEMA_BY_TOOL[name];
+  if (!schema) return { caseId: c.id, outcome: 'wrong_tool', toolCalled: name, detail: 'no schema registered' };
+
+  // Ollama returns arguments as a parsed object; tolerate a stringified payload too.
+  let args: unknown = call.function.arguments;
+  if (typeof args === 'string') {
+    try {
+      args = JSON.parse(args);
+    } catch {
+      return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues: ['arguments not valid JSON'] };
+    }
+  }
+  const parsed = schema.safeParse(args);
+  if (parsed.success) return { caseId: c.id, outcome: 'pass', toolCalled: name };
+  const issues = parsed.error.issues.slice(0, 4).map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
+  return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues };
+}
+
+// ── Per-model run ────────────────────────────────────────────────────────────
+
+interface ModelReport {
+  model: string;
+  available: boolean;
+  results: CaseResult[];
+  error?: string;
+}
+
+async function probeModel(ollama: Ollama, model: string, tools: Tool[]): Promise<ModelReport> {
+  const results: CaseResult[] = [];
+  for (const c of CASES) {
+    process.stderr.write(`  [${model}] ${c.id} … `);
+    try {
+      const res = await ollama.chat({
+        model,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are an OmniFocus assistant. Use the provided tools to fulfill the request. ' +
+              'Call exactly one tool with correctly structured arguments.',
+          },
+          { role: 'user', content: c.prompt },
+        ],
+        tools,
+        stream: false,
+        options: { temperature: 0 },
+      });
+      const call = res.message.tool_calls?.[0];
+      const graded = gradeToolCall(c, call);
+      results.push(graded);
+      process.stderr.write(`${graded.outcome}${graded.toolCalled ? ` (${graded.toolCalled})` : ''}\n`);
+    } catch (err) {
+      results.push({ caseId: c.id, outcome: 'model_error', detail: String(err) });
+      process.stderr.write('model_error\n');
+    }
+  }
+  return { model, available: true, results };
+}
+
+// ── Reporting ────────────────────────────────────────────────────────────────
+
+function pct(n: number, d: number): string {
+  return d === 0 ? '0%' : `${Math.round((100 * n) / d)}%`;
+}
+
+function renderReport(reports: ModelReport[]): string {
+  const lines: string[] = [];
+  lines.push('# LLM Conformance Probe Report');
+  lines.push('');
+  lines.push(`Cases: ${CASES.length}. Native tool-calling, strict-schema grading, no fallback, no execution.`);
+  lines.push('A "pass" = the model called the expected tool AND its arguments passed the server\'s strict Zod schema.');
+  lines.push('');
+  lines.push(
+    "> Caveat: each case is a **single sample** (n=1), graded on the model's **first** tool_call, " +
+      'from **one run** at temperature 0 (near-greedy, not bit-reproducible). Treat each percentage as a ' +
+      'point estimate, not a stable benchmark — a model near a schema-validity boundary can flip a case ' +
+      'between runs. Re-run to gauge variance before quoting a number.',
+  );
+  lines.push('');
+
+  // Summary table
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Model | Pass | Wrong tool | Schema invalid | No tool call | Errors | Score |');
+  lines.push('|-------|------|-----------|----------------|--------------|--------|-------|');
+  for (const r of reports) {
+    if (!r.available) {
+      lines.push(`| ${r.model} | — | — | — | — | — | UNAVAILABLE (${r.error ?? ''}) |`);
+      continue;
+    }
+    const tally = (o: Outcome) => r.results.filter((x) => x.outcome === o).length;
+    const pass = tally('pass');
+    lines.push(
+      `| ${r.model} | ${pass} | ${tally('wrong_tool')} | ${tally('schema_invalid')} | ${tally('no_tool_call')} | ${tally('model_error')} | **${pct(pass, CASES.length)}** |`,
+    );
+  }
+  lines.push('');
+
+  // Per-model detail
+  for (const r of reports) {
+    if (!r.available) continue;
+    lines.push(`## ${r.model} — per-case`);
+    lines.push('');
+    lines.push('| Case | Outcome | Tool called | Detail |');
+    lines.push('|------|---------|-------------|--------|');
+    for (const res of r.results) {
+      const detail = res.issues ? res.issues.join('; ') : (res.detail ?? '');
+      const toolCell = (res.toolCalled ?? '—').replace(/\|/g, '\\|');
+      lines.push(`| ${res.caseId} | ${res.outcome} | ${toolCell} | ${detail.replace(/\|/g, '\\|')} |`);
+    }
+    lines.push('');
+
+    // Aggregate the malformation patterns — the signal for whether a normalize-then-strict
+    // layer is worth building, and which leniencies would be load-bearing.
+    const schemaIssues = r.results.filter((x) => x.outcome === 'schema_invalid').flatMap((x) => x.issues ?? []);
+    if (schemaIssues.length) {
+      const counts = new Map<string, number>();
+      for (const i of schemaIssues) counts.set(i, (counts.get(i) ?? 0) + 1);
+      lines.push(`### ${r.model} — top schema-invalid patterns`);
+      lines.push('');
+      for (const [issue, n] of [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8)) {
+        lines.push(`- (${n}×) ${issue}`);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const models = process.argv.slice(2).filter((a) => !a.startsWith('-'));
+  if (models.length === 0 && process.env.REAL_LLM_MODEL) models.push(process.env.REAL_LLM_MODEL);
+  if (models.length === 0) {
+    process.stderr.write(
+      'Usage: npx tsx scripts/llm-conformance-probe.ts <model> [model ...]\n' +
+        '       (or set REAL_LLM_MODEL). Requires `npm run build` first and a running Ollama.\n',
+    );
+    process.exit(2);
+  }
+
+  const ollama = new Ollama({ host: process.env.OLLAMA_HOST || 'http://localhost:11434' });
+
+  // Confirm Ollama is up and which requested models are present.
+  let installed: Set<string>;
+  try {
+    const list = await ollama.list();
+    installed = new Set(list.models.map((m) => m.name));
+  } catch (err) {
+    process.stderr.write(`Ollama not reachable: ${String(err)}. Start it with \`ollama serve\`.\n`);
+    process.exit(2);
+  }
+
+  process.stderr.write('Starting MCP server for tools/list …\n');
+  const server = new McpServer();
+  let tools: Tool[];
+  try {
+    // Brief settle for the spawned server before the first request.
+    await new Promise((r) => setTimeout(r, 1500));
+    const mcpTools = await server.listTools();
+    tools = mcpTools.map((t) => ({
+      type: 'function',
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema as Tool['function']['parameters'],
+      },
+    }));
+    process.stderr.write(`Advertised tools: ${mcpTools.map((t) => t.name).join(', ')}\n`);
+  } finally {
+    server.stop();
+  }
+
+  const reports: ModelReport[] = [];
+  for (const model of models) {
+    if (!installed.has(model)) {
+      process.stderr.write(`! ${model} not installed (ollama pull ${model}) — skipping\n`);
+      reports.push({ model, available: false, results: [], error: 'not installed' });
+      continue;
+    }
+    process.stderr.write(`Probing ${model} …\n`);
+    reports.push(await probeModel(ollama, model, tools));
+  }
+
+  process.stdout.write(renderReport(reports) + '\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${String(err)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a conformance probe to evaluate whether a local Ollama model can reliably drive the unified MCP tools — the tool that turns "should we support local models for privacy-sensitive users?" from a judgment call into a **data** call, and provides a published support *contract* (run the probe; below-bar models are below spec, not a server bug).

## What it does
`scripts/llm-conformance-probe.ts` (`npm run conformance -- <model> [model ...]`):
- Presents the **real advertised tool schemas** (pulled from the running server's `tools/list`) to the model as Ollama tools, and uses **native tool-calling** (how a real MCP client works — not the regex/prose hack in the integration suite).
- Grades the model's raw first `tool_call` against the server's **strict Zod boundary schemas** (`ReadSchema`/`WriteSchema`/`AnalyzeSchema`/`SystemToolSchema`) — **no fallback substitution, no execution**. Side-effect-free; does not need OmniFocus running.
- Aggregates per-model malformation patterns — the signal for whether an evidence-driven `normalize-then-strict` leniency layer is worth building, and which leniencies are load-bearing.

The code reviewer verified the grading is a **1:1 faithful representation** of the real server boundary (same schemas the server validates against, same envelope the wire carries; reuse of the literal schema objects eliminates drift). Report carries an explicit n=1 / first-call-only / single-run caveat so the percentages aren't read as stable benchmarks.

## Baseline (llama3.1:8b, 19 cases): 74%
- Tool selection 100% correct; all 10 nested READ cases pass.
- The 5 failures are **two systematic, normalizable patterns**: analyze drops the `{analysis}` wrapper (`{type:...}` at root); write update/complete use the create `data` key instead of `id`/`changes`. → a small normalization layer could plausibly take 7-8B models to ~100% without loosening `.strict()` for capable clients.

## Verification
- `tsc --noEmit` clean; eslint 0 errors; **ran end-to-end** against llama3.1:8b (report above).
- Code-reviewed → **SAFE TO MERGE** (grading faithfulness confirmed; the two notes were reporting-honesty, now addressed via the caveat).

Tracking + decision in **OMN-121**. Next: run across a model range (<7B/7B/13B/30B/70B) to build the initial conformance list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)