### PR TITLE
feat(OMN-122): normalize-then-strict input layer for 7-8B local models

### DIFF
--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -34,6 +34,7 @@ import { ReadSchema } from '../src/tools/unified/schemas/read-schema.js';
 import { WriteSchema } from '../src/tools/unified/schemas/write-schema.js';
 import { AnalyzeSchema } from '../src/tools/unified/schemas/analyze-schema.js';
 import { SystemToolSchema } from '../src/tools/system/SystemTool.js';
+import { parseWithNormalization } from '../src/tools/normalization/normalize-input.js';
 
 // ── Grading config ──────────────────────────────────────────────────────────
 
@@ -223,6 +224,8 @@ interface CaseResult {
   toolCalled?: string;
   /** Top Zod issues (path + message) when schema_invalid. */
   issues?: string[];
+  /** OMN-122: leniencies the normalize-then-strict layer applied to make this pass. */
+  normalizedVia?: string[];
   detail?: string;
 }
 
@@ -244,9 +247,19 @@ function gradeToolCall(c: ConformanceCase, call: ToolCall | undefined): CaseResu
       return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues: ['arguments not valid JSON'] };
     }
   }
-  const parsed = schema.safeParse(args);
-  if (parsed.success) return { caseId: c.id, outcome: 'pass', toolCalled: name };
-  const issues = parsed.error.issues.slice(0, 4).map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
+  // OMN-122: grade against the server's REAL front door — strict schema first, then
+  // the normalize-then-strict layer. A pass that needed normalization is still a pass
+  // (the server would accept it), and we record which leniencies were load-bearing.
+  const result = parseWithNormalization(schema, args, name);
+  if (result.success) {
+    return {
+      caseId: c.id,
+      outcome: 'pass',
+      toolCalled: name,
+      normalizedVia: result.applied.length ? result.applied : undefined,
+    };
+  }
+  const issues = result.error!.issues.slice(0, 4).map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
   return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues };
 }
 
@@ -315,17 +328,18 @@ function renderReport(reports: ModelReport[]): string {
   // Summary table
   lines.push('## Summary');
   lines.push('');
-  lines.push('| Model | Pass | Wrong tool | Schema invalid | No tool call | Errors | Score |');
-  lines.push('|-------|------|-----------|----------------|--------------|--------|-------|');
+  lines.push('| Model | Pass | (of which normalized) | Wrong tool | Schema invalid | No tool call | Errors | Score |');
+  lines.push('|-------|------|----------------------|-----------|----------------|--------------|--------|-------|');
   for (const r of reports) {
     if (!r.available) {
-      lines.push(`| ${r.model} | — | — | — | — | — | UNAVAILABLE (${r.error ?? ''}) |`);
+      lines.push(`| ${r.model} | — | — | — | — | — | — | UNAVAILABLE (${r.error ?? ''}) |`);
       continue;
     }
     const tally = (o: Outcome) => r.results.filter((x) => x.outcome === o).length;
     const pass = tally('pass');
+    const normalized = r.results.filter((x) => x.outcome === 'pass' && x.normalizedVia).length;
     lines.push(
-      `| ${r.model} | ${pass} | ${tally('wrong_tool')} | ${tally('schema_invalid')} | ${tally('no_tool_call')} | ${tally('model_error')} | **${pct(pass, CASES.length)}** |`,
+      `| ${r.model} | ${pass} | ${normalized} | ${tally('wrong_tool')} | ${tally('schema_invalid')} | ${tally('no_tool_call')} | ${tally('model_error')} | **${pct(pass, CASES.length)}** |`,
     );
   }
   lines.push('');
@@ -338,11 +352,28 @@ function renderReport(reports: ModelReport[]): string {
     lines.push('| Case | Outcome | Tool called | Detail |');
     lines.push('|------|---------|-------------|--------|');
     for (const res of r.results) {
-      const detail = res.issues ? res.issues.join('; ') : (res.detail ?? '');
+      const detail = res.normalizedVia
+        ? `normalized via: ${res.normalizedVia.join(', ')}`
+        : res.issues
+          ? res.issues.join('; ')
+          : (res.detail ?? '');
       const toolCell = (res.toolCalled ?? '—').replace(/\|/g, '\\|');
       lines.push(`| ${res.caseId} | ${res.outcome} | ${toolCell} | ${detail.replace(/\|/g, '\\|')} |`);
     }
     lines.push('');
+
+    // OMN-122: which leniencies were load-bearing for this model (audit signal).
+    const normVia = r.results.filter((x) => x.normalizedVia).flatMap((x) => x.normalizedVia ?? []);
+    if (normVia.length) {
+      const counts = new Map<string, number>();
+      for (const n of normVia) counts.set(n, (counts.get(n) ?? 0) + 1);
+      lines.push(`### ${r.model} — normalizations applied (OMN-122)`);
+      lines.push('');
+      for (const [name, n] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
+        lines.push(`- (${n}×) ${name}`);
+      }
+      lines.push('');
+    }
 
     // Aggregate the malformation patterns — the signal for whether a normalize-then-strict
     // layer is worth building, and which leniencies would be load-bearing.

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -20,6 +20,7 @@ import { homedir } from 'os';
 import { ScriptResult, createScriptSuccess, createScriptError } from '../omnifocus/script-result-types.js';
 import { CircuitBreaker } from '../utils/circuit-breaker.js';
 import { classifyErrorWithContext } from '../utils/error-recovery.js';
+import { parseWithNormalization } from './normalization/normalize-input.js';
 
 // Type for raw data structure from OmniFocus scripts (used in execJson)
 interface RawOmniFocusData {
@@ -225,7 +226,19 @@ export abstract class BaseTool<TSchema extends z.ZodType = z.ZodType, TResponse 
     const parameterCount = typeof args === 'object' && args !== null ? Object.keys(args).length : 0;
 
     try {
-      const validated = this.schema.parse(args) as z.infer<TSchema>;
+      // OMN-122: strict-first, normalize-on-failure, re-validate-strict. Canonical
+      // (cloud/frontier) callers pass `this.schema` on the first try and never touch
+      // the normalizer — zero behavior change. Only inputs that would have errored
+      // anyway get a bounded repair attempt; an un-repairable input throws the SAME
+      // strict ZodError as before (handled below as a VALIDATION_ERROR).
+      const parseResult = parseWithNormalization(this.schema, args, this.name);
+      if (!parseResult.success) {
+        throw parseResult.error;
+      }
+      const validated = parseResult.data as z.infer<TSchema>;
+      if (parseResult.applied.length > 0) {
+        this.logNormalization(args, parseResult.applied);
+      }
       this.logger.debug(`Executing ${this.name} with validated args:`, validated);
 
       const result = await this.executeValidated(validated);
@@ -364,6 +377,38 @@ export abstract class BaseTool<TSchema extends z.ZodType = z.ZodType, TResponse 
     } catch (logError) {
       // Don't let logging failures break the tool
       this.logger.error('Failed to log tool failure:', logError);
+    }
+  }
+
+  /**
+   * OMN-122: record an applied input normalization so we can audit which leniencies
+   * are load-bearing and catch regressions. Reuses the failure-log suppression gate
+   * and diagnostics directory (sibling to the tool-failures log) so the diagnose-
+   * failures pipeline can read both. Logging never throws into the tool path.
+   */
+  private logNormalization(args: unknown, applied: string[]): void {
+    // Always emit a structured breadcrumb (visible at default LOG_LEVEL=info).
+    this.logger.info(`input normalized tool=${this.name} applied=[${applied.join(', ')}]`);
+    try {
+      const suppression = failureLogSuppression();
+      if (suppression.suppressed) {
+        return;
+      }
+      const logsDir = join(homedir(), '.omnifocus-mcp', 'tool-failures');
+      if (!existsSync(logsDir)) {
+        mkdirSync(logsDir, { recursive: true });
+      }
+      const logEntry = {
+        timestamp: new Date().toISOString(),
+        tool: this.name,
+        applied,
+        inputArgs: redactArgs(args),
+      };
+      const today = new Date().toISOString().split('T')[0];
+      const logFile = join(logsDir, `normalizations-${today}.jsonl`);
+      writeFileSync(logFile, JSON.stringify(logEntry) + '\n', { flag: 'a' });
+    } catch (logError) {
+      this.logger.debug('Failed to log normalization:', logError);
     }
   }
 

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod';
+
+/**
+ * OMN-122: normalize-then-strict input layer for local-model (7-8B Ollama) support.
+ *
+ * Capable/cloud models already emit the canonical envelope and never touch this code:
+ * `parseWithNormalization` tries the existing STRICT schema first, and only on a
+ * ZodError does it attempt a bounded, evidence-backed repair (the leniencies below)
+ * before re-validating against the SAME strict schema. An input that can't be repaired
+ * returns the ORIGINAL strict error — unchanged behavior for everyone.
+ *
+ * Every leniency here is justified by the OMN-121 conformance matrix (6 models, 19
+ * cases): tool *selection* was 100% correct across all models; the entire gap is
+ * request-ENVELOPE shape. See OMN-122 for the prioritized list and projected lift.
+ */
+
+/** Per-tool wrapper shape the normalizer needs to lift root-level fields correctly. */
+export interface NormalizationHint {
+  /** The canonical wrapper key the inner payload belongs under. */
+  wrapperKey: 'query' | 'analysis' | 'mutation';
+  /** The discriminant field that identifies the inner payload at the root. */
+  discriminant: 'type' | 'operation';
+}
+
+/**
+ * Single source of truth mapping advertised tool name → wrapper hint. Consumed by
+ * both `BaseTool.execute` (the server front door) and the conformance probe's grader,
+ * so the probe measures exactly what the server accepts. Tools absent from this map
+ * (e.g. `system`, which is flat) get strict-only behavior with zero normalization.
+ */
+export const WRAPPER_HINTS: Record<string, NormalizationHint> = {
+  omnifocus_read: { wrapperKey: 'query', discriminant: 'type' },
+  omnifocus_analyze: { wrapperKey: 'analysis', discriminant: 'type' },
+  omnifocus_write: { wrapperKey: 'mutation', discriminant: 'operation' },
+};
+
+export interface NormalizeResult<T> {
+  success: boolean;
+  /** Present when success — the strict-validated (and possibly transformed) payload. */
+  data?: T;
+  /** Present when !success — the ORIGINAL strict error (pre-normalization). */
+  error?: z.ZodError;
+  /** Names of the leniencies applied. Empty on the canonical path and on failure. */
+  applied: string[];
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Best-effort parse of a string a model intended as a JSON object. Tries strict
+ * JSON.parse first; on failure, repairs the dominant local-model malformation —
+ * TRUNCATED JSON with missing trailing closers (the 70b's signature, OMN-121) — by
+ * balancing unclosed `{`/`[` (respecting string literals + escapes) and retrying.
+ * Returns undefined if it still can't parse OR doesn't parse to a plain object, so an
+ * unrelated string (or a JSON scalar/array) is never coerced into a wrapper value.
+ */
+function tryParseObjectString(s: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(s);
+    return isPlainObject(parsed) ? parsed : undefined;
+  } catch {
+    /* fall through to repair */
+  }
+
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (const ch of s) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') stack.push('}');
+    else if (ch === '[') stack.push(']');
+    else if (ch === '}' || ch === ']') stack.pop();
+  }
+  if (stack.length === 0) return undefined; // not a truncation we can repair
+
+  const repaired = s + [...stack].reverse().join('');
+  try {
+    const parsed: unknown = JSON.parse(repaired);
+    return isPlainObject(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pure, side-effect-free transform: apply the bounded leniencies to `args`.
+ * Returns the rewritten args plus the names of the leniencies applied (empty if
+ * nothing was recognized as repairable).
+ */
+function normalizeArgs(args: unknown, hint: NormalizationHint): { args: unknown; applied: string[] } {
+  const applied: string[] = [];
+  let current = args;
+
+  // ── Leniency #2: stringified-wrapper repair-parse ──────────────────────────
+  // The wrapper value arrived as a JSON string, often TRUNCATED (missing trailing
+  // closers) so coerceObject's strict JSON.parse rejected it. Repair-parse it back
+  // to an object. (Well-formed JSON strings already pass via coerceObject and never
+  // reach here.) Runs first so #1/#3 see a real object.
+  if (isPlainObject(current) && typeof current[hint.wrapperKey] === 'string') {
+    const parsed = tryParseObjectString(current[hint.wrapperKey] as string);
+    if (parsed !== undefined) {
+      current = { ...current, [hint.wrapperKey]: parsed };
+      applied.push('stringified-wrapper-repair');
+    }
+  }
+
+  // ── Leniency #1: wrapper-lift ──────────────────────────────────────────────
+  // The model emitted the inner payload at the root, missing the wrapper key but
+  // carrying the discriminant (e.g. `{type:'tasks'}` → `{query:{type:'tasks'}}`).
+  if (isPlainObject(current) && !(hint.wrapperKey in current) && hint.discriminant in current) {
+    current = { [hint.wrapperKey]: { ...current } };
+    applied.push('wrapper-lift');
+  }
+
+  // ── Leniency #3: data-hoist on non-create mutations ────────────────────────
+  // Small models nest `id` inside `data` on complete/update/delete (the create
+  // shape) instead of placing it at the mutation level. Hoist `id` out of `data`;
+  // for update, map any remaining `data` fields → `changes`; for complete/delete,
+  // drop the emptied `data` (those operations don't carry it).
+  if (hint.wrapperKey === 'mutation' && isPlainObject(current) && isPlainObject(current.mutation)) {
+    const m = current.mutation;
+    const op = m.operation;
+    if (
+      (op === 'complete' || op === 'update' || op === 'delete') &&
+      m.id === undefined &&
+      isPlainObject(m.data) &&
+      typeof m.data.id === 'string'
+    ) {
+      const data = { ...m.data };
+      const id = data.id as string;
+      delete data.id;
+      const newMutation: Record<string, unknown> = { ...m, id };
+      delete newMutation.data;
+      // Don't silently drop residual fields the model nested in `data` (OMN-97
+      // anti-pattern). update: remaining → `changes` (the canonical field name).
+      // complete: remaining (e.g. completionDate) are top-level fields, spread them
+      // up. delete: takes no other fields, so leftovers are dropped — strict
+      // re-validation would reject them anyway, leaving the original error intact.
+      if (Object.keys(data).length > 0) {
+        if (op === 'update') {
+          newMutation.changes = data;
+        } else if (op === 'complete') {
+          Object.assign(newMutation, data);
+        }
+      }
+      current = { ...current, mutation: newMutation };
+      applied.push('data-hoist-id');
+    }
+  }
+
+  return { args: current, applied };
+}
+
+/**
+ * Strict-first, normalize-on-failure, re-validate-strict.
+ *
+ * 1. Try the strict schema. On success → return untouched (`applied: []`).
+ * 2. On ZodError, if the tool has a wrapper hint, attempt normalization.
+ * 3. Re-run the SAME strict schema on the normalized args. On success → return it
+ *    with the applied leniencies recorded. On failure → return the ORIGINAL error.
+ */
+export function parseWithNormalization<S extends z.ZodTypeAny>(
+  schema: S,
+  args: unknown,
+  toolName: string,
+): NormalizeResult<z.infer<S>> {
+  const first = schema.safeParse(args);
+  if (first.success) {
+    return { success: true, data: first.data as z.infer<S>, applied: [] };
+  }
+
+  const hint = WRAPPER_HINTS[toolName];
+  if (!hint) {
+    return { success: false, error: first.error, applied: [] };
+  }
+
+  const { args: normalized, applied } = normalizeArgs(args, hint);
+  if (applied.length === 0) {
+    return { success: false, error: first.error, applied: [] };
+  }
+
+  const second = schema.safeParse(normalized);
+  if (second.success) {
+    return { success: true, data: second.data as z.infer<S>, applied };
+  }
+
+  // Normalization didn't help → preserve the ORIGINAL strict error (unchanged behavior).
+  return { success: false, error: first.error, applied: [] };
+}

--- a/tests/unit/tools/normalization/base-normalization.test.ts
+++ b/tests/unit/tools/normalization/base-normalization.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { BaseTool } from '../../../../src/tools/base';
+import { CacheManager } from '../../../../src/cache/CacheManager';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { ReadSchema } from '../../../../src/tools/unified/schemas/read-schema';
+
+vi.mock('../../../../src/omnifocus/OmniAutomation');
+vi.mock('../../../../src/cache/CacheManager');
+
+// A tool whose name carries a wrapper hint (omnifocus_read) so the normalize-then-strict
+// front door is exercised end-to-end. executeValidated echoes the validated args so we can
+// assert what the strict schema produced.
+class ReadEchoTool extends BaseTool<typeof ReadSchema> {
+  name = 'omnifocus_read';
+  description = 'echo read tool';
+  meta = undefined;
+  schema = ReadSchema;
+  override get inputSchema(): Record<string, unknown> {
+    return { type: 'object', properties: { query: { type: 'object' } }, required: ['query'] };
+  }
+  protected async executeValidated(args: z.infer<typeof ReadSchema>): Promise<unknown> {
+    return { echoed: args };
+  }
+}
+
+describe('BaseTool.execute — normalize-then-strict (OMN-122)', () => {
+  let tool: ReadEchoTool;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tool = new ReadEchoTool(new CacheManager());
+  });
+
+  it('canonical input passes through and is NOT normalized', async () => {
+    const result = (await tool.execute({ query: { type: 'tasks' } })) as { echoed: unknown };
+    expect(result.echoed).toEqual({ query: { type: 'tasks' } });
+  });
+
+  it('lifts a root-level wrapper-less envelope and executes successfully', async () => {
+    // Model emitted {type:'tasks'} at root instead of {query:{type:'tasks'}}.
+    const result = (await tool.execute({ type: 'tasks', mode: 'flagged' })) as { echoed: { query: unknown } };
+    expect(result.echoed.query).toMatchObject({ type: 'tasks', mode: 'flagged' });
+  });
+
+  it('logs the applied normalization (auditable) when it repairs input', async () => {
+    const infoSpy = vi.spyOn(tool['logger'], 'info');
+    await tool.execute({ type: 'tasks' });
+    const logged = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(logged).toMatch(/normaliz/i);
+    expect(logged).toMatch(/wrapper-lift/);
+  });
+
+  it('un-normalizable input throws the SAME McpError as strict validation', async () => {
+    // No discriminant, no wrapper → nothing to repair → original strict error.
+    await expect(tool.execute({ limit: 10 })).rejects.toBeInstanceOf(McpError);
+  });
+});

--- a/tests/unit/tools/normalization/normalize-input.test.ts
+++ b/tests/unit/tools/normalization/normalize-input.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { ReadSchema } from '../../../../src/tools/unified/schemas/read-schema';
+import { WriteSchema } from '../../../../src/tools/unified/schemas/write-schema';
+import { AnalyzeSchema } from '../../../../src/tools/unified/schemas/analyze-schema';
+import { parseWithNormalization } from '../../../../src/tools/normalization/normalize-input';
+
+// OMN-122: normalize-then-strict input layer.
+// Invariants asserted across every leniency (the TDD contract from the ticket):
+//   1. malformed-in  → canonical-out (normalization applied, strict re-validate passes)
+//   2. canonical-in  → untouched     (strict passes first try, `applied` empty)
+//   3. un-normalizable → ORIGINAL strict error preserved (byte-for-byte behavior)
+
+describe('parseWithNormalization — invariants', () => {
+  it('canonical read input passes untouched (no normalization applied)', () => {
+    const r = parseWithNormalization(ReadSchema, { query: { type: 'tasks' } }, 'omnifocus_read');
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('canonical write input passes untouched (no normalization applied)', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'create', target: 'task', data: { name: 'Buy milk' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('un-normalizable input preserves the ORIGINAL strict ZodError', () => {
+    // A genuinely invalid read: unknown discriminant value, nothing the normalizer can repair.
+    const args = { query: { type: 'not_a_real_type' } };
+    const original = ReadSchema.safeParse(args);
+    expect(original.success).toBe(false);
+
+    const r = parseWithNormalization(ReadSchema, args, 'omnifocus_read');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+    // Same error issues as a plain strict parse — unchanged behavior.
+    expect(r.error).toBeInstanceOf(z.ZodError);
+    expect(JSON.stringify(r.error!.issues)).toBe(JSON.stringify((original as z.SafeParseError<unknown>).error.issues));
+  });
+
+  it('unknown tool name (no wrapper hint) returns the original strict error, no normalization', () => {
+    const args = { operation: 'create' };
+    const r = parseWithNormalization(WriteSchema, args, 'system');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+});
+
+describe('leniency #1 — wrapper-lift (malformed-in → canonical-out)', () => {
+  it('read: lifts root-level {type:"tasks"} into {query:{...}}', () => {
+    const r = parseWithNormalization(ReadSchema, { type: 'tasks' }, 'omnifocus_read');
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('wrapper-lift');
+    expect(r.data).toEqual({ query: { type: 'tasks' } });
+  });
+
+  it('read: lifts root-level query fields alongside the discriminant', () => {
+    const r = parseWithNormalization(ReadSchema, { type: 'tasks', mode: 'flagged', limit: 10 }, 'omnifocus_read');
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('wrapper-lift');
+    expect(r.data).toMatchObject({ query: { type: 'tasks', mode: 'flagged', limit: 10 } });
+  });
+
+  it('analyze: lifts root-level {type:"productivity_stats"} into {analysis:{...}}', () => {
+    const r = parseWithNormalization(AnalyzeSchema, { type: 'productivity_stats' }, 'omnifocus_analyze');
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('wrapper-lift');
+    expect(r.data).toEqual({ analysis: { type: 'productivity_stats' } });
+  });
+
+  it('write: lifts root-level create {operation,target,data} into {mutation:{...}}', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { operation: 'create', target: 'task', data: { name: 'Buy milk' } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('wrapper-lift');
+    expect(r.data).toMatchObject({ mutation: { operation: 'create', target: 'task', data: { name: 'Buy milk' } } });
+  });
+
+  it('does NOT lift when the wrapper key is already present (canonical wins)', () => {
+    const r = parseWithNormalization(ReadSchema, { query: { type: 'tasks' } }, 'omnifocus_read');
+    expect(r.applied).toEqual([]);
+  });
+
+  it('does NOT lift when the discriminant is absent (nothing to recognize)', () => {
+    // No `type` and no `query` → not a recognizable inner shape; original error preserved.
+    const r = parseWithNormalization(ReadSchema, { limit: 10 }, 'omnifocus_read');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+});
+
+describe('leniency #2 — stringified-wrapper repair-parse (malformed-in → canonical-out)', () => {
+  // The 70b's signature (OMN-121): the wrapper value is a JSON string, often TRUNCATED
+  // (missing trailing closing braces) so coerceObject's strict JSON.parse rejects it.
+  it('parses a well-formed stringified mutation wrapper', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: '{"operation":"create","target":"task","data":{"name":"Buy milk"}}' },
+      'omnifocus_write',
+    );
+    // coerceObject already handles valid JSON at the wrapper — passes WITHOUT our layer.
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('repairs a TRUNCATED stringified mutation (missing closing brace) — real 70b shape', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: '{"operation": "create", "target": "task", "data": {"name": "Buy milk"}' },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('stringified-wrapper-repair');
+    expect(r.data).toMatchObject({ mutation: { operation: 'create', target: 'task', data: { name: 'Buy milk' } } });
+  });
+
+  it('repairs a truncated stringified query wrapper (read)', () => {
+    const r = parseWithNormalization(
+      ReadSchema,
+      { query: '{"type": "tasks", "filters": {"project": null}' },
+      'omnifocus_read',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('stringified-wrapper-repair');
+    expect(r.data).toMatchObject({ query: { type: 'tasks', filters: { project: null } } });
+  });
+
+  it('does NOT misrepair an unrelated string → original strict error preserved', () => {
+    const r = parseWithNormalization(WriteSchema, { mutation: 'not json at all' }, 'omnifocus_write');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+});
+
+describe('leniency #3 — data-hoist on non-create mutations (malformed-in → canonical-out)', () => {
+  // The 8b's signature (OMN-121): `id` nested inside `data` on complete/update/delete.
+  it('hoists id out of data on complete — real 8b shape', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'complete', target: 'task', data: { id: 'abc123' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('data-hoist-id');
+    expect(r.data).toMatchObject({ mutation: { operation: 'complete', target: 'task', id: 'abc123' } });
+  });
+
+  it('hoists id and maps remaining data→changes on update', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'update', target: 'task', data: { id: 'xyz', flagged: true } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('data-hoist-id');
+    expect(r.data).toMatchObject({ mutation: { operation: 'update', id: 'xyz', changes: { flagged: true } } });
+  });
+
+  it('preserves a sibling completionDate when hoisting id out of data on complete (no silent drop)', () => {
+    // Double-malformation: id AND a schema-valid completionDate both nested in data.
+    // The hoist must not silently drop completionDate (OMN-97 anti-pattern).
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'complete', target: 'task', data: { id: 'abc', completionDate: '2026-06-01 17:00' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('data-hoist-id');
+    expect(r.data).toMatchObject({
+      mutation: { operation: 'complete', target: 'task', id: 'abc', completionDate: '2026-06-01 17:00' },
+    });
+  });
+
+  it('hoists id out of data on delete', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'delete', target: 'task', data: { id: 'del1' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('data-hoist-id');
+    expect(r.data).toMatchObject({ mutation: { operation: 'delete', target: 'task', id: 'del1' } });
+  });
+
+  it('does NOT touch create (data is canonical on create)', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'create', target: 'task', data: { name: 'x' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('does NOT touch a canonical update with id already at mutation level', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'update', id: 'abc', changes: { flagged: true } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds a bounded, evidence-driven **normalization front door** so capable-but-imperfect local models (7-8B class via Ollama, native tool-calling) can drive the unified tools — **without loosening `.strict()`** for cloud/frontier clients. Closes OMN-122; enables the privacy-sensitive local-model use case (OMN-121).

## Architecture — strict-first / normalize-on-failure / re-validate-strict

`BaseTool.execute` tries the **strict schema first**. Canonical callers pass on the first try and **never touch the normalizer** (zero overhead, zero behavior change, strictness fully intact). Only inputs that would have errored anyway get a bounded repair attempt; an un-repairable input throws the **same** strict `ZodError` as before.

The normalize-then-strict logic lives in a shared `parseWithNormalization()` keyed off a single tool-name→wrapper-hint registry, consumed by **both** `BaseTool.execute` and the conformance probe's grader — so the probe measures exactly what the server's front door accepts. Every applied normalization is logged (`normalizations-<date>.jsonl`, gated by the existing failure-log suppression) for audit.

**`inputSchema` stays canonical** (dual-schema rule): the normalizer *accepts* more than it advertises; the advertisement is unchanged, so the `inputSchema`↔Zod parity test stays green. No `inputSchema` edits.

## Leniencies (each justified + load-bearing per the OMN-121 matrix)

1. **wrapper-lift** — root-level inner payload (missing wrapper key but has the discriminant) lifted into `{query|analysis|mutation:{...}}`.
2. **stringified-wrapper-repair** — wrapper value arrived as **truncated** JSON (missing trailing closers — the 70b's signature); balance unclosed `{`/`[` (respecting string literals) and re-parse. Returns only plain objects, so an unrelated string is never coerced.
3. **data-hoist-id** — `id` nested in `data` on complete/update/delete hoisted to the mutation level; remaining `data` → `changes` (update) or spread up (complete, e.g. `completionDate`) so no field is silently dropped.

## Conformance lift (`npm run conformance`, before → after)

| Model | Before | After | Δ |
|---|---|---|---|
| llama3.1:8b | 74% | **100%** | +26 |
| qwen2.5:7b | 68% | **100%** | +32 |
| llama3.1:70b | 68% | **95%** | +27 |
| qwen2.5:3b | 42% | 63% | +21 (best-effort, below-bar by capability) |

70b's lone residual (`dateRange:"this_week"`) is a natural-language date token — semantic, out of scope (deferred bare-date leniency, OMN-117).

## Testing

- TDD: 24 unit tests across the three leniencies + invariants (malformed-in → canonical-out; canonical-in → untouched; un-normalizable → original strict error preserved).
- Full unit suite green (**2211 tests**); canonical/cloud shapes verified untouched.
- Conformance probe is the before/after oracle (baseline reproduced the OMN-121 matrix exactly).
- Code-review subagent verdict: **SAFE**; its one worth-fixing edge case (silent `completionDate` drop on a double-malformed complete) is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)