### PR TITLE
fix(OMN-123): parse_meeting_notes — list-membership gate, no name mangling, no silent drops

### DIFF
--- a/src/tools/capture/context-detection.ts
+++ b/src/tools/capture/context-detection.ts
@@ -210,8 +210,10 @@ function detectPeopleTags(text: string): string[] {
   const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
   const isName = (n: string): boolean => !commonWords.has(n.toLowerCase());
 
+  // The name capture excludes the apostrophe so a trailing possessive ("Dennis's
+  // reply") yields @agenda-Dennis, not @agenda-Dennis's.
   // "waiting for/on X" → flat @waiting-for + the person's agenda tag
-  const waiting = /\bwaiting\s+(?:for|on)\s+([a-z][\w'-]*)/i.exec(text);
+  const waiting = /\bwaiting\s+(?:for|on)\s+([a-z][\w-]*)/i.exec(text);
   if (waiting && isName(waiting[1])) {
     tags.push('@waiting-for');
     tags.push(`@agenda-${capitalize(waiting[1])}`);
@@ -219,7 +221,7 @@ function detectPeopleTags(text: string): string[] {
 
   // delegation / agenda cues → @agenda-{Name}. The leading \b prevents "task to"
   // from matching "ask to" → a spurious @agenda-To.
-  const agenda = /\b(?:ask|check with|discuss with|talk to|meet with)\s+([a-z][\w'-]*)/i.exec(text);
+  const agenda = /\b(?:ask|check with|discuss with|talk to|meet with)\s+([a-z][\w-]*)/i.exec(text);
   if (agenda && isName(agenda[1])) {
     const tag = `@agenda-${capitalize(agenda[1])}`;
     if (!tags.includes(tag)) tags.push(tag);

--- a/src/tools/capture/context-detection.ts
+++ b/src/tools/capture/context-detection.ts
@@ -107,27 +107,6 @@ const PRIORITY_CONTEXTS: ContextPattern[] = [
 ];
 
 /**
- * People-based context patterns (dynamic)
- */
-const PEOPLE_PATTERNS = [
-  {
-    // Pattern: "waiting for X" or "waiting on X" - handle possessive forms
-    pattern: /waiting\s+(?:for|on)\s+(\w+)(?:'s)?/i,
-    tagFormat: (name: string) => `@waiting-for-${name.toLowerCase()}`,
-  },
-  {
-    // Pattern: "ask X", "discuss with X", "talk to X", "check with X"
-    pattern: /(?:ask|discuss with|talk to|check with|meet with)\s+(\w+)/i,
-    tagFormat: (name: string) => `@agenda-${name.toLowerCase()}`,
-  },
-  {
-    // Pattern: "X to do" (assignee at start)
-    pattern: /^(\w+)\s+(?:to|will|should|needs to)\b/i,
-    tagFormat: (name: string) => `@${name.toLowerCase()}`,
-  },
-];
-
-/**
  * Detect appropriate context tags for a task
  *
  * @param text - Task text to analyze
@@ -215,21 +194,35 @@ function findBestEnergyContext(text: string): string | null {
 }
 
 /**
- * Detect people-based tags (waiting for, agenda items, assignees)
+ * Detect people-based tags in THIS vault's convention.
+ *
+ * OMN-123: the previous patterns emitted `@waiting-for-{name}`, lowercase
+ * `@agenda-{name}`, and a bare `@{name}` assignee shape — none of which match
+ * real tags in this vault and which polluted the tag namespace. The vault uses a
+ * flat `@waiting-for` plus a capitalized `@agenda-{Name}`. The bare-`@name` shape
+ * is dropped entirely (it fired on ordinary sentences, e.g. "Sarah will review…"
+ * → `@sarah`). This is the single source of truth for people tags — the analyze
+ * tool no longer has a parallel `detectAssignee`.
  */
 function detectPeopleTags(text: string): string[] {
   const tags: string[] = [];
+  const commonWords = new Set(['me', 'you', 'us', 'them', 'it', 'this', 'that']);
+  const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+  const isName = (n: string): boolean => !commonWords.has(n.toLowerCase());
 
-  for (const pattern of PEOPLE_PATTERNS) {
-    const match = pattern.pattern.exec(text);
-    if (match && match[1]) {
-      const name = match[1];
-      // Filter out common words that aren't names
-      const commonWords = ['me', 'you', 'us', 'them', 'it', 'this', 'that'];
-      if (!commonWords.includes(name.toLowerCase())) {
-        tags.push(pattern.tagFormat(name));
-      }
-    }
+  // "waiting for/on X" → flat @waiting-for + the person's agenda tag
+  const waiting = /\bwaiting\s+(?:for|on)\s+([a-z][\w'-]*)/i.exec(text);
+  if (waiting && isName(waiting[1])) {
+    tags.push('@waiting-for');
+    tags.push(`@agenda-${capitalize(waiting[1])}`);
+  }
+
+  // delegation / agenda cues → @agenda-{Name}. The leading \b prevents "task to"
+  // from matching "ask to" → a spurious @agenda-To.
+  const agenda = /\b(?:ask|check with|discuss with|talk to|meet with)\s+([a-z][\w'-]*)/i.exec(text);
+  if (agenda && isName(agenda[1])) {
+    const tag = `@agenda-${capitalize(agenda[1])}`;
+    if (!tags.includes(tag)) tags.push(tag);
   }
 
   return tags;

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -264,6 +264,9 @@ interface ExtractedProject {
 interface ExtractionResult {
   tasks: ExtractedTask[];
   projects: ExtractedProject[];
+  // OMN-123: content lines that were neither metadata nor turned into a task.
+  // Surfaced so nothing is ever silently discarded.
+  unparsed: string[];
 }
 
 // Convert string ID to branded ProjectId for type safety
@@ -2383,6 +2386,7 @@ SCOPE FILTERING:
     const lines = input.split('\n').filter((line) => line.trim());
     const tasks: ExtractedTask[] = [];
     const projects: ExtractedProject[] = [];
+    const unparsed: string[] = [];
 
     let taskCounter = 1;
     let projectCounter = 1;
@@ -2402,9 +2406,23 @@ SCOPE FILTERING:
         continue;
       }
 
+      // OMN-123: task-candidacy is decided by list-membership, NOT by a verb
+      // allowlist. A line is a task if it is a bullet/numbered list item, or if
+      // the caller is in explicit action_items mode (every line is asserted to be
+      // an action). Anything else is non-bullet prose — surface it in unparsed[]
+      // rather than silently dropping it.
+      const isTaskCandidate = this.isListItem(trimmed) || args.extractMode === 'action_items';
+      if (!isTaskCandidate) {
+        unparsed.push(trimmed);
+        continue;
+      }
+
       const taskResult = this.tryExtractAndAssignTask(trimmed, args, taskCounter, currentProject, tasks);
       if (taskResult) {
         taskCounter = taskResult.taskCounter;
+      } else {
+        // Candidate that failed extraction (e.g. too short) — surface, never drop.
+        unparsed.push(trimmed);
       }
     }
 
@@ -2412,7 +2430,17 @@ SCOPE FILTERING:
       projects.push(currentProject);
     }
 
-    return { tasks, projects };
+    return { tasks, projects, unparsed };
+  }
+
+  /**
+   * OMN-123: a line is a task candidate when it is a markdown list item —
+   * a bullet (-, *, •) or a numbered item (1. / 1)). This replaces the old
+   * hardcoded action-verb allowlist, which silently dropped any item whose
+   * leading verb was not on the list (finalize, coordinate, secure, ...).
+   */
+  private isListItem(line: string): boolean {
+    return /^\s*([-*•]|\d+[.)])\s+/.test(line);
   }
 
   private tryExtractProject(
@@ -2459,7 +2487,7 @@ SCOPE FILTERING:
   ): { taskCounter: number } | null {
     if (args.extractMode === 'projects') return null;
 
-    const task = this.extractTask(trimmed, args, taskCounter, currentProject !== null);
+    const task = this.extractTask(trimmed, args, taskCounter);
     if (!task) return null;
 
     if (currentProject) {
@@ -2534,59 +2562,22 @@ SCOPE FILTERING:
       defaultProject?: string;
     },
     taskId: number,
-    isUnderProject = false,
   ): ExtractedTask | null {
-    let cleaned = line
+    const cleaned = line
       .replace(/^[-*\u2022]\s*/, '')
-      .replace(/^\d+\.\s*/, '')
+      .replace(/^\d+[.)]\s*/, '')
       .trim();
 
     if (cleaned.length < 5) {
       return null;
     }
 
-    const actionVerbs = [
-      'send',
-      'call',
-      'email',
-      'review',
-      'update',
-      'create',
-      'write',
-      'schedule',
-      'discuss',
-      'follow up',
-      'check',
-      'prepare',
-      'organize',
-      'plan',
-      'research',
-      'contact',
-      'complete',
-      'finish',
-      'implement',
-      'test',
-      'deploy',
-      'ask',
-      'buy',
-      'purchase',
-      'get',
-      'pick up',
-      'drop off',
-      'waiting',
-      'task',
-    ];
-
-    const hasActionVerb = actionVerbs.some((verb) => new RegExp(`\\b${verb}\\b`, 'i').test(cleaned));
-
-    if (!hasActionVerb && !isUnderProject) {
-      return null;
-    }
-
-    if (isUnderProject && !hasActionVerb && cleaned.length < 3) {
-      return null;
-    }
-
+    // OMN-123: the hardcoded actionVerbs allowlist used to gate here dropped
+    // ~8/13 real action items whose leading verb (finalize, coordinate, secure,
+    // reorder, provide, attend, confirm, evaluate, ...) was not on the list, and
+    // its failure mode was silent. Task-candidacy is now decided upstream by
+    // list-membership (see isListItem / extractActionItems), so any candidate of
+    // sufficient length becomes a task.
     const taskName = this.extractTaskName(cleaned);
     const assigneeTags = this.detectAssignee(cleaned);
     const contextTags = args.suggestTags ? detectContextTags(cleaned) : [];
@@ -2620,30 +2611,45 @@ SCOPE FILTERING:
   }
 
   private extractTaskName(text: string): string {
-    let name = text.replace(/\b(by|for|with|from)\s+\w+\b/gi, '');
-    const datePreposIdx = name.search(/\s(by|on|before|after|until)\s/i);
-    if (datePreposIdx >= 0) {
-      name = name.substring(0, datePreposIdx);
-    }
-    name = name.replace(/\b(today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/i, '');
-    name = name.replace(/\b(next|this) week$/i, '');
+    // OMN-123: the old implementation ran two greedy operations that deleted
+    // real content:
+    //   1. /\b(by|for|with|from)\s+\w+\b/gi  — removed a preposition AND the
+    //      following word *anywhere* in the string ("with Westgate", "with PEDS",
+    //      "for testing" all vanished).
+    //   2. truncation at the first mid-sentence " by|on|before|after|until "
+    //      ("...before installing new microfilm station" was lopped off).
+    // Over-truncation is itself silent data loss, so the name now preserves the
+    // line essentially verbatim. Dates are captured separately by extractDates().
+    // We trim only two unambiguous, edge-anchored bits of noise:
+    //   - a leading single-word owner label ("Kip:", "Lantz:")
+    //   - a trailing standalone relative-date token
+    let name = text.replace(/^[A-Z][A-Za-z]+:\s*/, '');
+    name = name.replace(/\b(today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\.?\s*$/i, '');
+    name = name.replace(/\b(next|this)\s+week\.?\s*$/i, '');
     return name.trim();
   }
 
+  // OMN-123: emit tags in THIS vault's convention — a flat `@waiting-for` plus a
+  // capitalized `@agenda-{Name}` — not the old `@{name}` / `@waiting-for-{name}`
+  // shapes, which polluted the tag namespace and matched no real tag. The bogus
+  // bare-`@name` shape from "X to/will/should" is removed entirely: it fired on
+  // far too many ordinary sentences ("Sarah will review…" → `@sarah`).
   private detectAssignee(text: string): string[] {
     const tags: string[] = [];
-    const assigneeMatch = /^(\w+)\s+(to|needs to|will|should)\b/i.exec(text);
-    if (assigneeMatch) {
-      tags.push(`@${assigneeMatch[1].toLowerCase()}`);
-    }
-    const waitingMatch = /waiting\s+(?:for|on)\s+(\w+)(?:'s)?/i.exec(text);
+    const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+    const waitingMatch = /waiting\s+(?:for|on)\s+([a-z][\w'-]*)/i.exec(text);
     if (waitingMatch) {
-      tags.push(`@waiting-for-${waitingMatch[1].toLowerCase()}`);
+      tags.push('@waiting-for');
+      tags.push(`@agenda-${capitalize(waitingMatch[1])}`);
     }
-    const agendaMatch = /(ask|check with|discuss with|talk to)\s+(\w+)/i.exec(text);
+
+    const agendaMatch = /(?:ask|check with|discuss with|talk to)\s+([a-z][\w'-]*)/i.exec(text);
     if (agendaMatch) {
-      tags.push(`@agenda-${agendaMatch[2].toLowerCase()}`);
+      const tag = `@agenda-${capitalize(agendaMatch[1])}`;
+      if (!tags.includes(tag)) tags.push(tag);
     }
+
     return tags;
   }
 
@@ -2720,10 +2726,24 @@ SCOPE FILTERING:
       .filter((t) => t.confidence === 'low' || t.projectMatch === 'none')
       .map((t) => t.tempId);
 
+    const unparsed = extracted.unparsed;
+
     return {
-      extracted: { tasks: extracted.tasks, projects: extracted.projects },
-      summary: { totalTasks, totalProjects: extracted.projects.length, highConfidence, mediumConfidence, needsReview },
-      nextSteps: 'Review extracted items and use batch_create to add to OmniFocus',
+      // OMN-123: `unparsed` carries every content line that was NOT turned into a
+      // task, so nothing the user wrote can silently vanish.
+      extracted: { tasks: extracted.tasks, projects: extracted.projects, unparsed },
+      summary: {
+        totalTasks,
+        totalProjects: extracted.projects.length,
+        highConfidence,
+        mediumConfidence,
+        needsReview,
+        unparsedCount: unparsed.length,
+      },
+      nextSteps:
+        unparsed.length > 0
+          ? 'Review extracted items AND unparsed[] (lines not turned into tasks — add any missed actions by hand), then use batch_create to add to OmniFocus'
+          : 'Review extracted items and use batch_create to add to OmniFocus',
     };
   }
 

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2399,11 +2399,26 @@ SCOPE FILTERING:
         continue;
       }
 
-      const projectResult = this.tryExtractProject(trimmed, args.extractMode, currentProject, projects, projectCounter);
-      if (projectResult) {
-        currentProject = projectResult.currentProject;
-        projectCounter = projectResult.projectCounter;
-        continue;
+      const isList = this.isListItem(trimmed);
+
+      // OMN-123: only NON-bullet lines are considered project headers
+      // ("Website Redesign project:"). A bullet is always an action — without
+      // this gate, "- Marketing project: launch the new site" was misread as a
+      // project named "- Marketing" and its action text vanished from both
+      // tasks[] and unparsed[].
+      if (!isList) {
+        const projectResult = this.tryExtractProject(
+          trimmed,
+          args.extractMode,
+          currentProject,
+          projects,
+          projectCounter,
+        );
+        if (projectResult) {
+          currentProject = projectResult.currentProject;
+          projectCounter = projectResult.projectCounter;
+          continue;
+        }
       }
 
       // OMN-123: task-candidacy is decided by list-membership, NOT by a verb
@@ -2411,7 +2426,7 @@ SCOPE FILTERING:
       // the caller is in explicit action_items mode (every line is asserted to be
       // an action). Anything else is non-bullet prose — surface it in unparsed[]
       // rather than silently dropping it.
-      const isTaskCandidate = this.isListItem(trimmed) || args.extractMode === 'action_items';
+      const isTaskCandidate = isList || args.extractMode === 'action_items';
       if (!isTaskCandidate) {
         unparsed.push(trimmed);
         continue;
@@ -2579,9 +2594,11 @@ SCOPE FILTERING:
     // list-membership (see isListItem / extractActionItems), so any candidate of
     // sufficient length becomes a task.
     const taskName = this.extractTaskName(cleaned);
-    const assigneeTags = this.detectAssignee(cleaned);
+    // OMN-123: people tags (waiting-for / agenda) and context tags both come from
+    // detectContextTags now — the single source of truth. The old parallel
+    // detectAssignee re-emitted non-vault tag shapes into this same union.
     const contextTags = args.suggestTags ? detectContextTags(cleaned) : [];
-    const allTags = [...new Set([...assigneeTags, ...contextTags])];
+    const allTags = [...new Set(contextTags)];
     const dates = args.suggestDueDates ? extractDates(cleaned) : {};
     const estimate = args.suggestEstimates ? this.estimateDuration(cleaned) : undefined;
 
@@ -2611,46 +2628,20 @@ SCOPE FILTERING:
   }
 
   private extractTaskName(text: string): string {
-    // OMN-123: the old implementation ran two greedy operations that deleted
-    // real content:
-    //   1. /\b(by|for|with|from)\s+\w+\b/gi  — removed a preposition AND the
-    //      following word *anywhere* in the string ("with Westgate", "with PEDS",
-    //      "for testing" all vanished).
-    //   2. truncation at the first mid-sentence " by|on|before|after|until "
-    //      ("...before installing new microfilm station" was lopped off).
-    // Over-truncation is itself silent data loss, so the name now preserves the
-    // line essentially verbatim. Dates are captured separately by extractDates().
-    // We trim only two unambiguous, edge-anchored bits of noise:
-    //   - a leading single-word owner label ("Kip:", "Lantz:")
-    //   - a trailing standalone relative-date token
-    let name = text.replace(/^[A-Z][A-Za-z]+:\s*/, '');
-    name = name.replace(/\b(today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\.?\s*$/i, '');
-    name = name.replace(/\b(next|this)\s+week\.?\s*$/i, '');
-    return name.trim();
-  }
-
-  // OMN-123: emit tags in THIS vault's convention — a flat `@waiting-for` plus a
-  // capitalized `@agenda-{Name}` — not the old `@{name}` / `@waiting-for-{name}`
-  // shapes, which polluted the tag namespace and matched no real tag. The bogus
-  // bare-`@name` shape from "X to/will/should" is removed entirely: it fired on
-  // far too many ordinary sentences ("Sarah will review…" → `@sarah`).
-  private detectAssignee(text: string): string[] {
-    const tags: string[] = [];
-    const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-
-    const waitingMatch = /waiting\s+(?:for|on)\s+([a-z][\w'-]*)/i.exec(text);
-    if (waitingMatch) {
-      tags.push('@waiting-for');
-      tags.push(`@agenda-${capitalize(waitingMatch[1])}`);
-    }
-
-    const agendaMatch = /(?:ask|check with|discuss with|talk to)\s+([a-z][\w'-]*)/i.exec(text);
-    if (agendaMatch) {
-      const tag = `@agenda-${capitalize(agendaMatch[1])}`;
-      if (!tags.includes(tag)) tags.push(tag);
-    }
-
-    return tags;
+    // OMN-123: the old implementation ran two greedy operations that deleted real
+    // content — a global /\b(by|for|with|from)\s+\w+\b/gi strip (which ate
+    // "with Westgate", "with PEDS", "for testing") and a mid-sentence truncation
+    // at the first " by|on|before|after|until " (which lopped off
+    // "...before installing new microfilm station").
+    //
+    // Over-truncation is itself silent data loss, so the name is now the bullet-
+    // stripped line VERBATIM. Earlier drafts also trimmed a leading "Owner:"
+    // label and trailing date tokens, but both reintroduced the same failure
+    // class: "Owner:" can't be told from content labels ("Update:", "Order:"),
+    // and stripping a trailing weekday left dangling prepositions ("...report by").
+    // Dates are still captured separately by extractDates(); a slightly longer,
+    // faithful name is strictly safer than a cleverly-shortened, lossy one.
+    return text.trim();
   }
 
   private estimateDuration(text: string): number | undefined {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -701,6 +701,11 @@ describe('OmniFocusAnalyzeTool', () => {
       // "task to complete" must NOT yield a spurious @agenda-To (missing \b on "ask").
       const spurious = await tagsFor('task to complete the migration checklist');
       expect(spurious).not.toContain('@agenda-To');
+
+      // A trailing possessive must not bleed into the tag.
+      const possessive = await tagsFor("waiting on Dennis's reply");
+      expect(possessive).toContain('@agenda-Dennis');
+      expect(possessive).not.toContain("@agenda-Dennis's");
     });
   });
 

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -574,6 +574,74 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(res.success).toBe(true);
       expect(res.data.extracted.tasks).toHaveLength(0);
     });
+
+    // OMN-123 regression: the real ops-meeting sample, verbatim from the ticket's
+    // reproduction block. The old verb-allowlist + greedy preposition strip
+    // returned 5 mangled tasks from these clean bullets. All must survive with
+    // names intact and nothing dropped silently.
+    // NOTE: the ticket prose says "13 items" but its code block lists exactly 12
+    // bullets — we match the literal sample (12). Flagged for the owner.
+    const OMN_123_SAMPLE = [
+      '- Kip: finalize remote access solution for new Mac minis before deployment.',
+      '- Coordinate with Dennis Ball for feedback on bookmark files for book processing stations.',
+      '- Plan branch-by-branch Mac mini rollout starting with Westgate (oldest, 2016).',
+      '- Kip: secure Kensington lock for new microfilm station.',
+      '- Coordinate with PEDS supervisors for advance notice before installing new microfilm station; double-check printing.',
+      '- Order six self-check scanners and four lobby-style stand models for testing.',
+      '- Kip: provide network ports list for blocking Minecraft multiplayer/self-hosting.',
+      '- Reorder two CyberPower battery packs.',
+      '- Kip: help Joe Harris with Smart App Control blocking his XLS shortcut.',
+      '- Lantz: attend Iru AI webinar Thursday June 4th 2026.',
+      '- Phone system: confirm shipment dates and build prep timeline for July 20th rollout.',
+      '- Evaluate centralized software license tracking including Square proposal.',
+    ].join('\n');
+
+    it('OMN-123: extracts all 13 action items from a real ops-meeting sample', async () => {
+      const res: any = await tool.execute({
+        analysis: { type: 'parse_meeting_notes', params: { text: OMN_123_SAMPLE } },
+      });
+
+      expect(res.success).toBe(true);
+      const tasks = res.data.extracted.tasks;
+      // 12 bullet lines in the sample (one was merged above) → assert none dropped.
+      expect(tasks.length).toBe(12);
+      expect(res.data.summary.totalTasks).toBe(12);
+    });
+
+    it('OMN-123: preserves mid-sentence objects/proper nouns eaten by the old greedy strip', async () => {
+      const res: any = await tool.execute({
+        analysis: { type: 'parse_meeting_notes', params: { text: OMN_123_SAMPLE } },
+      });
+
+      const names: string[] = res.data.extracted.tasks.map((t: any) => t.name);
+      const joined = names.join('\n');
+      // "with Westgate", "with PEDS", "for testing" were deleted by the global
+      // /\b(by|for|with|from)\s+\w+\b/gi strip. They must survive now.
+      expect(joined).toContain('Westgate');
+      expect(joined).toContain('PEDS');
+      expect(joined).toContain('for testing');
+    });
+
+    it('OMN-123: never silently drops a content line — surfaces leftovers in unparsed[]', async () => {
+      const res: any = await tool.execute({
+        analysis: { type: 'parse_meeting_notes', params: { text: OMN_123_SAMPLE } },
+      });
+
+      // Every bullet became a task → nothing left unparsed for this clean sample.
+      expect(Array.isArray(res.data.extracted.unparsed)).toBe(true);
+      expect(res.data.extracted.unparsed).toHaveLength(0);
+      expect(res.data.summary.unparsedCount).toBe(0);
+    });
+
+    it('OMN-123: emits vault-convention assignee tags (@waiting-for, @agenda-{Name})', () => {
+      // detectAssignee is the unit under test for tag-shape correctness.
+      const anyTool = tool as any;
+      expect(anyTool.detectAssignee('waiting for Dennis to send bookmark files')).toContain('@waiting-for');
+      expect(anyTool.detectAssignee('waiting for Dennis to send bookmark files')).toContain('@agenda-Dennis');
+      expect(anyTool.detectAssignee('ask Joe Harris about the XLS shortcut')).toContain('@agenda-Joe');
+      // The old bogus bare "@name" shape from "X to/will/should" must be gone.
+      expect(anyTool.detectAssignee('Sarah will review the report')).not.toContain('@sarah');
+    });
   });
 
   // ==========================================================================

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -596,16 +596,49 @@ describe('OmniFocusAnalyzeTool', () => {
       '- Evaluate centralized software license tracking including Square proposal.',
     ].join('\n');
 
-    it('OMN-123: extracts all 13 action items from a real ops-meeting sample', async () => {
+    it('OMN-123: extracts all 12 sample bullets — including verbs off the old allowlist', async () => {
       const res: any = await tool.execute({
         analysis: { type: 'parse_meeting_notes', params: { text: OMN_123_SAMPLE } },
       });
 
       expect(res.success).toBe(true);
       const tasks = res.data.extracted.tasks;
-      // 12 bullet lines in the sample (one was merged above) → assert none dropped.
+      // Every bullet survives — nothing dropped.
       expect(tasks.length).toBe(12);
       expect(res.data.summary.totalTasks).toBe(12);
+
+      // Lock the list-membership semantics against a regression to verb-gating:
+      // these leading verbs were NOT on the old actionVerbs allowlist, so each is
+      // proof that candidacy now comes from being a bullet, not from a known verb.
+      const joined = tasks.map((t: any) => t.name).join('\n');
+      for (const offAllowlistVerb of [
+        'finalize',
+        'Coordinate',
+        'secure',
+        'Reorder',
+        'provide',
+        'attend',
+        'confirm',
+        'Evaluate',
+      ]) {
+        expect(joined).toContain(offAllowlistVerb);
+      }
+    });
+
+    it('OMN-123: a bulleted "X project:" line stays an action — its text never vanishes', async () => {
+      const res: any = await tool.execute({
+        analysis: {
+          type: 'parse_meeting_notes',
+          params: { text: '- Marketing project: launch the new site\n- Build the analytics dashboard' },
+        },
+      });
+
+      expect(res.success).toBe(true);
+      // Bullets are actions, not project headers — so the action text is preserved
+      // as a task rather than being lost to a phantom empty project.
+      const joined = res.data.extracted.tasks.map((t: any) => t.name).join('\n');
+      expect(joined).toContain('launch the new site');
+      expect(res.data.extracted.unparsed).toHaveLength(0);
     });
 
     it('OMN-123: preserves mid-sentence objects/proper nouns eaten by the old greedy strip', async () => {
@@ -633,14 +666,41 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(res.data.summary.unparsedCount).toBe(0);
     });
 
-    it('OMN-123: emits vault-convention assignee tags (@waiting-for, @agenda-{Name})', () => {
-      // detectAssignee is the unit under test for tag-shape correctness.
-      const anyTool = tool as any;
-      expect(anyTool.detectAssignee('waiting for Dennis to send bookmark files')).toContain('@waiting-for');
-      expect(anyTool.detectAssignee('waiting for Dennis to send bookmark files')).toContain('@agenda-Dennis');
-      expect(anyTool.detectAssignee('ask Joe Harris about the XLS shortcut')).toContain('@agenda-Joe');
-      // The old bogus bare "@name" shape from "X to/will/should" must be gone.
-      expect(anyTool.detectAssignee('Sarah will review the report')).not.toContain('@sarah');
+    // Assert on the ASSEMBLED task.suggestedTags (what the user actually sees),
+    // not on an internal detector in isolation — there used to be two people-tag
+    // detectors and only fixing one left the old shapes leaking into the union.
+    const tagsFor = async (line: string): Promise<string[]> => {
+      const res: any = await tool.execute({
+        analysis: { type: 'parse_meeting_notes', params: { text: `- ${line}` } },
+      });
+      return res.data.extracted.tasks[0]?.suggestedTags ?? [];
+    };
+
+    it('OMN-123: suggestedTags use the vault convention (@waiting-for + @agenda-{Name})', async () => {
+      const waiting = await tagsFor('waiting for Dennis to send bookmark files');
+      expect(waiting).toContain('@waiting-for');
+      expect(waiting).toContain('@agenda-Dennis');
+
+      const agenda = await tagsFor('ask Joe Harris about the XLS shortcut');
+      expect(agenda).toContain('@agenda-Joe');
+    });
+
+    it('OMN-123: the old non-vault tag shapes never leak into suggestedTags', async () => {
+      const waiting = await tagsFor('waiting for Dennis to send bookmark files');
+      // No @waiting-for-{name} and no lowercase @agenda-{name} duplicate.
+      expect(waiting).not.toContain('@waiting-for-dennis');
+      expect(waiting).not.toContain('@agenda-dennis');
+
+      const agenda = await tagsFor('ask Joe Harris about the XLS shortcut');
+      expect(agenda).not.toContain('@agenda-joe');
+
+      // The bogus bare "@name" shape from "X will/should/to" must be gone.
+      const bare = await tagsFor('Sarah will review the quarterly report');
+      expect(bare).not.toContain('@sarah');
+
+      // "task to complete" must NOT yield a spurious @agenda-To (missing \b on "ask").
+      const spurious = await tagsFor('task to complete the migration checklist');
+      expect(spurious).not.toContain('@agenda-To');
     });
   });
 


### PR DESCRIPTION
## OMN-123: make `parse_meeting_notes` trustworthy

`omnifocus_analyze { type: "parse_meeting_notes" }` returned **5 mangled tasks** from **12 clean action items** in the first production run of the ops-meeting → OmniFocus pipeline. Three issues fixed in the JS heuristic extractor. This is the **Option-2** ("keep a fixed extractor") path from the ticket — it meets all four acceptance criteria with **zero contract change** (input schema, skill doc, tool description untouched). The larger Option-1 repurpose (LLM-side extraction, server validates structured items) remains a deliberate follow-up and is **not** foreclosed.

### Root cause #1 — names mangled (greedy global preposition strip)
`extractTaskName` ran `/\b(by|for|with|from)\s+\w+\b/gi`, deleting a preposition **and the following word anywhere** in the string (`with Westgate`, `with PEDS`, `for testing` all vanished), plus a mid-sentence truncation. **Both removed.** The task name is now the bullet-stripped line **verbatim** — over-truncation is itself silent data loss. Dates are still captured separately by `extractDates`.

### Root cause #2 — most items dropped (hardcoded verb allowlist)
`extractTask` gated on a hardcoded `actionVerbs` array, **silently** dropping any item whose leading verb was off-list (`finalize`, `coordinate`, `secure`, `reorder`, `provide`, `attend`, `confirm`, `evaluate`, …). Replaced with **list-membership**: a line is a task if it is a bullet/numbered item, or if the caller is in explicit `action_items` mode. This switches the discrimination axis from "has a known verb" (a treadmill against open vocabulary) to "is a list item" — and preserves the existing `prose → 0 tasks` behavior (prose isn't a bullet). Project headers are now recognized only on **non-bullet** lines, so a bulleted "X project:" stays an action and its text can't vanish.

### No more silent loss
New `unparsed[]` on the result (+ `summary.unparsedCount`) surfaces every content line not turned into a task.

### Tag convention — single source of truth
There were **two** people-tag detectors feeding `suggestedTags`. Consolidated into one (`detectPeopleTags` in `context-detection.ts`); deleted the parallel `detectAssignee`. Output now uses only this vault's convention — flat `@waiting-for` + capitalized `@agenda-{Name}` — with the bogus `@waiting-for-{name}` / lowercase / bare-`@name` shapes gone. The agenda cue is `\b`-anchored so "task to …" no longer yields `@agenda-To`.

## Acceptance criteria
- [x] Real ops-meeting sample yields all tasks with names intact (Westgate / PEDS / "for testing" preserved)
- [x] No input line silently discarded — surfaced in `unparsed[]`
- [x] Suggested tags match the vault convention (`@waiting-for`, `@agenda-{Name}`)
- [x] Regression fixture added from the real 2026-06-04 meeting sample

## ⚠ Discrepancy flagged for the owner
The ticket prose says **"13 items"** but its reproduction block lists exactly **12 bullets**. The regression test matches the literal sample (**12 tasks**). If a 13th was intended, point me at it.

## Tests
- 6 OMN-123 regression tests: count + off-allowlist verb survival, name integrity, `unparsed[]`, bulleted-"project:" preservation, vault-convention tags, and an explicit leak-guard for the old tag shapes — asserted on the **assembled `task.suggestedTags`**, not an internal detector.
- Full suite: **2217 unit tests pass**, build clean, lint 0 errors.

## Review
Reviewed by a code-review subagent. Round 1 → NEEDS CHANGES (a second untouched tag detector re-leaked old shapes; `extractTaskName` owner/date strips had false-positive classes; bulleted "project:" lost text). All addressed in commit 36c51a7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
