### PR TITLE
fix(OMN-125): bridge-wrap incomplete-tasks pre-flight read — dedupe was silently disabled

### DIFF
--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -34,8 +34,8 @@ import { detectContextTags } from '../capture/context-detection.js';
 import { extractDates } from '../capture/date-extraction.js';
 
 // OMN-124: read-only pre-flight for structured meeting-note items.
-import { buildFilteredProjectsScript, buildFilteredTasksScript } from '../../contracts/ast/script-builder.js';
-import { normalizeFilter } from '../../contracts/filters.js';
+import { buildFilteredProjectsScript } from '../../contracts/ast/script-builder.js';
+import { buildListTasksScriptV4 } from '../../omnifocus/scripts/tasks/list-tasks-ast.js';
 import { buildTagsScript } from '../../contracts/ast/tag-script-builder.js';
 
 // Response types
@@ -2611,9 +2611,20 @@ SCOPE FILTERING:
   private async fetchExistingIncompleteTasks(): Promise<Array<{ name: string; project: string | null }>> {
     // Both terminal states excluded: a dropped task has completed===false, so
     // without dropped:false an abandoned task would false-positive as a duplicate.
-    const filter = normalizeFilter({ completed: false, dropped: false });
-    const gen = buildFilteredTasksScript(filter, { limit: 2000, fields: ['name', 'project'] });
-    const result = await this.execJson(gen.script);
+    //
+    // OMN-124 follow-up: use buildListTasksScriptV4, NOT the bare
+    // buildFilteredTasksScript — the latter returns an OmniJS body that uses
+    // `flattenedTasks`, which only exists inside the evaluateJavascript bridge.
+    // The V4 wrapper embeds that body in the JXA→bridge harness (unlike
+    // buildFilteredProjectsScript/buildTagsScript, which self-wrap). Passing the
+    // bare body to execJson throws "Can't find variable: flattenedTasks", and the
+    // swallowed failure silently disabled dedupe. Output shape is { tasks, metadata }.
+    const script = buildListTasksScriptV4({
+      filter: { completed: false, dropped: false },
+      fields: ['name', 'project'],
+      limit: 2000,
+    });
+    const result = await this.execJson(script);
     if (!isScriptSuccess(result)) return [];
     return this.unwrapList(result.data, ['tasks', 'items'])
       .map((t) => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -838,6 +838,30 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(res.data.batchPayload.operations).toHaveLength(1);
       });
 
+      it('wraps the incomplete-tasks read in the JXA bridge (flattenedTasks is OmniJS-only)', async () => {
+        // Regression guard: buildFilteredTasksScript returns a BARE OmniJS body
+        // that references `flattenedTasks` — a global that only exists inside the
+        // evaluateJavascript bridge. Passing it raw to execJson throws
+        // "Can't find variable: flattenedTasks" and silently disabled dedupe in
+        // prod (caught only by live verification, since mocks can't see a bad
+        // script). The tasks read must go through buildListTasksScriptV4, which
+        // embeds the body in the JXA→bridge harness.
+        const scripts: string[] = [];
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          scripts.push(script);
+          return Promise.resolve({ tasks: [] });
+        });
+
+        await tool.execute({
+          analysis: { type: 'parse_meeting_notes', params: { items: [{ name: 'X', project: 'Y' }] } },
+        });
+
+        const tasksScript = scripts.find((s) => s.includes('flattenedTasks'));
+        expect(tasksScript).toBeDefined();
+        // The flattenedTasks body must be embedded inside the evaluateJavascript bridge.
+        expect(tasksScript).toContain('evaluateJavascript');
+      });
+
       it('emits a batchPayload that round-trips unchanged through WriteSchema { batch }', async () => {
         const res: any = await tool.execute({
           analysis: {


### PR DESCRIPTION
## OMN-125: bridge-wrap the incomplete-tasks pre-flight read — dedupe was silently disabled

Found by `/verify` against **live OmniFocus** (the exact gap flagged in OMN-124's PR): the structured-items dedupe never worked against a real database. A structured item whose name+project matched an existing incomplete task returned `duplicateOf: null, readyToCreate: true`.

### Root cause
`fetchExistingIncompleteTasks` passed `buildFilteredTasksScript(...).script` straight to `execJson`. That builder returns a **bare OmniJS body** referencing `flattenedTasks` — a global that only exists inside the `app.evaluateJavascript()` bridge — so it threw `ReferenceError: Can't find variable: flattenedTasks (-2700)`.

The trap: `buildFilteredProjectsScript` and `buildTagsScript` **self-wrap** in the JXA→bridge harness (so project resolution and tag classification worked fine), but `buildFilteredTasksScript` does **not** — its body must be wrapped by the caller, as `buildListTasksScriptV4` does. Two things made it silent: the fetcher swallows script errors (`return []`), degrading the failure to "no duplicates"; and unit tests mock `execJson`, so they never executed the malformed script.

### Fix
Use `buildListTasksScriptV4({ filter: { completed: false, dropped: false }, fields: ['name','project'], limit: 2000 })`, which embeds the body in the bridge. One-import, one-call change.

### Regression guard
A unit test captures the script handed to `execJson` and asserts the `flattenedTasks` body is embedded inside an `evaluateJavascript` bridge — the bare-body trap that mocked-execution tests structurally cannot catch.

### Live verification (dev build with fix, real OmniFocus)
```
- Order another POS monitor mount...  | proj=exact    dup=YES ready=false   ← dedupe fires
- ZZZ Verify novel 8675309            | proj=exact    dup=no  ready=true
- ZZZ Verify partial 8675309          | proj=partial → "Pending Purchase Orders"  ready=true
- ZZZ Verify none 8675309             | proj=none     dup=no  ready=true
summary: {total:4, readyToCreate:3, duplicates:1, newProjects:1, newTags:1}
batchPayload ops: 3   (the duplicate is excluded)
```
Raw read confirmed: the wrapped script returns tasks (2000, the limit cap) and finds the dedupe target.

### Notes
- The dedupe scan caps at `limit: 2000` incomplete tasks; Kip's DB hit the cap, so dedupe is best-effort beyond 2000. Acceptable; revisit if false-negatives surface.
- Surfacing pre-flight read failures (a `warnings[]`) instead of silently degrading to `[]` is a sensible follow-up — deferred, noted in OMN-125.

Full suite: **2230 unit tests pass**, build clean, lint 0 errors. Fixes OMN-125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
