### PR TITLE
fix(OMN-127): consolidate folder resolution — kill silent root-fallback on create + path-blind update

### DIFF
--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -520,6 +520,32 @@ function resolveFolderPath(segments) {
   return current;
 }`;
 
+/**
+ * OmniJS: ONE flexible folder resolver shared by every write site that places a
+ * project/folder into a folder (create folder, create project, update project).
+ * Resolution order: (1) " : "/"/" path walk, (2) Folder.byIdentifier, (3) leaf-name
+ * match. Returns the Folder object or null. Requires parseFolderPath + resolveFolderPath
+ * to be injected alongside it. Consolidating here (OMN-127) stops the three sites from
+ * drifting apart again — they previously had three different resolution behaviors.
+ */
+const OMNIJS_RESOLVE_FOLDER_FLEXIBLE = `
+function resolveFolderFlexible(target) {
+  // 1. Try parsing as a path (" : " or "/")
+  var pathSegs = parseFolderPath(target);
+  if (pathSegs) {
+    var found = resolveFolderPath(pathSegs);
+    if (found) return found;
+  }
+  // 2. Try by identifier (id.primaryKey)
+  var byId = Folder.byIdentifier(target);
+  if (byId) return byId;
+  // 3. Fall back to leaf name match
+  for (var i = 0; i < flattenedFolders.length; i++) {
+    if (flattenedFolders[i].name === target) return flattenedFolders[i];
+  }
+  return null;
+}`;
+
 /** OmniJS: walk tag tree returning null if any segment missing (read-only) */
 const OMNIJS_RESOLVE_TAG_PATH = `
 function resolveTagByPath(segments) {
@@ -1001,33 +1027,26 @@ export function buildCreateProjectScript(data: ProjectCreateData): GeneratedMuta
         (() => {
           ${OMNIJS_PARSE_FOLDER_PATH}
           ${OMNIJS_RESOLVE_FOLDER_PATH}
+          ${OMNIJS_RESOLVE_FOLDER_FLEXIBLE}
 
           var target = \${JSON.stringify(projectData.folder)};
-
-          // 1. Try parsing as a path (" : " or "/")
-          var pathSegs = parseFolderPath(target);
-          if (pathSegs) {
-            var found = resolveFolderPath(pathSegs);
-            if (found) return JSON.stringify({ found: true, index: flattenedFolders.indexOf(found) });
-          }
-
-          // 2. Try by identifier (id.primaryKey)
-          var folder = Folder.byIdentifier(target);
+          var folder = resolveFolderFlexible(target);
           if (folder) return JSON.stringify({ found: true, index: flattenedFolders.indexOf(folder) });
-
-          // 3. Fall back to leaf name match
-          for (var i = 0; i < flattenedFolders.length; i++) {
-            if (flattenedFolders[i].name === target) {
-              return JSON.stringify({ found: true, index: i });
-            }
-          }
-
           return JSON.stringify({ found: false });
         })()
       \`;
       const findFolderResult = JSON.parse(app.evaluateJavascript(findFolderScript));
       if (findFolderResult.found && findFolderResult.index >= 0) {
         targetFolder = doc.flattenedFolders()[findFolderResult.index];
+      } else {
+        // OMN-127 #1: a folder WAS requested but did not resolve. Never silently
+        // file the project at the database root — that was the silent-success bug.
+        // Fail loudly so typos / partial paths surface instead of misfiling.
+        return JSON.stringify({
+          error: true,
+          message: 'Folder not found: ' + projectData.folder,
+          context: 'create_project'
+        });
       }
     }
 
@@ -1245,27 +1264,11 @@ export function buildCreateFolderScript(data: FolderCreateData): GeneratedMutati
         (() => {
           ${OMNIJS_PARSE_FOLDER_PATH}
           ${OMNIJS_RESOLVE_FOLDER_PATH}
+          ${OMNIJS_RESOLVE_FOLDER_FLEXIBLE}
 
           var target = \${JSON.stringify(folderData.parentFolder)};
-
-          // 1. Try parsing as a path (" : " or "/")
-          var pathSegs = parseFolderPath(target);
-          if (pathSegs) {
-            var found = resolveFolderPath(pathSegs);
-            if (found) return JSON.stringify({ found: true, index: flattenedFolders.indexOf(found) });
-          }
-
-          // 2. Try by identifier (id.primaryKey)
-          var folder = Folder.byIdentifier(target);
+          var folder = resolveFolderFlexible(target);
           if (folder) return JSON.stringify({ found: true, index: flattenedFolders.indexOf(folder) });
-
-          // 3. Fall back to leaf name match
-          for (var i = 0; i < flattenedFolders.length; i++) {
-            if (flattenedFolders[i].name === target) {
-              return JSON.stringify({ found: true, index: i });
-            }
-          }
-
           return JSON.stringify({ found: false });
         })()
       \`;
@@ -1805,14 +1808,17 @@ export async function buildUpdateProjectScript(
             }
           })()\`
         : \`(() => {
+            ${OMNIJS_PARSE_FOLDER_PATH}
+            ${OMNIJS_RESOLVE_FOLDER_PATH}
+            ${OMNIJS_RESOLVE_FOLDER_FLEXIBLE}
+
             const project = Project.byIdentifier('\${projectId}');
             if (!project) return JSON.stringify({ success: false, error: 'project_not_found' });
-            const targetId = '\${changes.folder}';
-            // Try by ID first, then by name
-            let folder = Folder.byIdentifier(targetId);
-            if (!folder) {
-              folder = flattenedFolders.find(f => f.name === targetId);
-            }
+            // OMN-127 #2: resolve identically to create — path walk (" : "/"/"),
+            // then byIdentifier, then leaf name. The old lookup was byIdentifier +
+            // flat-name only, so " : " nested paths could never resolve on update.
+            const targetId = \${JSON.stringify(changes.folder)};
+            const folder = resolveFolderFlexible(targetId);
             if (!folder) return JSON.stringify({ success: false, error: 'folder_not_found: ' + targetId });
             try {
               moveSections([project], folder.beginning);

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -123,6 +123,12 @@ FOLDER CREATION:
 - data.parentFolder: Parent folder name, path ("Parent : Child"), or ID (optional, omit for top-level)
 - Supports nested path lookup with " : " syntax (parent must already exist)
 
+PROJECT FOLDER PLACEMENT (data.folder on create / changes.folder on update):
+- Accepts a bare name, a nested path (" : " or "/", resolved as a strict parent→child chain from the root), or a folder ID
+- A nested path must be complete — partial paths (missing a top-level segment) do NOT resolve
+- An unresolvable folder returns an error; the project is NEVER silently filed at the root
+- On update, folder: null moves the project to the database root
+
 BATCH OPERATIONS:
 - operations: Array of create, update, complete, and delete operations
 - Execution order: creates first, then updates, completes, deletes last
@@ -195,6 +201,9 @@ SAFETY:
     // OMN-97: advertise the supported fields of `data`/`changes` so MCP clients
     // get field-level guidance and misplace fewer keys. Mirrors CreateDataSchema /
     // UpdateChangesSchema in write-schema.ts — keep in sync (dual-schema rule).
+    // BUDGET: a unit test enforces JSON.stringify(inputSchema).length < 4000 (token cost).
+    // Currently ~3941 bytes — only ~60 bytes of headroom. Trim an existing field
+    // description before adding a field or lengthening a description, or the guard fails.
     // (Plain `type: string` for enum-bearing fields like `status` to avoid
     // advertising an enum the inputSchema↔Zod parity test would police.)
     const createDataProperties: Record<string, unknown> = {
@@ -209,7 +218,7 @@ SAFETY:
       flagged: { type: 'boolean', description: 'no priority levels — use flagged' },
       estimatedMinutes: { type: 'number', description: 'minutes (not "estimate")' },
       repetitionRule: { type: 'object' },
-      folder: { type: 'string', description: 'project-only' },
+      folder: { type: 'string', description: 'project-only: name/path/ID; bad path errors; null→root (see desc)' },
       sequential: { type: 'boolean', description: 'project-only' },
       status: { type: 'string', description: 'project-only: active|on_hold|completed|dropped' },
       reviewInterval: { description: 'project-only: days or {steps,unit}' },

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -159,7 +159,12 @@ export const CreateDataSchema = z
       repetitionRule: RepetitionRuleSchema.optional(),
 
       // Project-specific
-      folder: z.string().optional(),
+      folder: z
+        .string()
+        .describe(
+          'Place the project in this folder. Accepts a bare name ("Shop Titans"), a nested path ("Personal : Other Games : Shop Titans" or "Personal/Other Games"), or a folder ID. Paths resolve as a strict parent→child chain from the root — partial paths do NOT resolve. An unresolvable folder returns an error (never a silent root placement). Omit for top-level.',
+        )
+        .optional(),
       sequential: coerceBoolean().optional(),
       status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
       reviewInterval: ReviewIntervalSchema.optional(),
@@ -189,7 +194,12 @@ export const UpdateChangesSchema = z
       // Task-specific narrowing happens in sanitizer + script builder.
       status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
       project: z.union([z.string(), z.null()]).optional(),
-      folder: z.union([z.string(), z.null()]).optional(),
+      folder: z
+        .union([z.string(), z.null()])
+        .describe(
+          'Move the project to this folder. Same resolution as create: bare name, nested path (" : " or "/", strict parent→child chain), or folder ID. An unresolvable folder errors. null moves the project to the database root.',
+        )
+        .optional(),
       parentTaskId: z.union([z.string(), z.null()]).optional(), // Bug OMN-5: Update parent task relationship
       estimatedMinutes: z
         .union([z.number(), z.string().transform((v) => parseInt(v, 10))])

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -426,6 +426,19 @@ describe('buildCreateProjectScript', () => {
     expect(result.script).toContain('Work/Engineering/Backend');
   });
 
+  it('returns a loud error instead of silent root fallback when a requested folder is unresolved (OMN-127 #1)', () => {
+    const result = buildCreateProjectScript({
+      name: 'Misfiled Project',
+      folder: 'Personal : Other Games : Shop Titans',
+    });
+
+    // A requested-but-unresolved folder must NOT silently file the project at the
+    // database root with success:true. The generated script must emit a loud error
+    // return for the folder-requested-but-not-found case (cf. buildCreateFolderScript).
+    expect(result.script).toContain('Folder not found');
+    expect(result.script).toContain("context: 'create_project'");
+  });
+
   it('falls back to leaf name matching for simple folder names', () => {
     const result = buildCreateProjectScript({
       name: 'Simple Folder Project',
@@ -609,6 +622,18 @@ describe('buildUpdateProjectScript', () => {
 
     expect(result.script).toContain('moveSections');
     expect(result.script).toContain('Development');
+  });
+
+  it('resolves " : " nested folder paths on update, identically to create (OMN-127 #2)', async () => {
+    const result = await buildUpdateProjectScript('project-123', {
+      folder: 'Personal : Other Games : Shop Titans',
+    });
+
+    // The update move-path must use the same path-aware resolver as create,
+    // not the old byIdentifier + flat-name-only lookup that can never resolve
+    // a " : " nested path.
+    expect(result.script).toContain('parseFolderPath');
+    expect(result.script).toContain('resolveFolderPath');
   });
 
   it('handles tags replacement (clearTags + addTag)', async () => {


### PR DESCRIPTION
## Problem (OMN-127)

`omnifocus_write` had **three divergent, hand-written folder resolvers** in `src/contracts/ast/mutation-script-builder.ts` that had drifted apart:

| Site | Path-aware (`" : "`)? | On unresolved folder |
| -- | -- | -- |
| `buildCreateFolderScript` | ✅ | returns error |
| `buildCreateProjectScript` | ✅ | **silently filed at DB root, returned `success:true`** ❌ |
| `buildUpdateProjectScript` (move) | ❌ byIdentifier + flat name only | `folder_not_found` (path-blind) ❌ |

Found during a real restructure: 9 projects created with a partial path (`"Other Games : Shop Titans"`) all returned `success:true` but landed at top level — silent data misplacement caught only by a `folderPath` read-back.

## Fix

Extract **one** shared OmniJS resolver (`resolveFolderFlexible`: path walk → `byIdentifier` → leaf name) and call it from all three sites so they cannot drift again.

- **#1** `create project` now returns a loud error (`context: 'create_project'`) when a requested folder is unresolvable. Root placement remains **only** for the genuinely-no-folder case.
- **#2** `update project` resolves `" : "`/`"/"` nested paths identically to create (previously impossible). Target value also switched to `JSON.stringify` for quote-safety.
- **#3** Documented project folder path semantics in the Zod schema (`.describe()`), the `inputSchema` override, and the tool description (dual-schema rule).

Net **−45 lines** of duplicated resolver logic.

## Verification

- `npm run build` clean; **2232/2232** unit tests pass (2 new regression tests, one per defect).
- inputSchema stays under the 4KB minified budget (3941 bytes; added a headroom-warning comment).
- **Live `/verify` against OmniFocus — 17/17:** create + update by full path *and* bare name read `folderPath` back correctly; partial/bogus paths error on both create and update; `folder:null` moves to root. Self-cleaning probe; DB restored.
- Code-review subagent verdict: **SAFE** (independently confirmed no backtick/`${` injection hazard in the nested move-script template — the OMN-111/113 risk class).

Closes OMN-127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)