### PR TITLE
feat(OMN-128): OmniJS-native write-side mutation AST — buildCreateProjectScript vertical slice

### DIFF
--- a/docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md
+++ b/docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md
@@ -744,6 +744,13 @@ describe('dispatchMutation guard (OMN-119/120 non-bypass)', () => {
       `target==='project'` (unchanged). Add: the script contains `app.evaluateJavascript(` and `new Project(`. Remove
       any assertion that depended on the old JXA `app.Project({...})` literal.
 
+      > Review **all six** `buildCreateProjectScript` sub-tests, not just the first. Most survive because their data
+      > now appears inside the JSON-encoded program (`toContain('on_hold')`, `toContain('reviewInterval')`,
+      > `toContain('Work Folder')`). But `includes sequential flag` (asserts `toContain('sequential')`) and the OMN-38
+      > regression guards (which assert the **absence** of specific JXA patterns) target the old scaffolding — re-read
+      > each and adjust any whose assertion was about removed JXA, keeping the OMN-38 *intent* (no
+      > seconds-conversion / plain-object / constructor reviewInterval patterns) expressed against the new OmniJS body.
+
 ```typescript
 // adjust within describe('buildCreateProjectScript', ...)
 it('emits an OmniJS-native create via the launcher boundary', () => {
@@ -801,6 +808,8 @@ registry).
 - [ ] **Step 2:** Through the live MCP (OmniFocus running, sandbox configured), create a project that exercises every
       branch, **inside the sandbox folder** the guard requires:
   - `omnifocus_write { mutation: { operation: 'create', target: 'project', data: { name: '__test- AST slice', folder: '<SANDBOX_FOLDER_NAME>', tags: ['__test-ast'], dueDate: '2026-06-30', flagged: true, sequential: true, status: 'on_hold', reviewInterval: 7 } } }`
+  - Also run a second case with `reviewInterval: 1` (and no other review-bearing fields) to exercise the `days` fallback
+    branch — `reviewInterval: 7` only covers the `% 7 === 0` weekly branch.
 - [ ] **Step 3: Confirm by reading back** (not by trusting the success envelope):
   - project exists in the sandbox folder (folder placement correct);
   - tags applied; due date set; flagged + sequential; status on-hold; review interval = weekly;

--- a/docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md
+++ b/docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md
@@ -1,0 +1,839 @@
+# Write-Side Mutation AST — Vertical Slice (`buildCreateProjectScript`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. TDD
+> throughout (@superpowers:test-driven-development). The final live-verify gate uses
+> @superpowers:verification-before-completion.
+
+**Goal:** Stand up a new OmniJS-native mutation AST (`src/contracts/ast/mutation/`) and migrate exactly one builder —
+`buildCreateProjectScript` — to emit from it, proving the architecture and establishing the test pattern for the
+remaining builders.
+
+**Architecture:** Mirror the read-side AST at the mutation altitude. A small statement/expression node set
+(`resolve → construct → set → assign → envelope`) is lowered from `ProjectCreateData` by a `MUTATION_DEFS` registry,
+validated, then emitted as **one OmniJS program** wrapped in a fixed, data-free JXA launcher. `JSON.stringify` owns both
+boundaries (TS→OmniJS data; OmniJS-program→JXA-string), eliminating the OMN-111/113 nested-backtick injection class by
+construction.
+
+**Tech Stack:** TypeScript (strict, ESM `.js` import specifiers), Vitest (`toEqual`/`toContain`, no snapshots), OmniJS
+(Omni Automation) executed via `osascript -l JavaScript`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md`. Read it before starting.
+
+---
+
+## Scope & deliberate non-goals (YAGNI)
+
+This plan migrates **only `buildCreateProjectScript`**. It builds **only the node subset that create/project
+exercises**. The following are explicitly deferred to later plans (one per builder), per the spec's vertical-slice
+strategy:
+
+- Other builders (create-task, create-folder, updates, complete, delete, batch, bulk-delete, tag builders).
+- A generic `Place` node for task/project _moves_ (create/project folds placement into construction via OmniJS
+  `new Project(name, folder)`).
+- `ResolveTag` (read-only) — create/project uses create-or-find (`ResolveOrCreateTag`) only.
+
+**Spec deviation to record (decided during planning, flag at handoff):** The spec §5/§8 model `SandboxGuard` as an
+_emitted runtime node_. The actual guard (`validateProjectCreate`) is a **build-time TypeScript throw** that emits
+nothing into the script. Emitting a runtime guard would change behavior. This plan keeps the guard build-time and makes
+it **non-bypassable at the `MUTATION_DEFS` dispatch layer** (a new op cannot be registered without declaring its guard),
+which is the faithful implementation of the spec's _intent_ (the OMN-119/120 non-bypass property). The validator asserts
+the structural property; it does not look for a runtime node.
+
+---
+
+## File structure
+
+**New files (mirror `src/contracts/ast/` read-side layout):**
+
+| File                                      | Responsibility                                                                     |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| `src/contracts/ast/mutation/types.ts`     | Node union (subset), type guards, factory functions (mirror read-side `types.ts`)  |
+| `src/contracts/ast/mutation/snippets.ts`  | Single-source OmniJS helper snippet registry (lifts the OMN-127 resolver consts)   |
+| `src/contracts/ast/mutation/emitter.ts`   | `emitProgram(program) → omnijs string`; `wrapInLauncher(omnijs, ctx) → JXA string` |
+| `src/contracts/ast/mutation/validator.ts` | `validateMutationProgram(program)` — structural static checks                      |
+| `src/contracts/ast/mutation/defs.ts`      | `MUTATION_DEFS` registry + `buildCreateProjectProgram(data)` + guarded `dispatch`  |
+| `src/contracts/ast/mutation/index.ts`     | Public exports                                                                     |
+
+**New test files:**
+
+| File                                                       | Covers                                                            |
+| ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| `tests/unit/contracts/ast/mutation/types.test.ts`          | factories produce expected node objects                           |
+| `tests/unit/contracts/ast/mutation/snippets.test.ts`       | registry canonical source + dependency collection/dedup           |
+| `tests/unit/contracts/ast/mutation/emitter.test.ts`        | expression + statement + program emission; **boundary/injection** |
+| `tests/unit/contracts/ast/mutation/validator.test.ts`      | rejects malformed programs, accepts valid                         |
+| `tests/unit/contracts/ast/mutation/create-project.test.ts` | create/project program structure + guarded dispatch               |
+
+**Modified files:**
+
+| File                                                       | Change                                                                                                                                                                                    |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/contracts/ast/mutation-script-builder.ts`             | `buildCreateProjectScript` body delegates to the new pipeline; the five `OMNIJS_*` resolver consts re-export from `snippets.ts` (single-source, byte-identical)                           |
+| `tests/unit/contracts/ast/mutation-script-builder.test.ts` | adjust `buildCreateProjectScript` assertions to the new (OmniJS-native) output where they reference removed JXA scaffolding; keep contract assertions (`operation`/`target`/name present) |
+
+---
+
+## Node subset for this slice
+
+**Statements:** `Bind`, `ResolveFolder`, `Guard`, `ConstructProject`, `SetProp`, `AssignTags`, `Return`.
+**Expressions:** `Ref`, `Member`, `New`, `EnumRef`, `DateExpr`, `Json`. **Value types:**
+`FolderResolution = { kind: 'resolved'; var } | { kind: 'none' } | { kind: 'notFound' }` — the typed fail-able result
+`ResolveFolder` yields and `ConstructProject`/`Guard` consume. **No node accepts a folder string.**
+
+---
+
+## Task 1: Node types + factories
+
+**Files:**
+
+- Create: `src/contracts/ast/mutation/types.ts`
+- Test: `tests/unit/contracts/ast/mutation/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/contracts/ast/mutation/types.test.ts
+import { describe, it, expect } from 'vitest';
+import { json, ref, member, setProp, return_, resolveFolder } from '../../../../../src/contracts/ast/mutation/types.js';
+
+describe('mutation node factories', () => {
+  it('json() wraps a value', () => {
+    expect(json('a"b')).toEqual({ type: 'json', value: 'a"b' });
+  });
+  it('member() captures object + path', () => {
+    expect(member(ref('proj'), 'id.primaryKey')).toEqual({
+      type: 'member',
+      object: { type: 'ref', name: 'proj' },
+      path: 'id.primaryKey',
+    });
+  });
+  it('setProp() defaults strategy to direct', () => {
+    expect(setProp(ref('proj'), 'flagged', json(true))).toEqual({
+      type: 'setProp',
+      target: { type: 'ref', name: 'proj' },
+      prop: 'flagged',
+      value: { type: 'json', value: true },
+      strategy: 'direct',
+    });
+  });
+  it('resolveFolder() binds a result var + ref string', () => {
+    expect(resolveFolder('folderVar', 'Work')).toEqual({
+      type: 'resolveFolder',
+      bind: 'folderVar',
+      ref: 'Work',
+    });
+  });
+  it('return_() wraps an envelope', () => {
+    expect(return_({ created: json(true) })).toEqual({
+      type: 'return',
+      envelope: { created: { type: 'json', value: true } },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest tests/unit/contracts/ast/mutation/types.test.ts --run` Expected: FAIL — module `mutation/types.js` not
+found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/contracts/ast/mutation/types.ts
+// Mutation AST — node set for the create/project vertical slice (OMN-128).
+// Mirrors the read-side types.ts: node union + type guards + factory functions.
+
+export type SetPropStrategy = 'direct' | 'dateExpr' | 'enum' | 'readModifyReassign';
+
+// --- Expressions ---
+export interface RefNode {
+  type: 'ref';
+  name: string;
+}
+export interface MemberNode {
+  type: 'member';
+  object: Expr;
+  path: string;
+}
+export interface NewNode {
+  type: 'new';
+  className: string;
+  args: Expr[];
+}
+export interface EnumRefNode {
+  type: 'enumRef';
+  path: string;
+} // e.g. 'Project.Status.OnHold'
+export interface DateExprNode {
+  type: 'dateExpr';
+  value: Expr;
+} // emits new Date(<value>)
+export interface JsonNode {
+  type: 'json';
+  value: unknown;
+} // ONLY data primitive → JSON.stringify
+export type Expr = RefNode | MemberNode | NewNode | EnumRefNode | DateExprNode | JsonNode;
+
+// --- Typed fail-able folder resolution ---
+export type FolderResolution = { kind: 'resolved'; var: string } | { kind: 'none' } | { kind: 'notFound' };
+
+// --- Statements ---
+export interface BindNode {
+  type: 'bind';
+  name: string;
+  expr: Expr;
+}
+export interface ResolveFolderNode {
+  type: 'resolveFolder';
+  bind: string;
+  ref: string;
+}
+export interface GuardNode {
+  type: 'guard';
+  cond: string;
+  envelope: Envelope;
+} // emits: if (cond) return JSON.stringify(env)
+export interface ConstructProjectNode {
+  type: 'constructProject';
+  bind: string; // variable the new Project is bound to
+  name: Expr; // Json node
+  folder: FolderResolution; // resolved var | none ; notFound must be Guarded earlier
+}
+export interface SetPropNode {
+  type: 'setProp';
+  target: Expr;
+  prop: string;
+  value: Expr;
+  strategy: SetPropStrategy;
+}
+export interface AssignTagsNode {
+  type: 'assignTags';
+  target: Expr;
+  tags: Expr;
+  bind: string;
+} // tags: Json(string[])
+export interface ReturnNode {
+  type: 'return';
+  envelope: Envelope;
+}
+export type Stmt =
+  | BindNode
+  | ResolveFolderNode
+  | GuardNode
+  | ConstructProjectNode
+  | SetPropNode
+  | AssignTagsNode
+  | ReturnNode;
+
+export type Envelope = Record<string, Expr>;
+
+export interface Program {
+  statements: Stmt[];
+  context: string; // error-envelope context tag, e.g. 'create_project'
+  snippetDeps: string[]; // snippet registry keys this program needs at OmniJS program-top
+}
+
+// --- Factories (mirror read-side and/or/compare/...) ---
+export const ref = (name: string): RefNode => ({ type: 'ref', name });
+export const member = (object: Expr, path: string): MemberNode => ({ type: 'member', object, path });
+export const newExpr = (className: string, args: Expr[]): NewNode => ({ type: 'new', className, args });
+export const enumRef = (path: string): EnumRefNode => ({ type: 'enumRef', path });
+export const dateExpr = (value: Expr): DateExprNode => ({ type: 'dateExpr', value });
+export const json = (value: unknown): JsonNode => ({ type: 'json', value });
+
+export const bind = (name: string, expr: Expr): BindNode => ({ type: 'bind', name, expr });
+export const resolveFolder = (bindVar: string, refStr: string): ResolveFolderNode => ({
+  type: 'resolveFolder',
+  bind: bindVar,
+  ref: refStr,
+});
+export const guard = (cond: string, envelope: Envelope): GuardNode => ({ type: 'guard', cond, envelope });
+export const constructProject = (bindVar: string, name: Expr, folder: FolderResolution): ConstructProjectNode => ({
+  type: 'constructProject',
+  bind: bindVar,
+  name,
+  folder,
+});
+export const setProp = (
+  target: Expr,
+  prop: string,
+  value: Expr,
+  strategy: SetPropStrategy = 'direct',
+): SetPropNode => ({ type: 'setProp', target, prop, value, strategy });
+export const assignTags = (target: Expr, tags: Expr, bindVar: string): AssignTagsNode => ({
+  type: 'assignTags',
+  target,
+  tags,
+  bind: bindVar,
+});
+export const return_ = (envelope: Envelope): ReturnNode => ({ type: 'return', envelope });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest tests/unit/contracts/ast/mutation/types.test.ts --run` Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/mutation/types.ts tests/unit/contracts/ast/mutation/types.test.ts
+git commit -m "feat(OMN-128): mutation AST node types + factories (slice subset)"
+```
+
+---
+
+## Task 2: Snippet registry (single-source; lift OMN-127 resolvers)
+
+**Files:**
+
+- Create: `src/contracts/ast/mutation/snippets.ts`
+- Modify: `src/contracts/ast/mutation-script-builder.ts` (re-point the five `OMNIJS_*` consts at the registry)
+- Test: `tests/unit/contracts/ast/mutation/snippets.test.ts`
+
+**Context:** The canonical resolvers currently live as `const OMNIJS_PARSE_FOLDER_PATH`, `OMNIJS_RESOLVE_FOLDER_PATH`,
+`OMNIJS_RESOLVE_FOLDER_FLEXIBLE`, `OMNIJS_PARSE_TAG_PATH`, `OMNIJS_RESOLVE_OR_CREATE_TAG_PATH` in
+`mutation-script-builder.ts` (~lines 450–547). This task makes the registry the single source and re-points the existing
+consts at it so output stays **byte-identical** (other builders still consume the consts; their tests guard against
+drift). `resolveFolderFlexible` depends on `parseFolderPath` + `resolveFolderPath` — encode that.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/contracts/ast/mutation/snippets.test.ts
+import { describe, it, expect } from 'vitest';
+import { SNIPPETS, collectSnippets } from '../../../../../src/contracts/ast/mutation/snippets.js';
+
+describe('snippet registry', () => {
+  it('exposes the flexible folder resolver source', () => {
+    expect(SNIPPETS.resolveFolderFlexible.source).toContain('function resolveFolderFlexible');
+  });
+  it('collectSnippets pulls declared deps + their transitive deps, deduped, in dependency order', () => {
+    const out = collectSnippets(['resolveFolderFlexible']);
+    // resolveFolderFlexible depends on parseFolderPath + resolveFolderPath
+    expect(out).toContain('function parseFolderPath');
+    expect(out).toContain('function resolveFolderPath');
+    expect(out).toContain('function resolveFolderFlexible');
+    // dependencies are defined before the dependent
+    expect(out.indexOf('function parseFolderPath')).toBeLessThan(out.indexOf('function resolveFolderFlexible'));
+  });
+  it('deduplicates a snippet requested twice', () => {
+    const out = collectSnippets(['resolveFolderFlexible', 'resolveFolderFlexible']);
+    expect(out.match(/function resolveFolderFlexible/g)).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run** `npx vitest tests/unit/contracts/ast/mutation/snippets.test.ts --run` → FAIL (module missing).
+
+- [ ] **Step 3: Implement.** Move the five resolver source strings verbatim into the registry, declare deps, write
+      `collectSnippets` (topological, deduped). Then in `mutation-script-builder.ts` redefine the consts as
+      `const OMNIJS_RESOLVE_FOLDER_FLEXIBLE = SNIPPETS.resolveFolderFlexible.source;` etc. (byte-identical).
+
+```typescript
+// src/contracts/ast/mutation/snippets.ts
+export interface Snippet {
+  readonly source: string;
+  readonly deps: readonly string[];
+}
+
+// Sources lifted verbatim from mutation-script-builder.ts (OMN-127 consolidation).
+const parseFolderPath = `\nfunction parseFolderPath(input) { /* ...verbatim... */ }`;
+const resolveFolderPath = `\nfunction resolveFolderPath(segments) { /* ...verbatim... */ }`;
+const resolveFolderFlexible = `\nfunction resolveFolderFlexible(target) { /* ...verbatim... */ }`;
+const parseTagPath = `\nfunction parseTagPath(input) { /* ...verbatim... */ }`;
+const resolveOrCreateTagByPath = `\nfunction resolveOrCreateTagByPath(segments) { /* ...verbatim... */ }`;
+
+export const SNIPPETS: Record<string, Snippet> = {
+  parseFolderPath: { source: parseFolderPath, deps: [] },
+  resolveFolderPath: { source: resolveFolderPath, deps: [] },
+  resolveFolderFlexible: { source: resolveFolderFlexible, deps: ['parseFolderPath', 'resolveFolderPath'] },
+  parseTagPath: { source: parseTagPath, deps: [] },
+  resolveOrCreateTagByPath: { source: resolveOrCreateTagByPath, deps: ['parseTagPath'] },
+};
+
+export function collectSnippets(keys: readonly string[]): string {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  const visit = (key: string): void => {
+    if (seen.has(key)) return;
+    seen.add(key);
+    const snip = SNIPPETS[key];
+    if (!snip) throw new Error(`Unknown snippet: ${key}`);
+    snip.deps.forEach(visit); // deps first → dependency order
+    ordered.push(snip.source);
+  };
+  keys.forEach(visit);
+  return ordered.join('\n');
+}
+```
+
+> IMPORTANT: copy the snippet bodies **verbatim** from the current consts. After re-pointing the consts, run the
+> existing folder/tag builder tests to prove byte-identical output:
+> `npx vitest tests/unit/contracts/ast/folder-builders.test.ts tests/unit/contracts/ast/mutation-script-builder.test.ts --run`
+
+- [ ] **Step 4: Run** the new test + the existing folder/mutation tests → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/mutation/snippets.ts src/contracts/ast/mutation-script-builder.ts tests/unit/contracts/ast/mutation/snippets.test.ts
+git commit -m "feat(OMN-128): single-source OmniJS snippet registry; re-point OMN-127 resolver consts"
+```
+
+---
+
+## Task 3: Expression emitter (incl. the `Json` injection guarantee)
+
+**Files:**
+
+- Create: `src/contracts/ast/mutation/emitter.ts`
+- Test: `tests/unit/contracts/ast/mutation/emitter.test.ts`
+
+- [ ] **Step 1: Write the failing test** (expression cases + the injection-safety property)
+
+```typescript
+// tests/unit/contracts/ast/mutation/emitter.test.ts
+import { describe, it, expect } from 'vitest';
+import { emitExpr } from '../../../../../src/contracts/ast/mutation/emitter.js';
+import { ref, member, newExpr, enumRef, dateExpr, json } from '../../../../../src/contracts/ast/mutation/types.js';
+
+describe('emitExpr', () => {
+  it('ref → bare name', () => expect(emitExpr(ref('proj'))).toBe('proj'));
+  it('member → dotted access', () => expect(emitExpr(member(ref('proj'), 'id.primaryKey'))).toBe('proj.id.primaryKey'));
+  it('new → constructor call', () =>
+    expect(emitExpr(newExpr('Project', [json('P'), ref('f')]))).toBe('new Project("P", f)'));
+  it('enumRef → path verbatim', () => expect(emitExpr(enumRef('Project.Status.OnHold'))).toBe('Project.Status.OnHold'));
+  it('dateExpr → new Date(...)', () => expect(emitExpr(dateExpr(json('2026-06-08')))).toBe('new Date("2026-06-08")'));
+
+  it('json uses JSON.stringify (strings)', () => expect(emitExpr(json('hi'))).toBe('"hi"'));
+  it('json is injection-safe: backticks, ${}, quotes, newlines survive as DATA', () => {
+    const hostile = 'a`b${c}d"e\nf';
+    const emitted = emitExpr(json(hostile));
+    // The emitted text is a JS literal that evaluates back to the original string.
+    // eslint-disable-next-line no-eval
+    expect(eval(emitted)).toBe(hostile);
+  });
+});
+```
+
+- [ ] **Step 2: Run** → FAIL (module missing).
+
+- [ ] **Step 3: Implement `emitExpr`.**
+
+```typescript
+// src/contracts/ast/mutation/emitter.ts  (part 1 of 3)
+import type { Expr } from './types.js';
+
+export function emitExpr(node: Expr): string {
+  switch (node.type) {
+    case 'ref':
+      return node.name;
+    case 'member':
+      return `${emitExpr(node.object)}.${node.path}`;
+    case 'new':
+      return `new ${node.className}(${node.args.map(emitExpr).join(', ')})`;
+    case 'enumRef':
+      return node.path;
+    case 'dateExpr':
+      return `new Date(${emitExpr(node.value)})`;
+    case 'json':
+      return JSON.stringify(node.value); // the ONLY data crossing; injection-proof
+    default: {
+      const _exhaustive: never = node;
+      throw new Error(`Unknown expr node: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `feat(OMN-128): mutation AST expression emitter (Json = injection-safe data boundary)`
+
+---
+
+## Task 4: Statement + program emitter
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation/emitter.ts`
+- Test: `tests/unit/contracts/ast/mutation/emitter.test.ts`
+
+**Statement emission contract:**
+
+| Node                             | Emits (OmniJS)                                                                                                                                                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bind`                           | `const <name> = <expr>;`                                                                                                                                                                                                |
+| `resolveFolder`                  | `const <bind> = resolveFolderFlexible(<json(ref)>);` (declares `resolveFolderFlexible` dep)                                                                                                                             |
+| `guard`                          | `if (<cond>) return JSON.stringify(<envelope>);`                                                                                                                                                                        |
+| `constructProject`               | `const <bind> = new Project(<name>, <folderExpr>);` where folderExpr = the resolved var for `resolved`, or omitted (1-arg `new Project(<name>)`) for `none`. `notFound` is illegal here (validator + Guard precede it). |
+| `setProp` (`direct`)             | `<target>.<prop> = <value>;`                                                                                                                                                                                            |
+| `setProp` (`dateExpr`)           | `try { <target>.<prop> = <value>; } catch (e) {}` (value is a `dateExpr`)                                                                                                                                               |
+| `setProp` (`enum`)               | `<target>.<prop> = <value>;` (value is an `enumRef`)                                                                                                                                                                    |
+| `setProp` (`readModifyReassign`) | emit the reviewInterval read-modify-reassign block (see Task 7 for the exact body)                                                                                                                                      |
+| `assignTags`                     | a `for` loop over `<tags>` calling `resolveOrCreateTagByPath`/find then `<target>.addTag(tag)` (declares `resolveOrCreateTagByPath` dep)                                                                                |
+| `return`                         | `return JSON.stringify(<envelope>);`                                                                                                                                                                                    |
+
+`emitProgram(program)` assembles: `(() => {` + injected snippets (`collectSnippets(program.snippetDeps)`) + statements
+
+- `})()`. Envelopes emit as `{ key: <emitExpr(value)>, ... }`.
+
+* [ ] **Step 1: Write the failing test** (small representative program)
+
+```typescript
+import { emitProgram } from '../../../../../src/contracts/ast/mutation/emitter.js';
+import {
+  bind,
+  constructProject,
+  setProp,
+  return_,
+  ref,
+  json,
+  member,
+} from '../../../../../src/contracts/ast/mutation/types.js';
+
+it('emitProgram assembles an OmniJS IIFE with statements', () => {
+  const program = {
+    context: 'create_project',
+    snippetDeps: [],
+    statements: [
+      constructProject('proj', json('P'), { kind: 'none' }),
+      setProp(ref('proj'), 'flagged', json(true)),
+      return_({ projectId: member(ref('proj'), 'id.primaryKey'), created: json(true) }),
+    ],
+  };
+  const out = emitProgram(program);
+  expect(out).toContain('const proj = new Project("P");');
+  expect(out).toContain('proj.flagged = true;');
+  expect(out).toContain('return JSON.stringify({ projectId: proj.id.primaryKey, created: true });');
+  expect(out.trim().startsWith('(() => {')).toBe(true);
+  expect(out.trim().endsWith('})()')).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run** → FAIL. **Step 3:** implement `emitStmt` + `emitProgram` per the table. **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `feat(OMN-128): mutation AST statement + program emitter`
+
+---
+
+## Task 5: JXA launcher boundary (`JSON.stringify(program)`) — the OMN-111/113 kill
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation/emitter.ts`
+- Test: `tests/unit/contracts/ast/mutation/emitter.test.ts`
+
+This is the load-bearing safety test. `wrapInLauncher(omnijs, context)` returns the fixed JXA launcher with the **whole
+OmniJS program JSON.stringify'd** into the `evaluateJavascript` argument.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { wrapInLauncher } from '../../../../../src/contracts/ast/mutation/emitter.js';
+
+describe('wrapInLauncher (JXA boundary)', () => {
+  it('produces a self-contained IIFE with app init (skips OmniAutomation.wrapScript)', () => {
+    const jxa = wrapInLauncher('return JSON.stringify({ok:true});', 'create_project');
+    expect(jxa).toContain('(() =>');
+    expect(jxa).toContain("Application('OmniFocus')");
+    expect(jxa).toContain('app.evaluateJavascript(');
+  });
+
+  it('a hostile OmniJS program survives the boundary intact (injection-proof)', () => {
+    const hostile = 'const x = `a${b}` + "\\" ); evil()"; \n return JSON.stringify({x});';
+    const jxa = wrapInLauncher(hostile, 'create_project');
+    // Extract the JSON string literal passed to evaluateJavascript and confirm it round-trips.
+    const m = jxa.match(/app\.evaluateJavascript\((".*?")\);/s);
+    expect(m).not.toBeNull();
+    expect(JSON.parse(m![1])).toBe(hostile); // the program is delivered byte-for-byte
+  });
+});
+```
+
+- [ ] **Step 2: Run** → FAIL.
+
+- [ ] **Step 3: Implement.**
+
+```typescript
+// src/contracts/ast/mutation/emitter.ts  (part 3 of 3)
+export function wrapInLauncher(omnijsProgram: string, context: string): string {
+  // The whole OmniJS program is escaped ONCE via JSON.stringify into a JXA string literal.
+  // No nested backticks; no escapeTemplateString. Handles every quote/backslash/newline/control char.
+  return `(() => {
+  const app = Application('OmniFocus');
+  try {
+    return app.evaluateJavascript(${JSON.stringify(omnijsProgram)});
+  } catch (e) {
+    return JSON.stringify({ error: true, message: String(e), context: ${JSON.stringify(context)} });
+  }
+})()`;
+}
+```
+
+- [ ] **Step 4: Run** → PASS. Note the round-trip assertion is the structural proof OMN-111/113 cannot recur here.
+- [ ] **Step 5: Commit** `feat(OMN-128): JXA launcher boundary via JSON.stringify(program) — kills OMN-111/113 class`
+
+---
+
+## Task 6: Validator
+
+**Files:**
+
+- Create: `src/contracts/ast/mutation/validator.ts`
+- Test: `tests/unit/contracts/ast/mutation/validator.test.ts`
+
+**Rules:** (1) last statement is `return`; (2) every `constructProject.folder` is a `FolderResolution` object (not a
+string) — enforced by the type system, but the validator guards against hand-built `as any` trees; (3) any
+`constructProject` with `folder.kind === 'notFound'` must be preceded by a `guard` (notFound is unconstructable); (4)
+program declares snippet deps actually used.
+
+- [ ] **Step 1: failing test**
+
+```typescript
+// tests/unit/contracts/ast/mutation/validator.test.ts
+import { describe, it, expect } from 'vitest';
+import { validateMutationProgram } from '../../../../../src/contracts/ast/mutation/validator.js';
+import { constructProject, setProp, return_, ref, json } from '../../../../../src/contracts/ast/mutation/types.js';
+
+const ok = {
+  context: 'create_project',
+  snippetDeps: [],
+  statements: [constructProject('proj', json('P'), { kind: 'none' }), return_({ created: json(true) })],
+};
+
+describe('validateMutationProgram', () => {
+  it('accepts a well-formed program', () => expect(() => validateMutationProgram(ok)).not.toThrow());
+  it('rejects a program that does not end in return', () => {
+    const bad = { ...ok, statements: [constructProject('proj', json('P'), { kind: 'none' })] };
+    expect(() => validateMutationProgram(bad)).toThrow(/must end in a return/i);
+  });
+  it('rejects a constructProject whose folder is a raw string', () => {
+    const bad = {
+      ...ok,
+      statements: [
+        { ...constructProject('proj', json('P'), { kind: 'none' }), folder: 'Work' as any },
+        return_({ created: json(true) }),
+      ],
+    };
+    expect(() => validateMutationProgram(bad)).toThrow(/folder.*resolution/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run** → FAIL. **Step 3:** implement the rules. **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `feat(OMN-128): mutation program validator (return-terminated, typed folder resolution)`
+
+---
+
+## Task 7: create/project lowering + guarded `MUTATION_DEFS` dispatch
+
+**Files:**
+
+- Create: `src/contracts/ast/mutation/defs.ts`
+- Create: `src/contracts/ast/mutation/index.ts`
+- Test: `tests/unit/contracts/ast/mutation/create-project.test.ts`
+
+**`buildCreateProjectProgram(data: ProjectCreateData): Program`** assembles (in order):
+
+1. `resolveFolder('targetFolder', data.folder)` — **only if** `data.folder` set; declares `resolveFolderFlexible` dep.
+2. `guard('targetFolder === null', { error: json(true), message: json('Folder not found: ' + data.folder), context: json('create_project') })`
+   — the OMN-127 loud failure; only when a folder was requested.
+3. `constructProject('proj', json(data.name), folderResolution)` where folderResolution =
+   `{kind:'resolved',var:'targetFolder'}` if folder requested else `{kind:'none'}`.
+4. `setProp(proj,'note', json(data.note ?? ''))`, `flagged`, `sequential` (direct) — match current defaults.
+5. date setters (`strategy: 'dateExpr'`) for due/defer/planned when present.
+6. status (`strategy: 'enum'`, value `enumRef(Project.Status.X)`) only when `status && status !== 'active'`.
+7. reviewInterval (`strategy: 'readModifyReassign'`) when present — emit the exact days→unit/steps +
+   read-modify-reassign body from the current builder (`mutation-script-builder.ts` ~lines 1145–1167).
+8. tags (`assignTags`, declares `resolveOrCreateTagByPath` dep) when present.
+9. `return_` success envelope reading back `proj.id.primaryKey`, `proj.name`, etc. **No `.id()` JXA dance** — direct
+   OmniJS property read.
+
+**`MUTATION_DEFS` dispatch** wires the build-time guard non-bypassably:
+
+```typescript
+// src/contracts/ast/mutation/defs.ts (dispatch shape)
+import { validateProjectCreate } from '../mutation-script-builder.js'; // or relocate guard; see note
+interface MutationDef<T> {
+  guard: (data: T) => void;
+  build: (data: T) => Program;
+}
+export const MUTATION_DEFS = {
+  'create/project': {
+    guard: validateProjectCreate,
+    build: buildCreateProjectProgram,
+  } as MutationDef<ProjectCreateData>,
+};
+export function dispatchMutation<T>(key: keyof typeof MUTATION_DEFS, data: T): Program {
+  const def = MUTATION_DEFS[key] as unknown as MutationDef<T>;
+  def.guard(data); // build-time sandbox guard — cannot be skipped for a registered op
+  return def.build(data);
+}
+```
+
+> Note: `validateProjectCreate` is currently `function`-scoped (not exported) in `mutation-script-builder.ts`. Export it
+> (or move it to a small `guards.ts`) so the registry can reference it. Keep its body unchanged.
+
+- [ ] **Step 1: failing test**
+
+```typescript
+// tests/unit/contracts/ast/mutation/create-project.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildCreateProjectProgram, dispatchMutation } from '../../../../../src/contracts/ast/mutation/defs.js';
+
+describe('buildCreateProjectProgram', () => {
+  it('no folder → constructProject with folder kind none, no resolveFolder/guard', () => {
+    const p = buildCreateProjectProgram({ name: 'P' });
+    expect(p.statements.find((s) => s.type === 'resolveFolder')).toBeUndefined();
+    const cp = p.statements.find((s) => s.type === 'constructProject') as any;
+    expect(cp.folder).toEqual({ kind: 'none' });
+    expect(p.statements.at(-1)!.type).toBe('return');
+  });
+  it('folder requested → resolveFolder + guard + resolved construct + snippet dep', () => {
+    const p = buildCreateProjectProgram({ name: 'P', folder: 'Work' });
+    expect(p.statements[0].type).toBe('resolveFolder');
+    expect(p.statements[1].type).toBe('guard');
+    expect(p.snippetDeps).toContain('resolveFolderFlexible');
+  });
+  it('status active is NOT emitted; on_hold IS', () => {
+    expect(
+      buildCreateProjectProgram({ name: 'P', status: 'active' }).statements.some(
+        (s) => s.type === 'setProp' && (s as any).prop === 'status',
+      ),
+    ).toBe(false);
+    expect(
+      buildCreateProjectProgram({ name: 'P', status: 'on_hold' }).statements.some(
+        (s) => s.type === 'setProp' && (s as any).prop === 'status',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('dispatchMutation guard (OMN-119/120 non-bypass)', () => {
+  it('calls the sandbox guard before building', () => {
+    const prev = { NODE_ENV: process.env.NODE_ENV, SG: process.env.SANDBOX_GUARD_ENABLED };
+    process.env.NODE_ENV = 'test';
+    process.env.SANDBOX_GUARD_ENABLED = 'true';
+    try {
+      expect(() => dispatchMutation('create/project', { name: 'P', folder: 'NotSandbox' })).toThrow(/TEST GUARD/);
+    } finally {
+      process.env.NODE_ENV = prev.NODE_ENV;
+      process.env.SANDBOX_GUARD_ENABLED = prev.SG;
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run** → FAIL. **Step 3:** implement `defs.ts` (+ export `validateProjectCreate`) + `index.ts`. **Step 4:
+      Run** → PASS.
+- [ ] **Step 5: Commit** `feat(OMN-128): create/project lowering + guarded MUTATION_DEFS dispatch`
+
+---
+
+## Task 8: Wire `buildCreateProjectScript` to the new pipeline
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation-script-builder.ts` (`buildCreateProjectScript` body)
+- Modify: `tests/unit/contracts/ast/mutation-script-builder.test.ts`
+
+- [ ] **Step 1: Update the existing test** to the new output. Keep contract assertions; replace JXA-scaffolding
+      assertions. The current tests assert `script.toContain("Application('OmniFocus')")` (still true — launcher),
+      `toContain('Test Project')` (still true — but now inside the JSON-encoded program), `operation==='create'`,
+      `target==='project'` (unchanged). Add: the script contains `app.evaluateJavascript(` and `new Project(`. Remove
+      any assertion that depended on the old JXA `app.Project({...})` literal.
+
+```typescript
+// adjust within describe('buildCreateProjectScript', ...)
+it('emits an OmniJS-native create via the launcher boundary', () => {
+  const result = buildCreateProjectScript({ name: 'Test Project' });
+  expect(result.operation).toBe('create');
+  expect(result.target).toBe('project');
+  expect(result.script).toContain("Application('OmniFocus')");
+  expect(result.script).toContain('app.evaluateJavascript(');
+  expect(result.script).toContain('Test Project'); // present as JSON data inside the program
+  expect(result.script).toContain('new Project(');
+});
+```
+
+- [ ] **Step 2: Run** the file → FAIL (old body still emits old output / new assertions unmet).
+
+- [ ] **Step 3: Replace the body** of `buildCreateProjectScript`:
+
+```typescript
+export function buildCreateProjectScript(data: ProjectCreateData): GeneratedMutationScript {
+  const program = dispatchMutation('create/project', data); // runs validateProjectCreate (guard) + builds
+  validateMutationProgram(program);
+  const omnijs = emitProgram(program);
+  const script = wrapInLauncher(omnijs, program.context);
+  return { script: script.trim(), operation: 'create', target: 'project', description: `Create project: ${data.name}` };
+}
+```
+
+Remove the old template-string body and the now-unused `buildProjectDataObject` **only if** nothing else references it
+(grep first — it may be shared). Leave `OMNIJS_*` consts (still consumed by un-migrated builders; now sourced from the
+registry).
+
+- [ ] **Step 4: Run** the file → PASS. Then run the whole AST suite to catch collateral:
+      `npx vitest tests/unit/contracts/ast --run` → all PASS.
+- [ ] **Step 5: Commit**
+      `refactor(OMN-128): buildCreateProjectScript emits from the mutation AST (template body deleted)`
+
+---
+
+## Task 9: Full unit suite + typecheck + lint (automated gate)
+
+- [ ] **Step 1:** `npm run build` → no TS errors (exhaustiveness guards compile).
+- [ ] **Step 2:** `npm run test:unit` → all PASS (note count from output; do not hardcode).
+- [ ] **Step 3:** `npm run lint` → clean (the one `eval` in the emitter test needs the inline
+      `// eslint-disable-next-line no-eval`).
+- [ ] **Step 4: Commit** any lint/type fixups: `chore(OMN-128): typecheck + lint clean for mutation AST slice`
+
+---
+
+## Task 10: LIVE `/verify` at the OmniFocus seam (mandatory human/agent gate)
+
+> REQUIRED SUB-SKILL: @superpowers:verification-before-completion. This is the OMN-125 trap guard — string tests passing
+> does NOT prove the generated OmniJS runs. Do NOT mark the slice complete without this.
+
+- [ ] **Step 1:** Rebuild: `npm run build`.
+- [ ] **Step 2:** Through the live MCP (OmniFocus running, sandbox configured), create a project that exercises every
+      branch, **inside the sandbox folder** the guard requires:
+  - `omnifocus_write { mutation: { operation: 'create', target: 'project', data: { name: '__test- AST slice', folder: '<SANDBOX_FOLDER_NAME>', tags: ['__test-ast'], dueDate: '2026-06-30', flagged: true, sequential: true, status: 'on_hold', reviewInterval: 7 } } }`
+- [ ] **Step 3: Confirm by reading back** (not by trusting the success envelope):
+  - project exists in the sandbox folder (folder placement correct);
+  - tags applied; due date set; flagged + sequential; status on-hold; review interval = weekly;
+  - returned `projectId` is a real `id.primaryKey` (resolvable by a follow-up read).
+- [ ] **Step 4: Confirm the two unknowns the spec flagged:**
+  - **root placement:** separately create `{ name: '__test- root', ... }` with **no folder** and confirm
+    `new Project(name)` lands it where the old builder did (DB root). If OmniJS 1-arg `new Project` does not place at
+    root, adjust `constructProject` emission (`none` → `new Project(name, library.ending)` or equivalent) and re-verify.
+  - **folder-not-found:** create with `folder: '__nonexistent__'` and confirm the loud error envelope
+    (`Folder not found: …`), NOT a silent root-file (the OMN-127 property).
+- [ ] **Step 5:** Delete the sandbox test projects. Record the verify result (what was run, what was observed) in the PR
+      description.
+
+---
+
+## Task 11: PR + review gate
+
+- [ ] **Step 1:** Push branch; open PR against `kip-d/omnifocus-mcp` (NOT any upstream fork). PR body: link the spec,
+      summarize the slice, paste the Task 10 live-verify observations, note the spec deviation (build-time guard at
+      dispatch vs. emitted node).
+- [ ] **Step 2:** Run a code-review subagent (@superpowers:requesting-code-review). Gate merge on Safe/Approved.
+- [ ] **Step 3:** `git pull --rebase` then `gh pr merge --squash --auto` (never `--admin`).
+- [ ] **Step 4:** Comment on OMN-128 with the slice result + what it implies for sizing the remaining builders (the next
+      plan).
+
+---
+
+## Definition of done (this slice)
+
+- New `src/contracts/ast/mutation/` subsystem exists with types/snippets/emitter/validator/defs + unit tests.
+- `buildCreateProjectScript` emits one OmniJS program via the launcher; its template-string body is gone.
+- The boundary test proves a hostile program round-trips (OMN-111/113 structurally impossible at this seam).
+- Folder resolution is typed fail-able (`Folder | NotFound | NoneRequested`); not-found fails loud (OMN-127 property).
+- The sandbox guard runs via `MUTATION_DEFS` dispatch and cannot be bypassed (OMN-119/120 property).
+- Live `/verify` passed and is recorded in the PR.
+- Other builders untouched; snippet registry is the single source for the OMN-127 resolvers.

--- a/docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md
+++ b/docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md
@@ -588,6 +588,11 @@ string) — enforced by the type system, but the validator guards against hand-b
 `constructProject` with `folder.kind === 'notFound'` must be preceded by a `guard` (notFound is unconstructable); (4)
 program declares snippet deps actually used.
 
+> **Implementation note (Rule 4 swap):** the planned Rule 4 (snippet-dep coverage) was kept but moved to an emit-time
+> guard in `emitProgram` (helper usage is implicit in emission, not in the typed tree). The validator's Rule 4 is
+> instead the `setProp` value/mutations invariant (non-`readModifyReassign` requires `value`; `readModifyReassign`
+> requires `mutations`).
+
 - [ ] **Step 1: failing test**
 
 ```typescript

--- a/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
+++ b/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
@@ -75,6 +75,11 @@ Each mutation emits **one OmniJS program**, wrapped in a fixed, **data-free** JX
 })()
 ```
 
+The `<<< … >>>` is a placeholder the emitter fills with `JSON.stringify(programString)`. The OmniJS program is a
+**string**; that string is `JSON.stringify`'d into a JXA string literal which `evaluateJavascript` receives — a single,
+deliberate double-encoding (data is already JSON _inside_ the program; the program is JSON _again_ into JXA). The
+pseudocode is not passing an object.
+
 Two boundaries, both owned by the emitter, both `JSON.stringify`:
 
 | Boundary                        | Mechanism                                                      | Property                                                                                            |
@@ -119,6 +124,18 @@ A `Program` is an ordered list of statements emitted into one OmniJS IIFE.
 `ResolveFolder` yields three **named** states; "no folder requested" (`NoneRequested`) and "requested but missing"
 (`NotFound`) are distinct constructor inputs. OMN-127's conflated `else` cannot be expressed.
 
+Tag resolution carries the same discipline, split by intent:
+
+| Node                             | Result type            | On missing                        |
+| -------------------------------- | ---------------------- | --------------------------------- |
+| `ResolveOrCreateTag { ref }`     | always `Tag` (mkdir-p) | cannot fail — creates the segment |
+| `ResolveTag { ref }` (read-only) | `Tag \| NotFound`      | surfaced to the build site        |
+
+`AssignTags` consumes resolved `Tag` results only. For the current create-or-find behavior (project/task create) every
+entry resolves via `ResolveOrCreateTag`, so `AssignTags` can never receive a missing tag. Where a read-only `ResolveTag`
+is used, the `NotFound` policy (skip-with-warning vs. fail-loud) is declared **at the `MUTATION_DEFS` build site**, not
+buried in the node — the policy stays visible, mirroring §5's folder rule.
+
 ## 6. Lowering registry (mirror of `FILTER_DEFS`)
 
 `MUTATION_DEFS`, keyed by `(operation, target)` → `build(data) → Program` (e.g.
@@ -146,6 +163,11 @@ Static checks on each program before emit:
 
 **Slice:** `buildCreateProjectScript` end-to-end (it exercises folder resolution + setters + status enum +
 reviewInterval read-modify-reassign + tags + id read-back). The OMN-28 `.id()`-matching loop deletes.
+
+The **snippet registry (§7) is stood up during this slice** — the create/project program is the first consumer of
+`parseFolderPath` / `resolveFolderFlexible` / `parseTagPath` / `resolveOrCreateTagByPath`. The later tag-builder
+migration (`tag-mutation-script-builder.ts`, a separate file with its own snippet copies) **reuses** the registry rather
+than re-introducing it; collapsing that duplication is part of the tag-builder PR, not the slice.
 
 **Acceptance for the slice**
 

--- a/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
+++ b/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
@@ -1,0 +1,185 @@
+# Design: OmniJS-native write-side mutation-statement AST
+
+**Ticket:** OMN-128 (expanded in place — see "Scope" below) **Date:** 2026-06-08 **Status:** Design — pending spec
+review + implementation plan **Supersedes the write-side portion of:**
+`docs/plans/2025-11-24-ast-filter-contracts-design.md` (read-side AST; this mirrors it)
+
+---
+
+## 1. Problem
+
+`src/contracts/ast/` contains a real AST + emitter pipeline, but it is used **only on the read side**
+(`TaskFilter → FilterAST → emit OmniJS/JXA`). The write side (`mutation-script-builder.ts`,
+`tag-mutation-script-builder.ts`) is still **template-string codegen**: a `script` string assembled from JS template
+literals with ~40 `${...}` interpolations and hand-written nested OmniJS backtick blocks.
+
+This re-incurs two bug classes on every new write path:
+
+| Class                           | Evidence                                                                                         | Today's only backstop        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------- |
+| **String-injection / escaping** | Shipped twice: OMN-111, OMN-113 (stray backticks broke `evaluateJavascript` bodies)              | Hand-review + live `/verify` |
+| **Logic duplication / drift**   | OMN-127: three hand-copied folder resolvers had diverged (one silent-root-filed, one path-blind) | Hand-consolidation           |
+
+A third, structural issue compounds both: the write side never adopted the repo's **own** documented OmniJS-First
+standard (`docs/dev/OMNIJS-FIRST-PATTERN.md`, 2025-11-27). It runs as a JXA shell with **28 `evaluateJavascript`
+bridge-islands** (5 in `buildCreateProjectScript` alone). Each island is a nested backtick block — i.e. the injection
+hazard _is_ the architecture.
+
+## 2. What this fixes — and what it does not
+
+| Hardened (structural)                                                    | NOT addressed                                                                              |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Injection/escaping (OMN-111/113) — _by construction_                     | Semantic/control-flow defects (an emitter faithfully emits whatever semantics it is given) |
+| Resolver drift (OMN-127 mechanism) — single-source nodes                 | —                                                                                          |
+| Sandbox-guard bypass (OMN-119/120) — validator _requires_ the guard node | —                                                                                          |
+
+OMN-127's headline defect was **semantic** (a conflated `else` treating "not found" as "no folder"). An emitter would
+not have _fixed_ it — but the typed-fail-able resolution model in this design (§5) would have made the conflation
+**unrepresentable**, surfacing it sooner. That is the contingent benefit, and it is a hard design requirement, not a
+hope.
+
+## 3. Design principle: mirror the read side at the _mutation altitude_
+
+The read side's real architectural move was **picking the substrate at the abstraction the domain naturally has**.
+Filters _are_ boolean algebra, so:
+
+| Read-side layer        | Concretely                                                                                     | File                 |
+| ---------------------- | ---------------------------------------------------------------------------------------------- | -------------------- |
+| Substrate (node set)   | boolean algebra: `and / or / not / comparison / exists / literal`                              | `types.ts`           |
+| Domain → node lowering | data-driven registry `FILTER_DEFS` / `DATE_FILTER_DEFS` (`build(filter) → FilterNode \| null`) | `builder.ts`         |
+| Hard-case escape hatch | `SYNTHETIC_FIELD_DEFS` — custom emitter fn keyed by field name                                 | `types.ts`           |
+| Validator              | `KNOWN_FIELDS` derived from the registry; static analysis                                      | `validator.ts`       |
+| Emitter                | walks generic nodes → `{ preamble, predicate }`                                                | `emitters/omnijs.ts` |
+
+**The natural algebra of OmniFocus mutations is `resolve → construct → set → place → assign → envelope`.** The write
+side mirrors the read side's four layers, pitched at that altitude — generic-enough to compose, domain-aware-enough that
+the validator and typed resolution are natural. This is deliberately **not** a generic ESTree-style JS printer (too low
+— we would be rebuilding a JS code generator), and **not** one-node-per-operation (too rigid).
+
+This decision is documented because it has live alternatives: a pure-generic ESTree-lite substrate (rejected:
+re-implements a JS printer, makes typed-fail-able resolution a convention not a type) and a domain-node-only AST
+(rejected: each new operation needs a new node type + emitter case; least "typical AST").
+
+## 4. Execution model: OmniJS-native, one program, data-free JXA launcher
+
+Each mutation emits **one OmniJS program**, wrapped in a fixed, **data-free** JXA launcher:
+
+```javascript
+(() => {
+  const app = Application('OmniFocus');
+  try {
+    return app.evaluateJavascript(<<< JSON.stringify(omnijsProgram) >>>);
+  } catch (e) {
+    return JSON.stringify({ error: true, message: String(e), context: '<op>' });
+  }
+})()
+```
+
+Two boundaries, both owned by the emitter, both `JSON.stringify`:
+
+| Boundary                        | Mechanism                                                      | Property                                                                                            |
+| ------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| TS → OmniJS **data**            | `Json` node → `JSON.stringify(value)`                          | only data primitive; no node carries an inline-quoted string                                        |
+| OmniJS **program** → JXA string | emitter wraps whole program once via `JSON.stringify(program)` | valid escaped JS string literal — injection-proof, human-readable in emitted JXA, no size inflation |
+
+**Consequences.** Zero hand-written nested backticks remain → OMN-111/113 gone by construction. OmniJS typed APIs are
+used directly (`new Project(name, folder)`, `new Tag(name, parent)`, `addTag`, `Project.Status.OnHold`, real
+`try/catch`). The OMN-28 `.id()` transient-id dance **deletes** — `obj.id.primaryKey` reads correctly on a
+freshly-created object in OmniJS.
+
+> Decision (escape mechanism): `JSON.stringify(program)` over base64+atob. Base64 is maximally quote-free at the JXA
+> boundary but inflates ~33% (matters near the 261 KB OmniJS-bridge limit for batch ops) and renders the emitted JXA
+> opaque. `JSON.stringify` is already the repo's proven safe pattern and stays debuggable.
+
+## 5. The node set (substrate)
+
+A `Program` is an ordered list of statements emitted into one OmniJS IIFE.
+
+**Statements**
+
+| Node                                                | Emits                                 | Notes                                                                                                             |
+| --------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `Bind { name, expr }`                               | `const <name> = <expr>;`              | binds results for later `Ref`                                                                                     |
+| `ResolveFolder { ref } → FolderResolution`          | canonical resolver call               | result type: `Folder \| NotFound \| NoneRequested` (three named states)                                           |
+| `ResolveTag { ref }` / `ResolveOrCreateTag { ref }` | canonical tag resolver call           | mkdir-p semantics for create variant                                                                              |
+| `SetProp { target, prop, value, strategy }`         | property assignment                   | `strategy ∈ direct \| dateExpr \| enum \| readModifyReassign` — SETTER-PATTERNS as typed dispatch                 |
+| `Place { project, folderResolution }`               | push into resolved folder **or** root | consumes a `FolderResolution`, **never a string**; on `NotFound` emits the loud error envelope, never a root push |
+| `AssignTags { target, tagResolutions }`             | `target.addTag(...)` per tag          |                                                                                                                   |
+| `Guard { cond, errorEnvelope }`                     | `if (cond) return <err>;`             | early-return                                                                                                      |
+| `SandboxGuard`                                      | test-mode guard                       | **validator requires it on every write program**                                                                  |
+| `Return { envelope }`                               | `return JSON.stringify({...});`       | success or error envelope                                                                                         |
+
+**Expressions**
+
+`Ref { name }` · `Member { obj, path }` (`proj.id.primaryKey`) · `Call { callee, args }` · `New { class, args }`
+(`new Project(name, folder)`) · `EnumRef { path }` (`Project.Status.OnHold`) · `DateExpr { value }` (`new Date("...")`)
+· **`Json { value }`** — the only TS→OmniJS data primitive.
+
+**Typed-fail-able resolution (hard requirement).** `Place` and `AssignTags` consume _resolved_ results, not strings.
+`ResolveFolder` yields three **named** states; "no folder requested" (`NoneRequested`) and "requested but missing"
+(`NotFound`) are distinct constructor inputs. OMN-127's conflated `else` cannot be expressed.
+
+## 6. Lowering registry (mirror of `FILTER_DEFS`)
+
+`MUTATION_DEFS`, keyed by `(operation, target)` → `build(data) → Program` (e.g.
+`create/project → buildCreateProjectProgram(data)`). Builders assemble programs via typed helpers (`resolveFolder(ref)`
+returns the node + its typed binding). The folder/tag resolution is emitted by **one** node type used everywhere — drift
+impossible by construction (the OMN-127 win, made structural).
+
+## 7. Snippet registry (mirror of `SYNTHETIC_FIELD_DEFS`)
+
+The OMN-127 canonical helpers (`parseFolderPath`, `resolveFolderFlexible`, `parseTagPath`, `resolveOrCreateTagByPath`)
+become **named library snippets** injected once at program-top when a node declares a dependency on them. One source.
+They already exist as `const` strings in `mutation-script-builder.ts`; this lifts them into the registry.
+
+## 8. Validator (mirror of `validator.ts`)
+
+Static checks on each program before emit:
+
+- every program ends in `Return`;
+- `Place` consumes a `FolderResolution` (not a string);
+- no raw string where a `Json` node is required;
+- **a `SandboxGuard` node is present** — structurally closes the OMN-119/120 guard-bypass class (today the guard is a
+  hand-call builders can forget).
+
+## 9. Vertical slice + sequencing
+
+**Slice:** `buildCreateProjectScript` end-to-end (it exercises folder resolution + setters + status enum +
+reviewInterval read-modify-reassign + tags + id read-back). The OMN-28 `.id()`-matching loop deletes.
+
+**Acceptance for the slice**
+
+- golden snapshot of the emitted OmniJS program + structural assertions;
+- validator unit tests (reject: missing `Return`, `Place`-takes-string, missing `SandboxGuard`);
+- **live `/verify` at the OmniFocus seam** — mandatory; template→emitter swaps are exactly the "wiring tests pass,
+  artifact broken" trap (OMN-125). String-`toContain` tests alone are insufficient;
+- behavior-or-byte equivalence vs the current builder's observable result shape.
+
+**Then** migrate in order, deleting template strings as each lands, each its own PR gated on code-review SAFE + live
+`/verify`:
+
+`create/project → create/task → create/folder → update/task → update/project → complete → delete → batch → bulk-delete → tag builders`.
+
+## 10. Scope
+
+This expands OMN-128 from "swap write-side codegen to the AST emitter" to "**OmniJS-native write-side re-architecture
+via a mutation-statement AST**." The injection + drift hardening the ticket asked for is delivered _by construction_
+rather than by retrofitting an emitter onto the JXA-island architecture. OMN-128 is updated in place to reflect this.
+The bulk migration is multi-PR; the vertical slice sizes it before scheduling.
+
+## 11. Risks & open questions
+
+| Risk                                                          | Mitigation                                                                                                                                                                                                    |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Some write op genuinely needs JXA (not expressible in OmniJS) | Inventory during the slice; OmniJS-First doc claims full coverage and OMN-28/127 evidence favors OmniJS. If a true JXA-only op exists, the launcher node gains a typed escape — but default is OmniJS-native. |
+| Script-size limits (261 KB OmniJS bridge) for batch ops       | `JSON.stringify` (no base64 inflation) chosen partly for this; batch builder measured during its migration.                                                                                                   |
+| Behavior-equivalence drift during migration                   | golden tests + live `/verify` per builder; one builder per PR.                                                                                                                                                |
+| Snippet registry vs tree-shaking / dead snippet injection     | inject a snippet only when a node declares the dependency.                                                                                                                                                    |
+
+## 12. Definition of done (whole effort)
+
+- All write builders emit from `MUTATION_DEFS` programs; no template-string `script` literals remain in
+  `mutation-script-builder.ts` / `tag-mutation-script-builder.ts`.
+- Emitter owns all quoting; no builder hand-writes an inline-quoted interpolation or a nested backtick.
+- Validator requires `SandboxGuard` + `Return`; `Place` is string-unable at the type level.
+- Each builder has golden tests + a recorded live `/verify` pass.

--- a/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
+++ b/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
@@ -92,9 +92,25 @@ used directly (`new Project(name, folder)`, `new Tag(name, parent)`, `addTag`, `
 `try/catch`). The OMN-28 `.id()` transient-id dance **deletes** — `obj.id.primaryKey` reads correctly on a
 freshly-created object in OmniJS.
 
-> Decision (escape mechanism): `JSON.stringify(program)` over base64+atob. Base64 is maximally quote-free at the JXA
-> boundary but inflates ~33% (matters near the 261 KB OmniJS-bridge limit for batch ops) and renders the emitted JXA
-> opaque. `JSON.stringify` is already the repo's proven safe pattern and stays debuggable.
+> Decision (escape mechanism): `JSON.stringify(program)` over (a) base64+atob and (b) the read side's current mechanism.
+> Base64 is maximally quote-free but inflates ~33% (matters near the 261 KB OmniJS-bridge limit for batch ops) and
+> renders the emitted JXA opaque. `JSON.stringify` is the proven safe pattern for **data leaves** and stays debuggable.
+>
+> **The read side is NOT the model to mirror at this boundary — it is the cautionary tale.** The read path
+> (`list-tasks-ast.ts`) crosses the same JXA→OmniJS boundary via a **nested backtick template literal** escaped by a
+> hand-rolled 3-replace helper, `escapeTemplateString` (`bridge-escape.ts`): `s.replace(/\\/g,'\\\\').replace(/` +
+> "`" + `/g,'\\` + "`" + `').replace(/\${/g,'\\${')`. That is the exact nested-backtick + hand-escaper mechanism behind
+> OMN-111/113. Its own sibling comment warns it **does not handle newlines** — requiring a separate
+> `sanitizeForScriptComment` patch for control chars. The read side has avoided the bug only because its program body
+> carries no newline-bearing user data; the exposure is **latent, not absent**.
+>
+> `JSON.stringify(program)` deletes the nested backtick entirely (no `escapeTemplateString` dependency) and escapes
+> every quote / backslash / newline / control char / unicode per the JS spec. So "mirror the read side" applies to the
+> AST _layering_ (§3), not to this boundary, where we deliberately diverge to a strictly safer mechanism.
+>
+> _Follow-up (out of scope here):_ the read side still carries the latent `escapeTemplateString` exposure. Once this
+> write-side boundary is proven, a separate ticket should retrofit the read path to the same `JSON.stringify` boundary
+> and retire `escapeTemplateString`.
 
 ## 5. The node set (substrate)
 

--- a/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
+++ b/docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md
@@ -108,9 +108,9 @@ freshly-created object in OmniJS.
 > every quote / backslash / newline / control char / unicode per the JS spec. So "mirror the read side" applies to the
 > AST _layering_ (§3), not to this boundary, where we deliberately diverge to a strictly safer mechanism.
 >
-> _Follow-up (out of scope here):_ the read side still carries the latent `escapeTemplateString` exposure. Once this
-> write-side boundary is proven, a separate ticket should retrofit the read path to the same `JSON.stringify` boundary
-> and retire `escapeTemplateString`.
+> _Follow-up (out of scope here) — filed as **OMN-129**:_ the read side still carries the latent `escapeTemplateString`
+> exposure. Once this write-side boundary is proven, OMN-129 retrofits the read path to the same `JSON.stringify`
+> boundary and retires `escapeTemplateString`.
 
 ## 5. The node set (substrate)
 

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -219,7 +219,7 @@ async function isTaskInSandbox(taskId: string): Promise<boolean> {
 /**
  * Validate that a project creation is inside the sandbox
  */
-function validateProjectCreate(data: ProjectCreateData): void {
+export function validateProjectCreate(data: ProjectCreateData): void {
   if (!isTestMode()) return;
 
   if (data.folder !== SANDBOX_FOLDER_NAME) {

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -25,6 +25,9 @@ import type {
   MutationTarget,
 } from '../mutations.js';
 import { SNIPPETS } from './mutation/snippets.js';
+import { dispatchMutation } from './mutation/defs.js';
+import { emitProgram, wrapInLauncher } from './mutation/emitter.js';
+import { validateMutationProgram } from './mutation/validator.js';
 
 // =============================================================================
 // TEST SANDBOX GUARD
@@ -935,227 +938,16 @@ return JSON.stringify({ results: results });`;
  * Build a JXA script for creating a project
  */
 export function buildCreateProjectScript(data: ProjectCreateData): GeneratedMutationScript {
-  // Test sandbox guard
-  validateProjectCreate(data);
-
-  const projectData = buildProjectDataObject(data);
-
-  const script = `
-(() => {
-  const app = Application('OmniFocus');
-  const doc = app.defaultDocument();
-  const projectData = ${JSON.stringify(projectData)};
-
-  try {
-    // Find folder if specified — use OmniJS bridge for id.primaryKey + path syntax
-    let targetFolder = null;
-    if (projectData.folder) {
-      const findFolderScript = \`
-        (() => {
-          ${OMNIJS_PARSE_FOLDER_PATH}
-          ${OMNIJS_RESOLVE_FOLDER_PATH}
-          ${OMNIJS_RESOLVE_FOLDER_FLEXIBLE}
-
-          var target = \${JSON.stringify(projectData.folder)};
-          var folder = resolveFolderFlexible(target);
-          if (folder) return JSON.stringify({ found: true, index: flattenedFolders.indexOf(folder) });
-          return JSON.stringify({ found: false });
-        })()
-      \`;
-      const findFolderResult = JSON.parse(app.evaluateJavascript(findFolderScript));
-      if (findFolderResult.found && findFolderResult.index >= 0) {
-        targetFolder = doc.flattenedFolders()[findFolderResult.index];
-      } else {
-        // OMN-127 #1: a folder WAS requested but did not resolve. Never silently
-        // file the project at the database root — that was the silent-success bug.
-        // Fail loudly so typos / partial paths surface instead of misfiling.
-        return JSON.stringify({
-          error: true,
-          message: 'Folder not found: ' + projectData.folder,
-          context: 'create_project'
-        });
-      }
-    }
-
-    // Create project
-    const project = app.Project({
-      name: projectData.name,
-      note: projectData.note || '',
-      flagged: projectData.flagged || false,
-      sequential: projectData.sequential || false
-    });
-
-    // Add to folder or root
-    if (targetFolder) {
-      targetFolder.projects.push(project);
-    } else {
-      doc.projects.push(project);
-    }
-
-    // Set dates
-    if (projectData.dueDate) {
-      try { project.dueDate = new Date(projectData.dueDate); } catch (e) {}
-    }
-    if (projectData.deferDate) {
-      try { project.deferDate = new Date(projectData.deferDate); } catch (e) {}
-    }
-    if (projectData.plannedDate) {
-      try { project.plannedDate = new Date(projectData.plannedDate); } catch (e) {}
-    }
-
-    // reviewInterval is set later, via OmniJS bridge — see the block after
-    // projectId resolution. JXA's setter rejects plain JS objects (requires
-    // typed Project.ReviewInterval), and constructing that type from JXA isn't
-    // available, so the bridge is the only working path.
-
-    const jxaProjectId = project.id();
-
-    // Bridge to get OmniJS id.primaryKey for the response.
-    // JXA .id() returns a transient internal ID that byIdentifier() cannot resolve
-    // for freshly created objects (OMN-28). Use JXA .id() matching to find the exact
-    // object's index in flattenedProjects(), then read primaryKey from OmniJS at that index.
-    // This handles duplicate project names correctly since JXA IDs are unique per object.
-    let projectId = jxaProjectId;
-    try {
-      const allProjects = doc.flattenedProjects();
-      let projectIndex = -1;
-      for (let i = 0; i < allProjects.length; i++) {
-        try { if (allProjects[i].id() === jxaProjectId) { projectIndex = i; break; } } catch (e) {}
-      }
-      if (projectIndex >= 0) {
-        const idScript = \`
-          (() => {
-            var p = flattenedProjects[\${projectIndex}];
-            if (p) return JSON.stringify({ pk: p.id.primaryKey });
-            return JSON.stringify({ pk: null });
-          })()
-        \`;
-        const idResult = JSON.parse(app.evaluateJavascript(idScript));
-        if (idResult.pk) projectId = idResult.pk;
-      }
-    } catch (e) {}
-
-    // SETTER-PATTERNS row 3 (Project.status — OmniJS, direct assign of enum constant).
-    // Set status via OmniJS bridge (Project.Status is OmniJS-only, not available in JXA)
-    if (projectData.status && projectData.status !== 'active') {
-      try {
-        const statusScript = \`
-          (() => {
-            const proj = Project.byIdentifier('\${projectId}');
-            if (!proj) return JSON.stringify({success: false});
-
-            const statusMap = {
-              'active': Project.Status.Active,
-              'on_hold': Project.Status.OnHold,
-              'completed': Project.Status.Done,
-              'dropped': Project.Status.Dropped
-            };
-            const targetStatus = statusMap['\${projectData.status}'];
-            if (targetStatus) {
-              proj.status = targetStatus;
-            }
-            return JSON.stringify({success: true});
-          })()
-        \`;
-        app.evaluateJavascript(statusScript);
-      } catch (e) {}
-    }
-
-    // SETTER-PATTERNS row 1 (Project.reviewInterval — OmniJS read-modify-reassign).
-    // Set reviewInterval via OmniJS bridge — strictly typechecked.
-    // The class is non-constructible from user code (zero-arg construction
-    // fails with a CallbackObject error). Plain objects and Numbers are also
-    // rejected. In-place mutation also silently no-ops (the getter returns
-    // a snapshot). The working pattern: read the existing typed instance,
-    // mutate the local reference, then re-assign it back.
-    // Convert the schema-normalized days value to the most natural unit first.
-    if (projectData.reviewInterval) {
-      try {
-        const _riDays = projectData.reviewInterval;
-        let _riUnit, _riSteps;
-        if (_riDays % 365 === 0) { _riUnit = "years"; _riSteps = _riDays / 365; }
-        else if (_riDays % 30 === 0) { _riUnit = "months"; _riSteps = _riDays / 30; }
-        else if (_riDays % 7 === 0) { _riUnit = "weeks"; _riSteps = _riDays / 7; }
-        else { _riUnit = "days"; _riSteps = _riDays; }
-        const riScript = \`
-          (() => {
-            const proj = Project.byIdentifier('\${projectId}');
-            if (!proj) return JSON.stringify({success: false});
-            const ri = proj.reviewInterval;
-            if (!ri) return JSON.stringify({success: false});
-            ri.steps = \${_riSteps};
-            ri.unit = "\${_riUnit}";
-            proj.reviewInterval = ri;
-            return JSON.stringify({success: true});
-          })()
-        \`;
-        app.evaluateJavascript(riScript);
-      } catch (e) {}
-    }
-
-    // Set tags via bridge using reliable O(1) lookup
-    let appliedTags = [];
-    if (projectData.tags && projectData.tags.length > 0) {
-      try {
-        const tagScript = \`
-          (() => {
-            ${OMNIJS_PARSE_TAG_PATH}
-            ${OMNIJS_RESOLVE_OR_CREATE_TAG_PATH}
-
-            const proj = Project.byIdentifier('\${projectId}');
-            if (!proj) return JSON.stringify({success: false, error: 'Project not found by ID: ' + '\${projectId}'});
-
-            const tagNames = \${JSON.stringify(projectData.tags)};
-            const appliedTags = [];
-
-            for (const tagName of tagNames) {
-              var pathSegs = parseTagPath(tagName);
-              var tag;
-              if (pathSegs) {
-                tag = resolveOrCreateTagByPath(pathSegs);
-              } else {
-                tag = flattenedTags.find(t => t.name === tagName);
-                if (!tag) tag = new Tag(tagName, null);
-              }
-              proj.addTag(tag);
-              appliedTags.push(tag.name);
-            }
-
-            return JSON.stringify({success: true, tags: appliedTags});
-          })()
-        \`;
-        const result = JSON.parse(app.evaluateJavascript(tagScript));
-        if (result.success) {
-          appliedTags = result.tags;
-        }
-      } catch (e) {
-        // Tag assignment errors don't fail project creation - tags can be added later
-      }
-    }
-
-    return JSON.stringify({
-      projectId: projectId,
-      name: project.name(),
-      note: project.note() || '',
-      flagged: project.flagged(),
-      sequential: project.sequential(),
-      dueDate: project.dueDate() ? project.dueDate().toISOString() : null,
-      deferDate: project.deferDate() ? project.deferDate().toISOString() : null,
-      plannedDate: project.plannedDate() ? project.plannedDate().toISOString() : null,
-      folder: targetFolder ? targetFolder.name() : null,
-      tags: appliedTags,
-      created: true
-    });
-
-  } catch (error) {
-    return JSON.stringify({
-      error: true,
-      message: error.message || String(error),
-      context: 'create_project'
-    });
-  }
-})();
-`;
+  // Emit from the mutation AST. dispatchMutation runs the build-time sandbox guard
+  // (validateProjectCreate) BEFORE building, so it can never be bypassed; the
+  // emitter produces ONE OmniJS program (native `new Project(...)`, no JXA
+  // app.Project / folder push) wrapped in a data-free JXA launcher. The old
+  // template-string body — multiple evaluateJavascript round-trips for folder,
+  // status, reviewInterval, and tags — is gone (OMN-128).
+  const program = dispatchMutation('create/project', data);
+  validateMutationProgram(program);
+  const omnijs = emitProgram(program);
+  const script = wrapInLauncher(omnijs, program.context);
 
   return {
     script: script.trim(),
@@ -2282,45 +2074,6 @@ function buildTaskDataObject(data: TaskCreateData): Record<string, unknown> {
   if (data.flagged !== undefined) obj.flagged = data.flagged;
   if (data.estimatedMinutes !== undefined) obj.estimatedMinutes = data.estimatedMinutes;
   if (data.repetitionRule !== undefined) obj.repetitionRule = data.repetitionRule;
-
-  return obj;
-}
-
-/**
- * Build project data object for script embedding
- */
-function buildProjectDataObject(data: ProjectCreateData): Record<string, unknown> {
-  // Exhaustiveness guard: compile error if ProjectCreateData gains a field not listed here.
-  // Add the new key below AND a corresponding `if (data.X)` line above the return.
-  const _allKeys: Record<keyof ProjectCreateData, true> = {
-    name: true,
-    note: true,
-    folder: true,
-    tags: true,
-    dueDate: true,
-    deferDate: true,
-    plannedDate: true,
-    flagged: true,
-    sequential: true,
-    status: true,
-    reviewInterval: true,
-  };
-  void _allKeys;
-
-  const obj: Record<string, unknown> = {
-    name: data.name,
-  };
-
-  if (data.note !== undefined) obj.note = data.note;
-  if (data.folder !== undefined) obj.folder = data.folder;
-  if (data.tags !== undefined) obj.tags = data.tags;
-  if (data.dueDate !== undefined) obj.dueDate = data.dueDate;
-  if (data.deferDate !== undefined) obj.deferDate = data.deferDate;
-  if (data.plannedDate !== undefined) obj.plannedDate = data.plannedDate;
-  if (data.flagged !== undefined) obj.flagged = data.flagged;
-  if (data.sequential !== undefined) obj.sequential = data.sequential;
-  if (data.status !== undefined) obj.status = data.status;
-  if (data.reviewInterval !== undefined) obj.reviewInterval = data.reviewInterval;
 
   return obj;
 }

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -24,6 +24,7 @@ import type {
   ProjectUpdateData,
   MutationTarget,
 } from '../mutations.js';
+import { SNIPPETS } from './mutation/snippets.js';
 
 // =============================================================================
 // TEST SANDBOX GUARD
@@ -447,78 +448,20 @@ export interface BatchOperation {
 // =============================================================================
 
 /** OmniJS: parse ` : ` separated tag path into segments, or null for plain names */
-const OMNIJS_PARSE_TAG_PATH = `
-function parseTagPath(input) {
-  if (input.indexOf(' : ') === -1) return null;
-  var segs = input.split(' : ');
-  for (var i = 0; i < segs.length; i++) {
-    segs[i] = segs[i].trim();
-    if (segs[i].length === 0) throw new Error('Invalid tag path: empty segment');
-  }
-  return segs;
-}`;
+const OMNIJS_PARSE_TAG_PATH = SNIPPETS.parseTagPath.source;
 
 /** OmniJS: walk tag tree creating missing segments (mkdir -p semantics) */
-const OMNIJS_RESOLVE_OR_CREATE_TAG_PATH = `
-function resolveOrCreateTagByPath(segments) {
-  var parent = null;
-  var current = null;
-  for (var i = 0; i < segments.length; i++) {
-    current = null;
-    var children = parent ? parent.children : tags;
-    for (var j = 0; j < children.length; j++) {
-      if (children[j].name === segments[i]) { current = children[j]; break; }
-    }
-    if (!current) {
-      current = parent ? new Tag(segments[i], parent) : new Tag(segments[i], null);
-    }
-    parent = current;
-  }
-  return current;
-}`;
+const OMNIJS_RESOLVE_OR_CREATE_TAG_PATH = SNIPPETS.resolveOrCreateTagByPath.source;
 
 // =============================================================================
 // OMNIJS FOLDER PATH HELPERS (interpolated into evaluateJavascript blocks)
 // =============================================================================
 
 /** OmniJS: parse ` : ` or `/` separated folder path into segments, or null for plain names */
-const OMNIJS_PARSE_FOLDER_PATH = `
-function parseFolderPath(input) {
-  if (input.indexOf(' : ') !== -1) {
-    var segs = input.split(' : ');
-    for (var i = 0; i < segs.length; i++) {
-      segs[i] = segs[i].trim();
-      if (segs[i].length === 0) return null;
-    }
-    return segs;
-  }
-  if (input.indexOf('/') !== -1) {
-    var segs = input.split('/');
-    for (var i = 0; i < segs.length; i++) {
-      segs[i] = segs[i].trim();
-      if (segs[i].length === 0) return null;
-    }
-    return segs;
-  }
-  return null;
-}`;
+const OMNIJS_PARSE_FOLDER_PATH = SNIPPETS.parseFolderPath.source;
 
 /** OmniJS: walk folder hierarchy by segments (read-only, no creation) */
-const OMNIJS_RESOLVE_FOLDER_PATH = `
-function resolveFolderPath(segments) {
-  var parent = null;
-  var current = null;
-  for (var i = 0; i < segments.length; i++) {
-    current = null;
-    var children = parent ? parent.children : folders;
-    for (var j = 0; j < children.length; j++) {
-      if (children[j].name === segments[i]) { current = children[j]; break; }
-    }
-    if (!current) return null;
-    parent = current;
-  }
-  return current;
-}`;
+const OMNIJS_RESOLVE_FOLDER_PATH = SNIPPETS.resolveFolderPath.source;
 
 /**
  * OmniJS: ONE flexible folder resolver shared by every write site that places a
@@ -528,23 +471,7 @@ function resolveFolderPath(segments) {
  * to be injected alongside it. Consolidating here (OMN-127) stops the three sites from
  * drifting apart again — they previously had three different resolution behaviors.
  */
-const OMNIJS_RESOLVE_FOLDER_FLEXIBLE = `
-function resolveFolderFlexible(target) {
-  // 1. Try parsing as a path (" : " or "/")
-  var pathSegs = parseFolderPath(target);
-  if (pathSegs) {
-    var found = resolveFolderPath(pathSegs);
-    if (found) return found;
-  }
-  // 2. Try by identifier (id.primaryKey)
-  var byId = Folder.byIdentifier(target);
-  if (byId) return byId;
-  // 3. Fall back to leaf name match
-  for (var i = 0; i < flattenedFolders.length; i++) {
-    if (flattenedFolders[i].name === target) return flattenedFolders[i];
-  }
-  return null;
-}`;
+const OMNIJS_RESOLVE_FOLDER_FLEXIBLE = SNIPPETS.resolveFolderFlexible.source;
 
 /** OmniJS: walk tag tree returning null if any segment missing (read-only) */
 const OMNIJS_RESOLVE_TAG_PATH = `

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -1,0 +1,158 @@
+// src/contracts/ast/mutation/defs.ts
+// Mutation lowerings: data → typed mutation-AST Program. Plus the guarded
+// dispatch registry (MUTATION_DEFS) that runs the build-time sandbox guard
+// BEFORE building, so a registered op can never bypass it (the OMN-119/120
+// non-bypass property — batch & bulk paths previously skipped the guard).
+import type { ProjectCreateData } from '../../mutations.js';
+import { validateProjectCreate } from '../mutation-script-builder.js';
+import {
+  assignTags,
+  constructProject,
+  dateExpr,
+  enumRef,
+  guard,
+  json,
+  member,
+  raw,
+  readModifyReassign,
+  ref,
+  resolveFolder,
+  return_,
+  setProp,
+  type Expr,
+  type Program,
+  type Stmt,
+} from './types.js';
+
+const STATUS_ENUM: Record<string, string> = {
+  on_hold: 'Project.Status.OnHold',
+  completed: 'Project.Status.Done',
+  dropped: 'Project.Status.Dropped',
+};
+
+/**
+ * Convert the schema-normalized "days between reviews" into the most natural
+ * (unit, steps) pair, mirroring the original buildCreateProjectScript. Computed
+ * at BUILD time so the emitted OmniJS carries plain literals.
+ */
+function reviewIntervalUnit(days: number): { unit: string; steps: number } {
+  if (days % 365 === 0) return { unit: 'years', steps: days / 365 };
+  if (days % 30 === 0) return { unit: 'months', steps: days / 30 };
+  if (days % 7 === 0) return { unit: 'weeks', steps: days / 7 };
+  return { unit: 'days', steps: days };
+}
+
+/**
+ * Lower a project-create request into a typed mutation Program. Statement order
+ * preserves the original builder's behavior (folder resolve+guard, construct,
+ * scalar props, dates, status, reviewInterval, tags, return).
+ */
+export function buildCreateProjectProgram(data: ProjectCreateData): Program {
+  const statements: Stmt[] = [];
+  const snippetDeps: string[] = [];
+
+  // Folder: resolve flexibly, then guard the not-found case so the project is
+  // never silently filed at the database root (OMN-127 #1).
+  if (data.folder) {
+    statements.push(resolveFolder('targetFolder', data.folder));
+    statements.push(
+      guard('targetFolder === null', {
+        error: json(true),
+        message: json('Folder not found: ' + data.folder),
+        context: json('create_project'),
+      }),
+    );
+    snippetDeps.push('resolveFolderFlexible');
+  }
+
+  statements.push(
+    constructProject(
+      'proj',
+      json(data.name),
+      data.folder ? { kind: 'resolved', var: 'targetFolder' } : { kind: 'none' },
+    ),
+  );
+
+  statements.push(setProp(ref('proj'), 'note', json(data.note || '')));
+  statements.push(setProp(ref('proj'), 'flagged', json(data.flagged || false)));
+  statements.push(setProp(ref('proj'), 'sequential', json(data.sequential || false)));
+
+  for (const field of ['dueDate', 'deferDate', 'plannedDate'] as const) {
+    const value = data[field];
+    if (value) {
+      statements.push(setProp(ref('proj'), field, dateExpr(json(value)), 'dateExpr'));
+    }
+  }
+
+  // Status: only non-active is emitted, best-effort (a status failure must NOT
+  // fail project creation — original swallowed errors in a separate bridge).
+  if (data.status && data.status !== 'active') {
+    statements.push(setProp(ref('proj'), 'status', enumRef(STATUS_ENUM[data.status]), 'enum', true));
+  }
+
+  // reviewInterval: read-modify-reassign the typed instance, best-effort.
+  if (data.reviewInterval) {
+    const { unit, steps } = reviewIntervalUnit(data.reviewInterval);
+    statements.push(
+      readModifyReassign(
+        ref('proj'),
+        'reviewInterval',
+        [
+          { prop: 'steps', value: json(steps) },
+          { prop: 'unit', value: json(unit) },
+        ],
+        true,
+      ),
+    );
+  }
+
+  // Tags: create-or-find, best-effort (tag failures must NOT fail creation).
+  if (data.tags && data.tags.length) {
+    statements.push(assignTags(ref('proj'), json(data.tags), 'appliedTags', true));
+    snippetDeps.push('resolveOrCreateTagByPath');
+  }
+
+  const envelope: Record<string, Expr> = {
+    projectId: member(ref('proj'), 'id.primaryKey'),
+    name: member(ref('proj'), 'name'),
+    note: raw("proj.note || ''"),
+    flagged: member(ref('proj'), 'flagged'),
+    sequential: member(ref('proj'), 'sequential'),
+    dueDate: raw('proj.dueDate ? proj.dueDate.toISOString() : null'),
+    deferDate: raw('proj.deferDate ? proj.deferDate.toISOString() : null'),
+    plannedDate: raw('proj.plannedDate ? proj.plannedDate.toISOString() : null'),
+    folder: data.folder ? raw('targetFolder.name') : json(null),
+    tags: data.tags && data.tags.length ? ref('appliedTags') : json([]),
+    created: json(true),
+  };
+  statements.push(return_(envelope));
+
+  return { statements, context: 'create_project', snippetDeps };
+}
+
+// =============================================================================
+// GUARDED DISPATCH (OMN-119/120 non-bypass)
+// =============================================================================
+
+interface MutationDef<T> {
+  guard: (data: T) => void;
+  build: (data: T) => Program;
+}
+
+export const MUTATION_DEFS = {
+  'create/project': {
+    guard: validateProjectCreate,
+    build: buildCreateProjectProgram,
+  } as MutationDef<ProjectCreateData>,
+} as const;
+
+/**
+ * Dispatch a registered mutation: run its build-time sandbox guard, THEN build.
+ * The guard cannot be skipped for a registered op — this is the non-bypass
+ * property that batch / bulk paths previously violated (OMN-119/120).
+ */
+export function dispatchMutation(key: keyof typeof MUTATION_DEFS, data: ProjectCreateData): Program {
+  const def = MUTATION_DEFS[key] as MutationDef<ProjectCreateData>;
+  def.guard(data); // build-time sandbox guard — cannot be skipped for a registered op
+  return def.build(data);
+}

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -151,6 +151,7 @@ export const MUTATION_DEFS = {
  * The guard cannot be skipped for a registered op — this is the non-bypass
  * property that batch / bulk paths previously violated (OMN-119/120).
  */
+// TODO(op #2): widen — data type is per-key (e.g. ProjectUpdateData), not always ProjectCreateData
 export function dispatchMutation(key: keyof typeof MUTATION_DEFS, data: ProjectCreateData): Program {
   const def = MUTATION_DEFS[key] as MutationDef<ProjectCreateData>;
   def.guard(data); // build-time sandbox guard — cannot be skipped for a registered op

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -48,6 +48,25 @@ function reviewIntervalUnit(days: number): { unit: string; steps: number } {
  * scalar props, dates, status, reviewInterval, tags, return).
  */
 export function buildCreateProjectProgram(data: ProjectCreateData): Program {
+  // Compile-time exhaustiveness guard (ported from the deleted buildProjectDataObject):
+  // forces a build error if ProjectCreateData gains a field this lowering doesn't handle,
+  // so a new schema field can't be silently dropped. When this stops compiling, add the
+  // field below AND emit the statement that lowers it.
+  const _exhaustive: Record<keyof ProjectCreateData, true> = {
+    name: true,
+    note: true,
+    folder: true,
+    tags: true,
+    dueDate: true,
+    deferDate: true,
+    plannedDate: true,
+    flagged: true,
+    sequential: true,
+    status: true,
+    reviewInterval: true,
+  };
+  void _exhaustive;
+
   const statements: Stmt[] = [];
   const snippetDeps: string[] = [];
 

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -105,3 +105,18 @@ export function emitProgram(program: Program): string {
   const inner = [snippets, body].filter((s) => s.length > 0).join('\n');
   return `(() => {\n${inner}\n})()`;
 }
+
+// Wraps an OmniJS program string in a JXA launcher. The OmniJS body crosses the
+// JXA→OmniJS boundary as a single JSON.stringify'd string literal — no template
+// interpolation, no concatenation — which is what kills the OMN-111/113
+// backtick/injection class outright.
+export function wrapInLauncher(omnijsProgram: string, context: string): string {
+  return `(() => {
+  const app = Application('OmniFocus');
+  try {
+    return app.evaluateJavascript(${JSON.stringify(omnijsProgram)});
+  } catch (e) {
+    return JSON.stringify({ error: true, message: String(e), context: ${JSON.stringify(context)} });
+  }
+})()`;
+}

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -84,8 +84,14 @@ export function emitStmt(node: Stmt): string {
     case 'assignTags': {
       const target = emitExpr(node.target);
       const tags = emitExpr(node.tags);
-      const block = [
-        `const ${node.bind} = [];`,
+      // The result binding is declared at PROGRAM scope (a `let`, OUTSIDE any bestEffort
+      // try-wrap) because later statements — e.g. the return envelope — consume it. If it
+      // were declared inside the try, a thrown best-effort block would leave the consumer
+      // referencing an undeclared variable (`ReferenceError`). Only the mutating loop is
+      // wrapped. (OMN-128: caught by live /verify. General rule: any bestEffort statement
+      // whose binding is consumed later MUST hoist that declaration out of the try.)
+      const decl = `let ${node.bind} = [];`;
+      const loop = [
         `for (const _tagName of ${tags}) {`,
         '  var _segs = parseTagPath(_tagName);',
         '  var _tag;',
@@ -95,9 +101,10 @@ export function emitStmt(node: Stmt): string {
         `  ${node.bind}.push(_tag.name);`,
         '}',
       ].join('\n');
-      // `bestEffort` wraps the tag block so a tag failure does not fail the
-      // surrounding mutation (original best-effort tag bridge semantics).
-      return node.bestEffort ? `try {\n${block}\n} catch (e) {}` : block;
+      // `bestEffort` wraps only the LOOP so a tag failure does not fail the surrounding
+      // mutation (original best-effort tag bridge semantics) — the binding survives.
+      const guardedLoop = node.bestEffort ? `try {\n${loop}\n} catch (e) {}` : loop;
+      return `${decl}\n${guardedLoop}`;
     }
     case 'return':
       return `return JSON.stringify(${emitEnvelope(node.envelope)});`;

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -19,6 +19,8 @@ export function emitExpr(node: Expr): string {
       return `new Date(${emitExpr(node.value)})`;
     case 'json':
       return JSON.stringify(node.value);
+    case 'raw':
+      return node.code;
     default: {
       const _x: never = node;
       throw new Error(`Unknown expr node: ${JSON.stringify(_x)}`);
@@ -58,16 +60,20 @@ export function emitStmt(node: Stmt): string {
     }
     case 'setProp': {
       const target = emitExpr(node.target);
+      // `bestEffort` wraps the block in try/catch so a failure does not fail the
+      // surrounding mutation. The dateExpr strategy ALREADY self-wraps, so it is
+      // never double-wrapped here.
+      const wrap = (block: string): string => (node.bestEffort ? `try { ${block} } catch (e) {}` : block);
       switch (node.strategy) {
         case 'direct':
-          return `${target}.${node.prop} = ${emitExpr(node.value as Expr)};`;
+          return wrap(`${target}.${node.prop} = ${emitExpr(node.value as Expr)};`);
         case 'dateExpr':
           return `try { ${target}.${node.prop} = ${emitExpr(node.value as Expr)}; } catch (e) {}`;
         case 'enum':
-          return `${target}.${node.prop} = ${emitExpr(node.value as Expr)};`;
+          return wrap(`${target}.${node.prop} = ${emitExpr(node.value as Expr)};`);
         case 'readModifyReassign': {
           const muts = (node.mutations ?? []).map((m) => `_rmr.${m.prop} = ${emitExpr(m.value)};`).join(' ');
-          return `{ const _rmr = ${target}.${node.prop}; if (_rmr) { ${muts} ${target}.${node.prop} = _rmr; } }`;
+          return wrap(`{ const _rmr = ${target}.${node.prop}; if (_rmr) { ${muts} ${target}.${node.prop} = _rmr; } }`);
         }
         default: {
           const _x: never = node.strategy;
@@ -78,7 +84,7 @@ export function emitStmt(node: Stmt): string {
     case 'assignTags': {
       const target = emitExpr(node.target);
       const tags = emitExpr(node.tags);
-      return [
+      const block = [
         `const ${node.bind} = [];`,
         `for (const _tagName of ${tags}) {`,
         '  var _segs = parseTagPath(_tagName);',
@@ -89,6 +95,9 @@ export function emitStmt(node: Stmt): string {
         `  ${node.bind}.push(_tag.name);`,
         '}',
       ].join('\n');
+      // `bestEffort` wraps the tag block so a tag failure does not fail the
+      // surrounding mutation (original best-effort tag bridge semantics).
+      return node.bestEffort ? `try {\n${block}\n} catch (e) {}` : block;
     }
     case 'return':
       return `return JSON.stringify(${emitEnvelope(node.envelope)});`;

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -2,7 +2,8 @@
 // Turns a mutation-AST Program into ONE OmniJS program string, then wraps it in a
 // JXA launcher. GENERIC: emits whatever Program it is given. The create/project
 // lowering and validator are separate (later) concerns and live elsewhere.
-import type { Expr } from './types.js';
+import type { Envelope, Expr, Program, Stmt } from './types.js';
+import { collectSnippets } from './snippets.js';
 
 export function emitExpr(node: Expr): string {
   switch (node.type) {
@@ -23,4 +24,84 @@ export function emitExpr(node: Expr): string {
       throw new Error(`Unknown expr node: ${JSON.stringify(_x)}`);
     }
   }
+}
+
+export function emitEnvelope(env: Envelope): string {
+  const entries = Object.entries(env).map(([key, value]) => `${key}: ${emitExpr(value)}`);
+  return `{ ${entries.join(', ')} }`;
+}
+
+export function emitStmt(node: Stmt): string {
+  switch (node.type) {
+    case 'bind':
+      return `const ${node.name} = ${emitExpr(node.expr)};`;
+    case 'resolveFolder':
+      return `const ${node.bind} = resolveFolderFlexible(${JSON.stringify(node.ref)});`;
+    case 'guard':
+      return `if (${node.cond}) return JSON.stringify(${emitEnvelope(node.envelope)});`;
+    case 'constructProject': {
+      const name = emitExpr(node.name);
+      switch (node.folder.kind) {
+        case 'resolved':
+          return `const ${node.bind} = new Project(${name}, ${node.folder.var});`;
+        case 'none':
+          return `const ${node.bind} = new Project(${name});`;
+        case 'notFound':
+          throw new Error(
+            'constructProject with folder.kind="notFound" is illegal — it must be Guarded earlier (validator enforces this).',
+          );
+        default: {
+          const _x: never = node.folder;
+          throw new Error(`Unknown folder resolution: ${JSON.stringify(_x)}`);
+        }
+      }
+    }
+    case 'setProp': {
+      const target = emitExpr(node.target);
+      switch (node.strategy) {
+        case 'direct':
+          return `${target}.${node.prop} = ${emitExpr(node.value as Expr)};`;
+        case 'dateExpr':
+          return `try { ${target}.${node.prop} = ${emitExpr(node.value as Expr)}; } catch (e) {}`;
+        case 'enum':
+          return `${target}.${node.prop} = ${emitExpr(node.value as Expr)};`;
+        case 'readModifyReassign': {
+          const muts = (node.mutations ?? []).map((m) => `_rmr.${m.prop} = ${emitExpr(m.value)};`).join(' ');
+          return `{ const _rmr = ${target}.${node.prop}; if (_rmr) { ${muts} ${target}.${node.prop} = _rmr; } }`;
+        }
+        default: {
+          const _x: never = node.strategy;
+          throw new Error(`Unknown setProp strategy: ${JSON.stringify(_x)}`);
+        }
+      }
+    }
+    case 'assignTags': {
+      const target = emitExpr(node.target);
+      const tags = emitExpr(node.tags);
+      return [
+        `const ${node.bind} = [];`,
+        `for (const _tagName of ${tags}) {`,
+        '  var _segs = parseTagPath(_tagName);',
+        '  var _tag;',
+        '  if (_segs) { _tag = resolveOrCreateTagByPath(_segs); }',
+        '  else { _tag = flattenedTags.find(t => t.name === _tagName); if (!_tag) _tag = new Tag(_tagName, null); }',
+        `  ${target}.addTag(_tag);`,
+        `  ${node.bind}.push(_tag.name);`,
+        '}',
+      ].join('\n');
+    }
+    case 'return':
+      return `return JSON.stringify(${emitEnvelope(node.envelope)});`;
+    default: {
+      const _x: never = node;
+      throw new Error(`Unknown stmt node: ${JSON.stringify(_x)}`);
+    }
+  }
+}
+
+export function emitProgram(program: Program): string {
+  const snippets = program.snippetDeps.length > 0 ? collectSnippets(program.snippetDeps) : '';
+  const body = program.statements.map(emitStmt).join('\n');
+  const inner = [snippets, body].filter((s) => s.length > 0).join('\n');
+  return `(() => {\n${inner}\n})()`;
 }

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -1,0 +1,26 @@
+// src/contracts/ast/mutation/emitter.ts
+// Turns a mutation-AST Program into ONE OmniJS program string, then wraps it in a
+// JXA launcher. GENERIC: emits whatever Program it is given. The create/project
+// lowering and validator are separate (later) concerns and live elsewhere.
+import type { Expr } from './types.js';
+
+export function emitExpr(node: Expr): string {
+  switch (node.type) {
+    case 'ref':
+      return node.name;
+    case 'member':
+      return `${emitExpr(node.object)}.${node.path}`;
+    case 'new':
+      return `new ${node.className}(${node.args.map(emitExpr).join(', ')})`;
+    case 'enumRef':
+      return node.path;
+    case 'dateExpr':
+      return `new Date(${emitExpr(node.value)})`;
+    case 'json':
+      return JSON.stringify(node.value);
+    default: {
+      const _x: never = node;
+      throw new Error(`Unknown expr node: ${JSON.stringify(_x)}`);
+    }
+  }
+}

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -3,7 +3,7 @@
 // JXA launcher. GENERIC: emits whatever Program it is given. The create/project
 // lowering and validator are separate (later) concerns and live elsewhere.
 import type { Envelope, Expr, Program, Stmt } from './types.js';
-import { collectSnippets } from './snippets.js';
+import { collectSnippets, SNIPPETS } from './snippets.js';
 
 export function emitExpr(node: Expr): string {
   switch (node.type) {
@@ -112,6 +112,18 @@ export function emitProgram(program: Program): string {
   const snippets = program.snippetDeps.length > 0 ? collectSnippets(program.snippetDeps) : '';
   const body = program.statements.map(emitStmt).join('\n');
   const inner = [snippets, body].filter((s) => s.length > 0).join('\n');
+
+  // Snippet-dependency coverage guard (replaces the plan's original validator
+  // Rule 4 — enforced HERE because helper usage is implicit in emission, not in
+  // the typed tree). If a statement emits a CALL to a known OmniJS helper but
+  // its definition is absent from the assembled program, the reference would be
+  // undefined at OmniFocus runtime. Catch that at build time instead.
+  for (const name of Object.keys(SNIPPETS)) {
+    if (body.includes(`${name}(`) && !inner.includes(`function ${name}`)) {
+      throw new Error(`Emitted program calls helper "${name}" not present in snippetDeps — declare it`);
+    }
+  }
+
   return `(() => {\n${inner}\n})()`;
 }
 
@@ -125,7 +137,7 @@ export function wrapInLauncher(omnijsProgram: string, context: string): string {
   try {
     return app.evaluateJavascript(${JSON.stringify(omnijsProgram)});
   } catch (e) {
-    return JSON.stringify({ error: true, message: String(e), context: ${JSON.stringify(context)} });
+    return JSON.stringify({ error: true, message: e && e.message ? e.message : String(e), context: ${JSON.stringify(context)} });
   }
 })()`;
 }

--- a/src/contracts/ast/mutation/index.ts
+++ b/src/contracts/ast/mutation/index.ts
@@ -1,0 +1,7 @@
+// src/contracts/ast/mutation/index.ts
+// Public surface of the mutation-AST vertical slice (OMN-128).
+export * from './types.js';
+export { emitExpr, emitEnvelope, emitStmt, emitProgram, wrapInLauncher } from './emitter.js';
+export { validateMutationProgram } from './validator.js';
+export { buildCreateProjectProgram, MUTATION_DEFS, dispatchMutation } from './defs.js';
+export { SNIPPETS, collectSnippets } from './snippets.js';

--- a/src/contracts/ast/mutation/snippets.ts
+++ b/src/contracts/ast/mutation/snippets.ts
@@ -1,0 +1,117 @@
+// src/contracts/ast/mutation/snippets.ts
+// Single-source registry of OmniJS helper snippets interpolated into
+// evaluateJavascript blocks. Lifted from mutation-script-builder.ts (OMN-127
+// resolver consts) so every write site shares ONE copy and a declared
+// dependency graph (OMN-128).
+
+export interface Snippet {
+  readonly source: string;
+  readonly deps: readonly string[];
+}
+
+const parseFolderPath = `
+function parseFolderPath(input) {
+  if (input.indexOf(' : ') !== -1) {
+    var segs = input.split(' : ');
+    for (var i = 0; i < segs.length; i++) {
+      segs[i] = segs[i].trim();
+      if (segs[i].length === 0) return null;
+    }
+    return segs;
+  }
+  if (input.indexOf('/') !== -1) {
+    var segs = input.split('/');
+    for (var i = 0; i < segs.length; i++) {
+      segs[i] = segs[i].trim();
+      if (segs[i].length === 0) return null;
+    }
+    return segs;
+  }
+  return null;
+}`;
+
+const resolveFolderPath = `
+function resolveFolderPath(segments) {
+  var parent = null;
+  var current = null;
+  for (var i = 0; i < segments.length; i++) {
+    current = null;
+    var children = parent ? parent.children : folders;
+    for (var j = 0; j < children.length; j++) {
+      if (children[j].name === segments[i]) { current = children[j]; break; }
+    }
+    if (!current) return null;
+    parent = current;
+  }
+  return current;
+}`;
+
+const resolveFolderFlexible = `
+function resolveFolderFlexible(target) {
+  // 1. Try parsing as a path (" : " or "/")
+  var pathSegs = parseFolderPath(target);
+  if (pathSegs) {
+    var found = resolveFolderPath(pathSegs);
+    if (found) return found;
+  }
+  // 2. Try by identifier (id.primaryKey)
+  var byId = Folder.byIdentifier(target);
+  if (byId) return byId;
+  // 3. Fall back to leaf name match
+  for (var i = 0; i < flattenedFolders.length; i++) {
+    if (flattenedFolders[i].name === target) return flattenedFolders[i];
+  }
+  return null;
+}`;
+
+const parseTagPath = `
+function parseTagPath(input) {
+  if (input.indexOf(' : ') === -1) return null;
+  var segs = input.split(' : ');
+  for (var i = 0; i < segs.length; i++) {
+    segs[i] = segs[i].trim();
+    if (segs[i].length === 0) throw new Error('Invalid tag path: empty segment');
+  }
+  return segs;
+}`;
+
+const resolveOrCreateTagByPath = `
+function resolveOrCreateTagByPath(segments) {
+  var parent = null;
+  var current = null;
+  for (var i = 0; i < segments.length; i++) {
+    current = null;
+    var children = parent ? parent.children : tags;
+    for (var j = 0; j < children.length; j++) {
+      if (children[j].name === segments[i]) { current = children[j]; break; }
+    }
+    if (!current) {
+      current = parent ? new Tag(segments[i], parent) : new Tag(segments[i], null);
+    }
+    parent = current;
+  }
+  return current;
+}`;
+
+export const SNIPPETS: Record<string, Snippet> = {
+  parseFolderPath: { source: parseFolderPath, deps: [] },
+  resolveFolderPath: { source: resolveFolderPath, deps: [] },
+  resolveFolderFlexible: { source: resolveFolderFlexible, deps: ['parseFolderPath', 'resolveFolderPath'] },
+  parseTagPath: { source: parseTagPath, deps: [] },
+  resolveOrCreateTagByPath: { source: resolveOrCreateTagByPath, deps: ['parseTagPath'] },
+};
+
+export function collectSnippets(keys: readonly string[]): string {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  const visit = (key: string): void => {
+    if (seen.has(key)) return;
+    seen.add(key);
+    const snip = SNIPPETS[key];
+    if (!snip) throw new Error(`Unknown snippet: ${key}`);
+    snip.deps.forEach(visit);
+    ordered.push(snip.source);
+  };
+  keys.forEach(visit);
+  return ordered.join('\n');
+}

--- a/src/contracts/ast/mutation/types.ts
+++ b/src/contracts/ast/mutation/types.ts
@@ -1,0 +1,128 @@
+// src/contracts/ast/mutation/types.ts
+// Mutation AST — node set for the create/project vertical slice (OMN-128).
+// Mirrors the read-side types.ts: node union + type guards + factory functions.
+
+export type SetPropStrategy = 'direct' | 'dateExpr' | 'enum' | 'readModifyReassign';
+
+// --- Expressions ---
+export interface RefNode {
+  type: 'ref';
+  name: string;
+}
+export interface MemberNode {
+  type: 'member';
+  object: Expr;
+  path: string;
+}
+export interface NewNode {
+  type: 'new';
+  className: string;
+  args: Expr[];
+}
+export interface EnumRefNode {
+  type: 'enumRef';
+  path: string;
+}
+export interface DateExprNode {
+  type: 'dateExpr';
+  value: Expr;
+}
+export interface JsonNode {
+  type: 'json';
+  value: unknown;
+}
+export type Expr = RefNode | MemberNode | NewNode | EnumRefNode | DateExprNode | JsonNode;
+
+// --- Typed fail-able folder resolution ---
+export type FolderResolution = { kind: 'resolved'; var: string } | { kind: 'none' } | { kind: 'notFound' };
+
+// --- Statements ---
+export interface BindNode {
+  type: 'bind';
+  name: string;
+  expr: Expr;
+}
+export interface ResolveFolderNode {
+  type: 'resolveFolder';
+  bind: string;
+  ref: string;
+}
+export interface GuardNode {
+  type: 'guard';
+  cond: string;
+  envelope: Envelope;
+}
+export interface ConstructProjectNode {
+  type: 'constructProject';
+  bind: string;
+  name: Expr;
+  folder: FolderResolution;
+}
+export interface SetPropNode {
+  type: 'setProp';
+  target: Expr;
+  prop: string;
+  value: Expr;
+  strategy: SetPropStrategy;
+}
+export interface AssignTagsNode {
+  type: 'assignTags';
+  target: Expr;
+  tags: Expr;
+  bind: string;
+}
+export interface ReturnNode {
+  type: 'return';
+  envelope: Envelope;
+}
+export type Stmt =
+  | BindNode
+  | ResolveFolderNode
+  | GuardNode
+  | ConstructProjectNode
+  | SetPropNode
+  | AssignTagsNode
+  | ReturnNode;
+
+export type Envelope = Record<string, Expr>;
+
+export interface Program {
+  statements: Stmt[];
+  context: string;
+  snippetDeps: string[];
+}
+
+// --- Factories ---
+export const ref = (name: string): RefNode => ({ type: 'ref', name });
+export const member = (object: Expr, path: string): MemberNode => ({ type: 'member', object, path });
+export const newExpr = (className: string, args: Expr[]): NewNode => ({ type: 'new', className, args });
+export const enumRef = (path: string): EnumRefNode => ({ type: 'enumRef', path });
+export const dateExpr = (value: Expr): DateExprNode => ({ type: 'dateExpr', value });
+export const json = (value: unknown): JsonNode => ({ type: 'json', value });
+
+export const bind = (name: string, expr: Expr): BindNode => ({ type: 'bind', name, expr });
+export const resolveFolder = (bindVar: string, refStr: string): ResolveFolderNode => ({
+  type: 'resolveFolder',
+  bind: bindVar,
+  ref: refStr,
+});
+export const guard = (cond: string, envelope: Envelope): GuardNode => ({ type: 'guard', cond, envelope });
+export const constructProject = (bindVar: string, name: Expr, folder: FolderResolution): ConstructProjectNode => ({
+  type: 'constructProject',
+  bind: bindVar,
+  name,
+  folder,
+});
+export const setProp = (
+  target: Expr,
+  prop: string,
+  value: Expr,
+  strategy: SetPropStrategy = 'direct',
+): SetPropNode => ({ type: 'setProp', target, prop, value, strategy });
+export const assignTags = (target: Expr, tags: Expr, bindVar: string): AssignTagsNode => ({
+  type: 'assignTags',
+  target,
+  tags,
+  bind: bindVar,
+});
+export const return_ = (envelope: Envelope): ReturnNode => ({ type: 'return', envelope });

--- a/src/contracts/ast/mutation/types.ts
+++ b/src/contracts/ast/mutation/types.ts
@@ -1,6 +1,6 @@
 // src/contracts/ast/mutation/types.ts
 // Mutation AST — node set for the create/project vertical slice (OMN-128).
-// Mirrors the read-side types.ts: node union + type guards + factory functions.
+// Mirrors the read-side types.ts: node union + factory functions.
 
 export type SetPropStrategy = 'direct' | 'dateExpr' | 'enum' | 'readModifyReassign';
 
@@ -65,6 +65,10 @@ export interface SetPropNode {
   value: Expr;
   strategy: SetPropStrategy;
 }
+// OMN-128: tag resolutions stay string-shaped (tags: Json(string[])) for the create-or-find
+// path that create/project uses — every tag resolves via resolveOrCreateTagByPath, so AssignTags
+// can never receive a missing tag. A typed TagResolution union (mirroring FolderResolution) is
+// deferred until a read-only ResolveTag node is needed (spec §5).
 export interface AssignTagsNode {
   type: 'assignTags';
   target: Expr;

--- a/src/contracts/ast/mutation/types.ts
+++ b/src/contracts/ast/mutation/types.ts
@@ -62,8 +62,13 @@ export interface SetPropNode {
   type: 'setProp';
   target: Expr;
   prop: string;
-  value: Expr;
+  // `value` is optional: the readModifyReassign strategy reads the existing typed
+  // instance and mutates sub-props instead of assigning a single new value.
+  value?: Expr;
   strategy: SetPropStrategy;
+  // Only used by the readModifyReassign strategy: sub-property mutations applied
+  // to the read-back typed instance before reassignment.
+  mutations?: Array<{ prop: string; value: Expr }>;
 }
 // OMN-128: tag resolutions stay string-shaped (tags: Json(string[])) for the create-or-find
 // path that create/project uses — every tag resolves via resolveOrCreateTagByPath, so AssignTags
@@ -123,6 +128,11 @@ export const setProp = (
   value: Expr,
   strategy: SetPropStrategy = 'direct',
 ): SetPropNode => ({ type: 'setProp', target, prop, value, strategy });
+export const readModifyReassign = (
+  target: Expr,
+  prop: string,
+  mutations: { prop: string; value: Expr }[],
+): SetPropNode => ({ type: 'setProp', target, prop, strategy: 'readModifyReassign', mutations });
 export const assignTags = (target: Expr, tags: Expr, bindVar: string): AssignTagsNode => ({
   type: 'assignTags',
   target,

--- a/src/contracts/ast/mutation/types.ts
+++ b/src/contracts/ast/mutation/types.ts
@@ -31,7 +31,15 @@ export interface JsonNode {
   type: 'json';
   value: unknown;
 }
-export type Expr = RefNode | MemberNode | NewNode | EnumRefNode | DateExprNode | JsonNode;
+// Builder-internal verbatim code fragment. ONLY for builder-constructed
+// envelope/condition fragments (ternaries, `.toISOString()`) that the typed
+// nodes can't express. NEVER carries user data — user data always goes through
+// `json`. Same trust model as GuardNode.cond (builder-internal raw string).
+export interface RawNode {
+  type: 'raw';
+  code: string;
+}
+export type Expr = RefNode | MemberNode | NewNode | EnumRefNode | DateExprNode | JsonNode | RawNode;
 
 // --- Typed fail-able folder resolution ---
 export type FolderResolution = { kind: 'resolved'; var: string } | { kind: 'none' } | { kind: 'notFound' };
@@ -69,6 +77,10 @@ export interface SetPropNode {
   // Only used by the readModifyReassign strategy: sub-property mutations applied
   // to the read-back typed instance before reassignment.
   mutations?: Array<{ prop: string; value: Expr }>;
+  // When true, the emitter wraps this statement in `try { ... } catch (e) {}` so
+  // a failure (e.g. status / reviewInterval) does NOT fail the surrounding
+  // mutation. Preserves the original best-effort bridge semantics.
+  bestEffort?: boolean;
 }
 // OMN-128: tag resolutions stay string-shaped (tags: Json(string[])) for the create-or-find
 // path that create/project uses — every tag resolves via resolveOrCreateTagByPath, so AssignTags
@@ -79,6 +91,10 @@ export interface AssignTagsNode {
   target: Expr;
   tags: Expr;
   bind: string;
+  // When true, the emitter wraps the tag-assignment block in
+  // `try { ... } catch (e) {}` so a tag failure does NOT fail the surrounding
+  // mutation. Preserves the original best-effort tag bridge semantics.
+  bestEffort?: boolean;
 }
 export interface ReturnNode {
   type: 'return';
@@ -108,6 +124,7 @@ export const newExpr = (className: string, args: Expr[]): NewNode => ({ type: 'n
 export const enumRef = (path: string): EnumRefNode => ({ type: 'enumRef', path });
 export const dateExpr = (value: Expr): DateExprNode => ({ type: 'dateExpr', value });
 export const json = (value: unknown): JsonNode => ({ type: 'json', value });
+export const raw = (code: string): RawNode => ({ type: 'raw', code });
 
 export const bind = (name: string, expr: Expr): BindNode => ({ type: 'bind', name, expr });
 export const resolveFolder = (bindVar: string, refStr: string): ResolveFolderNode => ({
@@ -127,16 +144,26 @@ export const setProp = (
   prop: string,
   value: Expr,
   strategy: SetPropStrategy = 'direct',
-): SetPropNode => ({ type: 'setProp', target, prop, value, strategy });
+  bestEffort = false,
+): SetPropNode => ({ type: 'setProp', target, prop, value, strategy, ...(bestEffort ? { bestEffort } : {}) });
 export const readModifyReassign = (
   target: Expr,
   prop: string,
   mutations: { prop: string; value: Expr }[],
-): SetPropNode => ({ type: 'setProp', target, prop, strategy: 'readModifyReassign', mutations });
-export const assignTags = (target: Expr, tags: Expr, bindVar: string): AssignTagsNode => ({
+  bestEffort = false,
+): SetPropNode => ({
+  type: 'setProp',
+  target,
+  prop,
+  strategy: 'readModifyReassign',
+  mutations,
+  ...(bestEffort ? { bestEffort } : {}),
+});
+export const assignTags = (target: Expr, tags: Expr, bindVar: string, bestEffort = false): AssignTagsNode => ({
   type: 'assignTags',
   target,
   tags,
   bind: bindVar,
+  ...(bestEffort ? { bestEffort } : {}),
 });
 export const return_ = (envelope: Envelope): ReturnNode => ({ type: 'return', envelope });

--- a/src/contracts/ast/mutation/validator.ts
+++ b/src/contracts/ast/mutation/validator.ts
@@ -1,0 +1,64 @@
+// src/contracts/ast/mutation/validator.ts
+// Structural validator for mutation-AST Programs. Throws on malformed programs
+// BEFORE they reach the emitter, so a bad lowering surfaces as a clear error at
+// the build seam rather than as broken OmniJS at runtime.
+import type { Program } from './types.js';
+
+const FOLDER_KINDS = new Set(['resolved', 'none', 'notFound']);
+
+/**
+ * Validate a mutation Program. Throws on the first structural violation.
+ *
+ * Rules:
+ *  1. The last statement must be a `return`.
+ *  2. Every `constructProject`'s `folder` must be a typed FolderResolution
+ *     object (kind ∈ {resolved, none, notFound}) — never a string / missing kind.
+ *  3. A `constructProject` with `folder.kind === 'notFound'` is illegal: the
+ *     not-found case must be handled by a preceding `guard` that returns.
+ *  4. A `setProp` with strategy !== 'readModifyReassign' MUST have a `value`;
+ *     a `setProp` with strategy === 'readModifyReassign' MUST have `mutations`.
+ */
+export function validateMutationProgram(program: Program): void {
+  const { statements } = program;
+
+  // Rule 1: return-terminated.
+  const last = statements[statements.length - 1];
+  if (!last || last.type !== 'return') {
+    throw new Error('Invalid mutation program: it must end in a return statement.');
+  }
+
+  for (const stmt of statements) {
+    if (stmt.type === 'constructProject') {
+      const folder = stmt.folder as unknown;
+      // Rule 2: typed FolderResolution object.
+      if (
+        typeof folder !== 'object' ||
+        folder === null ||
+        !FOLDER_KINDS.has((folder as { kind?: string }).kind ?? '')
+      ) {
+        throw new Error(
+          'Invalid constructProject: folder must be a typed FolderResolution object ' +
+            'with kind in {resolved, none, notFound}, not a string or untyped value.',
+        );
+      }
+      // Rule 3: notFound is illegal here.
+      if ((folder as { kind: string }).kind === 'notFound') {
+        throw new Error(
+          'Invalid constructProject: folder.kind="notFound" is illegal — ' +
+            'the not-found case must be handled by a preceding guard that returns.',
+        );
+      }
+    }
+
+    if (stmt.type === 'setProp') {
+      // Rule 4: value/mutations invariants.
+      if (stmt.strategy === 'readModifyReassign') {
+        if (stmt.mutations === undefined) {
+          throw new Error(`Invalid setProp on "${stmt.prop}": readModifyReassign strategy requires "mutations".`);
+        }
+      } else if (stmt.value === undefined) {
+        throw new Error(`Invalid setProp on "${stmt.prop}": strategy "${stmt.strategy}" requires a defined "value".`);
+      }
+    }
+  }
+}

--- a/src/contracts/ast/mutation/validator.ts
+++ b/src/contracts/ast/mutation/validator.ts
@@ -9,7 +9,7 @@ const FOLDER_KINDS = new Set(['resolved', 'none', 'notFound']);
 /**
  * Validate a mutation Program. Throws on the first structural violation.
  *
- * Rules:
+ * Structural rules (enforced here):
  *  1. The last statement must be a `return`.
  *  2. Every `constructProject`'s `folder` must be a typed FolderResolution
  *     object (kind ∈ {resolved, none, notFound}) — never a string / missing kind.
@@ -17,6 +17,10 @@ const FOLDER_KINDS = new Set(['resolved', 'none', 'notFound']);
  *     not-found case must be handled by a preceding `guard` that returns.
  *  4. A `setProp` with strategy !== 'readModifyReassign' MUST have a `value`;
  *     a `setProp` with strategy === 'readModifyReassign' MUST have `mutations`.
+ *
+ * NOT enforced here: snippet-dependency coverage (a statement that emits a call
+ * to an OmniJS helper must declare that helper in `snippetDeps`). That check is
+ * implicit in EMISSION, so it lives in `emitProgram` (emitter.ts), not here.
  */
 export function validateMutationProgram(program: Program): void {
   const { statements } = program;

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -459,7 +459,6 @@ describe('buildCreateProjectScript', () => {
     // The mutation-AST body emits the error envelope inside the JSON-encoded OmniJS
     // program, so the context tag appears double-quoted (and the JXA launcher also
     // carries its own context: "create_project" catch-arm).
-    expect(result.script).toContain('create_project');
     expect(result.script).toMatch(/context:\s*\\?"create_project\\?"/);
   });
 

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -219,6 +219,10 @@ describe('buildCreateProjectScript', () => {
     expect(result.script).toContain('Test Project');
     expect(result.operation).toBe('create');
     expect(result.target).toBe('project');
+    // The script is now a JXA launcher around a JSON-encoded OmniJS program that
+    // constructs the project natively (was: JXA app.Project({...}) + folder push).
+    expect(result.script).toContain('app.evaluateJavascript(');
+    expect(result.script).toContain('new Project(');
   });
 
   it('includes sequential flag', () => {
@@ -248,7 +252,9 @@ describe('buildCreateProjectScript', () => {
     });
 
     expect(result.script).toContain('status');
-    expect(result.script).toContain('on_hold');
+    // The mutation-AST body emits the typed OmniJS enum constant, not the raw
+    // 'on_hold' string the old JXA body carried as an embedded data value.
+    expect(result.script).toContain('Project.Status.OnHold');
   });
 
   it('includes review interval', () => {
@@ -258,7 +264,11 @@ describe('buildCreateProjectScript', () => {
     });
 
     expect(result.script).toContain('reviewInterval');
-    expect(result.script).toContain('7');
+    // The mutation-AST body converts the "days" value to the natural (unit, steps)
+    // pair at BUILD time, so 7 days emits as steps:1 / unit:"weeks" — the raw 7 no
+    // longer appears. (The conversion algorithm itself is verified in the
+    // 'conversion logic produces correct results' test below.)
+    expect(result.script).toContain('weeks');
   });
 
   // OMN-38 follow-up: full history of broken approaches the regression guards block.
@@ -310,31 +320,41 @@ describe('buildCreateProjectScript', () => {
         name: 'Bridged',
         reviewInterval: 7,
       });
-      // Bridge: Project.byIdentifier inside app.evaluateJavascript.
-      // Read-modify-reassign: read proj.reviewInterval into a local, mutate
-      // it, then assign back. Direct in-place mutation silently no-ops
-      // because the getter returns a snapshot.
-      expect(result.script).toContain('Project.byIdentifier');
+      // The mutation-AST body creates the project with `new Project(...)` directly
+      // inside the single app.evaluateJavascript bridge — no Project.byIdentifier
+      // re-lookup (the project is already in hand). The OMN-38 read-modify-reassign
+      // intent is preserved: read proj.reviewInterval into a local (_rmr), mutate
+      // it, then assign back. Direct in-place mutation silently no-ops because the
+      // getter returns a snapshot.
       expect(result.script).toContain('app.evaluateJavascript');
       // Local snapshot read
-      expect(result.script).toMatch(/(?:const|let|var)\s+ri\s*=\s*proj\.reviewInterval/);
+      expect(result.script).toMatch(/(?:const|let|var)\s+_rmr\s*=\s*proj\.reviewInterval/);
       // Mutation on the local
-      expect(result.script).toMatch(/\bri\.steps\s*=/);
-      expect(result.script).toMatch(/\bri\.unit\s*=/);
+      expect(result.script).toMatch(/\b_rmr\.steps\s*=/);
+      expect(result.script).toMatch(/\b_rmr\.unit\s*=/);
       // Re-assignment back
-      expect(result.script).toMatch(/proj\.reviewInterval\s*=\s*ri\b/);
+      expect(result.script).toMatch(/proj\.reviewInterval\s*=\s*_rmr\b/);
     });
 
-    it('embeds the days→{unit, steps} conversion logic for all natural units', () => {
-      const result = buildCreateProjectScript({
-        name: 'Conversion',
-        reviewInterval: 7,
-      });
-      // The runtime conversion must cover years, months, weeks, days.
-      expect(result.script).toContain('"years"');
-      expect(result.script).toContain('"months"');
-      expect(result.script).toContain('"weeks"');
-      expect(result.script).toContain('"days"');
+    it('emits the build-time-converted (unit, steps) pair for the requested interval', () => {
+      // The old JXA body embedded the full days→{unit, steps} conversion as RUNTIME
+      // logic (covering years/months/weeks/days), so all four unit literals appeared
+      // in every script. The mutation-AST body computes the natural unit at BUILD
+      // time, so only the selected unit + steps are emitted. Verify the conversion
+      // result for a few canonical inputs lands in the generated body.
+      // (The algorithm itself is exercised in 'conversion logic produces correct
+      // results' below.)
+      const weekly = buildCreateProjectScript({ name: 'Weekly', reviewInterval: 7 });
+      expect(weekly.script).toContain('weeks');
+      expect(weekly.script).toMatch(/_rmr\.steps\s*=\s*1\b/);
+
+      const monthly = buildCreateProjectScript({ name: 'Monthly', reviewInterval: 30 });
+      expect(monthly.script).toContain('months');
+      expect(monthly.script).toMatch(/_rmr\.steps\s*=\s*1\b/);
+
+      const daily = buildCreateProjectScript({ name: 'Daily', reviewInterval: 5 });
+      expect(daily.script).toContain('days');
+      expect(daily.script).toMatch(/_rmr\.steps\s*=\s*5\b/);
     });
 
     it('conversion logic produces correct results for canonical inputs', () => {
@@ -436,7 +456,11 @@ describe('buildCreateProjectScript', () => {
     // database root with success:true. The generated script must emit a loud error
     // return for the folder-requested-but-not-found case (cf. buildCreateFolderScript).
     expect(result.script).toContain('Folder not found');
-    expect(result.script).toContain("context: 'create_project'");
+    // The mutation-AST body emits the error envelope inside the JSON-encoded OmniJS
+    // program, so the context tag appears double-quoted (and the JXA launcher also
+    // carries its own context: "create_project" catch-arm).
+    expect(result.script).toContain('create_project');
+    expect(result.script).toMatch(/context:\s*\\?"create_project\\?"/);
   });
 
   it('falls back to leaf name matching for simple folder names', () => {

--- a/tests/unit/contracts/ast/mutation/create-project.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-project.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { buildCreateProjectProgram, dispatchMutation } from '../../../../../src/contracts/ast/mutation/defs.js';
+import { validateMutationProgram } from '../../../../../src/contracts/ast/mutation/validator.js';
+import { emitProgram } from '../../../../../src/contracts/ast/mutation/emitter.js';
+
+describe('buildCreateProjectProgram', () => {
+  it('no folder → constructProject folder kind none; no resolveFolder/guard', () => {
+    const p = buildCreateProjectProgram({ name: 'P' });
+    expect(p.statements.find((s) => s.type === 'resolveFolder')).toBeUndefined();
+    const cp = p.statements.find((s) => s.type === 'constructProject') as any;
+    expect(cp.folder).toEqual({ kind: 'none' });
+    expect(p.statements.at(-1)!.type).toBe('return');
+  });
+
+  it('folder requested → resolveFolder + guard + resolved construct + snippet dep', () => {
+    const p = buildCreateProjectProgram({ name: 'P', folder: 'Work' });
+    expect(p.statements[0].type).toBe('resolveFolder');
+    expect(p.statements[1].type).toBe('guard');
+    expect(p.snippetDeps).toContain('resolveFolderFlexible');
+    const cp = p.statements.find((s) => s.type === 'constructProject') as any;
+    expect(cp.folder).toEqual({ kind: 'resolved', var: 'targetFolder' });
+  });
+
+  it('status active is NOT emitted; on_hold IS', () => {
+    expect(
+      buildCreateProjectProgram({ name: 'P', status: 'active' }).statements.some(
+        (s) => s.type === 'setProp' && (s as any).prop === 'status',
+      ),
+    ).toBe(false);
+    expect(
+      buildCreateProjectProgram({ name: 'P', status: 'on_hold' }).statements.some(
+        (s) => s.type === 'setProp' && (s as any).prop === 'status',
+      ),
+    ).toBe(true);
+  });
+
+  it('reviewInterval 7 → weekly readModifyReassign with steps 1', () => {
+    const p = buildCreateProjectProgram({ name: 'P', reviewInterval: 7 });
+    const ri = p.statements.find((s) => s.type === 'setProp' && (s as any).prop === 'reviewInterval') as any;
+    expect(ri.strategy).toBe('readModifyReassign');
+    expect(ri.mutations).toEqual(
+      expect.arrayContaining([
+        { prop: 'steps', value: { type: 'json', value: 1 } },
+        { prop: 'unit', value: { type: 'json', value: 'weeks' } },
+      ]),
+    );
+  });
+
+  it('produced program passes the validator and emits a runnable-looking OmniJS program', () => {
+    const p = buildCreateProjectProgram({
+      name: 'P',
+      folder: 'Work',
+      tags: ['t'],
+      dueDate: '2026-06-30',
+      status: 'on_hold',
+      reviewInterval: 7,
+    });
+    expect(() => validateMutationProgram(p)).not.toThrow();
+    const out = emitProgram(p);
+    expect(out).toContain('new Project(');
+    expect(out).toContain('resolveFolderFlexible(');
+  });
+});
+
+describe('dispatchMutation guard (OMN-119/120 non-bypass)', () => {
+  it('calls the sandbox guard before building', () => {
+    const prev = { NODE_ENV: process.env.NODE_ENV, SG: process.env.SANDBOX_GUARD_ENABLED };
+    process.env.NODE_ENV = 'test';
+    process.env.SANDBOX_GUARD_ENABLED = 'true';
+    try {
+      expect(() => dispatchMutation('create/project', { name: 'P', folder: 'NotSandbox' } as any)).toThrow(
+        /TEST GUARD/,
+      );
+    } finally {
+      process.env.NODE_ENV = prev.NODE_ENV;
+      process.env.SANDBOX_GUARD_ENABLED = prev.SG;
+    }
+  });
+});

--- a/tests/unit/contracts/ast/mutation/emitter.test.ts
+++ b/tests/unit/contracts/ast/mutation/emitter.test.ts
@@ -114,7 +114,7 @@ describe('emitProgram', () => {
   it('bestEffort assignTags wraps the tag block in try/catch', () => {
     const out = emitProgram({
       context: 'create_project',
-      snippetDeps: [],
+      snippetDeps: ['resolveOrCreateTagByPath'],
       statements: [assignTags(ref('proj'), json(['t']), 'appliedTags', true)],
     });
     expect(out).toContain('try {');
@@ -125,7 +125,7 @@ describe('emitProgram', () => {
   it('emits assignTags as a resolve-or-create loop with addTag', () => {
     const program = {
       context: 'create_project',
-      snippetDeps: [],
+      snippetDeps: ['resolveOrCreateTagByPath'],
       statements: [assignTags(ref('proj'), json(['work', 'home']), 'appliedTags')],
     };
     const out = emitProgram(program);
@@ -133,6 +133,25 @@ describe('emitProgram', () => {
     expect(out).toContain('parseTagPath(_tagName)');
     expect(out).toContain('proj.addTag(_tag);');
     expect(out).toContain('appliedTags.push(_tag.name);');
+  });
+
+  it('throws if the body calls a helper not declared in snippetDeps', () => {
+    const program = {
+      context: 'create_project',
+      // BUG: assignTags emits parseTagPath(...) + resolveOrCreateTagByPath(...) but no dep declared
+      snippetDeps: [],
+      statements: [assignTags(ref('proj'), json(['work']), 'appliedTags')],
+    };
+    expect(() => emitProgram(program)).toThrow(/(parseTagPath|resolveOrCreateTagByPath).*snippetDeps/i);
+  });
+
+  it('does NOT throw when the helper IS declared in snippetDeps', () => {
+    const program = {
+      context: 'create_project',
+      snippetDeps: ['resolveOrCreateTagByPath'],
+      statements: [assignTags(ref('proj'), json(['work']), 'appliedTags')],
+    };
+    expect(() => emitProgram(program)).not.toThrow();
   });
 });
 

--- a/tests/unit/contracts/ast/mutation/emitter.test.ts
+++ b/tests/unit/contracts/ast/mutation/emitter.test.ts
@@ -7,6 +7,7 @@ import {
   enumRef,
   dateExpr,
   json,
+  raw,
   constructProject,
   setProp,
   return_,
@@ -27,6 +28,11 @@ describe('emitExpr', () => {
     const emitted = emitExpr(json(hostile));
 
     expect(eval(emitted)).toBe(hostile);
+  });
+  it('raw → emits its code verbatim (builder-internal fragments)', () => {
+    expect(emitExpr(raw('proj.dueDate ? proj.dueDate.toISOString() : null'))).toBe(
+      'proj.dueDate ? proj.dueDate.toISOString() : null',
+    );
   });
 });
 
@@ -65,6 +71,55 @@ describe('emitProgram', () => {
     expect(out).toContain('_rmr.steps = 1;');
     expect(out).toContain('_rmr.unit = "weeks";');
     expect(out).toContain('proj.reviewInterval = _rmr;');
+  });
+
+  it('bestEffort setProp (enum) wraps the assignment in try/catch', () => {
+    const out = emitProgram({
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [setProp(ref('proj'), 'status', enumRef('Project.Status.OnHold'), 'enum', true)],
+    });
+    expect(out).toContain('try { proj.status = Project.Status.OnHold; } catch (e) {}');
+  });
+
+  it('non-bestEffort enum setProp is NOT wrapped', () => {
+    const out = emitProgram({
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [setProp(ref('proj'), 'status', enumRef('Project.Status.OnHold'), 'enum')],
+    });
+    expect(out).toContain('proj.status = Project.Status.OnHold;');
+    expect(out).not.toContain('try { proj.status');
+  });
+
+  it('bestEffort readModifyReassign wraps the read-mutate-reassign block in try/catch', () => {
+    const out = emitProgram({
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [readModifyReassign(ref('proj'), 'reviewInterval', [{ prop: 'steps', value: json(1) }], true)],
+    });
+    expect(out).toMatch(/try \{ \{ const _rmr = proj\.reviewInterval;.*\} catch \(e\) \{\}/s);
+  });
+
+  it('bestEffort dateExpr is NOT double-wrapped (already self-wraps)', () => {
+    const out = emitProgram({
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [setProp(ref('proj'), 'dueDate', dateExpr(json('2026-06-30')), 'dateExpr', true)],
+    });
+    expect(out).toContain('try { proj.dueDate = new Date("2026-06-30"); } catch (e) {}');
+    expect(out).not.toContain('try { try {');
+  });
+
+  it('bestEffort assignTags wraps the tag block in try/catch', () => {
+    const out = emitProgram({
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [assignTags(ref('proj'), json(['t']), 'appliedTags', true)],
+    });
+    expect(out).toContain('try {');
+    expect(out).toContain('proj.addTag(_tag);');
+    expect(out).toContain('} catch (e) {}');
   });
 
   it('emits assignTags as a resolve-or-create loop with addTag', () => {

--- a/tests/unit/contracts/ast/mutation/emitter.test.ts
+++ b/tests/unit/contracts/ast/mutation/emitter.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { emitExpr } from '../../../../../src/contracts/ast/mutation/emitter.js';
-import { ref, member, newExpr, enumRef, dateExpr, json } from '../../../../../src/contracts/ast/mutation/types.js';
+import { emitExpr, emitProgram } from '../../../../../src/contracts/ast/mutation/emitter.js';
+import {
+  ref,
+  member,
+  newExpr,
+  enumRef,
+  dateExpr,
+  json,
+  constructProject,
+  setProp,
+  return_,
+  readModifyReassign,
+  assignTags,
+} from '../../../../../src/contracts/ast/mutation/types.js';
 
 describe('emitExpr', () => {
   it('ref → bare name', () => expect(emitExpr(ref('proj'))).toBe('proj'));
@@ -15,5 +27,56 @@ describe('emitExpr', () => {
     const emitted = emitExpr(json(hostile));
 
     expect(eval(emitted)).toBe(hostile);
+  });
+});
+
+describe('emitProgram', () => {
+  it('emitProgram assembles an OmniJS IIFE with statements', () => {
+    const program = {
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [
+        constructProject('proj', json('P'), { kind: 'none' as const }),
+        setProp(ref('proj'), 'flagged', json(true)),
+        return_({ projectId: member(ref('proj'), 'id.primaryKey'), created: json(true) }),
+      ],
+    };
+    const out = emitProgram(program);
+    expect(out).toContain('const proj = new Project("P");');
+    expect(out).toContain('proj.flagged = true;');
+    expect(out).toContain('return JSON.stringify({ projectId: proj.id.primaryKey, created: true });');
+    expect(out.trim().startsWith('(() => {')).toBe(true);
+    expect(out.trim().endsWith('})()')).toBe(true);
+  });
+
+  it('emits setProp readModifyReassign as read → mutate → reassign', () => {
+    const program = {
+      context: 'update_project',
+      snippetDeps: [],
+      statements: [
+        readModifyReassign(ref('proj'), 'reviewInterval', [
+          { prop: 'steps', value: json(1) },
+          { prop: 'unit', value: json('weeks') },
+        ]),
+      ],
+    };
+    const out = emitProgram(program);
+    expect(out).toContain('const _rmr = proj.reviewInterval;');
+    expect(out).toContain('_rmr.steps = 1;');
+    expect(out).toContain('_rmr.unit = "weeks";');
+    expect(out).toContain('proj.reviewInterval = _rmr;');
+  });
+
+  it('emits assignTags as a resolve-or-create loop with addTag', () => {
+    const program = {
+      context: 'create_project',
+      snippetDeps: [],
+      statements: [assignTags(ref('proj'), json(['work', 'home']), 'appliedTags')],
+    };
+    const out = emitProgram(program);
+    expect(out).toContain('const appliedTags = [];');
+    expect(out).toContain('parseTagPath(_tagName)');
+    expect(out).toContain('proj.addTag(_tag);');
+    expect(out).toContain('appliedTags.push(_tag.name);');
   });
 });

--- a/tests/unit/contracts/ast/mutation/emitter.test.ts
+++ b/tests/unit/contracts/ast/mutation/emitter.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { emitExpr } from '../../../../../src/contracts/ast/mutation/emitter.js';
+import { ref, member, newExpr, enumRef, dateExpr, json } from '../../../../../src/contracts/ast/mutation/types.js';
+
+describe('emitExpr', () => {
+  it('ref → bare name', () => expect(emitExpr(ref('proj'))).toBe('proj'));
+  it('member → dotted access', () => expect(emitExpr(member(ref('proj'), 'id.primaryKey'))).toBe('proj.id.primaryKey'));
+  it('new → constructor call', () =>
+    expect(emitExpr(newExpr('Project', [json('P'), ref('f')]))).toBe('new Project("P", f)'));
+  it('enumRef → path verbatim', () => expect(emitExpr(enumRef('Project.Status.OnHold'))).toBe('Project.Status.OnHold'));
+  it('dateExpr → new Date(...)', () => expect(emitExpr(dateExpr(json('2026-06-08')))).toBe('new Date("2026-06-08")'));
+  it('json uses JSON.stringify (strings)', () => expect(emitExpr(json('hi'))).toBe('"hi"'));
+  it('json is injection-safe: backticks, ${}, quotes, newlines survive as DATA', () => {
+    const hostile = 'a`b${c}d"e\nf';
+    const emitted = emitExpr(json(hostile));
+
+    expect(eval(emitted)).toBe(hostile);
+  });
+});

--- a/tests/unit/contracts/ast/mutation/emitter.test.ts
+++ b/tests/unit/contracts/ast/mutation/emitter.test.ts
@@ -1,3 +1,4 @@
+import vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import { emitExpr, emitProgram, wrapInLauncher } from '../../../../../src/contracts/ast/mutation/emitter.js';
 import {
@@ -111,7 +112,7 @@ describe('emitProgram', () => {
     expect(out).not.toContain('try { try {');
   });
 
-  it('bestEffort assignTags wraps the tag block in try/catch', () => {
+  it('bestEffort assignTags wraps only the LOOP — the consumed binding is hoisted to program scope', () => {
     const out = emitProgram({
       context: 'create_project',
       snippetDeps: ['resolveOrCreateTagByPath'],
@@ -120,6 +121,11 @@ describe('emitProgram', () => {
     expect(out).toContain('try {');
     expect(out).toContain('proj.addTag(_tag);');
     expect(out).toContain('} catch (e) {}');
+    // OMN-128 regression: the `let appliedTags = []` declaration MUST be hoisted OUTSIDE the
+    // try (a later statement, e.g. the return envelope, consumes it). If it were trapped in
+    // the try, a thrown best-effort block leaves the consumer with a ReferenceError.
+    expect(out).toContain('let appliedTags = [];');
+    expect(out.indexOf('let appliedTags = [];')).toBeLessThan(out.indexOf('try {'));
   });
 
   it('emits assignTags as a resolve-or-create loop with addTag', () => {
@@ -129,10 +135,43 @@ describe('emitProgram', () => {
       statements: [assignTags(ref('proj'), json(['work', 'home']), 'appliedTags')],
     };
     const out = emitProgram(program);
-    expect(out).toContain('const appliedTags = [];');
+    expect(out).toContain('let appliedTags = [];');
     expect(out).toContain('parseTagPath(_tagName)');
     expect(out).toContain('proj.addTag(_tag);');
     expect(out).toContain('appliedTags.push(_tag.name);');
+  });
+
+  // OMN-128: the bug a shape-only test cannot catch — EXECUTE the emitted OmniJS program
+  // in a vm with stubbed OmniFocus globals and confirm it runs to a valid envelope.
+  // Before the hoist fix, the return's reference to `appliedTags` (trapped in the
+  // best-effort try) threw `ReferenceError` here. Live /verify found it; this guards it.
+  it('emitted create-with-tags program EXECUTES and builds its envelope (no ReferenceError)', () => {
+    const program = emitProgram({
+      context: 'create_project',
+      snippetDeps: ['resolveOrCreateTagByPath'],
+      statements: [
+        constructProject('proj', json('P'), { kind: 'none' }),
+        assignTags(ref('proj'), json(['work']), 'appliedTags', true),
+        return_({ tags: ref('appliedTags'), created: json(true) }),
+      ],
+    });
+    // Minimal OmniJS runtime stubs so the program runs to its return.
+    const sandbox: Record<string, unknown> = {
+      Project: function (this: Record<string, unknown>, name: string) {
+        this.id = { primaryKey: 'p1' };
+        this.name = name;
+        this.addTag = (): void => {};
+      },
+      Tag: function (name: string) {
+        return { name };
+      },
+      flattenedTags: [],
+      tags: [],
+    };
+    const result = vm.runInNewContext(program, sandbox) as string;
+    const parsed = JSON.parse(result);
+    expect(parsed.created).toBe(true);
+    expect(parsed.tags).toEqual(['work']);
   });
 
   it('throws if the body calls a helper not declared in snippetDeps', () => {

--- a/tests/unit/contracts/ast/mutation/emitter.test.ts
+++ b/tests/unit/contracts/ast/mutation/emitter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { emitExpr, emitProgram } from '../../../../../src/contracts/ast/mutation/emitter.js';
+import { emitExpr, emitProgram, wrapInLauncher } from '../../../../../src/contracts/ast/mutation/emitter.js';
 import {
   ref,
   member,
@@ -78,5 +78,21 @@ describe('emitProgram', () => {
     expect(out).toContain('parseTagPath(_tagName)');
     expect(out).toContain('proj.addTag(_tag);');
     expect(out).toContain('appliedTags.push(_tag.name);');
+  });
+});
+
+describe('wrapInLauncher (JXA boundary)', () => {
+  it('produces a self-contained IIFE with app init (skips OmniAutomation.wrapScript)', () => {
+    const jxa = wrapInLauncher('return JSON.stringify({ok:true});', 'create_project');
+    expect(jxa).toContain('(() =>');
+    expect(jxa).toContain("Application('OmniFocus')");
+    expect(jxa).toContain('app.evaluateJavascript(');
+  });
+  it('a hostile OmniJS program survives the boundary intact (injection-proof)', () => {
+    const hostile = 'const x = `a${b}` + "\\" ); evil()"; \n return JSON.stringify({x});';
+    const jxa = wrapInLauncher(hostile, 'create_project');
+    const m = jxa.match(/app\.evaluateJavascript\((".*?")\);/s);
+    expect(m).not.toBeNull();
+    expect(JSON.parse(m![1])).toBe(hostile);
   });
 });

--- a/tests/unit/contracts/ast/mutation/snippets.test.ts
+++ b/tests/unit/contracts/ast/mutation/snippets.test.ts
@@ -1,0 +1,20 @@
+// tests/unit/contracts/ast/mutation/snippets.test.ts
+import { describe, it, expect } from 'vitest';
+import { SNIPPETS, collectSnippets } from '../../../../../src/contracts/ast/mutation/snippets.js';
+
+describe('snippet registry', () => {
+  it('exposes the flexible folder resolver source', () => {
+    expect(SNIPPETS.resolveFolderFlexible.source).toContain('function resolveFolderFlexible');
+  });
+  it('collectSnippets pulls declared deps + transitive deps, deduped, in dependency order', () => {
+    const out = collectSnippets(['resolveFolderFlexible']);
+    expect(out).toContain('function parseFolderPath');
+    expect(out).toContain('function resolveFolderPath');
+    expect(out).toContain('function resolveFolderFlexible');
+    expect(out.indexOf('function parseFolderPath')).toBeLessThan(out.indexOf('function resolveFolderFlexible'));
+  });
+  it('deduplicates a snippet requested twice', () => {
+    const out = collectSnippets(['resolveFolderFlexible', 'resolveFolderFlexible']);
+    expect(out.match(/function resolveFolderFlexible/g)).toHaveLength(1);
+  });
+});

--- a/tests/unit/contracts/ast/mutation/types.test.ts
+++ b/tests/unit/contracts/ast/mutation/types.test.ts
@@ -1,0 +1,34 @@
+// tests/unit/contracts/ast/mutation/types.test.ts
+import { describe, it, expect } from 'vitest';
+import { json, ref, member, setProp, return_, resolveFolder } from '../../../../../src/contracts/ast/mutation/types.js';
+
+describe('mutation node factories', () => {
+  it('json() wraps a value', () => {
+    expect(json('a"b')).toEqual({ type: 'json', value: 'a"b' });
+  });
+  it('member() captures object + path', () => {
+    expect(member(ref('proj'), 'id.primaryKey')).toEqual({
+      type: 'member',
+      object: { type: 'ref', name: 'proj' },
+      path: 'id.primaryKey',
+    });
+  });
+  it('setProp() defaults strategy to direct', () => {
+    expect(setProp(ref('proj'), 'flagged', json(true))).toEqual({
+      type: 'setProp',
+      target: { type: 'ref', name: 'proj' },
+      prop: 'flagged',
+      value: { type: 'json', value: true },
+      strategy: 'direct',
+    });
+  });
+  it('resolveFolder() binds a result var + ref string', () => {
+    expect(resolveFolder('folderVar', 'Work')).toEqual({ type: 'resolveFolder', bind: 'folderVar', ref: 'Work' });
+  });
+  it('return_() wraps an envelope', () => {
+    expect(return_({ created: json(true) })).toEqual({
+      type: 'return',
+      envelope: { created: { type: 'json', value: true } },
+    });
+  });
+});

--- a/tests/unit/contracts/ast/mutation/validator.test.ts
+++ b/tests/unit/contracts/ast/mutation/validator.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { validateMutationProgram } from '../../../../../src/contracts/ast/mutation/validator.js';
+import {
+  constructProject,
+  setProp,
+  readModifyReassign,
+  return_,
+  ref,
+  json,
+} from '../../../../../src/contracts/ast/mutation/types.js';
+
+const ok = {
+  context: 'create_project',
+  snippetDeps: [],
+  statements: [constructProject('proj', json('P'), { kind: 'none' as const }), return_({ created: json(true) })],
+};
+
+describe('validateMutationProgram', () => {
+  it('accepts a well-formed program', () => expect(() => validateMutationProgram(ok)).not.toThrow());
+
+  it('rejects a program that does not end in return', () => {
+    const bad = { ...ok, statements: [constructProject('proj', json('P'), { kind: 'none' as const })] };
+    expect(() => validateMutationProgram(bad)).toThrow(/must end in a return/i);
+  });
+
+  it('rejects a constructProject whose folder is a raw string', () => {
+    const bad = {
+      ...ok,
+      statements: [
+        { ...constructProject('proj', json('P'), { kind: 'none' as const }), folder: 'Work' as any },
+        return_({ created: json(true) }),
+      ],
+    };
+    expect(() => validateMutationProgram(bad)).toThrow(/folder.*resolution/i);
+  });
+
+  it('rejects a constructProject whose folder is missing kind', () => {
+    const bad = {
+      ...ok,
+      statements: [
+        { ...constructProject('proj', json('P'), { kind: 'none' as const }), folder: { var: 'x' } as any },
+        return_({ created: json(true) }),
+      ],
+    };
+    expect(() => validateMutationProgram(bad)).toThrow(/folder.*resolution/i);
+  });
+
+  // Rule 3: notFound is illegal in a constructProject — must be Guarded earlier.
+  it('rejects a constructProject whose folder kind is notFound', () => {
+    const bad = {
+      ...ok,
+      statements: [
+        constructProject('proj', json('P'), { kind: 'notFound' as const }),
+        return_({ created: json(true) }),
+      ],
+    };
+    expect(() => validateMutationProgram(bad)).toThrow(/notFound|not.found/i);
+  });
+
+  // Rule 4: setProp value/mutations invariants.
+  it('rejects a non-readModifyReassign setProp with no value', () => {
+    const broken = { ...setProp(ref('proj'), 'flagged', json(true)), value: undefined };
+    const bad = { ...ok, statements: [broken as any, return_({ created: json(true) })] };
+    expect(() => validateMutationProgram(bad)).toThrow(/value/i);
+  });
+
+  it('rejects a readModifyReassign setProp with no mutations', () => {
+    const broken = { ...readModifyReassign(ref('proj'), 'reviewInterval', []), mutations: undefined };
+    const bad = { ...ok, statements: [broken as any, return_({ created: json(true) })] };
+    expect(() => validateMutationProgram(bad)).toThrow(/mutations/i);
+  });
+
+  it('accepts a valid readModifyReassign setProp (has mutations, no value)', () => {
+    const good = {
+      ...ok,
+      statements: [
+        readModifyReassign(ref('proj'), 'reviewInterval', [{ prop: 'steps', value: json(1) }]),
+        return_({ created: json(true) }),
+      ],
+    };
+    expect(() => validateMutationProgram(good)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## OMN-128 — OmniJS-native write-side mutation AST (vertical slice)

Migrates `buildCreateProjectScript` from ~230 lines of template-string codegen to a small **OmniJS-native mutation AST** that mirrors the read-side AST at the mutation altitude. First vertical slice of the broader write-side migration; proves the architecture and establishes the test pattern for the remaining builders.

**Spec:** `docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md`
**Plan:** `docs/superpowers/plans/2026-06-08-write-side-mutation-ast-slice.md`

### What it does

New subsystem under `src/contracts/ast/mutation/` (types/factories · single-source snippet registry · emitter + JXA launcher · validator · create/project lowering + guarded dispatch). `buildCreateProjectScript` is now a 5-line delegation; its template body is deleted. Output is **one OmniJS program** wrapped in a fixed, data-free JXA launcher.

### Bug classes hardened *by construction*

- **Injection (OMN-111/113):** the whole OmniJS program crosses into JXA via a single `JSON.stringify`; data crosses via `json` nodes (`JSON.stringify`). Zero hand-written nested backticks. (The read side still uses the unsafe `escapeTemplateString` nested-backtick pattern — filed as **OMN-129** to retrofit later.)
- **Resolver drift (OMN-127):** the folder/tag resolvers are single-source snippets injected by dependency; an emit-time guard throws if a program calls a helper it didn't declare.
- **Sandbox-guard bypass (OMN-119/120):** the guard runs inside `MUTATION_DEFS` dispatch, before build — a registered op can't skip it.
- **Typed fail-able resolution:** `ResolveFolder → Folder | NotFound | NoneRequested`; placement consumes a resolved folder, never a string → OMN-127's conflated `else` is unrepresentable. Not-found fails loud (no silent root-file).

Incidentally deletes the OMN-28 JXA `.id()`-matching dance — `proj.id.primaryKey` is read directly on the freshly-created object.

### Live `/verify` at the OmniFocus seam (mandatory)

Verified against a real OmniFocus DB via a worktree-pointed MCP server:

| Path | Result |
|------|--------|
| Create with all fields **+ tags** | ✅ `success:true`, real `projectId`, `tags:["__test-ast"]`; read-back: folder/flagged/sequential/on-hold/due-17:00/review-weekly/tag all correct |
| Root placement (no folder) | ✅ lands at DB root via bare `new Project(name)` |
| Folder-not-found | ✅ loud error, no silent root-file (OMN-127 property) |
| Daily review interval | ✅ `days/1` (not weekly) |
| No duplicate after the (former) failure | ✅ exactly one project — false-failure resolved, not masked |

The verify caught a real runtime bug that 2274 unit tests + per-task reviews missed: a best-effort `try` trapped the `appliedTags` `const` that the return envelope consumes (`ReferenceError`), and the project was created-but-reported-failed (retry → duplicate). Fixed by hoisting the consumed binding to program scope; added a `node:vm` regression test that **executes** the emitted program (the shape-only tests couldn't reach it). Re-verified PASS.

### Review trail

Built subagent-driven: each task passed a two-stage spec-compliance + code-quality review; a final whole-implementation review returned clear-to-merge after restoring a `ProjectCreateData` compile-time exhaustiveness guard that the migration had dropped.

### Status

`npm run build` clean · `npm run test:unit` **2275 pass** · `npm run lint` **0 errors, 7 warnings** — 1 is the deliberate `op #2` `todo-tag` marker in new code (`defs.ts`), the other 6 are pre-existing in `src/diagnostics/`.

### Scope / deferred

Vertical slice only — other builders (task/folder/update/complete/delete/batch/bulk-delete, tag builders) migrate in later PRs. Noted for op #2: `dispatchMutation` per-key typing, `assignTags` loop-internal `var` names, and the currently-unimported `index.ts` barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
