### PR TITLE
feat(OMN-132): ESLint rule banning JXA .whose()/.where() in script layer

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -242,6 +242,44 @@ const plugin = {
         };
       },
     },
+
+    'no-whose-where': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Ban JXA .whose() / .where(): each predicate is serialized as a separate Apple Event round-trip, causing 25s+ timeouts on large databases. Iterate flattenedTasks directly instead. See docs/dev/LESSONS_LEARNED.md.',
+        },
+        schema: [],
+        messages: {
+          noWhoseWhere:
+            "JXA '.{{method}}()' serializes one Apple Event per item and hangs 25s+ on large databases. Iterate flattenedTasks directly (e.g. .filter on the array) instead — see docs/dev/LESSONS_LEARNED.md.",
+        },
+      },
+      // Intentionally carries no monitored-identifier annotation. This rule
+      // flags a banned AST shape (.whose / .where) that must have ZERO
+      // occurrences in src/ — the live-occurrence meta-check would (correctly)
+      // fail on absence. The rule depends on no renamable codebase symbol.
+      create(context) {
+        // Double-gate (cf. export-zod-schema): eslint.config.js scopes this to
+        // src/omnifocus/scripts/**, and the body re-checks the path so the rule
+        // stays correct if ever applied via a broader config. `.where` can be a
+        // legitimate method name in general TS; inside the OmniJS/JXA script
+        // layer it is only ever the JXA timeout footgun.
+        if (!context.filename.includes('/omnifocus/scripts/')) return {};
+        return {
+          CallExpression(node) {
+            const callee = node.callee;
+            if (!callee || callee.type !== 'MemberExpression' || callee.computed) return;
+            const prop = callee.property;
+            if (!prop || prop.type !== 'Identifier') return;
+            if (prop.name === 'whose' || prop.name === 'where') {
+              context.report({ node: prop, messageId: 'noWhoseWhere', data: { method: prop.name } });
+            }
+          },
+        };
+      },
+    },
   },
 };
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -163,6 +163,20 @@ export default [
     },
   },
 
+  // Custom OmniFocus MCP rules — applied to the OmniJS/JXA script layer.
+  // Bans .whose()/.where(): each predicate is an Apple Event round-trip →
+  // 25s+ timeouts on large databases (docs/dev/LESSONS_LEARNED.md). The rule
+  // body re-checks the '/omnifocus/scripts/' path (double-gate, deliberate).
+  {
+    files: ['src/omnifocus/scripts/**/*.ts'],
+    plugins: {
+      'local-rules': localRules,
+    },
+    rules: {
+      'local-rules/no-whose-where': 'error',
+    },
+  },
+
   // Ignore patterns
   {
     ignores: [

--- a/tests/unit/eslint-rules/no-whose-where.test.ts
+++ b/tests/unit/eslint-rules/no-whose-where.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import plugin from '../../../eslint-rules/index.js';
+
+// Wire ESLint's RuleTester into vitest's runner (see use-standard-response.test.ts).
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const rule = (plugin as { rules: Record<string, unknown> }).rules['no-whose-where'];
+if (!rule) {
+  throw new Error('no-whose-where rule not found on plugin export');
+}
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser: tsParser, ecmaVersion: 2022, sourceType: 'module' },
+});
+
+// The rule double-gates: config scopes it to src/omnifocus/scripts/**, and the
+// body re-checks the path. IN_SCOPE must engage the rule; OUT_OF_SCOPE must not.
+const IN_SCOPE = 'src/omnifocus/scripts/tasks/list-tasks-ast.ts';
+const OUT_OF_SCOPE = 'src/tools/unified/OmniFocusReadTool.ts';
+
+ruleTester.run('no-whose-where', rule as never, {
+  valid: [
+    // The sanctioned pattern: direct iteration over the array.
+    {
+      filename: IN_SCOPE,
+      code: 'const out = doc.flattenedTasks.filter((t) => !t.completed());',
+    },
+    // A `.where(` outside the script layer is some other library's method, not
+    // the JXA footgun — the path gate must keep the rule from firing here.
+    {
+      filename: OUT_OF_SCOPE,
+      code: 'const q = builder.where({ flagged: true });',
+    },
+  ],
+  invalid: [
+    {
+      // The classic JXA timeout footgun.
+      filename: IN_SCOPE,
+      code: 'const r = doc.flattenedTasks.whose({ completed: false })();',
+      errors: [{ messageId: 'noWhoseWhere' }],
+    },
+    {
+      // `.where` is the alias form of the same Apple Event predicate.
+      filename: IN_SCOPE,
+      code: 'const r = doc.flattenedTasks.where({ flagged: true })();',
+      errors: [{ messageId: 'noWhoseWhere' }],
+    },
+  ],
+});


### PR DESCRIPTION
Closes OMN-132. Surfaced by JesKingDev's fork audit (CONCERNS.md → "Missing Critical Features").

## What

Adds a `no-whose-where` local ESLint rule flagging `.whose(` / `.where(` call sites in `src/omnifocus/scripts/**`. JXA `.whose()`/`.where()` serialize **one Apple Event per predicate**, causing the documented **25s+ timeouts** on large databases (`docs/dev/LESSONS_LEARNED.md`). The footgun was banned by convention but never lint-enforced — so the next contributor could silently reintroduce it. This locks it in.

## Implementation

- **`eslint-rules/index.js`** — new `no-whose-where` rule (`type: 'problem'`). Visits `CallExpression` with a non-computed `MemberExpression` callee whose `property.name` is `whose` or `where`. **Double-gated** (config glob + body path re-check), matching the `export-zod-schema` precedent. Deliberately carries **no monitored-identifier annotation** — it flags a banned shape that must have *zero* `src/` occurrences, so the live-occurrence meta-check (`monitored-identifiers-live.test.ts`) would correctly fail on absence.
- **`eslint.config.js`** — wires the rule to `src/omnifocus/scripts/**/*.ts` via a dedicated config block.
- **`tests/unit/eslint-rules/no-whose-where.test.ts`** — `RuleTester` coverage: valid (direct `.filter` iteration; a `.where(` *outside* the script layer must not fire — proves the path gate), invalid (`.whose(` and `.where(` inside a script file).

## Verification

- `npm run test:unit` — **2279 passed** (incl. 4 new + the 29-test eslint-rules suite).
- `npm run lint` — **0 errors**, and the rule **fired on zero existing files**, confirming the script layer is currently `.whose()`/`.where()`-free (the rule now keeps it that way).
- `npm run build` (`tsc`) — clean.

## Non-interference

Touches only `eslint-rules/index.js`, `eslint.config.js`, and a new test file — **zero overlap** with the in-flight OMN-128/129/130 work, so this can merge independently without rebase pressure on those branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)