### PR TITLE
feat(OMN-143): integration-suite single-instance lock + orphan watchdog

### DIFF
--- a/docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md
+++ b/docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md
@@ -33,12 +33,21 @@ Wiring in `tests/support/setup-integration.ts`:
 Behavior notes: the lock also serializes `test:smoke`/`test:ci` paths that share this globalSetup — desirable, they
 touch the same OmniFocus DB.
 
-**Kill-test amendment (found during live verification):** the main-process watchdog alone is INSUFFICIENT — the live
-kill-test showed vitest main dying ~1s after its parent was killed, while the forked pool worker (which runs the test
-files and their destructive `afterAll` teardowns) survived at ppid 1. Fix: `startWorkerOrphanGuard`, loaded via vitest
-`setupFiles` (`tests/support/setup-worker-guard.ts`, runs in EVERY worker), self-gated to forked workers by IPC-channel
-presence (`typeof process.send === 'function'`) — a no-op in thread-pool unit workers. Integration runs use
-`pool: forks, singleFork: true`, so this covers exactly the surviving process class.
+**Kill-test amendments (found during live verification):**
+
+1. The main-process watchdog alone is INSUFFICIENT — round 2 showed vitest main dying ~1s after its parent was killed
+   while the forked pool worker (which runs the test files and their destructive `afterAll` teardowns) survived at
+   ppid 1. Fix: `startWorkerOrphanGuard`, loaded via vitest `setupFiles` (`tests/support/setup-worker-guard.ts`, runs in
+   EVERY worker), gated on IPC-channel presence (`typeof process.send === 'function'`). NOTE: vitest 3's default pool is
+   forks, so the guard also arms in unit workers — deliberate and harmless (transition-gated, below); worker-thread
+   pools (no orphan signal) no-op.
+2. A plain `process.exit(130)` did NOT kill a vitest fork worker (vitest patches `process.exit` inside workers). The
+   default `onOrphan` escalates: EPIPE-safe log → `process.exit(130)` → unconditional self-`SIGKILL` fallthrough, which
+   nothing can intercept. Round-4 verdict: main AND worker dead ~1s after the parent kill.
+3. The orphan trigger is the ppid TRANSITION to 1, not the value: a process born under PID 1 (container init /
+   launchd-launched) never arms — eliminating the false-positive class for that environment outright.
+4. Live run-B evidence: stale lock from the kill-test reclaimed with the dead PID named; full suite green (106 passed /
+   0 failed); lock released after teardown.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md
+++ b/docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md
@@ -1,0 +1,50 @@
+# OMN-143 — Integration-suite single-instance lock + orphan watchdog
+
+**Date:** 2026-06-09 · **Ticket:** OMN-143 · **Approved:** Kip ("Go ahead and do the OMN-143 PR now"), design as
+presented in-session and in the ticket.
+
+## Problem
+
+2026-06-09 forensics: killed shells do not kill vitest's process tree; orphaned + concurrently relaunched integration
+runs executed destructive teardowns (`fullCleanup`, sandbox-folder deletion) into a live verify session for an hour
+after their launching agent stopped. The globalSetup's own startup `fullCleanup` sweep is equally destructive and
+currently runs unconditionally.
+
+## Design
+
+New file `tests/support/integration-guard.ts` — two dependency-injected, unit-testable helpers:
+
+1. **`acquireIntegrationLock({lockPath?, pid?, isPidAlive?}) → {acquired, holderPid?, stale?}`** Lock file
+   `~/.omnifocus-mcp/integration.lock` containing the holder PID. Acquire with `wx` (atomic create); on EEXIST read the
+   holder: live PID (`process.kill(pid, 0)`, EPERM counts as alive) → `{acquired: false, holderPid}`; dead/garbage →
+   stale, reclaim by overwrite. `releaseIntegrationLock` deletes ONLY when the file still contains the caller's PID
+   (never release someone else's lock).
+2. **`startOrphanWatchdog({getPpid?, onOrphan?, intervalMs?=2000}) → stop()`** Unref'd interval; when `getPpid() === 1`
+   (reparented to launchd ⇒ parent died), clear the interval and invoke `onOrphan` (default: loud `console.error` naming
+   OMN-143, `process.exit(130)`).
+
+Wiring in `tests/support/setup-integration.ts`:
+
+- `setup()`: acquire the lock **before anything else — especially before the startup `fullCleanup` sweep**. Not acquired
+  → `throw` with an actionable message naming the holder PID (vitest aborts the run; nothing destructive has happened).
+  Then start the watchdog (module-level stop handle).
+- `teardown()`: existing teardown work, then stop the watchdog and release the lock **last**.
+
+Behavior notes: the lock also serializes `test:smoke`/`test:ci` paths that share this globalSetup — desirable, they
+touch the same OmniFocus DB. The watchdog lives in the vitest main process; its exit collapses the worker pool (IPC
+closure), stopping in-flight teardowns within seconds of orphaning.
+
+## Out of scope
+
+`fullCleanup` run-scoping (the ticket's optional item 3) — the lock makes concurrent cross-run sweeps impossible, which
+was the damage vector; further scoping would trade away the OMN-46 leak-catching purpose.
+
+## Testing
+
+- Unit (`tests/unit/support/integration-guard.test.ts`, runs in `test:unit`): fresh acquire (file contains PID);
+  contended-live (injected `isPidAlive: true` → refused with holderPid); stale reclaim (dead PID + garbage content);
+  owner-only release (other-PID release leaves file; owner release removes); watchdog via injected `getPpid` + fake
+  timers (fires once, interval cleared, no fire while ppid ≠ 1).
+- Manual kill-test performed live in the PR session and documented in the PR body: launch the suite, kill the parent
+  shell, confirm the run aborts within the watchdog interval and the lock is reclaimable (stale) afterward.
+- Gates: build, test:unit, lint. A full `test:integration` run to prove the lock acquire/release round-trip in situ.

--- a/docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md
+++ b/docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md
@@ -31,8 +31,14 @@ Wiring in `tests/support/setup-integration.ts`:
 - `teardown()`: existing teardown work, then stop the watchdog and release the lock **last**.
 
 Behavior notes: the lock also serializes `test:smoke`/`test:ci` paths that share this globalSetup — desirable, they
-touch the same OmniFocus DB. The watchdog lives in the vitest main process; its exit collapses the worker pool (IPC
-closure), stopping in-flight teardowns within seconds of orphaning.
+touch the same OmniFocus DB.
+
+**Kill-test amendment (found during live verification):** the main-process watchdog alone is INSUFFICIENT — the live
+kill-test showed vitest main dying ~1s after its parent was killed, while the forked pool worker (which runs the test
+files and their destructive `afterAll` teardowns) survived at ppid 1. Fix: `startWorkerOrphanGuard`, loaded via vitest
+`setupFiles` (`tests/support/setup-worker-guard.ts`, runs in EVERY worker), self-gated to forked workers by IPC-channel
+presence (`typeof process.send === 'function'`) — a no-op in thread-pool unit workers. Integration runs use
+`pool: forks, singleFork: true`, so this covers exactly the surviving process class.
 
 ## Out of scope
 

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -84,8 +84,11 @@ export function acquireIntegrationLock(
   }
 
   // Dead holder or garbage content → stale lock. Unlink-then-recreate so the
-  // atomic `wx` decides between two concurrent reclaimers: exactly one wins;
-  // the loser sees the winner's live PID and refuses.
+  // atomic `wx` decides between concurrent reclaimers in all but a
+  // sub-millisecond unlink/create interleaving (a strictly narrower residue
+  // than plain overwrite; closing it fully needs flock/link(2) — not worth
+  // the dependency for a single-dev-machine lock). The loser sees the
+  // winner's live PID and refuses.
   try {
     fs.unlinkSync(lockPath);
   } catch (e) {

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -105,6 +105,29 @@ export function releaseIntegrationLock(
  *
  * Returns a stop() handle for clean teardown.
  */
+/**
+ * Worker-side orphan guard. Vitest's globalSetup (where startOrphanWatchdog
+ * runs) executes ONLY in the vitest main process — forked pool workers, which
+ * run the test files AND their destructive afterAll teardowns, outlive a dead
+ * main (kill-test 2026-06-09: main died in ~1s, the fork survived at ppid 1).
+ *
+ * Forked workers have an IPC channel (`process.send`); thread-pool workers do
+ * not. Gating on IPC presence makes this a no-op in unit thread runs and
+ * active exactly where orphan survival was observed.
+ */
+export function startWorkerOrphanGuard(
+  opts: {
+    hasIpcChannel?: boolean;
+    getPpid?: () => number;
+    onOrphan?: () => void;
+    intervalMs?: number;
+  } = {},
+): (() => void) | undefined {
+  const hasIpc = opts.hasIpcChannel ?? typeof process.send === 'function';
+  if (!hasIpc) return undefined;
+  return startOrphanWatchdog(opts);
+}
+
 export function startOrphanWatchdog(
   opts: {
     getPpid?: () => number;

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -139,11 +139,26 @@ export function startOrphanWatchdog(
   const onOrphan =
     opts.onOrphan ??
     ((): void => {
-      console.error(
-        '[Integration Guard] Parent process died (reparented to PID 1) — ' +
-          'aborting orphaned integration run before it executes more destructive teardowns (OMN-143).',
-      );
-      process.exit(130);
+      // Logging must never block the abort: the parent is dead, so stderr's
+      // pipe consumer may be gone (EPIPE) — swallow and proceed.
+      try {
+        console.error(
+          '[Integration Guard] Parent process died (reparented to PID 1) — ' +
+            'aborting orphaned integration run before it executes more destructive teardowns (OMN-143).',
+        );
+      } catch {
+        /* dead pipe — abort anyway */
+      }
+      // Round-2 kill-test finding: a plain process.exit did NOT kill a vitest
+      // fork worker (vitest patches process.exit inside workers to catch tests
+      // calling it). Try the graceful exit first, then fall through to
+      // self-SIGKILL — which nothing can intercept.
+      try {
+        process.exit(130);
+      } catch {
+        /* patched/intercepted exit — escalate */
+      }
+      process.kill(process.pid, 'SIGKILL');
     });
   const intervalMs = opts.intervalMs ?? 2000;
 

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -61,7 +61,21 @@ export function acquireIntegrationLock(
     if ((e as { code?: string }).code !== 'EEXIST') throw e;
   }
 
-  const raw = fs.readFileSync(lockPath, 'utf8').trim();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(lockPath, 'utf8').trim();
+  } catch (e) {
+    // The holder released (unlinked) between our EEXIST and this read — retry
+    // the atomic create once; a second EEXIST means a new holder won the race.
+    if ((e as { code?: string }).code !== 'ENOENT') throw e;
+    try {
+      fs.writeFileSync(lockPath, String(pid), { flag: 'wx' });
+      return { acquired: true };
+    } catch (e2) {
+      if ((e2 as { code?: string }).code !== 'EEXIST') throw e2;
+      raw = fs.readFileSync(lockPath, 'utf8').trim();
+    }
+  }
   const holder = Number.parseInt(raw, 10);
   const holderValid = Number.isFinite(holder) && holder > 0;
 
@@ -69,10 +83,21 @@ export function acquireIntegrationLock(
     return { acquired: false, holderPid: holder };
   }
 
-  // Dead holder or garbage content → stale lock. Reclaim by overwrite. (A
-  // race between two reclaiming processes is acceptable: both believe the
-  // prior holder is dead, and the lock's purpose is refusing LIVE overlap.)
-  fs.writeFileSync(lockPath, String(pid));
+  // Dead holder or garbage content → stale lock. Unlink-then-recreate so the
+  // atomic `wx` decides between two concurrent reclaimers: exactly one wins;
+  // the loser sees the winner's live PID and refuses.
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (e) {
+    if ((e as { code?: string }).code !== 'ENOENT') throw e;
+  }
+  try {
+    fs.writeFileSync(lockPath, String(pid), { flag: 'wx' });
+  } catch (e) {
+    if ((e as { code?: string }).code !== 'EEXIST') throw e;
+    const winner = Number.parseInt(fs.readFileSync(lockPath, 'utf8').trim(), 10);
+    return { acquired: false, ...(Number.isFinite(winner) && winner > 0 ? { holderPid: winner } : {}) };
+  }
   return { acquired: true, stale: true, ...(holderValid ? { holderPid: holder } : {}) };
 }
 
@@ -99,21 +124,17 @@ export function releaseIntegrationLock(
 }
 
 /**
- * Abort the process when its parent dies. On macOS/Linux an orphaned process
- * is reparented to PID 1, so `process.ppid === 1` is the orphan signature.
- * The interval is unref'd: the watchdog never keeps the process alive.
- *
- * Returns a stop() handle for clean teardown.
- */
-/**
  * Worker-side orphan guard. Vitest's globalSetup (where startOrphanWatchdog
  * runs) executes ONLY in the vitest main process — forked pool workers, which
  * run the test files AND their destructive afterAll teardowns, outlive a dead
  * main (kill-test 2026-06-09: main died in ~1s, the fork survived at ppid 1).
  *
- * Forked workers have an IPC channel (`process.send`); thread-pool workers do
- * not. Gating on IPC presence makes this a no-op in unit thread runs and
- * active exactly where orphan survival was observed.
+ * Gating: forked workers have an IPC channel (`process.send`); worker-thread
+ * pools do not. NOTE vitest 3's DEFAULT pool is forks, so in this repo the
+ * guard arms in unit-test workers too — deliberate and harmless: it only acts
+ * on a ppid TRANSITION to 1 (see startOrphanWatchdog), and reaping an orphaned
+ * unit worker is also correct. The gate's job is merely to no-op where the
+ * orphan signal doesn't exist (threads share their host process).
  */
 export function startWorkerOrphanGuard(
   opts: {
@@ -128,6 +149,16 @@ export function startWorkerOrphanGuard(
   return startOrphanWatchdog(opts);
 }
 
+/**
+ * Abort the process when its parent dies. On macOS/Linux an orphaned process
+ * is reparented to PID 1 — but the trigger is the TRANSITION to ppid 1, not
+ * the value itself: a process legitimately BORN under PID 1 (e.g. node as a
+ * container's init launching the suite) must never be treated as orphaned.
+ * When the initial ppid is already 1, the watchdog never arms.
+ * The interval is unref'd: the watchdog never keeps the process alive.
+ *
+ * Returns a stop() handle for clean teardown.
+ */
 export function startOrphanWatchdog(
   opts: {
     getPpid?: () => number;
@@ -161,6 +192,12 @@ export function startOrphanWatchdog(
       process.kill(process.pid, 'SIGKILL');
     });
   const intervalMs = opts.intervalMs ?? 2000;
+
+  // Transition baseline: born-at-ppid-1 is NOT an orphan (container init /
+  // launchd-launched invocations) — never arm in that case.
+  if (getPpid() === 1) {
+    return (): void => undefined;
+  }
 
   const interval = setInterval(() => {
     if (getPpid() === 1) {

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -1,0 +1,136 @@
+/**
+ * OMN-143: integration-suite single-instance lock + orphan watchdog.
+ *
+ * Why this exists (2026-06-09 forensics): killing the shell that launched
+ * `npm run test:integration` does NOT kill vitest's process tree. Orphaned and
+ * concurrently relaunched runs kept executing destructive teardowns
+ * (fullCleanup, sandbox-folder deletion) into a live verify session for an
+ * hour after their launching agent stopped — and the globalSetup's own startup
+ * cleanup sweep is equally destructive, so concurrency must be refused BEFORE
+ * it runs.
+ *
+ * Both helpers are dependency-injected so unit tests can drive them without
+ * real PIDs, real lock contention, or real process exits.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const DEFAULT_LOCK_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'integration.lock');
+
+export interface LockResult {
+  acquired: boolean;
+  /** PID found in an existing lock file (live holder when refused; previous holder when stale-reclaimed). */
+  holderPid?: number;
+  /** True when an existing lock was reclaimed because its holder is dead (or its content was garbage). */
+  stale?: boolean;
+}
+
+/**
+ * Liveness probe: signal 0 sends nothing but checks deliverability. EPERM
+ * means the process exists but belongs to another user — that still counts
+ * as alive (we must not steal its lock).
+ */
+export function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as { code?: string }).code === 'EPERM';
+  }
+}
+
+export function acquireIntegrationLock(
+  opts: {
+    lockPath?: string;
+    pid?: number;
+    isPidAlive?: (pid: number) => boolean;
+  } = {},
+): LockResult {
+  const lockPath = opts.lockPath ?? DEFAULT_LOCK_PATH;
+  const pid = opts.pid ?? process.pid;
+  const isAlive = opts.isPidAlive ?? pidIsAlive;
+
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  // Happy path: atomic create-exclusive. Anything but EEXIST is a real error.
+  try {
+    fs.writeFileSync(lockPath, String(pid), { flag: 'wx' });
+    return { acquired: true };
+  } catch (e) {
+    if ((e as { code?: string }).code !== 'EEXIST') throw e;
+  }
+
+  const raw = fs.readFileSync(lockPath, 'utf8').trim();
+  const holder = Number.parseInt(raw, 10);
+  const holderValid = Number.isFinite(holder) && holder > 0;
+
+  if (holderValid && isAlive(holder)) {
+    return { acquired: false, holderPid: holder };
+  }
+
+  // Dead holder or garbage content → stale lock. Reclaim by overwrite. (A
+  // race between two reclaiming processes is acceptable: both believe the
+  // prior holder is dead, and the lock's purpose is refusing LIVE overlap.)
+  fs.writeFileSync(lockPath, String(pid));
+  return { acquired: true, stale: true, ...(holderValid ? { holderPid: holder } : {}) };
+}
+
+/**
+ * Release ONLY if the lock still contains our PID — never delete a lock a
+ * later run legitimately reclaimed (e.g. after we were SIGKILLed and restarted).
+ */
+export function releaseIntegrationLock(
+  opts: {
+    lockPath?: string;
+    pid?: number;
+  } = {},
+): boolean {
+  const lockPath = opts.lockPath ?? DEFAULT_LOCK_PATH;
+  const pid = opts.pid ?? process.pid;
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf8').trim();
+    if (raw !== String(pid)) return false;
+    fs.unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false; // already gone (or unreadable) — nothing to release
+  }
+}
+
+/**
+ * Abort the process when its parent dies. On macOS/Linux an orphaned process
+ * is reparented to PID 1, so `process.ppid === 1` is the orphan signature.
+ * The interval is unref'd: the watchdog never keeps the process alive.
+ *
+ * Returns a stop() handle for clean teardown.
+ */
+export function startOrphanWatchdog(
+  opts: {
+    getPpid?: () => number;
+    onOrphan?: () => void;
+    intervalMs?: number;
+  } = {},
+): () => void {
+  const getPpid = opts.getPpid ?? ((): number => process.ppid);
+  const onOrphan =
+    opts.onOrphan ??
+    ((): void => {
+      console.error(
+        '[Integration Guard] Parent process died (reparented to PID 1) — ' +
+          'aborting orphaned integration run before it executes more destructive teardowns (OMN-143).',
+      );
+      process.exit(130);
+    });
+  const intervalMs = opts.intervalMs ?? 2000;
+
+  const interval = setInterval(() => {
+    if (getPpid() === 1) {
+      clearInterval(interval);
+      onOrphan();
+    }
+  }, intervalMs);
+  interval.unref();
+
+  return (): void => clearInterval(interval);
+}

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -16,7 +16,12 @@
 
 import { shutdownSharedClient } from '../integration/helpers/shared-server.js';
 import { fullCleanup, scanForFixtures } from '../integration/helpers/sandbox-manager.js';
-import { acquireIntegrationLock, releaseIntegrationLock, startOrphanWatchdog } from './integration-guard.js';
+import {
+  acquireIntegrationLock,
+  DEFAULT_LOCK_PATH,
+  releaseIntegrationLock,
+  startOrphanWatchdog,
+} from './integration-guard.js';
 
 // OMN-143: watchdog stop handle, cleared in teardown().
 let stopOrphanWatchdog: (() => void) | undefined;
@@ -37,9 +42,9 @@ export async function setup() {
   const lock = acquireIntegrationLock();
   if (!lock.acquired) {
     throw new Error(
-      `[Integration Guard] Another integration run (PID ${lock.holderPid}) holds the lock — ` +
-        'refusing to run concurrently (OMN-143). Wait for it, or if it is dead, the lock ' +
-        'self-clears on the next attempt.',
+      `[Integration Guard] Another integration run (PID ${lock.holderPid}) holds ${DEFAULT_LOCK_PATH} — ` +
+        'refusing to run concurrently (OMN-143). Wait for it; a dead holder self-clears on the next ' +
+        'attempt. (If the PID was recycled by an unrelated process, remove the lock file manually.)',
     );
   }
   if (lock.stale) {

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -16,6 +16,10 @@
 
 import { shutdownSharedClient } from '../integration/helpers/shared-server.js';
 import { fullCleanup, scanForFixtures } from '../integration/helpers/sandbox-manager.js';
+import { acquireIntegrationLock, releaseIntegrationLock, startOrphanWatchdog } from './integration-guard.js';
+
+// OMN-143: watchdog stop handle, cleared in teardown().
+let stopOrphanWatchdog: (() => void) | undefined;
 
 /**
  * Global setup - runs BEFORE all tests
@@ -25,6 +29,29 @@ import { fullCleanup, scanForFixtures } from '../integration/helpers/sandbox-man
  * which happens in the test process (not this global setup process).
  */
 export async function setup() {
+  // OMN-143: refuse concurrent suite runs BEFORE the startup cleanup sweep —
+  // the sweep below is itself destructive, and a second run's sweep firing
+  // while another run (or a live verify session) holds OmniFocus state is
+  // exactly the 2026-06-09 incident class. Throwing here aborts the run with
+  // nothing touched.
+  const lock = acquireIntegrationLock();
+  if (!lock.acquired) {
+    throw new Error(
+      `[Integration Guard] Another integration run (PID ${lock.holderPid}) holds the lock — ` +
+        'refusing to run concurrently (OMN-143). Wait for it, or if it is dead, the lock ' +
+        'self-clears on the next attempt.',
+    );
+  }
+  if (lock.stale) {
+    const deadHolder = lock.holderPid ? ` (dead PID ${lock.holderPid})` : '';
+    console.warn(`[Integration Guard] Reclaimed a stale lock${deadHolder} — a previous run did not shut down cleanly.`);
+  }
+
+  // OMN-143: if the process that launched this suite dies (killed shell,
+  // capped tool timeout), abort within seconds instead of running minutes of
+  // destructive teardowns as an orphan.
+  stopOrphanWatchdog = startOrphanWatchdog();
+
   console.log('[Integration Setup] Running startup cleanup sweep...');
 
   try {
@@ -111,7 +138,9 @@ export async function teardown() {
         }
       }
       console.error('');
-      console.error('  Run `npm run test:cleanup -- --apply` to purge, then investigate why the in-test teardown left these behind.');
+      console.error(
+        '  Run `npm run test:cleanup -- --apply` to purge, then investigate why the in-test teardown left these behind.',
+      );
       console.error('');
       process.exitCode = 1;
     }
@@ -124,4 +153,8 @@ export async function teardown() {
 
   // Shutdown shared client
   await shutdownSharedClient();
+
+  // OMN-143: release the single-instance guard LAST, after all teardown work.
+  stopOrphanWatchdog?.();
+  releaseIntegrationLock();
 }

--- a/tests/support/setup-worker-guard.ts
+++ b/tests/support/setup-worker-guard.ts
@@ -1,0 +1,11 @@
+/**
+ * OMN-143: per-worker orphan guard, loaded via vitest `setupFiles` (runs in
+ * EVERY worker, unlike globalSetup which runs only in the vitest main
+ * process). No-ops in thread-pool workers (no IPC channel); in forked workers
+ * it aborts within seconds of the worker being orphaned — forks are where the
+ * destructive afterAll teardowns run, and the 2026-06-09 kill-test showed a
+ * fork surviving its dead main at ppid 1.
+ */
+import { startWorkerOrphanGuard } from './integration-guard.js';
+
+startWorkerOrphanGuard();

--- a/tests/support/setup-worker-guard.ts
+++ b/tests/support/setup-worker-guard.ts
@@ -1,10 +1,12 @@
 /**
  * OMN-143: per-worker orphan guard, loaded via vitest `setupFiles` (runs in
  * EVERY worker, unlike globalSetup which runs only in the vitest main
- * process). No-ops in thread-pool workers (no IPC channel); in forked workers
- * it aborts within seconds of the worker being orphaned — forks are where the
- * destructive afterAll teardowns run, and the 2026-06-09 kill-test showed a
- * fork surviving its dead main at ppid 1.
+ * process). Arms in forked workers (IPC channel present — and note vitest 3's
+ * DEFAULT pool is forks, so this includes unit-test workers: deliberate and
+ * harmless, the guard only fires on a ppid TRANSITION to 1). No-ops in
+ * worker-thread pools, where no orphan signal exists. Forks are where the
+ * destructive afterAll teardowns run; the 2026-06-09 kill-test showed a fork
+ * surviving its dead main at ppid 1.
  */
 import { startWorkerOrphanGuard } from './integration-guard.js';
 

--- a/tests/unit/support/integration-guard.test.ts
+++ b/tests/unit/support/integration-guard.test.ts
@@ -10,6 +10,7 @@ import {
   acquireIntegrationLock,
   releaseIntegrationLock,
   startOrphanWatchdog,
+  startWorkerOrphanGuard,
   pidIsAlive,
 } from '../../support/integration-guard.js';
 
@@ -121,5 +122,26 @@ describe('startOrphanWatchdog', () => {
     stop();
     vi.advanceTimersByTime(1000);
     expect(onOrphan).not.toHaveBeenCalled();
+  });
+});
+
+describe('startWorkerOrphanGuard (forked-worker gate)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('no-ops without an IPC channel (thread-pool unit workers)', () => {
+    const onOrphan = vi.fn();
+    const stop = startWorkerOrphanGuard({ hasIpcChannel: false, getPpid: () => 1, onOrphan, intervalMs: 100 });
+    expect(stop).toBeUndefined();
+    vi.advanceTimersByTime(1000);
+    expect(onOrphan).not.toHaveBeenCalled();
+  });
+
+  it('guards forked workers (IPC present): fires when orphaned', () => {
+    const onOrphan = vi.fn();
+    const stop = startWorkerOrphanGuard({ hasIpcChannel: true, getPpid: () => 1, onOrphan, intervalMs: 100 });
+    expect(stop).toBeTypeOf('function');
+    vi.advanceTimersByTime(150);
+    expect(onOrphan).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/support/integration-guard.test.ts
+++ b/tests/unit/support/integration-guard.test.ts
@@ -1,0 +1,125 @@
+// tests/unit/support/integration-guard.test.ts
+// OMN-143: single-instance lock + orphan watchdog. All cases drive the
+// dependency-injected seams (lockPath, pid, isPidAlive, getPpid, onOrphan) —
+// no real lock contention, no real process exits.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  acquireIntegrationLock,
+  releaseIntegrationLock,
+  startOrphanWatchdog,
+  pidIsAlive,
+} from '../../support/integration-guard.js';
+
+describe('acquireIntegrationLock / releaseIntegrationLock', () => {
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omn143-'));
+    lockPath = path.join(dir, 'nested', 'integration.lock'); // nested: proves mkdir -p
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('fresh acquire creates the lock containing the PID', () => {
+    const res = acquireIntegrationLock({ lockPath, pid: 12345 });
+    expect(res).toEqual({ acquired: true });
+    expect(fs.readFileSync(lockPath, 'utf8')).toBe('12345');
+  });
+
+  it('refuses when a LIVE holder owns the lock, reporting the holder PID', () => {
+    acquireIntegrationLock({ lockPath, pid: 11111 });
+    const res = acquireIntegrationLock({ lockPath, pid: 22222, isPidAlive: () => true });
+    expect(res).toEqual({ acquired: false, holderPid: 11111 });
+    // the holder's lock is untouched
+    expect(fs.readFileSync(lockPath, 'utf8')).toBe('11111');
+  });
+
+  it('reclaims a stale lock when the holder is dead', () => {
+    acquireIntegrationLock({ lockPath, pid: 11111 });
+    const res = acquireIntegrationLock({ lockPath, pid: 22222, isPidAlive: () => false });
+    expect(res).toEqual({ acquired: true, stale: true, holderPid: 11111 });
+    expect(fs.readFileSync(lockPath, 'utf8')).toBe('22222');
+  });
+
+  it('treats garbage lock content as stale (no holderPid reported)', () => {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, 'not-a-pid');
+    const res = acquireIntegrationLock({
+      lockPath,
+      pid: 33333,
+      isPidAlive: () => {
+        throw new Error('must not probe liveness for garbage content');
+      },
+    });
+    expect(res).toEqual({ acquired: true, stale: true });
+    expect(fs.readFileSync(lockPath, 'utf8')).toBe('33333');
+  });
+
+  it('release is owner-only: a non-owner release leaves the lock in place', () => {
+    acquireIntegrationLock({ lockPath, pid: 11111 });
+    expect(releaseIntegrationLock({ lockPath, pid: 99999 })).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(releaseIntegrationLock({ lockPath, pid: 11111 })).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('release of a missing lock is a quiet no-op', () => {
+    expect(releaseIntegrationLock({ lockPath, pid: 11111 })).toBe(false);
+  });
+
+  it('acquire-after-release round-trip works (the teardown→next-run path)', () => {
+    acquireIntegrationLock({ lockPath, pid: 11111 });
+    releaseIntegrationLock({ lockPath, pid: 11111 });
+    const res = acquireIntegrationLock({ lockPath, pid: 22222 });
+    expect(res).toEqual({ acquired: true });
+  });
+});
+
+describe('pidIsAlive', () => {
+  it('is true for the current process and false for an unlikely PID', () => {
+    expect(pidIsAlive(process.pid)).toBe(true);
+    // PID near the macOS pid_max ceiling, overwhelmingly unlikely to exist;
+    // if it ever does exist the probe still answers correctly, so no flake.
+    expect(typeof pidIsAlive(99999998)).toBe('boolean');
+  });
+});
+
+describe('startOrphanWatchdog', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does not fire while the parent is alive', () => {
+    const onOrphan = vi.fn();
+    const stop = startOrphanWatchdog({ getPpid: () => 4242, onOrphan, intervalMs: 100 });
+    vi.advanceTimersByTime(1000);
+    expect(onOrphan).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('fires exactly once when reparented to PID 1, then stops polling', () => {
+    const ppids = [4242, 4242, 1, 1, 1];
+    const getPpid = vi.fn(() => ppids.shift() ?? 1);
+    const onOrphan = vi.fn();
+    startOrphanWatchdog({ getPpid, onOrphan, intervalMs: 100 });
+    vi.advanceTimersByTime(1000);
+    expect(onOrphan).toHaveBeenCalledTimes(1);
+    // interval cleared on fire: no further polling after the orphan tick
+    const callsAtFire = getPpid.mock.calls.length;
+    vi.advanceTimersByTime(1000);
+    expect(getPpid.mock.calls.length).toBe(callsAtFire);
+  });
+
+  it('stop() handle cancels the watchdog before it ever fires', () => {
+    const onOrphan = vi.fn();
+    const stop = startOrphanWatchdog({ getPpid: () => 1, onOrphan, intervalMs: 100 });
+    stop();
+    vi.advanceTimersByTime(1000);
+    expect(onOrphan).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/support/integration-guard.test.ts
+++ b/tests/unit/support/integration-guard.test.ts
@@ -117,11 +117,22 @@ describe('startOrphanWatchdog', () => {
   });
 
   it('stop() handle cancels the watchdog before it ever fires', () => {
+    const ppids = [4242, 1, 1, 1];
     const onOrphan = vi.fn();
-    const stop = startOrphanWatchdog({ getPpid: () => 1, onOrphan, intervalMs: 100 });
+    const stop = startOrphanWatchdog({ getPpid: () => ppids.shift() ?? 1, onOrphan, intervalMs: 100 });
     stop();
     vi.advanceTimersByTime(1000);
     expect(onOrphan).not.toHaveBeenCalled();
+  });
+
+  it('born at ppid 1 (container init / launchd) NEVER arms — value is not the signal, the transition is', () => {
+    const onOrphan = vi.fn();
+    const getPpid = vi.fn(() => 1);
+    const stop = startOrphanWatchdog({ getPpid, onOrphan, intervalMs: 100 });
+    expect(stop).toBeTypeOf('function');
+    vi.advanceTimersByTime(1000);
+    expect(onOrphan).not.toHaveBeenCalled();
+    expect(getPpid).toHaveBeenCalledTimes(1); // baseline probe only — no interval was ever started
   });
 });
 
@@ -129,19 +140,31 @@ describe('startWorkerOrphanGuard (forked-worker gate)', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('no-ops without an IPC channel (thread-pool unit workers)', () => {
+  it('no-ops without an IPC channel (worker-thread pools — no orphan signal there)', () => {
+    const ppids = [4242, 1, 1];
     const onOrphan = vi.fn();
-    const stop = startWorkerOrphanGuard({ hasIpcChannel: false, getPpid: () => 1, onOrphan, intervalMs: 100 });
+    const stop = startWorkerOrphanGuard({
+      hasIpcChannel: false,
+      getPpid: () => ppids.shift() ?? 1,
+      onOrphan,
+      intervalMs: 100,
+    });
     expect(stop).toBeUndefined();
     vi.advanceTimersByTime(1000);
     expect(onOrphan).not.toHaveBeenCalled();
   });
 
-  it('guards forked workers (IPC present): fires when orphaned', () => {
+  it('guards forked workers (IPC present): fires on the ppid transition to 1', () => {
+    const ppids = [4242, 4242, 1];
     const onOrphan = vi.fn();
-    const stop = startWorkerOrphanGuard({ hasIpcChannel: true, getPpid: () => 1, onOrphan, intervalMs: 100 });
+    const stop = startWorkerOrphanGuard({
+      hasIpcChannel: true,
+      getPpid: () => ppids.shift() ?? 1,
+      onOrphan,
+      intervalMs: 100,
+    });
     expect(stop).toBeTypeOf('function');
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(250);
     expect(onOrphan).toHaveBeenCalledTimes(1);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    setupFiles: ['tests/support/setup-unit.ts'],
+    // setup-worker-guard (OMN-143) runs in every worker; it self-gates to
+    // forked workers (IPC present), so thread-pool unit runs are untouched.
+    setupFiles: ['tests/support/setup-unit.ts', 'tests/support/setup-worker-guard.ts'],
     // Global setup for integration test teardown - enable when any integration tests might run
     globalSetup: isUnitTestOnly ? undefined : ['tests/support/setup-integration.ts'],
     // Default timeouts accommodate integration tests; unit tests finish faster anyway

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // setup-worker-guard (OMN-143) runs in every worker; it self-gates to
-    // forked workers (IPC present), so thread-pool unit runs are untouched.
+    // setup-worker-guard (OMN-143) runs in every worker. It arms wherever an
+    // IPC channel exists — which under vitest 3's default forks pool includes
+    // unit workers (deliberate: it only fires on a ppid TRANSITION to 1, i.e.
+    // genuine orphaning) — and no-ops in worker-thread pools.
     setupFiles: ['tests/support/setup-unit.ts', 'tests/support/setup-worker-guard.ts'],
     // Global setup for integration test teardown - enable when any integration tests might run
     globalSetup: isUnitTestOnly ? undefined : ['tests/support/setup-integration.ts'],


### PR DESCRIPTION
## Summary

Prevents the 2026-06-09 incident class: killed shells don't kill vitest's process tree, and orphaned/concurrent integration runs executed destructive `fullCleanup` teardowns into a live session for an hour (collaterally deleting one real task — restored; see OMN-142 for the filter bug that made it matchable).

Two mechanical defenses in `tests/support/integration-guard.ts`, wired into globalSetup + every worker:

1. **Single-instance lock** (`~/.omnifocus-mcp/integration.lock`, PID-checked): a second concurrent run fails fast and loud — **before** the destructive startup sweep. Stale locks (dead holder, garbage content) reclaim via unlink + atomic `wx` retry; release is owner-only.
2. **Orphan watchdog**: fires on the ppid **transition** to 1 (born-at-1 container/launchd invocations never arm). Default abort escalates EPIPE-safe log → `process.exit(130)` → unconditional self-`SIGKILL` (vitest patches `process.exit` in fork workers — discovered empirically). Loaded via `setupFiles` in every worker (vitest 3 defaults to forks; thread pools no-op), because the kill-test showed fork workers surviving their dead main.

## Verification (live, four kill-test rounds — each found a real gap)

| Round | Finding |
|---|---|
| 1 | main died ~1s (good) — but the fork worker **survived at ppid 1** → worker-side guard added |
| 2 | worker guard armed but abort was neutered → vitest patches `process.exit`; SIGKILL escalation added |
| 4 | **VERDICT: main AND worker dead ~1s** after parent kill; stale lock left for reclaim |
| Run B | full suite green (106 passed/0 failed) with guard active; stale lock reclaimed naming the dead PID; lock released after teardown |

Concurrent-run refusal also observed live (second invocation refused in seconds, naming holder PID, nothing touched).

## Gates

`npm run build` clean · `test:unit` 2405/2405 (14 new guard tests) · lint 0 errors · full `test:integration` green with guard active. Two-stage review (spec compliance + code quality); quality review's Important finding (false gating premise + born-at-1 false positive) fixed by transition-gating, final verdict Approved/Safe to merge.

Spec: `docs/superpowers/specs/2026-06-09-omn-143-integration-guard.md` (in this PR, incl. kill-test amendments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)