### PR TITLE
feat(OMN-128): slice 3 — create-folder on the mutation AST

### DIFF
--- a/docs/superpowers/plans/2026-06-09-create-folder-mutation-ast.md
+++ b/docs/superpowers/plans/2026-06-09-create-folder-mutation-ast.md
@@ -1,0 +1,952 @@
+# OMN-128 Slice 3: create-folder on the Mutation AST — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `buildCreateFolderScript` to the OmniJS-native mutation AST — one `constructFolder` node, one
+lowering, one `MUTATION_DEFS` entry — finishing the create family.
+
+**Architecture:** The substrate already fits: `FolderResolution`, the `resolveFolder` node, and the
+`resolveFolderFlexible` snippet all shipped in slice 1. This slice adds a `constructFolder` statement node (near-clone
+of `constructProject`), the `buildCreateFolderProgram` lowering, the `'create/folder'` guarded dispatch key, and extends
+validator rule 7 (resolution-guard discipline) to folder resolution. The legacy JXA shell and both its
+`evaluateJavascript` islands (parent lookup + the JXA→OmniJS id bridge) are deleted, not migrated.
+
+**Tech Stack:** TypeScript, vitest (incl. `node:vm` execution tests), existing mutation-AST substrate in
+`src/contracts/ast/mutation/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-create-folder-mutation-ast-design.md` — read it first.
+
+**Ground rules for every task:**
+
+- TDD: failing test first, then minimal implementation, then green, then commit.
+- Unit tests: `npx vitest run <file>` for the file under work; `npm run test:unit` + `npm run build` before each commit.
+- Mirror established patterns: `src/contracts/ast/mutation/defs.ts` (lowering style, exhaustiveness guard),
+  `tests/unit/contracts/ast/mutation/create-task.test.ts` (golden + vm-execution pattern, dispatch-guard negative test),
+  `tests/unit/contracts/ast/mutation-script-builder.test.ts` (`extractOmniJsProgram` decode helper for launcher-shape
+  assertions).
+- Commit messages: `type(OMN-128): subject` + `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+## File map
+
+| File                                                       | Change                                                                                                          |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `src/contracts/ast/mutation/types.ts`                      | `ConstructFolderNode` interface, `Stmt` union member, `constructFolder` factory                                 |
+| `src/contracts/ast/mutation/emitter.ts`                    | `case 'constructFolder'` in `emitStmt`                                                                          |
+| `src/contracts/ast/mutation/validator.ts`                  | constructFolder rules (typed parent, notFound illegal, reserved bind); rule-7 extension to folder resolution    |
+| `src/contracts/ast/mutation/defs.ts`                       | `buildCreateFolderProgram` lowering; `'create/folder'` in `MUTATION_DEFS`                                       |
+| `src/contracts/ast/mutation/index.ts`                      | barrel: `buildCreateFolderProgram` (types/factories ride the existing `export *`)                               |
+| `src/contracts/ast/mutation-script-builder.ts`             | export `validateFolderCreate`; `buildCreateFolderScript` → thin async AST wrapper; legacy template body deleted |
+| `src/tools/unified/OmniFocusWriteTool.ts`                  | `handleFolderCreate`: `await` builder, spread `liftWarnings`                                                    |
+| `tests/unit/contracts/ast/mutation/create-folder.test.ts`  | NEW — node/emitter/validator/golden/vm/guard tests                                                              |
+| `tests/unit/contracts/ast/mutation-script-builder.test.ts` | rewrite `buildCreateFolderScript` describe block (async, launcher shape)                                        |
+| `tests/integration/tools/unified/create-paths.test.ts`     | OMN-138: folder-create live coverage (nested create read-back; loud not-found on unguarded child server)        |
+
+---
+
+### Task 1: `constructFolder` node — types, emitter, validator basics
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation/types.ts`
+- Modify: `src/contracts/ast/mutation/emitter.ts`
+- Modify: `src/contracts/ast/mutation/validator.ts`
+- Create: `tests/unit/contracts/ast/mutation/create-folder.test.ts`
+
+Types, emitter, and validator land together in this task: adding the union member makes the emitter's `never` default a
+compile error until its case exists, so they cannot be split across commits.
+
+- [ ] **Step 1: Write failing tests** — create `tests/unit/contracts/ast/mutation/create-folder.test.ts`:
+
+```ts
+// tests/unit/contracts/ast/mutation/create-folder.test.ts
+// OMN-128 slice 3 — constructFolder node + create/folder lowering tests.
+import { describe, it, expect } from 'vitest';
+import {
+  constructFolder,
+  json,
+  emitStmt,
+  emitProgram,
+  validateMutationProgram,
+  resolveFolder,
+  guard,
+  return_,
+  ref,
+  member,
+  constructProject,
+  type Program,
+} from '../../../../../src/contracts/ast/mutation/index.js';
+
+describe('constructFolder node (types + emitter)', () => {
+  it('factory builds the typed node', () => {
+    const node = constructFolder('f', json('Home'), { kind: 'none' });
+    expect(node).toEqual({ type: 'constructFolder', bind: 'f', name: json('Home'), parent: { kind: 'none' } });
+  });
+
+  it('emits top-level construction for kind none', () => {
+    expect(emitStmt(constructFolder('f', json('Home'), { kind: 'none' }))).toBe('const f = new Folder("Home");');
+  });
+
+  it('emits parented construction for kind resolved', () => {
+    expect(emitStmt(constructFolder('f', json('Home'), { kind: 'resolved', var: 'targetParent' }))).toBe(
+      'const f = new Folder("Home", targetParent);',
+    );
+  });
+
+  it('throws at emit time for kind notFound', () => {
+    expect(() => emitStmt(constructFolder('f', json('Home'), { kind: 'notFound' }))).toThrow(/notFound.*illegal/i);
+  });
+});
+
+describe('constructFolder validator rules', () => {
+  const wrap = (stmts: Program['statements']): Program => ({
+    statements: stmts,
+    context: 'create_folder',
+    snippetDeps: [],
+  });
+  const envelope = { folderId: member(ref('f'), 'id.primaryKey') };
+
+  it('rejects parent.kind notFound (must be guard-handled earlier)', () => {
+    expect(() =>
+      validateMutationProgram(wrap([constructFolder('f', json('X'), { kind: 'notFound' }), return_(envelope)])),
+    ).toThrow(/notFound.*illegal/i);
+  });
+
+  it('rejects an untyped parent (string smuggled past the types)', () => {
+    const node = constructFolder('f', json('X'), { kind: 'none' });
+    (node as unknown as { parent: unknown }).parent = 'Personal';
+    expect(() => validateMutationProgram(wrap([node, return_(envelope)]))).toThrow(/typed FolderResolution/i);
+  });
+
+  it('rejects a reserved emitter identifier as bind', () => {
+    expect(() =>
+      validateMutationProgram(wrap([constructFolder('_warnings', json('X'), { kind: 'none' }), return_(envelope)])),
+    ).toThrow(/reserved emitter identifier/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/contracts/ast/mutation/create-folder.test.ts` Expected: FAIL — `constructFolder` is not
+exported (import error).
+
+- [ ] **Step 3: Implement.** In `src/contracts/ast/mutation/types.ts`, after `ConstructTaskNode`:
+
+```ts
+export interface ConstructFolderNode {
+  type: 'constructFolder';
+  bind: string;
+  name: Expr;
+  parent: FolderResolution;
+}
+```
+
+Add `ConstructFolderNode` to the `Stmt` union (after `ConstructTaskNode`). After the `constructTask` factory:
+
+```ts
+export const constructFolder = (bindVar: string, name: Expr, parent: FolderResolution): ConstructFolderNode => ({
+  type: 'constructFolder',
+  bind: bindVar,
+  name,
+  parent,
+});
+```
+
+In `src/contracts/ast/mutation/emitter.ts`, after `case 'constructProject'`:
+
+```ts
+    case 'constructFolder': {
+      // Near-clone of constructProject at the folder altitude. `new Folder(name,
+      // parentFolder)` appends inside the parent (OmniJS position param), matching
+      // the legacy `targetParent.folders.push(folder)`; omitted position = library
+      // root. `const`, not `var`: folders have no batch path, so no cross-item
+      // hoisting concern (contrast constructTask).
+      const name = emitExpr(node.name);
+      switch (node.parent.kind) {
+        case 'resolved':
+          return `const ${node.bind} = new Folder(${name}, ${node.parent.var});`;
+        case 'none':
+          return `const ${node.bind} = new Folder(${name});`;
+        case 'notFound':
+          throw new Error(
+            'constructFolder with parent.kind="notFound" is illegal — it must be Guarded earlier (validator enforces this).',
+          );
+        default: {
+          const _x: never = node.parent;
+          throw new Error(`Unknown folder resolution: ${JSON.stringify(_x)}`);
+        }
+      }
+    }
+```
+
+In `src/contracts/ast/mutation/validator.ts`, inside `validateStatementList` after the `constructProject` block (mirror
+rules 2/3/10 — reuse the existing `FOLDER_KINDS` set):
+
+```ts
+if (stmt.type === 'constructFolder') {
+  const parent = stmt.parent as unknown;
+  // Rules 2/3 at the folder altitude: typed FolderResolution; notFound illegal.
+  if (typeof parent !== 'object' || parent === null || !FOLDER_KINDS.has((parent as { kind?: string }).kind ?? '')) {
+    throw new Error(
+      'Invalid constructFolder: parent must be a typed FolderResolution object ' +
+        'with kind in {resolved, none, notFound}, not a string or untyped value.',
+    );
+  }
+  if ((parent as { kind: string }).kind === 'notFound') {
+    throw new Error(
+      'Invalid constructFolder: parent.kind="notFound" is illegal — ' +
+        'the not-found case must be handled by a preceding guard that returns.',
+    );
+  }
+  assertNotReserved(stmt.bind, 'constructFolder bind');
+}
+```
+
+Also update the validator's doc comment (rules 2/3/10 mention constructFolder now).
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `npx vitest run tests/unit/contracts/ast/mutation/create-folder.test.ts` → PASS. Run:
+`npm run build && npm run test:unit` → clean / green (the union growth must not break other switches).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/mutation/types.ts src/contracts/ast/mutation/emitter.ts \
+  src/contracts/ast/mutation/validator.ts tests/unit/contracts/ast/mutation/create-folder.test.ts
+git commit -m "feat(OMN-128): constructFolder mutation-AST node (types, emitter, validator)"
+```
+
+---
+
+### Task 2: Validator rule-7 extension — folder resolution joins the guard discipline
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation/validator.ts`
+- Test: `tests/unit/contracts/ast/mutation/create-folder.test.ts`
+
+- [ ] **Step 1: Write failing tests** (append to create-folder.test.ts):
+
+```ts
+describe('rule-7 extension: resolveFolder needs a guard before consumption', () => {
+  const wrap = (stmts: Program['statements']): Program => ({
+    statements: stmts,
+    context: 'create_folder',
+    snippetDeps: [],
+  });
+  const envelope = { ok: json(true) };
+
+  it('rejects resolveFolder → constructFolder with no guard between', () => {
+    expect(() =>
+      validateMutationProgram(
+        wrap([
+          resolveFolder('p', 'Personal'),
+          constructFolder('f', json('X'), { kind: 'resolved', var: 'p' }),
+          return_(envelope),
+        ]),
+      ),
+    ).toThrow(/consumes resolution bind "p" without a guard/);
+  });
+
+  it('rejects resolveFolder → constructProject with no guard between (pre-existing gap, closed)', () => {
+    expect(() =>
+      validateMutationProgram(
+        wrap([
+          resolveFolder('p', 'Personal'),
+          constructProject('proj', json('X'), { kind: 'resolved', var: 'p' }),
+          return_(envelope),
+        ]),
+      ),
+    ).toThrow(/consumes resolution bind "p" without a guard/);
+  });
+
+  it('accepts the guarded shape', () => {
+    expect(() =>
+      validateMutationProgram(
+        wrap([
+          resolveFolder('p', 'Personal'),
+          guard('p === null', { error: json(true), message: json('nope'), context: json('create_folder') }),
+          constructFolder('f', json('X'), { kind: 'resolved', var: 'p' }),
+          return_(envelope),
+        ]),
+      ),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — the two reject cases pass validation today (rule 7 ignores `resolveFolder`),
+      so the `toThrow` assertions FAIL.
+
+- [ ] **Step 3: Implement.** In `validator.ts`, replace the rule-7 loop's resolve filter and the constructTask-only
+      consumer check with a per-construct consumed-bind accessor:
+
+```ts
+// Rule 7: resolution-guard discipline, at THIS list level. A failed
+// resolution (null bind) reaching `new Task` / `new Project` / `new Folder` /
+// moveTasks explodes with an opaque runtime TypeError instead of a typed
+// envelope — so every consumed resolution bind must be guarded between
+// resolve and construct. The cond check is string-level: same trust model as
+// GuardNode.cond generally. (Slice 3 widened this from constructTask-only to
+// all three constructs — resolveFolder → constructProject was a pre-existing
+// enforcement gap.)
+const consumedBind = (construct: Stmt): string | null => {
+  if (construct.type === 'constructTask' && construct.container.kind !== 'inbox') return construct.container.var;
+  if (construct.type === 'constructProject' && construct.folder.kind === 'resolved') return construct.folder.var;
+  if (construct.type === 'constructFolder' && construct.parent.kind === 'resolved') return construct.parent.var;
+  return null;
+};
+for (let ri = 0; ri < statements.length; ri++) {
+  const resolve = statements[ri];
+  if (resolve.type !== 'resolveProject' && resolve.type !== 'resolveParentTask' && resolve.type !== 'resolveFolder')
+    continue;
+  // Word-boundary match, not substring: a guard on `proj` must not satisfy
+  // bind `p`. Regex-escaped for safety even though binds are identifiers.
+  const bindPattern = new RegExp(`\\b${resolve.bind.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
+  for (let ci = 0; ci < statements.length; ci++) {
+    const construct = statements[ci];
+    if (consumedBind(construct) !== resolve.bind) continue;
+    const guarded = statements.some((s, si) => si > ri && si < ci && s.type === 'guard' && bindPattern.test(s.cond));
+    if (!guarded) {
+      throw new Error(
+        `Invalid mutation program: ${construct.type} consumes resolution bind "${resolve.bind}" ` +
+          'without a guard between the resolve and the construct (the guard cond must mention the bind).',
+      );
+    }
+  }
+}
+```
+
+Note the error message now leads with `${construct.type}` — for constructTask programs it renders identically to the old
+text, so existing rule-7 tests keep passing. Update the rule-7 doc comment at the top of the file to name the widened
+coverage.
+
+- [ ] **Step 4: Run to verify green**
+
+Run:
+`npx vitest run tests/unit/contracts/ast/mutation/create-folder.test.ts tests/unit/contracts/ast/mutation/validator.test.ts tests/unit/contracts/ast/mutation/create-project.test.ts`
+→ PASS (the slice-1 lowering already guards, so no churn).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/mutation/validator.ts tests/unit/contracts/ast/mutation/create-folder.test.ts
+git commit -m "feat(OMN-128): extend validator rule 7 to folder resolution (closes resolveFolder→construct gap)"
+```
+
+---
+
+### Task 3: `buildCreateFolderProgram` lowering + `create/folder` dispatch + guard export
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation/defs.ts`
+- Modify: `src/contracts/ast/mutation/index.ts`
+- Modify: `src/contracts/ast/mutation-script-builder.ts` (export `validateFolderCreate` only — body swap is Task 5)
+- Test: `tests/unit/contracts/ast/mutation/create-folder.test.ts`
+
+- [ ] **Step 1: Write failing tests** (append; extend the import list with `buildCreateFolderProgram`,
+      `dispatchMutation`, `emitProgram`):
+
+```ts
+describe('buildCreateFolderProgram lowering', () => {
+  it('top-level: construct + envelope, no resolve, no snippets', () => {
+    const program = buildCreateFolderProgram({ name: 'Home' });
+    expect(program.context).toBe('create_folder');
+    expect(program.snippetDeps).toEqual([]);
+    expect(program.statements.map((s) => s.type)).toEqual(['constructFolder', 'return']);
+    expect(() => validateMutationProgram(program)).not.toThrow();
+
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain('const folder = new Folder("Home");');
+    expect(omnijs).toContain('folderId: folder.id.primaryKey');
+    expect(omnijs).toContain('parentFolder: null');
+    expect(omnijs).toContain('warnings: _warnings');
+    expect(omnijs).toContain('created: true');
+  });
+
+  it('nested: resolve + guard (exact legacy message) + parented construct + snippet dep', () => {
+    const program = buildCreateFolderProgram({ name: 'Sub', parentFolder: 'Personal : Areas' });
+    expect(program.snippetDeps).toEqual(['resolveFolderFlexible']);
+    expect(program.statements.map((s) => s.type)).toEqual(['resolveFolder', 'guard', 'constructFolder', 'return']);
+    expect(() => validateMutationProgram(program)).not.toThrow();
+
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain('const targetParent = resolveFolderFlexible("Personal : Areas");');
+    expect(omnijs).toContain(
+      'if (targetParent === null) return JSON.stringify({ error: true, message: "Parent folder not found: Personal : Areas", context: "create_folder" });',
+    );
+    expect(omnijs).toContain('const folder = new Folder("Sub", targetParent);');
+    expect(omnijs).toContain('parentFolder: targetParent.name');
+    // Transitive snippet assembly: the flexible resolver pulls its path helpers.
+    expect(omnijs).toContain('function parseFolderPath');
+    expect(omnijs).toContain('function resolveFolderPath');
+    expect(omnijs).toContain('function resolveFolderFlexible');
+  });
+
+  it('user data is JSON-encoded, never spliced (a quote in the name cannot escape)', () => {
+    const program = buildCreateFolderProgram({ name: 'He said "hi" \\ `tick`' });
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain(JSON.stringify('He said "hi" \\ `tick`'));
+  });
+});
+
+describe('dispatchMutation create/folder guard (OMN-119/120 non-bypass)', () => {
+  it('rejects a non-sandbox folder create when the sandbox guard is enabled', async () => {
+    const prev = { NODE_ENV: process.env.NODE_ENV, SG: process.env.SANDBOX_GUARD_ENABLED };
+    process.env.NODE_ENV = 'test';
+    process.env.SANDBOX_GUARD_ENABLED = 'true';
+    try {
+      await expect(dispatchMutation('create/folder', { name: 'Rogue', parentFolder: 'Personal' })).rejects.toThrow(
+        /TEST GUARD/,
+      );
+    } finally {
+      process.env.NODE_ENV = prev.NODE_ENV;
+      process.env.SANDBOX_GUARD_ENABLED = prev.SG;
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `buildCreateFolderProgram` not exported.
+
+- [ ] **Step 3: Implement.** In `mutation-script-builder.ts`: add `export` to `function validateFolderCreate`. In
+      `defs.ts`: extend the `FolderCreateData` type import (from `'../../mutations.js'`) and the `validateFolderCreate`
+      import; add `constructFolder` to the types import; then:
+
+```ts
+/**
+ * Lower a folder-create request into a typed mutation Program (OMN-128 slice 3).
+ * Statement order preserves the legacy builder: parent resolve + guard (loud
+ * not-found, exact legacy message — already loud since OMN-127), construct,
+ * return. The legacy JXA→OmniJS id-bridge island is deleted, not migrated:
+ * folderId reads id.primaryKey directly off the fresh binding. `warnings` is
+ * additive (always [] today — no best-effort statements) for one-semantics
+ * uniformity across migrated create envelopes.
+ */
+export function buildCreateFolderProgram(data: FolderCreateData): Program {
+  // Compile-time exhaustiveness guard (same discipline as the other create
+  // lowerings): a new FolderCreateData field cannot be silently dropped.
+  const _exhaustive: Record<keyof FolderCreateData, true> = {
+    name: true,
+    parentFolder: true,
+  };
+  void _exhaustive;
+
+  const statements: Stmt[] = [];
+  const snippetDeps: string[] = [];
+
+  if (data.parentFolder) {
+    statements.push(resolveFolder('targetParent', data.parentFolder));
+    statements.push(
+      guard('targetParent === null', {
+        error: json(true),
+        message: json('Parent folder not found: ' + data.parentFolder),
+        context: json('create_folder'),
+      }),
+    );
+    snippetDeps.push('resolveFolderFlexible');
+  }
+
+  statements.push(
+    constructFolder(
+      'folder',
+      json(data.name),
+      data.parentFolder ? { kind: 'resolved', var: 'targetParent' } : { kind: 'none' },
+    ),
+  );
+
+  const envelope: Envelope = {
+    folderId: member(ref('folder'), 'id.primaryKey'),
+    name: member(ref('folder'), 'name'),
+    parentFolder: data.parentFolder ? raw('targetParent.name') : json(null),
+    warnings: ref('_warnings'),
+    created: json(true),
+  };
+  statements.push(return_(envelope));
+
+  return { statements, context: 'create_folder', snippetDeps };
+}
+```
+
+Register in `MUTATION_DEFS` (after `'create/project'`):
+
+```ts
+  'create/folder': {
+    guard: validateFolderCreate,
+    build: buildCreateFolderProgram,
+  } as MutationDef<FolderCreateData>,
+```
+
+Barrel (`index.ts`): add `buildCreateFolderProgram` to the `defs.js` export list (the node type and factory ride the
+existing `export * from './types.js'`).
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `npx vitest run tests/unit/contracts/ast/mutation/create-folder.test.ts` → PASS. Run:
+`npm run build && npm run test:unit` → clean / green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/mutation/defs.ts src/contracts/ast/mutation/index.ts \
+  src/contracts/ast/mutation-script-builder.ts tests/unit/contracts/ast/mutation/create-folder.test.ts
+git commit -m "feat(OMN-128): buildCreateFolderProgram lowering + guarded create/folder dispatch"
+```
+
+---
+
+### Task 4: vm-execution tests — the emitted program actually runs
+
+**Files:**
+
+- Test: `tests/unit/contracts/ast/mutation/create-folder.test.ts`
+
+No production code expected — these tests prove the emitted string executes (the layer that caught both prior
+compose-time scope bugs). If a vm test fails, fix the substrate, not the test.
+
+- [ ] **Step 1: Write the tests** (append; this task adds `import vm from 'node:vm';` to the test file's imports — do
+      NOT add it earlier, an unused import fails lint on the Task 1–3 commits):
+
+```ts
+// EXECUTE the emitted program in a vm with stubbed OmniFocus globals — the
+// layer that caught slice 1's appliedTags and slice 2's const-in-try bugs.
+describe('emitted create-folder program executes (vm)', () => {
+  interface FolderStub {
+    name: string;
+    parent: FolderStub | null;
+    children: FolderStub[];
+    id: { primaryKey: string };
+  }
+
+  function makeSandbox(): {
+    sandbox: Record<string, unknown>;
+    topLevel: FolderStub[];
+    flat: FolderStub[];
+    constructorCalls: string[];
+  } {
+    const topLevel: FolderStub[] = [];
+    const flat: FolderStub[] = [];
+    const constructorCalls: string[] = [];
+    let nextId = 1;
+    const FolderCtor = function (this: FolderStub, name: string, parent?: FolderStub) {
+      constructorCalls.push(name);
+      this.name = name;
+      this.parent = parent ?? null;
+      this.children = [];
+      this.id = { primaryKey: `folder-pk-${nextId++}` };
+      (parent ? parent.children : topLevel).push(this);
+      flat.push(this);
+    } as unknown as Record<string, unknown> & { byIdentifier: (ref: string) => FolderStub | null };
+    FolderCtor.byIdentifier = (refStr: string): FolderStub | null =>
+      flat.find((f) => f.id.primaryKey === refStr) ?? null;
+    const sandbox: Record<string, unknown> = {
+      Folder: FolderCtor,
+      folders: topLevel,
+      flattenedFolders: flat,
+    };
+    return { sandbox, topLevel, flat, constructorCalls };
+  }
+
+  /** Pre-seed a folder hierarchy through the same stub constructor. */
+  function seed(sandbox: Record<string, unknown>, name: string, parent?: FolderStub): FolderStub {
+    const FolderCtor = sandbox.Folder as new (name: string, parent?: FolderStub) => FolderStub;
+    return new FolderCtor(name, parent);
+  }
+
+  it('vm A: top-level create returns the success envelope and lands at library root', () => {
+    const { sandbox, topLevel } = makeSandbox();
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Home' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.created).toBe(true);
+    expect(parsed.name).toBe('Home');
+    expect(parsed.folderId).toMatch(/^folder-pk-/);
+    expect(parsed.parentFolder).toBeNull();
+    expect(parsed.warnings).toEqual([]);
+    expect(topLevel.map((f) => f.name)).toEqual(['Home']);
+  });
+
+  it('vm B: nested create resolves the parent by name and appends at the END of its children', () => {
+    const { sandbox } = makeSandbox();
+    const parent = seed(sandbox, 'Personal');
+    seed(sandbox, 'Existing Sibling', parent);
+
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Sub', parentFolder: 'Personal' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.created).toBe(true);
+    expect(parsed.parentFolder).toBe('Personal');
+    expect(parent.children.map((f) => f.name)).toEqual(['Existing Sibling', 'Sub']); // appended, not prepended
+  });
+
+  it('vm C: nested create resolves a " : " path through the seeded hierarchy', () => {
+    const { sandbox } = makeSandbox();
+    const top = seed(sandbox, 'Personal');
+    seed(sandbox, 'Areas', top);
+
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Deep', parentFolder: 'Personal : Areas' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.created).toBe(true);
+    expect(parsed.parentFolder).toBe('Areas'); // resolved parent's own name, legacy-faithful
+  });
+
+  it('vm D: parent-not-found returns the error envelope and NEVER constructs a Folder', () => {
+    const { sandbox, constructorCalls } = makeSandbox();
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Orphan', parentFolder: 'NonExistent' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.error).toBe(true);
+    expect(parsed.message).toBe('Parent folder not found: NonExistent');
+    expect(parsed.context).toBe('create_folder');
+    expect(constructorCalls).toEqual([]); // guard short-circuits before construct
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `npx vitest run tests/unit/contracts/ast/mutation/create-folder.test.ts` Expected: PASS (the substrate from Tasks
+1–3 should execute cleanly; a failure here is a real substrate bug — debug it, do not weaken the test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/contracts/ast/mutation/create-folder.test.ts
+git commit -m "test(OMN-128): vm-execution coverage for the create-folder program"
+```
+
+---
+
+### Task 5: Swap `buildCreateFolderScript` to the AST path; delete the template body; rewrite legacy tests
+
+**Files:**
+
+- Modify: `src/contracts/ast/mutation-script-builder.ts`
+- Modify: `tests/unit/contracts/ast/mutation-script-builder.test.ts` (the `buildCreateFolderScript` describe block,
+  currently near line 1146)
+
+- [ ] **Step 1: Rewrite the legacy describe block first (failing tests).** Every test becomes async and awaits the
+      builder (a sync call would hand `.script` a Promise property read of `undefined`, not a loud failure). Replace the
+      whole block with:
+
+```ts
+// OMN-128 slice 3: buildCreateFolderScript emits ONE OmniJS program from the
+// mutation AST (dispatchMutation → emitProgram → wrapInLauncher) — the legacy
+// JXA shell and both its evaluateJavascript islands (parent lookup + the
+// JXA→OmniJS id bridge) are gone. Runtime behavior (vm execution, guard
+// short-circuits) is covered in tests/unit/contracts/ast/mutation/create-folder.test.ts.
+describe('buildCreateFolderScript (OMN-128 AST emission)', () => {
+  it('emits the JXA launcher around a JSON-encoded OmniJS program', async () => {
+    const result = await buildCreateFolderScript({ name: 'Home' });
+
+    expect(result.script).toContain("Application('OmniFocus')");
+    expect(result.script).toContain('app.evaluateJavascript(');
+    expect(result.operation).toBe('create');
+    expect(result.target).toBe('folder');
+    expect(result.description).toBe('Create folder: Home');
+
+    const program = extractOmniJsProgram(result.script);
+    expect(program).toContain('const folder = new Folder("Home");');
+    expect(program).toContain('folderId: folder.id.primaryKey');
+  });
+
+  it('nested create resolves the parent in-program via the shared flexible resolver', async () => {
+    const result = await buildCreateFolderScript({ name: 'Sub', parentFolder: 'Personal' });
+
+    const program = extractOmniJsProgram(result.script);
+    expect(program).toContain('const targetParent = resolveFolderFlexible("Personal");');
+    expect(program).toContain('function parseFolderPath');
+    expect(program).toContain('function resolveFolderPath');
+    expect(program).toContain('const folder = new Folder("Sub", targetParent);');
+  });
+
+  it('parent-not-found is a loud in-program guard with the legacy message', async () => {
+    const result = await buildCreateFolderScript({ name: 'Orphan', parentFolder: 'NonExistent' });
+
+    const program = extractOmniJsProgram(result.script);
+    expect(program).toContain('Parent folder not found: NonExistent');
+    expect(program).toContain('if (targetParent === null) return JSON.stringify(');
+  });
+
+  it('generates syntactically valid JavaScript', async () => {
+    const result = await buildCreateFolderScript({ name: 'Test Folder', parentFolder: 'Parent : Child' });
+
+    // Syntax-only validation: Function(body) parses but does not execute — for
+    // both the launcher and the decoded OmniJS program.
+    expect(() => Function(result.script)).not.toThrow();
+    expect(() => Function(extractOmniJsProgram(result.script))).not.toThrow();
+  });
+});
+```
+
+(The legacy "includes folder ID bridging logic" test is deleted outright — the bridge it asserts is the thing this slice
+removes.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/contracts/ast/mutation-script-builder.test.ts` Expected: FAIL — builder is still
+sync/template (`await` on non-Promise is harmless, but the launcher-shape `extractOmniJsProgram` extraction throws on
+the legacy template).
+
+- [ ] **Step 3: Swap the builder.** Replace `buildCreateFolderScript`'s entire body in `mutation-script-builder.ts`
+      with:
+
+```ts
+/**
+ * Build a JXA script for creating a folder.
+ * Supports:
+ * - Top-level folders (no parentFolder)
+ * - Nested folders (parentFolder by name, path " : " or "/", or ID)
+ */
+export async function buildCreateFolderScript(data: FolderCreateData): Promise<GeneratedMutationScript> {
+  // Emit from the mutation AST. dispatchMutation runs the build-time sandbox
+  // guard (validateFolderCreate) BEFORE building, so it can never be bypassed;
+  // the emitter produces ONE OmniJS program (native `new Folder(...)`, parent
+  // resolved in-program with a loud not-found guard) wrapped in a data-free JXA
+  // launcher. The old template-string body — a JXA shell with two
+  // evaluateJavascript islands (parent lookup + the JXA→OmniJS id bridge) — is
+  // gone (OMN-128). Async because dispatchMutation awaits its (possibly async)
+  // sandbox guard.
+  const program = await dispatchMutation('create/folder', data);
+  validateMutationProgram(program);
+  const omnijs = emitProgram(program);
+  const script = wrapInLauncher(omnijs, program.context);
+
+  return {
+    script: script.trim(),
+    operation: 'create',
+    target: 'folder',
+    description: `Create folder: ${data.name}`,
+  };
+}
+```
+
+Note: the direct `validateFolderCreate(data)` call inside the old body is gone — the guard now runs at dispatch (the
+non-bypass chokepoint). Do NOT delete the `OMNIJS_PARSE_FOLDER_PATH` / `OMNIJS_RESOLVE_FOLDER_PATH` /
+`OMNIJS_RESOLVE_FOLDER_FLEXIBLE` consts — the update builders still interpolate them (their migration is slice 4+).
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `npx vitest run tests/unit/contracts/ast/mutation-script-builder.test.ts` → PASS. Run: `npm run build` → expect ONE
+compile error at the call site: `handleFolderCreate` still reads `generatedScript.script` off what is now a
+`Promise<GeneratedMutationScript>`. That error is the seam surfacing at compile time — deliberate. The build is broken
+between this step and Step 5; do NOT commit in that window. If the build is clean instead, STOP and check the call site
+really awaits.
+
+- [ ] **Step 5: Fix the call site (minimal `await` only — the warnings plumbing is Task 6's separate commit).** In
+      `src/tools/unified/OmniFocusWriteTool.ts` `handleFolderCreate`:
+
+```ts
+const generatedScript = await buildCreateFolderScript(folderData);
+```
+
+Run: `npm run build && npm run test:unit` → clean / green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/contracts/ast/mutation-script-builder.ts src/tools/unified/OmniFocusWriteTool.ts \
+  tests/unit/contracts/ast/mutation-script-builder.test.ts
+git commit -m "feat(OMN-128): buildCreateFolderScript emits from the mutation AST; legacy template body deleted"
+```
+
+---
+
+### Task 6: Tool layer — warnings pass-through
+
+**Files:**
+
+- Modify: `src/tools/unified/OmniFocusWriteTool.ts` (`handleFolderCreate` success response)
+
+- [ ] **Step 1: Apply the create-task/create-project precedent.** In `handleFolderCreate`'s success return:
+
+```ts
+return createSuccessResponseV2(
+  'omnifocus_write',
+  { folder: result.data, operation: 'create_folder', ...liftWarnings(result.data) },
+  undefined,
+  {
+    ...timer.toMetadata(),
+    operation: 'create_folder',
+  },
+);
+```
+
+(`liftWarnings` returns `{}` when warnings are empty/missing, so the happy path is byte-identical to today's response.
+Folder creates have no best-effort statements yet — this is uniformity plumbing, spec §3.)
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run build && npm run test:unit` → clean / green. `npx eslint src/` (or `npm run lint`) → 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusWriteTool.ts
+git commit -m "feat(OMN-128): create_folder response lifts OMN-137 warnings (uniform create envelope)"
+```
+
+---
+
+### Task 7: OMN-138 — live integration coverage for folder creation
+
+**Files:**
+
+- Modify: `tests/integration/tools/unified/create-paths.test.ts`
+
+Two live behaviors the unit suite cannot prove: (a) a real nested create persists parentage in real OmniFocus, (b) the
+loud not-found guard fires at the real seam and creates nothing. Follow the suite's existing harness exactly —
+run-scoped names, per-id cleanup where possible, the unguarded-child-server pattern for the not-found probe (its long
+header comment explains why the guarded server masks the script-level guard).
+
+- [ ] **Step 1: Add fixtures + two tests.** Fixture names near the existing ones:
+
+```ts
+const FOLDER_NAME = runScopedName(`${OMN138_MARKER}_folder_${TS}`);
+const BOGUS_PARENT = `__TEST__ Nonexistent Parent ${OMN138_MARKER} ${TS}`;
+```
+
+Test 4 (guarded server — sandbox parent passes `validateFolderCreate`):
+
+```ts
+// ── 4. Folder create (OMN-128 slice 3): nested create persists parentage ─
+it('creates a folder under the sandbox and the parentage persists on read-back', async () => {
+  const res = await client.callTool('omnifocus_write', {
+    mutation: {
+      operation: 'create_folder',
+      data: { name: FOLDER_NAME, parentFolder: SANDBOX_FOLDER_NAME },
+    },
+  });
+  expectOk(res, 'sandbox folder create');
+  const folderId = res.data?.folder?.folderId;
+  expect(folderId, `created folder id (response: ${JSON.stringify(res.data).slice(0, 300)})`).toBeTruthy();
+  expect(res.data.folder.parentFolder).toBe(SANDBOX_FOLDER_NAME);
+  // Clean create: no lifted warnings (OMN-137 lifts only when non-empty).
+  expect(res.data.warnings).toBeUndefined();
+
+  // Independent read-back — never trust the write response's own echo.
+  const read = await client.callTool('omnifocus_read', { query: { type: 'folders' } });
+  expectOk(read, 'folders read-back');
+  const folders = read.data?.folders ?? [];
+  const created = folders.find((f: any) => f.id === folderId);
+  expect(created, `folder ${folderId} not found on read-back`).toBeTruthy();
+  expect(created.path ?? created.name).toContain(FOLDER_NAME);
+  // No per-id folder delete op exists; the folder lives inside the sandbox,
+  // so afterAll's fullCleanup() cascade removes it (residue assertion guards).
+}, 120000);
+```
+
+(`SANDBOX_FOLDER_NAME` — import it from the sandbox-manager helper alongside the existing imports; check its actual
+export name in `tests/integration/helpers/sandbox-manager.ts` first.)
+
+Test 5 (unguarded child server — same pattern as the existing not-found test, with the same env shape incl.
+`OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1'`):
+
+```ts
+// ── 5. Folder create: loud parent-not-found, nothing created ─────────────
+it('folder create with nonexistent parent errors loudly and creates nothing', async () => {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    NODE_ENV: 'development',
+    OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
+  };
+  delete env.SANDBOX_GUARD_ENABLED;
+  const serverPath = path.join(__dirname, '../../../../dist/index.js');
+  const unguarded = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'], env });
+
+  let res: any;
+  try {
+    await initializeServer(unguarded);
+    res = await callToolOn(unguarded, 'omnifocus_write', {
+      mutation: { operation: 'create_folder', data: { name: FOLDER_NAME + '-orphan', parentFolder: BOGUS_PARENT } },
+    });
+  } finally {
+    unguarded.kill();
+  }
+
+  expect(res.success, `expected error, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+  expect(JSON.stringify(res.error)).toContain('Parent folder not found');
+
+  // Regression half: nothing was created anywhere (read on the main server).
+  const read = await client.callTool('omnifocus_read', { query: { type: 'folders' } });
+  expectOk(read, 'folders read-back after not-found probe');
+  const ghost = (read.data?.folders ?? []).find((f: any) => String(f.name).includes('-orphan'));
+  expect(ghost, `not-found probe created a folder: ${JSON.stringify(ghost)}`).toBeUndefined();
+}, 120000);
+```
+
+NOTE for the implementer: the folders read path caches for 5 minutes (`folders_list_basic`). The write path invalidates
+the `folders` cache on create, but the **not-found probe writes nothing and so invalidates nothing** — if an earlier
+test's read primed the cache, a stale-but-correct list is fine for the ghost check (the ghost was never created). The
+parentage read-back in test 4 happens after a successful create on the SAME server, which invalidated the cache — fresh
+read guaranteed.
+
+- [ ] **Step 2: Run the suite (background, never foreground — orphan class OMN-143)**
+
+Run via Bash `run_in_background: true`: `npm run test:integration -- create-paths` Expected: all create-paths tests PASS
+(existing 3 + new 2). Check `pgrep -fl vitest` is empty afterward.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/tools/unified/create-paths.test.ts
+git commit -m "test(OMN-138): live folder-create coverage — nested parentage + loud not-found"
+```
+
+---
+
+### Task 8: Gates
+
+- [ ] `npm run build` — clean.
+- [ ] `npm run test:unit` — green.
+- [ ] `npm run lint` — 0 errors.
+- [ ] Full `npm run test:integration` via `run_in_background` — green; verify no orphaned vitest after
+      (`pgrep -fl vitest`).
+- [ ] Commit anything outstanding.
+
+---
+
+### Task 9: Live `/verify` matrix (parent session, NOT a subagent)
+
+Spec §5.1, summarized. Verification runs against the **worktree's built `dist/`** over stdio JSON-RPC (slice-2 lesson:
+the omnifocus-dev MCP server loads the main tree's code — wrong artifact). `pgrep -fl vitest` first.
+
+| #   | Probe                                                                                                                      | Server            |
+| --- | -------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| 1   | Non-sandbox folder create refused (`TEST GUARD`), nothing created                                                          | guarded           |
+| 2   | Nested create under sandbox by name; read back parent + primaryKey id; sibling pre-created → new folder at END of children | guarded           |
+| 3   | Nested create under a `" : "` path (pre-create the child first)                                                            | unguarded bounded |
+| 4   | Nested create by parent **id**                                                                                             | unguarded bounded |
+| 5   | Bogus parent → `Parent folder not found`, zero folders created                                                             | unguarded bounded |
+| 6   | Top-level create lands at library root                                                                                     | unguarded bounded |
+
+All artifacts `__TEST__`-prefixed or sandbox-scoped; full sweep + residue check after. Record findings in the verify
+notes (Obsidian, slice-2 precedent) — including the §6 insertion-position result.
+
+---
+
+### Task 10: Finish — PR + review gate
+
+- [ ] Update `docs/superpowers/specs/2026-06-09-create-folder-mutation-ast-design.md` if implementation deviated.
+- [ ] Push branch; open PR against `kip-d/omnifocus-mcp` main (never the upstream fork), titled
+      `feat(OMN-128): slice 3 — create-folder on the mutation AST`.
+- [ ] Dispatch the final `superpowers:code-reviewer` over the PR's commit range (base = freshly-fetched origin/main).
+      Mutation-verify carve-out: allowed with restore-confirmation (this PR changes test shapes).
+- [ ] Merge ONLY on "Safe to merge": `gh pr merge <n> --repo kip-d/omnifocus-mcp --squash --auto` (never `--admin`).
+- [ ] Verify the squash SHA landed on freshly-fetched main.
+
+---
+
+## Out of scope (do not let tasks grow into these)
+
+- update-task / update-project (slice 4, paired), complete, delete, batch-mixed `buildBatchScript`, bulk-delete, tag
+  builders.
+- OMN-129 (read-side boundary retrofit), OMN-141 (batch stopOnError flattening), OMN-142 (name filter matches notes).
+- mkdir-p folder-path creation (legacy never had it; parents must exist).
+- A per-id folder delete operation (would be nice for test cleanup; not this slice).

--- a/docs/superpowers/specs/2026-06-09-create-folder-mutation-ast-design.md
+++ b/docs/superpowers/specs/2026-06-09-create-folder-mutation-ast-design.md
@@ -1,0 +1,208 @@
+# OMN-128 Slice 3 — create-folder on the Mutation AST
+
+**Date:** 2026-06-09 **Ticket:** OMN-128 (umbrella) **Predecessors:**
+`docs/superpowers/specs/2026-06-08-write-side-mutation-ast-design.md` (slice 1, `buildCreateProjectScript`, PR #74);
+`docs/superpowers/specs/2026-06-09-create-task-batch-mutation-ast-design.md` (slice 2, create-task + batch-create, PR
+#78). This slice finishes the **create family**.
+
+## 1. Scope
+
+Migrate `buildCreateFolderScript` (`src/contracts/ast/mutation-script-builder.ts`) to the OmniJS-native mutation AST
+(`src/contracts/ast/mutation/`):
+
+| Builder                   | Legacy shape                                                                                         | New shape                                                      |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `buildCreateFolderScript` | JXA shell + 2 `evaluateJavascript` islands (parent-folder lookup; JXA→OmniJS `id.primaryKey` bridge) | one OmniJS program from `dispatchMutation('create/folder', …)` |
+
+The builder keeps its `GeneratedMutationScript` return shape but goes sync → **async** (dispatch awaits the sandbox
+guard, same forcing as slices 1–2). The single call site (`OmniFocusWriteTool.handleFolderCreate`) adds `await`.
+`validateFolderCreate` (currently module-private) gets exported for `MUTATION_DEFS` registration.
+
+The id-bridge island (find JXA index → re-query `id.primaryKey` via a second `evaluateJavascript`) is **deleted, not
+migrated** — in a single-runtime program `folder.id.primaryKey` reads directly off the fresh binding (same precedent as
+slice 2 deleting the OMN-29 nonce).
+
+Out of scope: update-task/update-project (slice 4, paired — shared update substrate), complete, delete, batch-mixed
+`buildBatchScript` (carries the last `batchNonce`, OMN-134 residue), bulk-delete, tag builders; OMN-129 read-side
+retrofit; OMN-141/OMN-142 (open tickets from slice 2).
+
+## 2. Substrate additions
+
+### 2.1 `constructFolder` node (`mutation/types.ts`, `mutation/emitter.ts`)
+
+Near-clone of `constructProject`, consuming the **existing** `FolderResolution` type. Full substrate checklist (every
+touch point, so none is silently skipped):
+
+```ts
+export interface ConstructFolderNode {
+  type: 'constructFolder';
+  bind: string;
+  name: Expr;
+  parent: FolderResolution;
+}
+```
+
+- `types.ts`: the interface above; add `ConstructFolderNode` to the `Stmt` union; add the factory
+  `constructFolder(bindVar: string, name: Expr, parent: FolderResolution): ConstructFolderNode` (mirrors
+  `constructProject`'s factory).
+- `emitter.ts`: new `case 'constructFolder'` in `emitStmt`'s exhaustive switch (the `never` default forces this at
+  compile time once the union grows).
+- `validator.ts`: new rules in `validateStatementList` (§2.2).
+- `index.ts` barrel: export `ConstructFolderNode` (type), `constructFolder` (factory), and `buildCreateFolderProgram`
+  (lowering).
+
+Emission (OmniJS API verified against omni-automation.com:
+`new Folder(name: String, position: Folder | Folder.ChildInsertionLocation | null)`; omitted position = top-level
+library placement):
+
+| `parent.kind` | Emission                                                    |
+| ------------- | ----------------------------------------------------------- |
+| `resolved`    | `const <bind> = new Folder(<name>, <var>);`                 |
+| `none`        | `const <bind> = new Folder(<name>);`                        |
+| `notFound`    | illegal at emit time (throw) — mirror of `constructProject` |
+
+Passing the resolved `Folder` object directly as position appends inside it — the same convention `constructProject`
+uses (`new Project(name, folderVar)`), and behavior-equivalent to the legacy `targetParent.folders.push(folder)`.
+`const` (not `var`) — folders have no batch path, so no cross-item hoisting concern.
+
+### 2.2 Validator (`mutation/validator.ts`)
+
+- Extend rules 2/3 to `constructFolder`: `parent` must be a typed `FolderResolution` (kind ∈ {resolved, none,
+  notFound}); `notFound` is illegal — must be guard-handled earlier.
+- Rule 10: `constructFolder.bind` must not be a reserved emitter identifier.
+- **Rule 7 extension (pre-existing gap, closed here):** the resolution-guard discipline currently covers only
+  `resolveProject`/`resolveParentTask` → `constructTask`. Extend it to `resolveFolder` binds consumed by
+  `constructProject.folder.var` or `constructFolder.parent.var` (kind `resolved`): a `guard` whose `cond` mentions the
+  bind (word-boundary match) must sit between resolve and construct. **Implementation structure** (the existing rule-7
+  loop generalizes): widen the resolve-node filter to include `resolveFolder`; per construct node the consumed-bind
+  accessor differs — `constructTask` reads `container.var` (kind ≠ `inbox`), `constructProject` reads `folder.var` (kind
+  = `resolved`), `constructFolder` reads `parent.var` (kind = `resolved`). This retroactively covers the slice-1
+  create-project lowering (which already complies — its guard sits between resolve and construct) and protects the new
+  lowering. No existing unit test hand-builds an unguarded `resolveFolder` + `constructProject` pair, so no test churn
+  (verified during spec review).
+
+No new snippets — `resolveFolderFlexible` (+ its `parseFolderPath`/`resolveFolderPath` deps) is already in the
+single-source registry, and the existing `resolveFolder` statement node already emits the call.
+
+## 3. Lowering (`mutation/defs.ts`)
+
+`buildCreateFolderProgram(data: FolderCreateData): Program`, with the established compile-time exhaustiveness guard
+(`Record<keyof FolderCreateData, true>` — `name`, `parentFolder`).
+
+Statement order (legacy-faithful):
+
+1. If `data.parentFolder`: `resolveFolder('targetParent', data.parentFolder)` + return-mode
+   `guard('targetParent === null', { error: json(true), message: json('Parent folder not found: ' + data.parentFolder), context: json('create_folder') })`
+   — envelope values are `Expr` nodes (`json(...)`), exactly like `buildCreateProjectProgram`'s guard; the message text
+   is the **exact legacy string**, already loud since OMN-127 (no behavior delta). `snippetDeps` is conditionally
+   `['resolveFolderFlexible']` here and `[]` on the top-level path (mirrors create/project's conditional push;
+   transitive `parseFolderPath`/`resolveFolderPath` come via `collectSnippets`).
+2. `constructFolder('folder', json(data.name), resolved | none)`.
+3. Return envelope:
+
+```ts
+{
+  folderId: member(ref('folder'), 'id.primaryKey'),
+  name: member(ref('folder'), 'name'),
+  parentFolder: data.parentFolder ? raw('targetParent.name') : json(null),
+  warnings: ref('_warnings'),   // OMN-137 uniformity — see below
+  created: json(true),
+}
+```
+
+**Envelope deltas vs legacy, both deliberate:**
+
+1. `folderId` is always the OmniJS `id.primaryKey` — the legacy JXA-id fallback (used only when the bridge re-query
+   failed) is dead along with the bridge. Strictly more correct: one id namespace.
+2. `warnings: ref('_warnings')` is **additive** — the emitter declares `_warnings` unconditionally, and the folder
+   lowering has no best-effort statements, so it is always `[]` today. Included for one-semantics uniformity across
+   migrated create envelopes (slice-2 §3.1.2 precedent); `liftWarnings` at the tool layer omits empty arrays.
+
+Nested-path semantics (`Parent : Child`, `/`) preserved exactly: `resolveFolderFlexible` walks existing paths only —
+**parents must already exist**; a missing segment is the loud not-found, never mkdir-p.
+
+## 4. Dispatch, guard, and tool-layer changes
+
+- `MUTATION_DEFS` gains `'create/folder'` (`FolderCreateData`), guard `validateFolderCreate` (sync — the widened
+  `void | Promise<void>` signature accepts it as-is), build `buildCreateFolderProgram`.
+- `validateFolderCreate` exported from `mutation-script-builder.ts` (mirrors `validateProjectCreate` /
+  `validateTaskCreate`). Its semantics are untouched: test mode requires `parentFolder === SANDBOX_FOLDER_NAME` (exact
+  string match).
+- `buildCreateFolderScript` becomes the thin async wrapper (dispatch → validate → emit → `wrapInLauncher`), same shape
+  as `buildCreateProjectScript`. Legacy template body **deleted**.
+- `OmniFocusWriteTool.handleFolderCreate`: `await` the builder; spread `...liftWarnings(result.data)` into the success
+  response data object (top-level alongside `folder`/`operation` — the exact create-task/create-project precedent:
+  warnings stay nested in `folder.warnings` AND are promoted top-level when non-empty; `liftWarnings` returns `{}` for
+  empty/missing). Additive: the legacy envelope never had a `warnings` key.
+- **Guard-throw surface (unchanged class):** in test mode, `dispatchMutation` runs `validateFolderCreate` before
+  building, so a guard violation now throws from `await buildCreateFolderScript(...)` rather than surfacing as a
+  script-level error envelope. `handleFolderCreate` does not catch it — deliberately the same surface as
+  `handleProjectCreate`/`handleCreateTask` after slices 1–2 (the throw propagates to the tool-level error handler). Live
+  matrix item 1 asserts the observable: a `TEST GUARD` error response, nothing created.
+- `mutation/index.ts` barrel exports the new symbols (§2.1 checklist).
+
+## 5. Testing & verification
+
+| Layer                      | What it proves                   | This slice                                                                                                                                       |
+| -------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Type system                | illegal trees unrepresentable    | `constructFolder` consumes only `FolderResolution`; exhaustiveness guard on `FolderCreateData`                                                   |
+| Unit/golden                | emitted program shape            | new `tests/unit/contracts/ast/mutation/create-folder.test.ts`: top-level, nested (name / path / id refs), guard envelope, snippet inclusion      |
+| Validator                  | malformed programs throw         | `constructFolder` notFound illegal; untyped parent; reserved bind; **rule-7 extension** (unguarded resolveFolder→construct throws)               |
+| `node:vm` execution        | the emitted string actually runs | top-level + nested create against the OmniJS shims (Folder constructor, flattenedFolders); not-found returns the error envelope, creates nothing |
+| Live `/verify`             | real-DB correctness              | matrix §5.1                                                                                                                                      |
+| Live integration (OMN-138) | regression coverage at the seam  | folder-create paths added to the integration suite in this PR                                                                                    |
+
+**Test placement (slice-2 precedent):** all new node/validator/golden/vm tests live in the slice-specific
+`tests/unit/contracts/ast/mutation/create-folder.test.ts`, not in `validator.test.ts`.
+
+**vm shim surface (must be added — the existing create-task shims have no folder support):** the slice's vm sandbox
+needs, beyond what `create-task.test.ts` already shims: a `Folder` constructor accepting `(name, parent?)` that records
+`name`, `parent`, and a fresh `id.primaryKey`, and appends itself to the parent's children (or the top-level
+collection); a static `Folder.byIdentifier(ref)`; `flattenedFolders` (array of folder stubs with `.name` and
+`.id.primaryKey`); and the top-level `folders` collection (the `resolveFolderPath` snippet walks
+`parent ? parent.children : folders`).
+
+**Legacy test rewrite (`mutation-script-builder.test.ts`, `buildCreateFolderScript` describe block):** every test
+becomes `async` and **awaits** the builder — a sync call on the now-async builder returns a Promise, so un-awaited
+assertions on `result.script` would read `undefined` rather than fail loudly at the right seam. Expectations change
+substantively: the script is now the JSON-encoded one-program launcher (assert against the JSON-decoded program where
+needed, as the slice-2 rewrites do); the `primaryKey`-bridge and `flattenedFolders`-index expectations are deleted; the
+"parent folder not found" test asserts the guard emission inside the encoded program rather than a JXA-island string.
+
+### 5.1 Live `/verify` matrix
+
+Sandbox-guard constraint discovered in slice 2 carries over with a folder-specific twist: `validateFolderCreate`
+requires `parentFolder === SANDBOX_FOLDER_NAME` (exact string), so on the guarded dev server only a simple-name sandbox
+parent passes. Path refs, id refs, top-level creates, and not-found probes all need the **bounded unguarded window**
+(`of-call.mjs --unguarded` pattern, one call per process, killed in `finally`).
+
+1. Guard refuses non-sandbox folder create (guarded) — `TEST GUARD` error, nothing created.
+2. Nested create under sandbox by **name** (guarded) — read back `parentFolder`, `folderId` is a primaryKey; with a
+   sibling pre-created, confirm the new folder lands at the **end** of the parent's children (legacy `push()` appended;
+   `new Folder(name, folderObj)` must match — this is the §6 position-form risk's authoritative check).
+3. Nested create under a path ref (`__MCP_TEST_SANDBOX__ : <child>` after pre-creating the child) (unguarded, bounded) —
+   path walk works end-to-end.
+4. Nested create by **parent id** (unguarded, bounded).
+5. Loud parent-not-found: bogus parent → `Parent folder not found: …` envelope, **no folder created anywhere**.
+6. Top-level create (unguarded, bounded) — placed at library root; deleted in cleanup.
+
+All artifacts `__TEST__`-prefixed or sandbox-scoped; full sweep + residue check at the end (slice-2 cleanup discipline).
+`pgrep -fl vitest` before any live verify (orphaned-run class, OMN-143 norm).
+
+### 5.2 Acceptance
+
+- `npm run build` clean; `npm run test:unit` green; lint 0 errors; integration suite green (run via `run_in_background`
+  only).
+- Legacy template body of `buildCreateFolderScript` deleted (no dead path left behind).
+- Sandbox guard fires on the new dispatch key (negative test).
+- Live `/verify` matrix passes against real OmniFocus before PR review; findings recorded.
+
+## 6. Risks / open edges
+
+- **Rule-7 extension blast radius:** it newly constrains `constructProject` programs too. The only existing lowering
+  (`buildCreateProjectProgram`) already guards its folder resolve, so no churn expected; if a hand-built test program
+  violates it, the test gets fixed — the rule is the spec.
+- **`new Folder(name, folderObj)` position form:** verified against the published OmniJS API and mirrors the shipped
+  `constructProject` convention, but the live matrix (§5.1 items 2–4) is the authoritative check.
+- **Warnings field is always empty today** — it's plumbing for uniformity, not a feature; if a reviewer flags it as
+  speculative, the counter is slice-2's one-semantics-across-builders decision (envelope shape should not fork per-op).

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -245,7 +245,7 @@ export function validateProjectCreate(data: ProjectCreateData): void {
 /**
  * Validate that a folder creation is inside the sandbox
  */
-function validateFolderCreate(data: FolderCreateData): void {
+export function validateFolderCreate(data: FolderCreateData): void {
   if (!isTestMode()) return;
 
   if (data.parentFolder !== SANDBOX_FOLDER_NAME) {

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -638,95 +638,19 @@ export async function buildCreateProjectScript(data: ProjectCreateData): Promise
  * - Top-level folders (no parentFolder)
  * - Nested folders (parentFolder by name, path " : " or "/", or ID)
  */
-export function buildCreateFolderScript(data: FolderCreateData): GeneratedMutationScript {
-  // Test sandbox guard
-  validateFolderCreate(data);
-
-  const folderData = { name: data.name, parentFolder: data.parentFolder };
-
-  const script = `
-(() => {
-  const app = Application('OmniFocus');
-  const doc = app.defaultDocument();
-  const folderData = ${JSON.stringify(folderData)};
-
-  try {
-    // Find parent folder if specified — use OmniJS bridge for id.primaryKey + path syntax
-    let targetParent = null;
-    if (folderData.parentFolder) {
-      const findFolderScript = \`
-        (() => {
-          ${OMNIJS_PARSE_FOLDER_PATH}
-          ${OMNIJS_RESOLVE_FOLDER_PATH}
-          ${OMNIJS_RESOLVE_FOLDER_FLEXIBLE}
-
-          var target = \${JSON.stringify(folderData.parentFolder)};
-          var folder = resolveFolderFlexible(target);
-          if (folder) return JSON.stringify({ found: true, index: flattenedFolders.indexOf(folder) });
-          return JSON.stringify({ found: false });
-        })()
-      \`;
-      const findFolderResult = JSON.parse(app.evaluateJavascript(findFolderScript));
-      if (findFolderResult.found && findFolderResult.index >= 0) {
-        targetParent = doc.flattenedFolders()[findFolderResult.index];
-      } else {
-        return JSON.stringify({
-          error: true,
-          message: 'Parent folder not found: ' + folderData.parentFolder,
-          context: 'create_folder'
-        });
-      }
-    }
-
-    // Create folder
-    const folder = app.Folder({ name: folderData.name });
-
-    // Add to parent or root
-    if (targetParent) {
-      targetParent.folders.push(folder);
-    } else {
-      doc.folders.push(folder);
-    }
-
-    const jxaFolderId = folder.id();
-
-    // Bridge to get OmniJS id.primaryKey
-    let folderId = jxaFolderId;
-    try {
-      const allFolders = doc.flattenedFolders();
-      let folderIndex = -1;
-      for (let i = 0; i < allFolders.length; i++) {
-        try { if (allFolders[i].id() === jxaFolderId) { folderIndex = i; break; } } catch (e) {}
-      }
-      if (folderIndex >= 0) {
-        const idScript = \`
-          (() => {
-            var f = flattenedFolders[\${folderIndex}];
-            if (f) return JSON.stringify({ pk: f.id.primaryKey });
-            return JSON.stringify({ pk: null });
-          })()
-        \`;
-        const idResult = JSON.parse(app.evaluateJavascript(idScript));
-        if (idResult.pk) folderId = idResult.pk;
-      }
-    } catch (e) {}
-
-    return JSON.stringify({
-      folderId: folderId,
-      name: folder.name(),
-      parentFolder: targetParent ? targetParent.name() : null,
-      created: true
-    });
-
-  } catch (error) {
-    return JSON.stringify({
-      error: true,
-      message: error.message || String(error),
-      context: 'create_folder'
-    });
-  }
-})();
-`;
+export async function buildCreateFolderScript(data: FolderCreateData): Promise<GeneratedMutationScript> {
+  // Emit from the mutation AST. dispatchMutation runs the build-time sandbox
+  // guard (validateFolderCreate) BEFORE building, so it can never be bypassed;
+  // the emitter produces ONE OmniJS program (native `new Folder(...)`, parent
+  // resolved in-program with a loud not-found guard) wrapped in a data-free JXA
+  // launcher. The old template-string body — a JXA shell with two
+  // evaluateJavascript islands (parent lookup + the JXA→OmniJS id bridge) — is
+  // gone (OMN-128). Async because dispatchMutation awaits its (possibly async)
+  // sandbox guard.
+  const program = await dispatchMutation('create/folder', data);
+  validateMutationProgram(program);
+  const omnijs = emitProgram(program);
+  const script = wrapInLauncher(omnijs, program.context);
 
   return {
     script: script.trim(),

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -646,7 +646,7 @@ export async function buildCreateFolderScript(data: FolderCreateData): Promise<G
   // launcher. The old template-string body — a JXA shell with two
   // evaluateJavascript islands (parent lookup + the JXA→OmniJS id bridge) — is
   // gone (OMN-128). Async because dispatchMutation awaits its (possibly async)
-  // sandbox guard.
+  // sandbox guard — spec §1/§4.
   const program = await dispatchMutation('create/folder', data);
   validateMutationProgram(program);
   const omnijs = emitProgram(program);

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -3,9 +3,10 @@
 // dispatch registry (MUTATION_DEFS) that runs the build-time sandbox guard
 // BEFORE building, so a registered op can never bypass it (the OMN-119/120
 // non-bypass property — batch & bulk paths previously skipped the guard).
-import type { ProjectCreateData, TaskCreateData } from '../../mutations.js';
+import type { FolderCreateData, ProjectCreateData, TaskCreateData } from '../../mutations.js';
 import {
   validateBatchTaskSpecs,
+  validateFolderCreate,
   validateProjectCreate,
   validateTaskCreate,
   type BatchTaskSpec,
@@ -15,6 +16,7 @@ import {
   assignTags,
   batchItem,
   bind,
+  constructFolder,
   constructProject,
   constructTask,
   dateExpr,
@@ -164,6 +166,63 @@ export function buildCreateProjectProgram(data: ProjectCreateData): Program {
   statements.push(return_(envelope));
 
   return { statements, context: 'create_project', snippetDeps };
+}
+
+// =============================================================================
+// FOLDER CREATE LOWERING
+// =============================================================================
+
+/**
+ * Lower a folder-create request into a typed mutation Program (OMN-128 slice 3).
+ * Statement order preserves the legacy builder: parent resolve + guard (loud
+ * not-found, exact legacy message — already loud since OMN-127), construct,
+ * return. The legacy JXA→OmniJS id-bridge island is deleted, not migrated:
+ * folderId reads id.primaryKey directly off the fresh binding. `warnings` is
+ * additive (always [] today — no best-effort statements) for one-semantics
+ * uniformity across migrated create envelopes.
+ */
+export function buildCreateFolderProgram(data: FolderCreateData): Program {
+  // Compile-time exhaustiveness guard (same discipline as the other create
+  // lowerings): a new FolderCreateData field cannot be silently dropped.
+  const _exhaustive: Record<keyof FolderCreateData, true> = {
+    name: true,
+    parentFolder: true,
+  };
+  void _exhaustive;
+
+  const statements: Stmt[] = [];
+  const snippetDeps: string[] = [];
+
+  if (data.parentFolder) {
+    statements.push(resolveFolder('targetParent', data.parentFolder));
+    statements.push(
+      guard('targetParent === null', {
+        error: json(true),
+        message: json('Parent folder not found: ' + data.parentFolder),
+        context: json('create_folder'),
+      }),
+    );
+    snippetDeps.push('resolveFolderFlexible');
+  }
+
+  statements.push(
+    constructFolder(
+      'folder',
+      json(data.name),
+      data.parentFolder ? { kind: 'resolved', var: 'targetParent' } : { kind: 'none' },
+    ),
+  );
+
+  const envelope: Envelope = {
+    folderId: member(ref('folder'), 'id.primaryKey'),
+    name: member(ref('folder'), 'name'),
+    parentFolder: data.parentFolder ? raw('targetParent.name') : json(null),
+    warnings: ref('_warnings'),
+    created: json(true),
+  };
+  statements.push(return_(envelope));
+
+  return { statements, context: 'create_folder', snippetDeps };
 }
 
 // =============================================================================
@@ -482,6 +541,10 @@ export const MUTATION_DEFS = {
     guard: validateProjectCreate,
     build: buildCreateProjectProgram,
   } as MutationDef<ProjectCreateData>,
+  'create/folder': {
+    guard: validateFolderCreate,
+    build: buildCreateFolderProgram,
+  } as MutationDef<FolderCreateData>,
   'create/task': {
     guard: validateTaskCreate,
     build: buildCreateTaskProgram,

--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -78,6 +78,28 @@ export function emitStmt(node: Stmt): string {
         }
       }
     }
+    case 'constructFolder': {
+      // Near-clone of constructProject at the folder altitude. `new Folder(name,
+      // parentFolder)` appends inside the parent (OmniJS position param), matching
+      // the legacy `targetParent.folders.push(folder)`; omitted position = library
+      // root. `const`, not `var`: folders have no batch path, so no cross-item
+      // hoisting concern (contrast constructTask).
+      const name = emitExpr(node.name);
+      switch (node.parent.kind) {
+        case 'resolved':
+          return `const ${node.bind} = new Folder(${name}, ${node.parent.var});`;
+        case 'none':
+          return `const ${node.bind} = new Folder(${name});`;
+        case 'notFound':
+          throw new Error(
+            'constructFolder with parent.kind="notFound" is illegal — it must be Guarded earlier (validator enforces this).',
+          );
+        default: {
+          const _x: never = node.parent;
+          throw new Error(`Unknown folder resolution: ${JSON.stringify(_x)}`);
+        }
+      }
+    }
     case 'setProp': {
       const target = emitExpr(node.target);
       // `bestEffort` wraps the block in try/catch so a failure does not fail the

--- a/src/contracts/ast/mutation/index.ts
+++ b/src/contracts/ast/mutation/index.ts
@@ -11,6 +11,7 @@ export {
 } from './emitter.js';
 export { validateMutationProgram, RESERVED_EMITTER_IDENTIFIERS } from './validator.js';
 export {
+  buildCreateFolderProgram,
   buildCreateProjectProgram,
   buildCreateTaskProgram,
   buildBatchCreateTasksProgram,

--- a/src/contracts/ast/mutation/types.ts
+++ b/src/contracts/ast/mutation/types.ts
@@ -96,6 +96,12 @@ export interface ConstructTaskNode {
   name: Expr;
   container: ContainerResolution;
 }
+export interface ConstructFolderNode {
+  type: 'constructFolder';
+  bind: string;
+  name: Expr;
+  parent: FolderResolution;
+}
 // Batch composition: one item's statements wrapped in try/capture. Emits
 // results.push({tempId, taskId, success, warnings}) on success and
 // ({tempId, taskId:null, success:false, error, warnings}) on failure.
@@ -157,6 +163,7 @@ export type Stmt =
   | GuardNode
   | ConstructProjectNode
   | ConstructTaskNode
+  | ConstructFolderNode
   | BatchItemNode
   | SetPropNode
   | AssignTagsNode
@@ -212,6 +219,12 @@ export const constructTask = (bindVar: string, name: Expr, container: ContainerR
   bind: bindVar,
   name,
   container,
+});
+export const constructFolder = (bindVar: string, name: Expr, parent: FolderResolution): ConstructFolderNode => ({
+  type: 'constructFolder',
+  bind: bindVar,
+  name,
+  parent,
 });
 export const batchItem = (
   tempId: string,

--- a/src/contracts/ast/mutation/validator.ts
+++ b/src/contracts/ast/mutation/validator.ts
@@ -40,10 +40,11 @@ function assertNotReserved(name: string, where: string): void {
  * Structural rules (enforced here):
  *  1. The last TOP-LEVEL statement must be a `return`. batchItem inner lists
  *     are exempt — they must NOT return (rule 8).
- *  2. Every `constructProject`'s `folder` must be a typed FolderResolution
- *     object (kind ∈ {resolved, none, notFound}) — never a string / missing kind.
- *  3. A `constructProject` with `folder.kind === 'notFound'` is illegal: the
- *     not-found case must be handled by a preceding `guard` that returns.
+ *  2. Every `constructProject`'s `folder` and `constructFolder`'s `parent` must
+ *     be a typed FolderResolution object (kind ∈ {resolved, none, notFound}) —
+ *     never a string / missing kind.
+ *  3. A `constructProject` or `constructFolder` with `folder/parent.kind === 'notFound'`
+ *     is illegal: the not-found case must be handled by a preceding `guard` that returns.
  *  4. A `setProp` with strategy !== 'readModifyReassign' MUST have a `value`;
  *     a `setProp` with strategy === 'readModifyReassign' MUST have `mutations`.
  *  5. Every `constructTask`'s `container` must be a typed ContainerResolution
@@ -74,8 +75,9 @@ function assertNotReserved(name: string, where: string): void {
  *     by the item catch as a FALSE per-item failure with an opaque message),
  *     and taskVar itself must not be a reserved identifier.
  * 10. No binding statement (bind, resolveFolder, resolveProject,
- *     resolveParentTask, constructProject, constructTask, assignTags) may use
- *     a reserved emitter identifier — see RESERVED_EMITTER_IDENTIFIERS.
+ *     resolveParentTask, constructProject, constructTask, constructFolder,
+ *     assignTags) may use a reserved emitter identifier — see
+ *     RESERVED_EMITTER_IDENTIFIERS.
  *
  * NOT enforced here: snippet-dependency coverage (a statement that emits a call
  * to an OmniJS helper must declare that helper in `snippetDeps`). That check is
@@ -129,6 +131,28 @@ function validateStatementList(statements: Stmt[], ctx: ValidationContext): void
       }
       // Rule 10: reserved emitter identifiers.
       assertNotReserved(stmt.bind, 'constructProject bind');
+    }
+
+    if (stmt.type === 'constructFolder') {
+      const parent = stmt.parent as unknown;
+      // Rules 2/3 at the folder altitude: typed FolderResolution; notFound illegal.
+      if (
+        typeof parent !== 'object' ||
+        parent === null ||
+        !FOLDER_KINDS.has((parent as { kind?: string }).kind ?? '')
+      ) {
+        throw new Error(
+          'Invalid constructFolder: parent must be a typed FolderResolution object ' +
+            'with kind in {resolved, none, notFound}, not a string or untyped value.',
+        );
+      }
+      if ((parent as { kind: string }).kind === 'notFound') {
+        throw new Error(
+          'Invalid constructFolder: parent.kind="notFound" is illegal — ' +
+            'the not-found case must be handled by a preceding guard that returns.',
+        );
+      }
+      assertNotReserved(stmt.bind, 'constructFolder bind');
     }
 
     if (stmt.type === 'setProp') {

--- a/src/contracts/ast/mutation/validator.ts
+++ b/src/contracts/ast/mutation/validator.ts
@@ -52,13 +52,16 @@ function assertNotReserved(name: string, where: string): void {
  *     require a non-empty string `var`.
  *  6. A guard with mode 'throw' must have `envelope.message` defined (the
  *     emitter also throws — belt and suspenders at the validation seam).
- *  7. Resolution-guard discipline: a `resolveProject`/`resolveParentTask` bind
- *     consumed by a later `constructTask` container `var` must have a `guard`
- *     BETWEEN them whose `cond` mentions that bind (word-boundary match, not
- *     substring). String-level check on
- *     `cond` — same trust model as GuardNode.cond generally. Applies at each
+ *  7. Resolution-guard discipline: a `resolveProject`/`resolveParentTask`/
+ *     `resolveFolder` bind consumed by a later `constructTask` container `var`,
+ *     `constructProject` folder `var`, or `constructFolder` parent `var` must
+ *     have a `guard` BETWEEN them whose `cond` mentions that bind
+ *     (word-boundary match, not substring). String-level check on `cond` —
+ *     same trust model as GuardNode.cond generally. Applies at each
  *     statement-list level independently (resolve/guard/construct triplets
- *     stay within one list in practice).
+ *     stay within one list in practice). (Slice 3 widened this from
+ *     constructTask-only to all three constructs — resolveFolder →
+ *     constructProject was a pre-existing enforcement gap.)
  *  8. Inside `batchItem.statements`: all per-statement rules recurse, but a
  *     `return` statement is ILLEGAL (it would return from the whole program
  *     IIFE, skipping remaining items and the results envelope — Task 5 review
@@ -253,24 +256,33 @@ function validateStatementList(statements: Stmt[], ctx: ValidationContext): void
   }
 
   // Rule 7: resolution-guard discipline, at THIS list level. A failed
-  // resolution (null bind) reaching `new Task` / moveTasks explodes with an
-  // opaque runtime TypeError instead of a typed envelope — so every consumed
-  // resolution bind must be guarded between resolve and construct. The cond
-  // check is string-level: same trust model as GuardNode.cond generally.
+  // resolution (null bind) reaching `new Task` / `new Project` / `new Folder` /
+  // moveTasks explodes with an opaque runtime TypeError instead of a typed
+  // envelope — so every consumed resolution bind must be guarded between
+  // resolve and construct. The cond check is string-level: same trust model as
+  // GuardNode.cond generally. (Slice 3 widened this from constructTask-only to
+  // all three constructs — resolveFolder → constructProject was a pre-existing
+  // enforcement gap.)
+  const consumedBind = (construct: Stmt): string | null => {
+    if (construct.type === 'constructTask' && construct.container.kind !== 'inbox') return construct.container.var;
+    if (construct.type === 'constructProject' && construct.folder.kind === 'resolved') return construct.folder.var;
+    if (construct.type === 'constructFolder' && construct.parent.kind === 'resolved') return construct.parent.var;
+    return null;
+  };
   for (let ri = 0; ri < statements.length; ri++) {
     const resolve = statements[ri];
-    if (resolve.type !== 'resolveProject' && resolve.type !== 'resolveParentTask') continue;
+    if (resolve.type !== 'resolveProject' && resolve.type !== 'resolveParentTask' && resolve.type !== 'resolveFolder')
+      continue;
     // Word-boundary match, not substring: a guard on `proj` must not satisfy
     // bind `p`. Regex-escaped for safety even though binds are identifiers.
     const bindPattern = new RegExp(`\\b${resolve.bind.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
     for (let ci = 0; ci < statements.length; ci++) {
       const construct = statements[ci];
-      if (construct.type !== 'constructTask') continue;
-      if (construct.container.kind === 'inbox' || construct.container.var !== resolve.bind) continue;
+      if (consumedBind(construct) !== resolve.bind) continue;
       const guarded = statements.some((s, si) => si > ri && si < ci && s.type === 'guard' && bindPattern.test(s.cond));
       if (!guarded) {
         throw new Error(
-          `Invalid mutation program: constructTask consumes resolution bind "${resolve.bind}" ` +
+          `Invalid mutation program: ${construct.type} consumes resolution bind "${resolve.bind}" ` +
             'without a guard between the resolve and the construct (the guard cond must mention the bind).',
         );
       }

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1340,10 +1340,15 @@ SAFETY:
     this.cache.invalidate('projects');
     this.cache.invalidate('folders');
 
-    return createSuccessResponseV2('omnifocus_write', { folder: result.data, operation: 'create_folder' }, undefined, {
-      ...timer.toMetadata(),
-      operation: 'create_folder',
-    });
+    return createSuccessResponseV2(
+      'omnifocus_write',
+      { folder: result.data, operation: 'create_folder', ...liftWarnings(result.data) },
+      undefined,
+      {
+        ...timer.toMetadata(),
+        operation: 'create_folder',
+      },
+    );
   }
 
   /**

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1342,7 +1342,13 @@ SAFETY:
 
     return createSuccessResponseV2(
       'omnifocus_write',
-      { folder: result.data, operation: 'create_folder', ...liftWarnings(result.data) },
+      {
+        folder: result.data,
+        operation: 'create_folder',
+        // OMN-137: lifted when non-empty, omitted when none (folder creates have no
+        // best-effort steps today — uniformity plumbing, see buildCreateFolderProgram).
+        ...liftWarnings(result.data),
+      },
       undefined,
       {
         ...timer.toMetadata(),

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1318,7 +1318,7 @@ SAFETY:
       parentFolder: data.parentFolder,
     };
 
-    const generatedScript = buildCreateFolderScript(folderData);
+    const generatedScript = await buildCreateFolderScript(folderData);
     const result = await this.execJson(generatedScript.script);
 
     if (isScriptError(result)) {

--- a/tests/integration/tools/unified/create-paths.test.ts
+++ b/tests/integration/tools/unified/create-paths.test.ts
@@ -410,13 +410,30 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain + fo
     // Clean create: no lifted warnings (OMN-137 lifts only when non-empty).
     expect(res.data.warnings, `unexpected create warnings: ${JSON.stringify(res.data.warnings)}`).toBeUndefined();
 
-    // Independent read-back — never trust the write response's own echo.
+    // Independent read-back — never trust the write response's own echo. The
+    // envelope's parentFolder above echoes the RESOLVED TARGET (the emitter's
+    // raw `targetParent.name`), NOT the created folder's actual parent — it
+    // would still read correctly if the emitter dropped the position argument
+    // and the folder landed at the library root (the OMN-127 silent-fallback
+    // class this test exists to catch). The read-back asserts the PERSISTED
+    // parent: buildFilteredFoldersScript emits parentId/parentName off
+    // `folder.parent` (omitted entirely for root folders) and a '/'-joined
+    // ancestor path.
     const read = await client.callTool('omnifocus_read', { query: { type: 'folders' } });
     expectOk(read, 'folders read-back');
     const folders = read.data?.folders ?? [];
     const created = folders.find((f: any) => f.id === folderId);
     expect(created, `folder ${folderId} not found on read-back`).toBeTruthy();
-    expect(created.path ?? created.name).toContain(FOLDER_NAME);
+    const sandbox = folders.find((f: any) => f.name === SANDBOX_FOLDER_NAME);
+    expect(sandbox, 'sandbox folder missing from read-back').toBeTruthy();
+    expect(
+      created.parentId,
+      `persisted parent is not the sandbox (root-placement regression?): ${JSON.stringify(created)}`,
+    ).toBe(sandbox.id);
+    expect(created.parentName).toBe(SANDBOX_FOLDER_NAME);
+    // Anchor on the sandbox's OWN path from the same payload (no assumption
+    // about where the sandbox itself lives).
+    expect(created.path).toBe(`${sandbox.path}/${FOLDER_NAME}`);
     // No per-id folder delete op exists; the folder lives inside the sandbox,
     // so afterAll's fullCleanup() cascade removes it (residue assertion guards).
   }, 120000);
@@ -433,6 +450,11 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain + fo
   // invalidated by writes from a DIFFERENT process, so a regression-created
   // ghost could hide behind it. The unguarded child is a fresh process with a
   // cold cache — its read is guaranteed straight from OmniFocus.
+  //
+  // Known read window: handleFolderQuery hardcodes limit:100, applied while
+  // iterating (BEFORE sorting) — in a database with >100 folders the ghost
+  // could fall outside the returned page and this check would silently
+  // false-pass. Fine today (a handful of folders); revisit if that grows.
   it('folder create with nonexistent parent errors loudly and creates nothing', async () => {
     const env: Record<string, string | undefined> = {
       ...process.env,

--- a/tests/integration/tools/unified/create-paths.test.ts
+++ b/tests/integration/tools/unified/create-paths.test.ts
@@ -19,6 +19,12 @@
  *   3. Batch parentTempId chain: parent → child → grandchild in one batch op,
  *      real ids for all three, and the parent relationship persisted (read
  *      back via parentTaskId, not the write response's own echo).
+ *   4. Folder create (OMN-128 slice 3): a nested create under the sandbox
+ *      persists parentage in real OmniFocus (independent folders read-back),
+ *      clean envelope (no lifted warnings).
+ *   5. Folder loud not-found: a create naming a nonexistent parent folder
+ *      ERRORS — and creates nothing (ghost check on a fresh-cache server).
+ *      Same unguarded-child-server pattern as #2.
  *
  * Harness follows field-roundtrip.test.ts: own spawned server, run-scoped
  * `__TEST__` fixture names (OMN-84), per-id deletion in afterAll plus a
@@ -33,7 +39,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 import { expectOk } from '../../helpers/expect-ok.js';
-import { ensureSandboxFolder, fullCleanup } from '../../helpers/sandbox-manager.js';
+import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from '../../helpers/sandbox-manager.js';
 import { RUN_NAME_PREFIX, runScopedName, runScopedTag } from '../../helpers/run-id.js';
 
 // Fixed, unambiguous future datetimes (same rationale as field-roundtrip: not
@@ -58,8 +64,11 @@ const CHAIN_B_NAME = runScopedName(`${OMN138_MARKER}_chain-b_${TS}`);
 const CHAIN_C_NAME = runScopedName(`${OMN138_MARKER}_chain-c_${TS}`);
 const SINGLE_TAG = runScopedTag(`omn138-${TS}`);
 const BOGUS_PROJECT = `__TEST__ Nonexistent Project ${OMN138_MARKER} ${TS}`;
+const FOLDER_NAME = runScopedName(`${OMN138_MARKER}_folder_${TS}`);
+const ORPHAN_FOLDER_NAME = `${FOLDER_NAME}-orphan`;
+const BOGUS_PARENT = `__TEST__ Nonexistent Parent ${OMN138_MARKER} ${TS}`;
 
-describe('OMN-138: live create paths (single + loud not-found + batch chain)', () => {
+describe('OMN-138: live create paths (single + loud not-found + batch chain + folder)', () => {
   let serverProcess: ChildProcess;
   let nextId = 1;
   const createdTaskIds: string[] = [];
@@ -380,5 +389,79 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain)', (
     expect(grandchildC, `chain grandchild ${idC} not found on read-back`).toBeTruthy();
     expect(grandchildC.parentTaskId).toBe(idB);
     expect(grandchildC.parentTaskName).toBe(CHAIN_B_NAME);
+  }, 120000);
+
+  // ── 4. Folder create (OMN-128 slice 3): nested create persists parentage ─
+  //
+  // Runs on the guarded main server: a sandbox parent passes
+  // validateFolderCreate's pre-flight. The successful create invalidates the
+  // server's 5-minute folders cache, so the read-back is guaranteed fresh.
+  it('creates a folder under the sandbox and the parentage persists on read-back', async () => {
+    const res = await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'create_folder',
+        data: { name: FOLDER_NAME, parentFolder: SANDBOX_FOLDER_NAME },
+      },
+    });
+    expectOk(res, 'sandbox folder create');
+    const folderId = res.data?.folder?.folderId;
+    expect(folderId, `created folder id (response: ${JSON.stringify(res.data).slice(0, 300)})`).toBeTruthy();
+    expect(res.data.folder.parentFolder).toBe(SANDBOX_FOLDER_NAME);
+    // Clean create: no lifted warnings (OMN-137 lifts only when non-empty).
+    expect(res.data.warnings, `unexpected create warnings: ${JSON.stringify(res.data.warnings)}`).toBeUndefined();
+
+    // Independent read-back — never trust the write response's own echo.
+    const read = await client.callTool('omnifocus_read', { query: { type: 'folders' } });
+    expectOk(read, 'folders read-back');
+    const folders = read.data?.folders ?? [];
+    const created = folders.find((f: any) => f.id === folderId);
+    expect(created, `folder ${folderId} not found on read-back`).toBeTruthy();
+    expect(created.path ?? created.name).toContain(FOLDER_NAME);
+    // No per-id folder delete op exists; the folder lives inside the sandbox,
+    // so afterAll's fullCleanup() cascade removes it (residue assertion guards).
+  }, 120000);
+
+  // ── 5. Folder create: loud parent-not-found, nothing created ─────────────
+  //
+  // Same GUARD INTERACTION as test 2: the guarded server's pre-flight rejects
+  // any non-sandbox parentFolder before the mutation script runs, masking the
+  // script-level loud not-found guard — so this probe needs a dedicated
+  // UNGUARDED server (killed in finally; correct behavior writes NOTHING).
+  //
+  // The ghost check also runs on the UNGUARDED server, not the main one: the
+  // main server's folders cache (5 min, primed by test 4's read-back) is never
+  // invalidated by writes from a DIFFERENT process, so a regression-created
+  // ghost could hide behind it. The unguarded child is a fresh process with a
+  // cold cache — its read is guaranteed straight from OmniFocus.
+  it('folder create with nonexistent parent errors loudly and creates nothing', async () => {
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      NODE_ENV: 'development',
+      OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
+    };
+    delete env.SANDBOX_GUARD_ENABLED;
+    const serverPath = path.join(__dirname, '../../../../dist/index.js');
+    const unguarded = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'], env });
+
+    let res: any;
+    let read: any;
+    try {
+      await initializeServer(unguarded);
+      res = await callToolOn(unguarded, 'omnifocus_write', {
+        mutation: { operation: 'create_folder', data: { name: ORPHAN_FOLDER_NAME, parentFolder: BOGUS_PARENT } },
+      });
+      read = await callToolOn(unguarded, 'omnifocus_read', { query: { type: 'folders' } });
+    } finally {
+      unguarded.kill();
+    }
+
+    expect(res.success, `expected error, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+    expect(JSON.stringify(res.error)).toContain('Parent folder not found');
+
+    // Regression half: the orphan folder must not exist anywhere. Exact-name
+    // match (run-scoped + __TEST__-prefixed) — can never trip on real folders.
+    expectOk(read, 'folders read-back after not-found probe');
+    const ghost = (read.data?.folders ?? []).find((f: any) => f.name === ORPHAN_FOLDER_NAME);
+    expect(ghost, `not-found probe created a folder: ${JSON.stringify(ghost)}`).toBeUndefined();
   }, 120000);
 });

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -1143,60 +1143,51 @@ describe('script structure consistency', () => {
   });
 });
 
-describe('buildCreateFolderScript', () => {
-  it('generates valid JXA script for top-level folder creation', () => {
-    const result = buildCreateFolderScript({
-      name: 'Home',
-    });
+// OMN-128 slice 3: buildCreateFolderScript emits ONE OmniJS program from the
+// mutation AST (dispatchMutation → emitProgram → wrapInLauncher) — the legacy
+// JXA shell and both its evaluateJavascript islands (parent lookup + the
+// JXA→OmniJS id bridge) are gone. Runtime behavior (vm execution, guard
+// short-circuits) is covered in tests/unit/contracts/ast/mutation/create-folder.test.ts.
+describe('buildCreateFolderScript (OMN-128 AST emission)', () => {
+  it('emits the JXA launcher around a JSON-encoded OmniJS program', async () => {
+    const result = await buildCreateFolderScript({ name: 'Home' });
 
     expect(result.script).toContain("Application('OmniFocus')");
-    expect(result.script).toContain('Home');
+    expect(result.script).toContain('app.evaluateJavascript(');
     expect(result.operation).toBe('create');
     expect(result.target).toBe('folder');
     expect(result.description).toBe('Create folder: Home');
+
+    const program = extractOmniJsProgram(result.script);
+    expect(program).toContain('const folder = new Folder("Home");');
+    expect(program).toContain('folderId: folder.id.primaryKey');
   });
 
-  it('generates valid JXA script for nested folder creation', () => {
-    const result = buildCreateFolderScript({
-      name: 'Home',
-      parentFolder: 'Personal',
-    });
+  it('nested create resolves the parent in-program via the shared flexible resolver', async () => {
+    const result = await buildCreateFolderScript({ name: 'Sub', parentFolder: 'Personal' });
 
-    expect(result.script).toContain("Application('OmniFocus')");
-    expect(result.script).toContain('Home');
-    expect(result.script).toContain('Personal');
-    expect(result.script).toContain('parseFolderPath');
-    expect(result.script).toContain('resolveFolderPath');
+    const program = extractOmniJsProgram(result.script);
+    expect(program).toContain('const targetParent = resolveFolderFlexible("Personal");');
+    expect(program).toContain('function parseFolderPath');
+    expect(program).toContain('function resolveFolderPath');
+    expect(program).toContain('const folder = new Folder("Sub", targetParent);');
   });
 
-  it('generates syntactically valid JavaScript', () => {
-    const result = buildCreateFolderScript({
-      name: 'Test Folder',
-      parentFolder: 'Parent : Child',
-    });
+  it('parent-not-found is a loud in-program guard with the legacy message', async () => {
+    const result = await buildCreateFolderScript({ name: 'Orphan', parentFolder: 'NonExistent' });
 
-    // Syntax-only validation: Function(body) parses but does not execute.
-    // The bare call form (no `new`) is equivalent for parsing purposes but
-    // doesn't trigger sonarjs/constructor-for-side-effects.
+    const program = extractOmniJsProgram(result.script);
+    expect(program).toContain('Parent folder not found: NonExistent');
+    expect(program).toContain('if (targetParent === null) return JSON.stringify(');
+  });
+
+  it('generates syntactically valid JavaScript', async () => {
+    const result = await buildCreateFolderScript({ name: 'Test Folder', parentFolder: 'Parent : Child' });
+
+    // Syntax-only validation: Function(body) parses but does not execute — for
+    // both the launcher and the decoded OmniJS program.
     expect(() => Function(result.script)).not.toThrow();
-  });
-
-  it('includes folder ID bridging logic', () => {
-    const result = buildCreateFolderScript({
-      name: 'Bridged Folder',
-    });
-
-    expect(result.script).toContain('primaryKey');
-    expect(result.script).toContain('flattenedFolders');
-  });
-
-  it('handles parent folder not found with error response', () => {
-    const result = buildCreateFolderScript({
-      name: 'Orphan',
-      parentFolder: 'NonExistent',
-    });
-
-    expect(result.script).toContain('Parent folder not found');
+    expect(() => Function(extractOmniJsProgram(result.script))).not.toThrow();
   });
 });
 

--- a/tests/unit/contracts/ast/mutation/create-folder.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-folder.test.ts
@@ -6,9 +6,12 @@ import {
   json,
   emitStmt,
   validateMutationProgram,
+  resolveFolder,
+  guard,
   return_,
   ref,
   member,
+  constructProject,
   type Program,
 } from '../../../../../src/contracts/ast/mutation/index.js';
 
@@ -57,5 +60,51 @@ describe('constructFolder validator rules', () => {
     expect(() =>
       validateMutationProgram(wrap([constructFolder('_warnings', json('X'), { kind: 'none' }), return_(envelope)])),
     ).toThrow(/reserved emitter identifier/i);
+  });
+});
+
+describe('rule-7 extension: resolveFolder needs a guard before consumption', () => {
+  const wrap = (stmts: Program['statements']): Program => ({
+    statements: stmts,
+    context: 'create_folder',
+    snippetDeps: [],
+  });
+  const envelope = { ok: json(true) };
+
+  it('rejects resolveFolder → constructFolder with no guard between', () => {
+    expect(() =>
+      validateMutationProgram(
+        wrap([
+          resolveFolder('p', 'Personal'),
+          constructFolder('f', json('X'), { kind: 'resolved', var: 'p' }),
+          return_(envelope),
+        ]),
+      ),
+    ).toThrow(/consumes resolution bind "p" without a guard/);
+  });
+
+  it('rejects resolveFolder → constructProject with no guard between (pre-existing gap, closed)', () => {
+    expect(() =>
+      validateMutationProgram(
+        wrap([
+          resolveFolder('p', 'Personal'),
+          constructProject('proj', json('X'), { kind: 'resolved', var: 'p' }),
+          return_(envelope),
+        ]),
+      ),
+    ).toThrow(/consumes resolution bind "p" without a guard/);
+  });
+
+  it('accepts the guarded shape', () => {
+    expect(() =>
+      validateMutationProgram(
+        wrap([
+          resolveFolder('p', 'Personal'),
+          guard('p === null', { error: json(true), message: json('nope'), context: json('create_folder') }),
+          constructFolder('f', json('X'), { kind: 'resolved', var: 'p' }),
+          return_(envelope),
+        ]),
+      ),
+    ).not.toThrow();
   });
 });

--- a/tests/unit/contracts/ast/mutation/create-folder.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-folder.test.ts
@@ -1,5 +1,6 @@
 // tests/unit/contracts/ast/mutation/create-folder.test.ts
 // OMN-128 slice 3 — constructFolder node + create/folder lowering tests.
+import vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import {
   constructFolder,
@@ -167,5 +168,105 @@ describe('dispatchMutation create/folder guard (OMN-119/120 non-bypass)', () => 
       process.env.NODE_ENV = prev.NODE_ENV;
       process.env.SANDBOX_GUARD_ENABLED = prev.SG;
     }
+  });
+});
+
+// EXECUTE the emitted program in a vm with stubbed OmniFocus globals — the
+// layer that caught slice 1's appliedTags and slice 2's const-in-try bugs.
+describe('emitted create-folder program executes (vm)', () => {
+  interface FolderStub {
+    name: string;
+    parent: FolderStub | null;
+    children: FolderStub[];
+    id: { primaryKey: string };
+  }
+
+  function makeSandbox(): {
+    sandbox: Record<string, unknown>;
+    topLevel: FolderStub[];
+    flat: FolderStub[];
+    constructorCalls: string[];
+  } {
+    const topLevel: FolderStub[] = [];
+    const flat: FolderStub[] = [];
+    const constructorCalls: string[] = [];
+    let nextId = 1;
+    const FolderCtor = function (this: FolderStub, name: string, parent?: FolderStub) {
+      constructorCalls.push(name);
+      this.name = name;
+      this.parent = parent ?? null;
+      this.children = [];
+      this.id = { primaryKey: `folder-pk-${nextId++}` };
+      (parent ? parent.children : topLevel).push(this);
+      flat.push(this);
+    } as unknown as Record<string, unknown> & { byIdentifier: (ref: string) => FolderStub | null };
+    FolderCtor.byIdentifier = (refStr: string): FolderStub | null =>
+      flat.find((f) => f.id.primaryKey === refStr) ?? null;
+    const sandbox: Record<string, unknown> = {
+      Folder: FolderCtor,
+      folders: topLevel,
+      flattenedFolders: flat,
+    };
+    return { sandbox, topLevel, flat, constructorCalls };
+  }
+
+  /** Pre-seed a folder hierarchy through the same stub constructor. */
+  function seed(sandbox: Record<string, unknown>, name: string, parent?: FolderStub): FolderStub {
+    const FolderCtor = sandbox.Folder as new (name: string, parent?: FolderStub) => FolderStub;
+    return new FolderCtor(name, parent);
+  }
+
+  it('vm A: top-level create returns the success envelope and lands at library root', () => {
+    const { sandbox, topLevel } = makeSandbox();
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Home' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.created).toBe(true);
+    expect(parsed.name).toBe('Home');
+    expect(parsed.folderId).toMatch(/^folder-pk-/);
+    expect(parsed.parentFolder).toBeNull();
+    expect(parsed.warnings).toEqual([]);
+    expect(topLevel.map((f) => f.name)).toEqual(['Home']);
+
+    // No-raw-splice check: the name must appear only JSON-encoded, never as a
+    // raw identifier-like splice (e.g. `new Folder(He said` would be invalid JS).
+    const raw = emitProgram(buildCreateFolderProgram({ name: 'He said "hi"' }));
+    expect(raw).not.toContain('new Folder(He said');
+  });
+
+  it('vm B: nested create resolves the parent by name and appends at the END of its children', () => {
+    const { sandbox } = makeSandbox();
+    const parent = seed(sandbox, 'Personal');
+    seed(sandbox, 'Existing Sibling', parent);
+
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Sub', parentFolder: 'Personal' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.created).toBe(true);
+    expect(parsed.parentFolder).toBe('Personal');
+    expect(parent.children.map((f) => f.name)).toEqual(['Existing Sibling', 'Sub']); // appended, not prepended
+  });
+
+  it('vm C: nested create resolves a " : " path through the seeded hierarchy', () => {
+    const { sandbox } = makeSandbox();
+    const top = seed(sandbox, 'Personal');
+    seed(sandbox, 'Areas', top);
+
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Deep', parentFolder: 'Personal : Areas' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.created).toBe(true);
+    expect(parsed.parentFolder).toBe('Areas'); // resolved parent's own name, legacy-faithful
+  });
+
+  it('vm D: parent-not-found returns the error envelope and NEVER constructs a Folder', () => {
+    const { sandbox, constructorCalls } = makeSandbox();
+    const program = emitProgram(buildCreateFolderProgram({ name: 'Orphan', parentFolder: 'NonExistent' }));
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+
+    expect(parsed.error).toBe(true);
+    expect(parsed.message).toBe('Parent folder not found: NonExistent');
+    expect(parsed.context).toBe('create_folder');
+    expect(constructorCalls).toEqual([]); // guard short-circuits before construct
   });
 });

--- a/tests/unit/contracts/ast/mutation/create-folder.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-folder.test.ts
@@ -1,0 +1,61 @@
+// tests/unit/contracts/ast/mutation/create-folder.test.ts
+// OMN-128 slice 3 — constructFolder node + create/folder lowering tests.
+import { describe, it, expect } from 'vitest';
+import {
+  constructFolder,
+  json,
+  emitStmt,
+  validateMutationProgram,
+  return_,
+  ref,
+  member,
+  type Program,
+} from '../../../../../src/contracts/ast/mutation/index.js';
+
+describe('constructFolder node (types + emitter)', () => {
+  it('factory builds the typed node', () => {
+    const node = constructFolder('f', json('Home'), { kind: 'none' });
+    expect(node).toEqual({ type: 'constructFolder', bind: 'f', name: json('Home'), parent: { kind: 'none' } });
+  });
+
+  it('emits top-level construction for kind none', () => {
+    expect(emitStmt(constructFolder('f', json('Home'), { kind: 'none' }))).toBe('const f = new Folder("Home");');
+  });
+
+  it('emits parented construction for kind resolved', () => {
+    expect(emitStmt(constructFolder('f', json('Home'), { kind: 'resolved', var: 'targetParent' }))).toBe(
+      'const f = new Folder("Home", targetParent);',
+    );
+  });
+
+  it('throws at emit time for kind notFound', () => {
+    expect(() => emitStmt(constructFolder('f', json('Home'), { kind: 'notFound' }))).toThrow(/notFound.*illegal/i);
+  });
+});
+
+describe('constructFolder validator rules', () => {
+  const wrap = (stmts: Program['statements']): Program => ({
+    statements: stmts,
+    context: 'create_folder',
+    snippetDeps: [],
+  });
+  const envelope = { folderId: member(ref('f'), 'id.primaryKey') };
+
+  it('rejects parent.kind notFound (must be guard-handled earlier)', () => {
+    expect(() =>
+      validateMutationProgram(wrap([constructFolder('f', json('X'), { kind: 'notFound' }), return_(envelope)])),
+    ).toThrow(/notFound.*illegal/i);
+  });
+
+  it('rejects an untyped parent (string smuggled past the types)', () => {
+    const node = constructFolder('f', json('X'), { kind: 'none' });
+    (node as unknown as { parent: unknown }).parent = 'Personal';
+    expect(() => validateMutationProgram(wrap([node, return_(envelope)]))).toThrow(/typed FolderResolution/i);
+  });
+
+  it('rejects a reserved emitter identifier as bind', () => {
+    expect(() =>
+      validateMutationProgram(wrap([constructFolder('_warnings', json('X'), { kind: 'none' }), return_(envelope)])),
+    ).toThrow(/reserved emitter identifier/i);
+  });
+});

--- a/tests/unit/contracts/ast/mutation/create-folder.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-folder.test.ts
@@ -5,6 +5,7 @@ import {
   constructFolder,
   json,
   emitStmt,
+  emitProgram,
   validateMutationProgram,
   resolveFolder,
   guard,
@@ -12,6 +13,8 @@ import {
   ref,
   member,
   constructProject,
+  buildCreateFolderProgram,
+  dispatchMutation,
   type Program,
 } from '../../../../../src/contracts/ast/mutation/index.js';
 
@@ -80,7 +83,7 @@ describe('rule-7 extension: resolveFolder needs a guard before consumption', () 
           return_(envelope),
         ]),
       ),
-    ).toThrow(/consumes resolution bind "p" without a guard/);
+    ).toThrow(/constructFolder consumes resolution bind "p" without a guard/);
   });
 
   it('rejects resolveFolder → constructProject with no guard between (pre-existing gap, closed)', () => {
@@ -92,7 +95,7 @@ describe('rule-7 extension: resolveFolder needs a guard before consumption', () 
           return_(envelope),
         ]),
       ),
-    ).toThrow(/consumes resolution bind "p" without a guard/);
+    ).toThrow(/constructProject consumes resolution bind "p" without a guard/);
   });
 
   it('accepts the guarded shape', () => {
@@ -106,5 +109,63 @@ describe('rule-7 extension: resolveFolder needs a guard before consumption', () 
         ]),
       ),
     ).not.toThrow();
+  });
+});
+
+describe('buildCreateFolderProgram lowering', () => {
+  it('top-level: construct + envelope, no resolve, no snippets', () => {
+    const program = buildCreateFolderProgram({ name: 'Home' });
+    expect(program.context).toBe('create_folder');
+    expect(program.snippetDeps).toEqual([]);
+    expect(program.statements.map((s) => s.type)).toEqual(['constructFolder', 'return']);
+    expect(() => validateMutationProgram(program)).not.toThrow();
+
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain('const folder = new Folder("Home");');
+    expect(omnijs).toContain('folderId: folder.id.primaryKey');
+    expect(omnijs).toContain('parentFolder: null');
+    expect(omnijs).toContain('warnings: _warnings');
+    expect(omnijs).toContain('created: true');
+  });
+
+  it('nested: resolve + guard (exact legacy message) + parented construct + snippet dep', () => {
+    const program = buildCreateFolderProgram({ name: 'Sub', parentFolder: 'Personal : Areas' });
+    expect(program.snippetDeps).toEqual(['resolveFolderFlexible']);
+    expect(program.statements.map((s) => s.type)).toEqual(['resolveFolder', 'guard', 'constructFolder', 'return']);
+    expect(() => validateMutationProgram(program)).not.toThrow();
+
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain('const targetParent = resolveFolderFlexible("Personal : Areas");');
+    expect(omnijs).toContain(
+      'if (targetParent === null) return JSON.stringify({ error: true, message: "Parent folder not found: Personal : Areas", context: "create_folder" });',
+    );
+    expect(omnijs).toContain('const folder = new Folder("Sub", targetParent);');
+    expect(omnijs).toContain('parentFolder: targetParent.name');
+    // Transitive snippet assembly: the flexible resolver pulls its path helpers.
+    expect(omnijs).toContain('function parseFolderPath');
+    expect(omnijs).toContain('function resolveFolderPath');
+    expect(omnijs).toContain('function resolveFolderFlexible');
+  });
+
+  it('user data is JSON-encoded, never spliced (a quote in the name cannot escape)', () => {
+    const program = buildCreateFolderProgram({ name: 'He said "hi" \\ `tick`' });
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain(JSON.stringify('He said "hi" \\ `tick`'));
+  });
+});
+
+describe('dispatchMutation create/folder guard (OMN-119/120 non-bypass)', () => {
+  it('rejects a non-sandbox folder create when the sandbox guard is enabled', async () => {
+    const prev = { NODE_ENV: process.env.NODE_ENV, SG: process.env.SANDBOX_GUARD_ENABLED };
+    process.env.NODE_ENV = 'test';
+    process.env.SANDBOX_GUARD_ENABLED = 'true';
+    try {
+      await expect(dispatchMutation('create/folder', { name: 'Rogue', parentFolder: 'Personal' })).rejects.toThrow(
+        /TEST GUARD/,
+      );
+    } finally {
+      process.env.NODE_ENV = prev.NODE_ENV;
+      process.env.SANDBOX_GUARD_ENABLED = prev.SG;
+    }
   });
 });

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -609,6 +609,34 @@ describe('OmniFocusWriteTool task operations', () => {
     });
   });
 
+  // ─── FOLDER CREATE WARNINGS PASS-THROUGH (OMN-137) ──────────────────
+
+  describe('folder create warnings pass-through', () => {
+    it('OMN-137: surfaces script warnings in the folder create response data', async () => {
+      execJsonSpy.mockResolvedValue(
+        createScriptSuccess({ folderId: 'folder-w', name: 'Warned Folder', warnings: ['parent: boom'] }),
+      );
+
+      const result = (await tool.execute({
+        mutation: { operation: 'create_folder', data: { name: 'Warned Folder' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.warnings).toEqual(['parent: boom']);
+    });
+
+    it('OMN-137: omits the warnings key when the folder script reports none', async () => {
+      execJsonSpy.mockResolvedValue(createScriptSuccess({ folderId: 'folder-nw', name: 'Clean Folder', warnings: [] }));
+
+      const result = (await tool.execute({
+        mutation: { operation: 'create_folder', data: { name: 'Clean Folder' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect('warnings' in result.data).toBe(false);
+    });
+  });
+
   // ─── BATCH WARNINGS PASS-THROUGH (OMN-137) ──────────────────────────
 
   describe('batch create warnings pass-through', () => {


### PR DESCRIPTION
## Summary

Migrates `buildCreateFolderScript` to the OmniJS-native mutation AST, finishing the **create family** (slices 1+2: #74, #78). The legacy JXA shell and both its `evaluateJavascript` islands (parent lookup + the JXA→OmniJS `id.primaryKey` bridge) are deleted, not migrated — `folderId` reads directly off the fresh binding in the single-runtime program.

- **New `constructFolder` node** (types/emitter/validator) — near-clone of `constructProject`, consuming the existing `FolderResolution`; `notFound` illegal at both validator and emit time.
- **Validator rule-7 extension:** the resolution-guard discipline now covers `resolveFolder` binds consumed by `constructProject`/`constructFolder` (closes a pre-existing enforcement gap; zero churn — the slice-1 lowering already complied).
- **`buildCreateFolderProgram` lowering** + guarded `'create/folder'` dispatch key (`validateFolderCreate` runs at the `MUTATION_DEFS` chokepoint — OMN-119/120 non-bypass). Exact legacy error message preserved (`Parent folder not found: <ref>`); nested-path semantics unchanged (parents must exist, no mkdir-p).
- **OMN-137 warnings uniformity:** envelope carries `warnings` (always `[]` today — no best-effort steps), tool layer lifts via `liftWarnings` like the other migrated creates.
- **Tests:** 18 unit tests in `create-folder.test.ts` (golden + validator + injection probe + 4 `node:vm` execution tests with folder shims); legacy describe block rewritten for the launcher shape; 2 warnings symmetry tests; **2 live integration tests** (OMN-138) incl. a parentage read-back hardened against the silent root-placement class (asserts `parentId` + sandbox-anchored exact `path` — the envelope `parentFolder` echoes the resolved target and cannot catch it alone).

## Deliberate deltas vs legacy (spec §3)

1. `folderId` is always the OmniJS primaryKey — the JXA-id fallback died with the bridge.
2. `warnings` field added to the envelope (additive; lifted only when non-empty).

## Verification

- `npm run build` clean · `npm run test:unit` 2424/2424 · lint 0 errors · full `test:integration` 108 passed / 22 skipped, exit 0.
- Live verify matrix (6 probes, guarded + bounded-unguarded): guard refusal at dispatch (`query_time_ms: 0`), nested by name/path/id all correctly parented on read-back, **END-of-children placement proven in document order**, loud not-found with zero creation, top-level at library root. Cleanup: zero residue; real data intact. Full record: Obsidian “OMN-128 Slice 3 - Verify Findings”.

Spec: `docs/superpowers/specs/2026-06-09-create-folder-mutation-ast-design.md` · Plan: `docs/superpowers/plans/2026-06-09-create-folder-mutation-ast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)