### PR TITLE
fix(OMN-142): name filter is name-scoped — no longer matches note content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **`filters.name` no longer matches note content** (OMN-142) — The `name` filter compiled onto the legacy `search`
+  field, whose every consumer (tasks, projects, export) implements name-OR-note matching — so a task whose _note_ cited
+  a term matched a "name" search for it. That over-match fed a deletion sweep that collaterally deleted a real user task
+  (restored from the OmniFocus transaction snapshot). `name` now has a name-scoped internal representation end to end;
+  `text` keeps full-text (name OR note) semantics. Two riders fixed by the same change: `name: { matches }` no longer
+  silently degrades regex to substring matching, and sending both `name` and `text` now applies both (the old alias made
+  `text` silently win). Also un-dropped on projects queries: `filters.text` was advertised (the tool's own error message
+  recommends it) but silently ignored — it now performs full-text project search, with regex support via `{ matches }`.
 - **Tag `unnest` and `reparent`-to-root work** (OMN-128 slice 6) — Moving a tag to the root level never worked: the
   generated script passed a null position to `Database.moveTags`, which the OmniFocus API rejects
   (`argument "position" … requires a non-null value`), so every unnest/reparent-to-root returned an error. Root moves

--- a/src/contracts/ast/builder.ts
+++ b/src/contracts/ast/builder.ts
@@ -153,6 +153,19 @@ export const FILTER_DEFS: readonly FilterDef[] = [
     },
   },
 
+  // --- Name search (OMN-142) ---
+  // Name-scoped: matches task.name ONLY, never task.note. Composes with
+  // text/search above (AND) rather than aliasing onto them — the old alias
+  // routed name through the name-OR-note search and over-matched notes.
+  {
+    fields: ['task.name'],
+    build: (f) => {
+      if (f.name === undefined) return null;
+      const operator = f.nameOperator === 'MATCHES' ? 'matches' : 'includes';
+      return comparison('task.name', operator, f.name);
+    },
+  },
+
   // --- Date filters (data-driven from DATE_FILTER_DEFS) ---
   ...DATE_FILTER_DEFS.map(
     (def): FilterDef => ({

--- a/src/contracts/ast/filter-generator.ts
+++ b/src/contracts/ast/filter-generator.ts
@@ -14,7 +14,7 @@
  * @see docs/plans/2025-11-24-ast-filter-contracts-design.md
  */
 
-import type { TaskFilter, ProjectFilter, ProjectStatus, NormalizedTaskFilter } from '../filters.js';
+import type { TaskFilter, ProjectFilter, ProjectStatus, NormalizedTaskFilter, TextOperator } from '../filters.js';
 import type { FilterNode } from './types.js';
 import { buildAST } from './builder.js';
 import { validateFilterAST, type ValidationResult } from './validator.js';
@@ -228,6 +228,10 @@ export function describeFilter(filter: TaskFilter): string {
   if (filter.text) {
     conditions.push(`name ${filter.textOperator || 'CONTAINS'} "${filter.text}"`);
   }
+  if (filter.name) {
+    // OMN-142: name-only filter (text above also matches notes)
+    conditions.push(`name-only ${filter.nameOperator || 'CONTAINS'} "${filter.name}"`);
+  }
   const dateDesc = describeDateRange(filter);
   if (dateDesc) conditions.push(dateDesc);
   if (filter.projectId) conditions.push(`in project ${filter.projectId}`);
@@ -249,6 +253,19 @@ const PROJECT_STATUS_MAP: Record<ProjectStatus, string> = {
   done: 'Project.Status.Done',
   dropped: 'Project.Status.Dropped',
 };
+
+/**
+ * Emit one case-insensitive match condition against a project string field.
+ * CONTAINS lowercases both sides; MATCHES compiles to a RegExp test. The
+ * term is injected via JSON.stringify only — never raw interpolation.
+ */
+function projectTextCondition(field: 'name' | 'note', term: string, operator?: TextOperator): string {
+  const accessor = `(project.${field} || '')`;
+  if (operator === 'MATCHES') {
+    return `new RegExp(${JSON.stringify(term)}, 'i').test(${accessor})`;
+  }
+  return `${accessor}.toLowerCase().includes(${JSON.stringify(term.toLowerCase())})`;
+}
 
 /**
  * Generate OmniJS filter code for a ProjectFilter
@@ -285,11 +302,17 @@ export function generateProjectFilterCode(filter: ProjectFilter): string {
 
   // Text search (case-insensitive on name and note)
   if (filter.text) {
-    const escaped = JSON.stringify(filter.text.toLowerCase());
     conditions.push(
-      `((project.name || '').toLowerCase().includes(${escaped}) || ` +
-        `(project.note || '').toLowerCase().includes(${escaped}))`,
+      `(${projectTextCondition('name', filter.text, filter.textOperator)} || ` +
+        `${projectTextCondition('note', filter.text, filter.textOperator)})`,
     );
+  }
+
+  // OMN-142: name search — name ONLY, never the note. `text` above is the
+  // full-text (name OR note) filter; aliasing name onto it over-matched
+  // notes and fed a destructive sweep.
+  if (filter.name) {
+    conditions.push(`(${projectTextCondition('name', filter.name, filter.nameOperator)})`);
   }
 
   // Folder filter by ID
@@ -324,6 +347,7 @@ export function isEmptyProjectFilter(filter: ProjectFilter): boolean {
     filter.flagged === undefined &&
     filter.needsReview === undefined &&
     !filter.text &&
+    !filter.name && // OMN-142
     !filter.folderId &&
     !filter.folderName &&
     !filter.topLevelOnly // OMN-96
@@ -346,7 +370,11 @@ export function describeProjectFilter(filter: ProjectFilter): string {
     conditions.push(filter.needsReview ? 'needs review' : 'does not need review');
   }
   if (filter.text) {
-    conditions.push(`text contains "${filter.text}"`);
+    conditions.push(`text ${filter.textOperator === 'MATCHES' ? 'matches' : 'contains'} "${filter.text}"`);
+  }
+  if (filter.name) {
+    // OMN-142
+    conditions.push(`name ${filter.nameOperator === 'MATCHES' ? 'matches' : 'contains'} "${filter.name}"`);
   }
   if (filter.folderId) {
     conditions.push(`folder ID = ${filter.folderId}`);

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -13,7 +13,7 @@
  * @see docs/plans/2025-11-24-ast-filter-contracts-design.md
  */
 
-import type { TaskFilter, ProjectFilter, NormalizedTaskFilter } from '../filters.js';
+import type { TaskFilter, ProjectFilter, NormalizedTaskFilter, TextOperator } from '../filters.js';
 import { normalizeFilter } from '../filters.js';
 import {
   generateFilterCode,
@@ -1015,6 +1015,10 @@ function describeFilterForScript(filter: TaskFilter): string {
   if (filter.text || filter.search) {
     conditions.push(`text: "${filter.text || filter.search}"`);
   }
+  if (filter.name) {
+    // OMN-142: name-only filter (distinct from text, which matches notes)
+    conditions.push(`name: "${filter.name}"`);
+  }
 
   const dueDescription = describeDueDateRange(filter);
   if (dueDescription) {
@@ -1480,6 +1484,9 @@ export interface ExportFilter {
   tags?: string[];
   tagsOperator?: 'AND' | 'OR' | 'NOT_IN';
   search?: string; // Maps to 'text' in TaskFilter
+  // OMN-142: name-scoped filter — matches task.name only, never the note
+  name?: string;
+  nameOperator?: TextOperator;
   limit?: number;
 }
 
@@ -1498,6 +1505,11 @@ function normalizeExportFilter(filter: ExportFilter): TaskFilter {
   if (filter.tagsOperator !== undefined) taskFilter.tagsOperator = filter.tagsOperator;
   // Map 'search' to 'text' for AST compatibility
   if (filter.search !== undefined) taskFilter.text = filter.search;
+  // OMN-142: name passes through name-scoped (text/search match notes too)
+  if (filter.name !== undefined) {
+    taskFilter.name = filter.name;
+    taskFilter.nameOperator = filter.nameOperator;
+  }
 
   return taskFilter;
 }

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -78,6 +78,16 @@ export interface TaskFilter {
   text?: string; // Search term
   textOperator?: TextOperator; // How to match (default: CONTAINS)
 
+  // --- Name Search (OMN-142) ---
+  /**
+   * Name-scoped search term — matches task.name ONLY, never the note.
+   * Distinct from `text`/`search`, which match name OR note. The public
+   * `filters.name` compiles here; before OMN-142 it aliased onto `search`
+   * and the note over-match fed a destructive sweep.
+   */
+  name?: string;
+  nameOperator?: TextOperator; // How to match (default: CONTAINS)
+
   // --- Date Filters ---
   dueAfter?: string; // ISO date string
   dueBefore?: string; // ISO date string
@@ -253,6 +263,18 @@ export interface ProjectFilter {
    * Case-insensitive substring match
    */
   text?: string;
+  /**
+   * OMN-142: how `text` matches (default CONTAINS; MATCHES = regex).
+   */
+  textOperator?: TextOperator;
+
+  // --- Name Search (OMN-142) ---
+  /**
+   * Name-scoped search term — matches project.name ONLY, never the note.
+   * Distinct from `text`, which matches name OR note.
+   */
+  name?: string;
+  nameOperator?: TextOperator; // How to match (default: CONTAINS)
 
   // --- Folder Filter ---
   /**
@@ -283,6 +305,9 @@ export const PROJECT_FILTER_PROPERTY_NAMES = [
   'flagged',
   'needsReview',
   'text',
+  'textOperator', // OMN-142
+  'name', // OMN-142: name-only match (text also matches notes)
+  'nameOperator', // OMN-142
   'folderId',
   'folderName',
   'topLevelOnly', // OMN-96
@@ -353,6 +378,9 @@ export const FILTER_PROPERTY_NAMES = [
   'tagsOperator',
   'text',
   'textOperator',
+  'name', // OMN-142: name-only match (text/search also match notes)
+  'nameOperator', // OMN-142
+
   'dueAfter',
   'dueBefore',
   'dueDateOperator',
@@ -491,6 +519,11 @@ export function normalizeFilter(filter: TaskFilter): NormalizedTaskFilter {
   // Default textOperator
   if (normalized.text && !normalized.textOperator) {
     normalized.textOperator = 'CONTAINS';
+  }
+
+  // OMN-142: default nameOperator
+  if (normalized.name && !normalized.nameOperator) {
+    normalized.nameOperator = 'CONTAINS';
   }
 
   // Brand the filter as normalized using Object.assign to add the symbol property

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -179,7 +179,8 @@ MODES (tasks queries ONLY — not valid on type:"projects"):
 FILTER OPERATORS:
 - tags: { any: [...] } (has any), { all: [...] } (has all), { none: [...] } (has none)
 - dates (dueDate, deferDate, plannedDate, added): { before: "YYYY-MM-DD" }, { after: "..." }, { between: ["...", "..."] }
-- text: { contains: "..." }, { matches: "regex" }
+- text: { contains: "..." }, { matches: "regex" } — full-text: matches name OR note
+- name: { contains: "..." }, { matches: "regex" } — name ONLY (never matches note content)
 - boolean: flagged, blocked, available, inInbox
 - folder (projects queries): "<name>" matches folder-name substring; null = top-level projects only (no containing folder)
 - logic: { OR: [...] }, { AND: [...] }, { NOT: {...} }
@@ -623,6 +624,18 @@ PERFORMANCE:
     if (compiled.filters.search) {
       projectFilter.text = compiled.filters.search;
     }
+    // OMN-142: `filters.text` is the full-text (name OR note) filter. Before
+    // OMN-142 it was silently dropped on projects queries — the only working
+    // text search was the name filter's accidental note over-match.
+    if (compiled.filters.text) {
+      projectFilter.text = compiled.filters.text;
+      projectFilter.textOperator = compiled.filters.textOperator;
+    }
+    // OMN-142: `filters.name` is name-scoped — matches project.name only.
+    if (compiled.filters.name) {
+      projectFilter.name = compiled.filters.name;
+      projectFilter.nameOperator = compiled.filters.nameOperator;
+    }
 
     // OMN-19: suppress review/bottleneck summary on narrow lookups (name or id).
     // Rationale: the summary is built for weekly-review/dashboard flows but is
@@ -630,7 +643,7 @@ PERFORMANCE:
     // Status- and folder-only browses still return the summary — those look
     // dashboard-ish and users may be scanning review state. See Linear OMN-19
     // for the full option trade-off (explicit param vs heuristic vs slim mode).
-    const isNarrowLookup = Boolean(compiled.filters.search || compiled.filters.id);
+    const isNarrowLookup = Boolean(compiled.filters.search || compiled.filters.name || compiled.filters.id);
 
     // Build cache key
     const cacheParams = { ...projectFilter, limit, includeStats };
@@ -920,6 +933,10 @@ PERFORMANCE:
       tags: compiled.filters.tags,
       tagsOperator: compiled.filters.tagsOperator as ExportFilter['tagsOperator'],
       search: compiled.filters.search,
+      // OMN-142: name is name-scoped (never matches notes); search above
+      // keeps the legacy full-text (name OR note) semantics.
+      name: compiled.filters.name,
+      nameOperator: compiled.filters.nameOperator,
     };
     // OMN-44: response-size pressure does not apply when writing to disk, so
     // raise the implicit cap; a user-supplied `limit` always wins.

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -643,7 +643,9 @@ PERFORMANCE:
     // Status- and folder-only browses still return the summary — those look
     // dashboard-ish and users may be scanning review state. See Linear OMN-19
     // for the full option trade-off (explicit param vs heuristic vs slim mode).
-    const isNarrowLookup = Boolean(compiled.filters.search || compiled.filters.name || compiled.filters.id);
+    const isNarrowLookup = Boolean(
+      compiled.filters.search || compiled.filters.name || compiled.filters.text || compiled.filters.id,
+    );
 
     // Build cache key
     const cacheParams = { ...projectFilter, limit, includeStats };

--- a/src/tools/unified/compilers/QueryCompiler.ts
+++ b/src/tools/unified/compilers/QueryCompiler.ts
@@ -311,12 +311,17 @@ export class QueryCompiler {
       }
     }
 
+    // OMN-142: `name` compiles to the name-scoped fields, NEVER the legacy
+    // `search` alias — `search` matches note content too, and that over-match
+    // collaterally deleted a real user task (2026-06-09).
     if (input.name) {
       const nameFilter = input.name as { contains?: string; matches?: string };
       if ('contains' in nameFilter && nameFilter.contains) {
-        result.search = nameFilter.contains;
+        result.name = nameFilter.contains;
+        result.nameOperator = 'CONTAINS';
       } else if ('matches' in nameFilter && nameFilter.matches) {
-        result.search = nameFilter.matches;
+        result.name = nameFilter.matches;
+        result.nameOperator = 'MATCHES';
       }
     }
   }

--- a/tests/integration/name-filter-scope.test.ts
+++ b/tests/integration/name-filter-scope.test.ts
@@ -1,0 +1,184 @@
+/**
+ * OMN-142 regression: `filters.name` must be name-scoped.
+ *
+ * The bug: `name: { contains }` compiled to the legacy `search` field, which
+ * matches name OR note — so a task whose NOTE cited a term matched a "name"
+ * search for it. A deletion sweep keyed on `name contains 'OMN-138'` then
+ * collaterally deleted a real user task that merely cited OMN-138 in its note.
+ *
+ * Contract under test (tasks AND projects):
+ * - name.contains hits a name-only marker, and does NOT hit a note-only marker
+ * - text.contains hits both (full-text semantics unchanged)
+ *
+ * Uses the test sandbox for isolation (tasks created inside a sandbox-folder
+ * project — NOT the inbox — so cleanup stays folder-scoped).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getSharedClient } from './helpers/shared-server.js';
+import { MCPTestClient } from './helpers/mcp-test-client.js';
+import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from './helpers/sandbox-manager.js';
+import { runScopedName, RUN_ID } from './helpers/run-id.js';
+
+const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
+const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
+
+interface TaskRow {
+  id: string;
+  name: string;
+}
+interface TasksReadResponse {
+  success: boolean;
+  data?: { tasks?: TaskRow[] };
+}
+interface ProjectsReadResponse {
+  success: boolean;
+  data?: { projects?: TaskRow[] };
+}
+interface BatchResponse {
+  success: boolean;
+  data: { tempIdMapping?: Record<string, string> };
+}
+
+d('OMN-142: name filter is name-scoped (never matches notes)', () => {
+  let client: MCPTestClient;
+
+  // Run-unique markers: never appear in any real name/note, so result sets
+  // are exactly the probe records.
+  const TASK_MARKER = `XYZNAMESCOPE${RUN_ID.replace(/[^a-z0-9]/gi, '')}`;
+  const PROJECT_MARKER = `XYZPROJSCOPE${RUN_ID.replace(/[^a-z0-9]/gi, '')}`;
+
+  let nameTaskId: string;
+  let noteTaskId: string;
+  let nameProjectId: string;
+  let noteProjectId: string;
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+
+    // One sandbox project holding both probe tasks, plus the two probe
+    // projects themselves (name-marker vs note-marker).
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'project',
+            data: {
+              tempId: 'holder',
+              name: runScopedName('NameScope_Holder'),
+              folder: SANDBOX_FOLDER_NAME,
+            },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'nameTask',
+              name: runScopedName(`NameScope_InName_${TASK_MARKER}`),
+              note: 'bland note with no marker',
+              parentTempId: 'holder',
+            },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'noteTask',
+              name: runScopedName('NameScope_InNoteOnly'),
+              note: `note citing the marker (${TASK_MARKER}) — must NOT match a name search`,
+              parentTempId: 'holder',
+            },
+          },
+          {
+            operation: 'create',
+            target: 'project',
+            data: {
+              tempId: 'nameProject',
+              name: runScopedName(`NameScope_ProjInName_${PROJECT_MARKER}`),
+              note: 'bland project note',
+              folder: SANDBOX_FOLDER_NAME,
+            },
+          },
+          {
+            operation: 'create',
+            target: 'project',
+            data: {
+              tempId: 'noteProject',
+              name: runScopedName('NameScope_ProjInNoteOnly'),
+              note: `project note citing the marker (${PROJECT_MARKER})`,
+              folder: SANDBOX_FOLDER_NAME,
+            },
+          },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+
+    expect(response.success).toBe(true);
+    const mapping = response.data.tempIdMapping ?? {};
+    nameTaskId = mapping['nameTask'];
+    noteTaskId = mapping['noteTask'];
+    nameProjectId = mapping['nameProject'];
+    noteProjectId = mapping['noteProject'];
+    expect(nameTaskId).toBeTruthy();
+    expect(noteTaskId).toBeTruthy();
+    expect(nameProjectId).toBeTruthy();
+    expect(noteProjectId).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it('tasks: name.contains matches the name-marker task and NOT the note-marker task', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { name: { contains: TASK_MARKER } }, limit: 50 },
+    })) as TasksReadResponse;
+
+    expect(result.success).toBe(true);
+    const ids = (result.data?.tasks ?? []).map((t) => t.id);
+    expect(ids).toContain(nameTaskId);
+    expect(ids).not.toContain(noteTaskId);
+  }, 60000);
+
+  it('tasks: text.contains matches BOTH (full-text semantics unchanged)', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { text: { contains: TASK_MARKER } }, limit: 50 },
+    })) as TasksReadResponse;
+
+    expect(result.success).toBe(true);
+    const ids = (result.data?.tasks ?? []).map((t) => t.id);
+    expect(ids).toContain(nameTaskId);
+    expect(ids).toContain(noteTaskId);
+  }, 60000);
+
+  it('projects: name.contains matches the name-marker project and NOT the note-marker project', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: { type: 'projects', filters: { name: { contains: PROJECT_MARKER } }, limit: 50 },
+    })) as ProjectsReadResponse;
+
+    expect(result.success).toBe(true);
+    const ids = (result.data?.projects ?? []).map((p) => p.id);
+    expect(ids).toContain(nameProjectId);
+    expect(ids).not.toContain(noteProjectId);
+  }, 60000);
+
+  it('projects: text.contains matches BOTH (OMN-142 also un-dropped filters.text on projects)', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: { type: 'projects', filters: { text: { contains: PROJECT_MARKER } }, limit: 50 },
+    })) as ProjectsReadResponse;
+
+    expect(result.success).toBe(true);
+    const ids = (result.data?.projects ?? []).map((p) => p.id);
+    expect(ids).toContain(nameProjectId);
+    expect(ids).toContain(noteProjectId);
+  }, 60000);
+});

--- a/tests/unit/ast-phase3-builders.test.ts
+++ b/tests/unit/ast-phase3-builders.test.ts
@@ -53,6 +53,23 @@ describe('Phase 3 AST Builders', () => {
       expect(code).toContain('test project');
     });
 
+    // OMN-142: name is name-scoped — must never read project.note (text does that)
+    it('should generate name-only filter without touching project.note', () => {
+      const filter: ProjectFilter = { name: 'review' };
+      const code = generateProjectFilterCode(filter);
+      expect(code).toContain('project.name');
+      expect(code).toContain('review');
+      expect(code).not.toContain('project.note');
+    });
+
+    it('should generate regex name filter for MATCHES, still name only', () => {
+      const filter: ProjectFilter = { name: '^Q[1-4]', nameOperator: 'MATCHES' };
+      const code = generateProjectFilterCode(filter);
+      expect(code).toContain('project.name');
+      expect(code).toContain('test');
+      expect(code).not.toContain('project.note');
+    });
+
     it('should generate folder ID filter', () => {
       const filter: ProjectFilter = { folderId: 'abc123' };
       const code = generateProjectFilterCode(filter);
@@ -96,6 +113,11 @@ describe('Phase 3 AST Builders', () => {
 
     it('should return false for filter with flagged', () => {
       expect(isEmptyProjectFilter({ flagged: true })).toBe(false);
+    });
+
+    // OMN-142: a name filter is a real constraint
+    it('should return false for filter with name', () => {
+      expect(isEmptyProjectFilter({ name: 'review' })).toBe(false);
     });
 
     // OMN-96: topLevelOnly is a real constraint, so the filter isn't empty

--- a/tests/unit/ast-phase3-builders.test.ts
+++ b/tests/unit/ast-phase3-builders.test.ts
@@ -66,7 +66,8 @@ describe('Phase 3 AST Builders', () => {
       const filter: ProjectFilter = { name: '^Q[1-4]', nameOperator: 'MATCHES' };
       const code = generateProjectFilterCode(filter);
       expect(code).toContain('project.name');
-      expect(code).toContain('test');
+      expect(code).toContain('new RegExp');
+      expect(code).toContain('^Q[1-4]');
       expect(code).not.toContain('project.note');
     });
 

--- a/tests/unit/contracts/ast/builder.test.ts
+++ b/tests/unit/contracts/ast/builder.test.ts
@@ -291,6 +291,69 @@ describe('buildAST', () => {
     });
   });
 
+  // OMN-142: `name` is name-scoped — it must NEVER touch task.note. The old
+  // behavior (name compiled to the search alias → name OR note) collaterally
+  // matched tasks whose note cited the search term, and fed a deletion sweep.
+  describe('name filters (OMN-142)', () => {
+    it('name filter matches task.name only — never task.note', () => {
+      const filter: TaskFilter = { name: 'review', nameOperator: 'CONTAINS' };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'includes',
+        value: 'review',
+      });
+    });
+
+    it('name filter honors MATCHES operator, still name only', () => {
+      const filter: TaskFilter = { name: '^review.*', nameOperator: 'MATCHES' };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'matches',
+        value: '^review.*',
+      });
+    });
+
+    it('defaults to CONTAINS when nameOperator omitted', () => {
+      const filter: TaskFilter = { name: 'review' };
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'includes',
+        value: 'review',
+      });
+    });
+
+    it('name and text compose with AND — neither drops the other', () => {
+      const filter: TaskFilter = { name: 'alpha', nameOperator: 'CONTAINS', text: 'beta', textOperator: 'CONTAINS' };
+      const ast = buildAST(filter);
+
+      expect(ast.type).toBe('and');
+      if (ast.type !== 'and') return;
+
+      expect(ast.children).toContainEqual({
+        type: 'comparison',
+        field: 'task.name',
+        operator: 'includes',
+        value: 'alpha',
+      });
+      expect(ast.children).toContainEqual({
+        type: 'or',
+        children: [
+          { type: 'comparison', field: 'task.name', operator: 'includes', value: 'beta' },
+          { type: 'comparison', field: 'task.note', operator: 'includes', value: 'beta' },
+        ],
+      });
+    });
+  });
+
   describe('parent task filter (OMN-114)', () => {
     it('transforms parentTaskId to a synthetic comparison node', () => {
       const filter: TaskFilter = { parentTaskId: 'abc123' };

--- a/tests/unit/contracts/ast/filter-coverage.test.ts
+++ b/tests/unit/contracts/ast/filter-coverage.test.ts
@@ -14,6 +14,7 @@ import { QueryCompiler } from '../../../../src/tools/unified/compilers/QueryComp
 import { buildAST } from '../../../../src/contracts/ast/builder.js';
 import { emitOmniJS } from '../../../../src/contracts/ast/emitters/omnijs.js';
 import { validateFilterAST } from '../../../../src/contracts/ast/validator.js';
+import { normalizeFilter } from '../../../../src/contracts/filters.js';
 import type { TaskFilter } from '../../../../src/contracts/filters.js';
 
 // =============================================================================
@@ -236,15 +237,21 @@ describe('QueryCompiler.transformFilters', () => {
     });
   });
 
+  // OMN-142: name is a name-scoped filter, distinct from text/search which
+  // also match note content.
   describe('name filter transformation', () => {
-    it('transforms name.contains to search', () => {
+    it('transforms name.contains to name + CONTAINS operator (not search)', () => {
       const result = compiler.transformFilters({ name: { contains: 'weekly' } });
-      expect(result.search).toBe('weekly');
+      expect(result.name).toBe('weekly');
+      expect(result.nameOperator).toBe('CONTAINS');
+      expect(result.search).toBeUndefined();
     });
 
-    it('transforms name.matches to search', () => {
+    it('transforms name.matches to name + MATCHES operator (not search)', () => {
       const result = compiler.transformFilters({ name: { matches: '^Q[1-4]' } });
-      expect(result.search).toBe('^Q[1-4]');
+      expect(result.name).toBe('^Q[1-4]');
+      expect(result.nameOperator).toBe('MATCHES');
+      expect(result.search).toBeUndefined();
     });
   });
 
@@ -270,6 +277,8 @@ describe('emitter parity', () => {
     { name: 'tags NOT_IN', filter: { tags: ['waiting'], tagsOperator: 'NOT_IN' } },
     { name: 'text CONTAINS', filter: { text: 'review', textOperator: 'CONTAINS' } },
     { name: 'text MATCHES', filter: { text: '^meet', textOperator: 'MATCHES' } },
+    { name: 'name CONTAINS (OMN-142)', filter: { name: 'review', nameOperator: 'CONTAINS' } },
+    { name: 'name MATCHES (OMN-142)', filter: { name: '^meet', nameOperator: 'MATCHES' } },
     { name: 'due date before', filter: { dueBefore: '2025-12-31' } },
     { name: 'due date after', filter: { dueAfter: '2025-01-01' } },
     {
@@ -404,5 +413,21 @@ describe('DATE_FILTER_DEFS data-driven date handling', () => {
     if (dateComp && dateComp.type === 'comparison') {
       expect(dateComp.operator).toBe('>');
     }
+  });
+});
+
+// =============================================================================
+// normalizeFilter defaults (OMN-142)
+// =============================================================================
+
+describe('normalizeFilter name defaults', () => {
+  it('defaults nameOperator to CONTAINS when name is set', () => {
+    const normalized = normalizeFilter({ name: 'review' });
+    expect(normalized.nameOperator).toBe('CONTAINS');
+  });
+
+  it('preserves an explicit nameOperator', () => {
+    const normalized = normalizeFilter({ name: '^review', nameOperator: 'MATCHES' });
+    expect(normalized.nameOperator).toBe('MATCHES');
   });
 });

--- a/tests/unit/contracts/ast/filter-generator.test.ts
+++ b/tests/unit/contracts/ast/filter-generator.test.ts
@@ -56,6 +56,23 @@ describe('generateFilterCode', () => {
       expect(result.predicate).toContain('task.note');
     });
 
+    it('OMN-142: name filter emits a name-only predicate (no task.note read)', () => {
+      const filter: TaskFilter = { name: 'review', nameOperator: 'CONTAINS' };
+      const result = generateFilterCode(filter, 'omnijs');
+
+      expect(result.predicate).toContain('task.name');
+      expect(result.predicate).not.toContain('task.note');
+    });
+
+    it('OMN-142: name MATCHES emits a regex test, still name only', () => {
+      const filter: TaskFilter = { name: '^review', nameOperator: 'MATCHES' };
+      const result = generateFilterCode(filter, 'omnijs');
+
+      expect(result.predicate).toContain('task.name');
+      expect(result.predicate).toContain('test');
+      expect(result.predicate).not.toContain('task.note');
+    });
+
     it('OMN-114: parentTaskId emits a null-guarded parent id comparison', () => {
       const filter: TaskFilter = { parentTaskId: 'abc123' };
       const result = generateFilterCode(filter, 'omnijs');

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -6,6 +6,7 @@ import {
   buildRecurringTasksScript,
   buildTaskCountScript,
   buildFilteredProjectsScript,
+  buildExportTasksScript,
   MINIMAL_FIELDS,
   DETAIL_FIELDS,
   DEFAULT_FIELDS,
@@ -1000,5 +1001,22 @@ describe('buildFilteredTasksScript preamble and warning injection', () => {
     const result = buildFilteredTasksScript(filter, { limit: 10 });
     expect(result.script).not.toContain('__warnings');
     expect(result.script).not.toContain('__duplicateProjects');
+  });
+});
+
+// OMN-142: the export path threads `name` through ExportFilter as a
+// name-scoped predicate; only `search` (the documented full-text param)
+// may read task.note.
+describe('buildExportTasksScript name filter (OMN-142)', () => {
+  it('name filter emits a name-only predicate (no note comparison)', () => {
+    const { script } = buildExportTasksScript({ name: 'XYZPROBE', nameOperator: 'CONTAINS' });
+    expect(script).toMatch(/task\.name[^\n]*XYZPROBE/);
+    expect(script).not.toMatch(/task\.note[^\n]*XYZPROBE/);
+  });
+
+  it('search filter still matches both name and note', () => {
+    const { script } = buildExportTasksScript({ search: 'XYZPROBE' });
+    expect(script).toMatch(/task\.name[^\n]*XYZPROBE/);
+    expect(script).toMatch(/task\.note[^\n]*XYZPROBE/);
   });
 });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -361,6 +361,35 @@ describe('OmniFocusReadTool', () => {
       expect(result.summary).toBeUndefined();
     });
 
+    // OMN-142: a projects name filter must compile to a name-only predicate.
+    // The old path routed name → search → ProjectFilter.text, which also
+    // matched project NOTE content.
+    it('OMN-142: name filter generates a name-only project predicate (no note match)', async () => {
+      execJsonSpy.mockResolvedValueOnce(projectsPayload satisfies ScriptResult);
+
+      await tool.execute({
+        query: { type: 'projects', filters: { name: { contains: 'OmniFocus' } } },
+      });
+
+      const script = execJsonSpy.mock.calls[0][0] as string;
+      expect(script).toMatch(/project\.name[^\n]*omnifocus/i);
+      expect(script).not.toMatch(/project\.note[^\n]*omnifocus/i);
+    });
+
+    // OMN-142 adjacent guard: filters.text on projects keeps full-text
+    // semantics (name OR note).
+    it('OMN-142: text filter still matches project notes', async () => {
+      execJsonSpy.mockResolvedValueOnce(projectsPayload satisfies ScriptResult);
+
+      await tool.execute({
+        query: { type: 'projects', filters: { text: { contains: 'OmniFocus' } } },
+      });
+
+      const script = execJsonSpy.mock.calls[0][0] as string;
+      expect(script).toMatch(/project\.name[^\n]*omnifocus/i);
+      expect(script).toMatch(/project\.note[^\n]*omnifocus/i);
+    });
+
     it('strips summary when id filter is present (lookup-by-id)', async () => {
       execJsonSpy.mockResolvedValueOnce(projectsPayload satisfies ScriptResult);
 

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -728,15 +728,31 @@ describe('QueryCompiler', () => {
       });
     });
 
-    describe('name filter transformation', () => {
-      it('name.contains routes to result.search', () => {
+    // OMN-142: `name` must compile to a name-scoped filter, never the legacy
+    // `search` field — `search` matches note content too, and that over-match
+    // collaterally deleted a real user task on 2026-06-09.
+    describe('name filter transformation (OMN-142)', () => {
+      it('name.contains compiles to name + CONTAINS, not search', () => {
         const result = compiler.transformFilters({ name: { contains: 'Quarterly' } });
-        expect(result.search).toBe('Quarterly');
+        expect(result.name).toBe('Quarterly');
+        expect(result.nameOperator).toBe('CONTAINS');
+        expect(result.search).toBeUndefined();
       });
 
-      it('name.matches also routes to result.search (no separate operator)', () => {
+      it('name.matches compiles to name + MATCHES (regex no longer degrades to substring)', () => {
         const result = compiler.transformFilters({ name: { matches: 'Review.*' } });
-        expect(result.search).toBe('Review.*');
+        expect(result.name).toBe('Review.*');
+        expect(result.nameOperator).toBe('MATCHES');
+        expect(result.search).toBeUndefined();
+      });
+
+      it('name and text filters coexist — neither silently drops the other', () => {
+        const result = compiler.transformFilters({
+          name: { contains: 'Alpha' },
+          text: { contains: 'Beta' },
+        });
+        expect(result.name).toBe('Alpha');
+        expect(result.text).toBe('Beta');
       });
     });
 


### PR DESCRIPTION
## Bug (data-loss class)

`omnifocus_read` with `filters: { name: { contains: "X" } }` returned tasks whose **note** contains X even when the **name** does not. A deletion sweep keyed on `name contains 'OMN-138'` collaterally deleted a real user task whose note cited OMN-138 (2026-06-09; restored from the OF transaction snapshot).

## Root cause

`name` had no internal representation: `QueryCompiler` compiled it onto the legacy `search` field, and every consumer of `search` (tasks AST builder, projects path, export path) implements name-OR-note matching. The documented name/text distinction evaporated at the first compile step. Riders: `name: {matches}` silently degraded regex→substring (no operator set), and `name`+`text` together silently dropped `name` (`f.text ?? f.search`).

## Fix

`name`/`nameOperator` threaded end to end as a name-scoped filter:

- **Contracts** — `TaskFilter` + `ProjectFilter` gain `name`/`nameOperator`; whitelists + `normalizeFilter` default
- **Compiler** — `name.contains`/`name.matches` → name-scoped fields with proper CONTAINS/MATCHES operator
- **Tasks** — new name-only `FilterDef`; composes with `text` via AND
- **Projects** — name-only codegen via shared `projectTextCondition()` (JSON.stringify injection, regex via `RegExp` test). Also fixes: `filters.text` was silently **dropped** on projects queries (the tool's own error message recommends it) — required here because the buggy name filter was accidentally the only full-text path for projects
- **Export** — `name` threads through `ExportFilter` name-scoped; `search` keeps legacy full-text semantics
- **OMN-19 heuristic** — `isNarrowLookup` keys off `name` (existing behavior preserved)

`search` is untouched as the legacy full-text alias; `text` semantics unchanged.

## Testing

- Unit: 2625 passed (the two tests that **pinned the buggy alias** now assert the name-scoped contract)
- Integration vs real OmniFocus: 137 passed — new `name-filter-scope.test.ts` creates name-marker vs note-marker tasks AND projects, asserts `name.contains` hits only the name-marker record and `text.contains` hits both (the ticket's exact repro shape)

Closes OMN-142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)