### PR TITLE
fix(OMN-149): matches emitter escapes the pattern via RegExp constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Task-side `{ matches }` regex patterns may contain `/` and can no longer inject code** (OMN-149) — The AST emitter's
+  `matches` case interpolated the user pattern raw into a regex _literal_ (`/pattern/i`), so any in-contract pattern
+  containing `/` (e.g. `OMN/142`) produced a syntax-broken script and a crafted pattern could break out of the literal
+  into executable OmniJS. The pattern now crosses into generated code only as a JSON string literal via the `RegExp`
+  constructor — same form the project side already used — unifying `{ matches }` behavior across tasks and projects.
+  Invalid regex patterns now fail loudly at predicate construction. Found by the OMN-142 pre-merge review (the
+  name-filter fix made the path newly reachable via `name: { matches }`; it was always reachable via
+  `text: { matches }`).
 - **`filters.name` no longer matches note content** (OMN-142) — The `name` filter compiled onto the legacy `search`
   field, whose every consumer (tasks, projects, export) implements name-OR-note matching — so a task whose _note_ cited
   a term matched a "name" search for it. That over-match fed a deletion sweep that collaterally deleted a real user task

--- a/src/contracts/ast/emitters/omnijs.ts
+++ b/src/contracts/ast/emitters/omnijs.ts
@@ -126,7 +126,12 @@ export function emitOmniJS(ast: FilterNode): EmitResult {
         break;
 
       case 'matches':
-        predicate = `/${String(value)}/i.test(${accessor})`;
+        // OMN-149: the pattern crosses into generated code ONLY as a JSON
+        // string literal. A regex literal (`/${pattern}/i`) raw-interpolates
+        // user data — a pattern containing `/` breaks the script, and a
+        // crafted pattern can inject code into the predicate. Matches the
+        // project-side projectTextCondition() form.
+        predicate = `new RegExp(${JSON.stringify(String(value))}, 'i').test(${accessor})`;
         break;
 
       case 'some':

--- a/tests/integration/name-filter-scope.test.ts
+++ b/tests/integration/name-filter-scope.test.ts
@@ -47,9 +47,13 @@ d('OMN-142: name filter is name-scoped (never matches notes)', () => {
   // are exactly the probe records.
   const TASK_MARKER = `XYZNAMESCOPE${RUN_ID.replace(/[^a-z0-9]/gi, '')}`;
   const PROJECT_MARKER = `XYZPROJSCOPE${RUN_ID.replace(/[^a-z0-9]/gi, '')}`;
+  // OMN-149: marker containing "/" — the old matches emitter raw-interpolated
+  // the pattern into a regex literal, so any "/" broke the generated script.
+  const SLASH_MARKER = `XYZSLASH${RUN_ID.replace(/[^a-z0-9]/gi, '')}/probe`;
 
   let nameTaskId: string;
   let noteTaskId: string;
+  let slashTaskId: string;
   let nameProjectId: string;
   let noteProjectId: string;
 
@@ -95,6 +99,16 @@ d('OMN-142: name filter is name-scoped (never matches notes)', () => {
           },
           {
             operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'slashTask',
+              name: runScopedName(`NameScope_${SLASH_MARKER}`),
+              note: 'bland note',
+              parentTempId: 'holder',
+            },
+          },
+          {
+            operation: 'create',
             target: 'project',
             data: {
               tempId: 'nameProject',
@@ -125,10 +139,12 @@ d('OMN-142: name filter is name-scoped (never matches notes)', () => {
     const mapping = response.data.tempIdMapping ?? {};
     nameTaskId = mapping['nameTask'];
     noteTaskId = mapping['noteTask'];
+    slashTaskId = mapping['slashTask'];
     nameProjectId = mapping['nameProject'];
     noteProjectId = mapping['noteProject'];
     expect(nameTaskId).toBeTruthy();
     expect(noteTaskId).toBeTruthy();
+    expect(slashTaskId).toBeTruthy();
     expect(nameProjectId).toBeTruthy();
     expect(noteProjectId).toBeTruthy();
   }, 120000);
@@ -158,6 +174,19 @@ d('OMN-142: name filter is name-scoped (never matches notes)', () => {
     const ids = (result.data?.tasks ?? []).map((t) => t.id);
     expect(ids).toContain(nameTaskId);
     expect(ids).toContain(noteTaskId);
+  }, 60000);
+
+  // OMN-149: a "/" in the pattern used to produce a syntax-broken script
+  // (regex-literal interpolation). Must now match as a real regex.
+  it('tasks: name.matches with a "/" in the pattern works (OMN-149)', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { name: { matches: SLASH_MARKER } }, limit: 50 },
+    })) as TasksReadResponse;
+
+    expect(result.success).toBe(true);
+    const ids = (result.data?.tasks ?? []).map((t) => t.id);
+    expect(ids).toContain(slashTaskId);
+    expect(ids).not.toContain(noteTaskId);
   }, 60000);
 
   it('projects: name.contains matches the name-marker project and NOT the note-marker project', async () => {

--- a/tests/unit/contracts/ast/emitters/omnijs.test.ts
+++ b/tests/unit/contracts/ast/emitters/omnijs.test.ts
@@ -79,7 +79,7 @@ describe('emitOmniJS', () => {
       expectPredicate(code, 'task.name.toLowerCase().includes("review".toLowerCase())');
     });
 
-    it('emits regex match for matches operator', () => {
+    it('emits regex match via RegExp constructor (OMN-149: pattern is JSON-escaped, never a raw literal)', () => {
       const ast: FilterNode = {
         type: 'comparison',
         field: 'task.name',
@@ -87,7 +87,7 @@ describe('emitOmniJS', () => {
         value: '^review.*',
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, '/^review.*/i.test(task.name)');
+      expectPredicate(code, 'new RegExp("^review.*", \'i\').test(task.name)');
     });
 
     it('emits project ID check', () => {
@@ -410,7 +410,7 @@ describe('emitOmniJS', () => {
       expectPredicate(code, 'task.note.toLowerCase().includes("important".toLowerCase())');
     });
 
-    it('emits regex match for note field', () => {
+    it('emits regex match for note field via RegExp constructor (OMN-149)', () => {
       const ast: FilterNode = {
         type: 'comparison',
         field: 'task.note',
@@ -418,7 +418,52 @@ describe('emitOmniJS', () => {
         value: '\\d+-note',
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, '/\\d+-note/i.test(task.note)');
+      expectPredicate(code, 'new RegExp("\\\\d+-note", \'i\').test(task.note)');
+    });
+  });
+
+  // OMN-149: the old emitter raw-interpolated the user pattern into a regex
+  // LITERAL (`/${pattern}/i`), so any pattern containing `/` produced a
+  // syntax-broken script, and a crafted pattern could break out of the
+  // literal and inject arbitrary OmniJS into the predicate. The RegExp
+  // constructor form injects the pattern via JSON.stringify only.
+  describe('matches operator regex safety (OMN-149)', () => {
+    function emitMatches(field: string, pattern: string) {
+      const ast: FilterNode = { type: 'comparison', field, operator: 'matches', value: pattern };
+      return emitOmniJS(ast);
+    }
+
+    // The emitted predicate is plain JS over a `task` object — execute it
+    // directly so the tests pin behavior, not just string shape.
+    function evalPredicate(result: ReturnType<typeof emitOmniJS>, task: Record<string, unknown>): boolean {
+      expect(result.preamble).toBe('');
+      return new Function('task', `return ${result.predicate};`)(task) as boolean;
+    }
+
+    it('pattern containing "/" compiles and matches (was: syntax-broken script)', () => {
+      const code = emitMatches('task.name', 'OMN/142');
+      expect(evalPredicate(code, { name: 'fix OMN/142 today' })).toBe(true);
+      expect(evalPredicate(code, { name: 'unrelated task' })).toBe(false);
+    });
+
+    it('code-shaped pattern stays an inert JSON string literal in the predicate', () => {
+      const payload = 'x/i.test("x") || true || /y';
+      const code = emitMatches('task.name', payload);
+      // The payload may appear ONLY as the JSON-stringified RegExp argument —
+      // never as executable code outside the string literal.
+      expect(code.predicate).toBe(`new RegExp(${JSON.stringify(payload)}, 'i').test(task.name)`);
+    });
+
+    it('matching stays case-insensitive through the constructor form', () => {
+      const code = emitMatches('task.name', '^review');
+      expect(evalPredicate(code, { name: 'REVIEWING the quarter' })).toBe(true);
+    });
+
+    it('an invalid regex pattern fails loudly at predicate construction, not silently', () => {
+      const code = emitMatches('task.name', '(unclosed');
+      // new RegExp('(unclosed') throws SyntaxError when the predicate runs —
+      // a loud script error, not a silent match-nothing or match-all.
+      expect(() => evalPredicate(code, { name: 'anything' })).toThrow();
     });
   });
 


### PR DESCRIPTION
## Bug

The AST emitter's `matches` case raw-interpolated the user pattern into a regex **literal** (`/${pattern}/i.test(...)`):

1. **Loud breakage on in-contract input** — any pattern containing `/` (e.g. `OMN/142`) produced a syntax-broken script on tasks, while the identical filter worked on projects (which already use the constructor form). Inconsistent semantics for the same advertised `{ matches }` operator.
2. **Injection seam** — a crafted pattern could break out of the regex literal into executable OmniJS, violating the repo's no-raw-user-data rule for generated code.

Pre-existing for `text: { matches }`; OMN-142 made it newly reachable via `name: { matches }`. Found by the OMN-142 pre-merge review gate (PR #84).

## Fix

One line: the pattern crosses into generated code only as a JSON string literal —

```js
new RegExp(${JSON.stringify(String(value))}, 'i').test(${accessor})
```

matching the project-side `projectTextCondition()` form. Invalid regex patterns now fail loudly at predicate construction instead of silently.

## Testing

- Unit (2629 passed): emitter tests now **execute** the generated predicate via `new Function` rather than string-matching it — `OMN/142` compiles and discriminates match/non-match, case-insensitivity survives the constructor form, `(unclosed` throws loudly, and a code-shaped payload is pinned structurally as an inert JSON literal (evaluation-based containment checks are unreliable here: `||` payloads contain regex alternation whose empty alternative matches everything)
- Integration vs real OmniFocus (138 passed): new live probe creates a task with `/` in its name and matches it via `name: { matches }` — the exact query shape that previously returned SCRIPT_ERROR

Closes OMN-149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)