### PR TITLE
fix(OMN-131): unsupported NOT filters reject instead of matching everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Unsupported NOT filters reject instead of silently returning ALL tasks** (OMN-131) — `transformLogicalOperator`
+  special-cased only `NOT: { status: 'completed' | 'active' }`; every other NOT payload (e.g. `NOT: { tags: ... }`)
+  logged a console warning and compiled to an _empty_ filter — the query silently matched the whole database, with no
+  diagnostic visible to the caller. Unsupported payloads now throw a validation error (VALIDATION_ERROR in the failure
+  log, InvalidParams over MCP) whose message names the working alternatives: tag exclusion → `tags: { none: [...] }`,
+  flag exclusion → `flagged: false`. Rider fixed: a multi-key NOT (e.g. `{ status: 'completed', flagged: true }`) used
+  to take the status special-case and silently drop the other keys — it now rejects too. The supported status inversions
+  are unchanged.
 - **Task-side `{ matches }` regex patterns may contain `/` and can no longer inject code** (OMN-149) — The AST emitter's
   `matches` case interpolated the user pattern raw into a regex _literal_ (`/pattern/i`), so any in-contract pattern
   containing `/` (e.g. `OMN/142`) produced a syntax-broken script and a crafted pattern could break out of the literal

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -183,7 +183,7 @@ FILTER OPERATORS:
 - name: { contains: "..." }, { matches: "regex" } — name ONLY (never matches note content)
 - boolean: flagged, blocked, available, inInbox
 - folder (projects queries): "<name>" matches folder-name substring; null = top-level projects only (no containing folder)
-- logic: { OR: [...] }, { AND: [...] }, { NOT: {...} }
+- logic: { OR: [...] }, { AND: [...] }; NOT supports ONLY { status: "completed" } or { status: "active" } — anything else is rejected. For tag exclusion use tags: { none: [...] }; for flag exclusion use flagged: false
 
 RESPONSE CONTROL:
 - Default returns minimal fields (id, name, flagged, completed, dueDate, deferDate, tags, project, available)

--- a/src/tools/unified/compilers/QueryCompiler.ts
+++ b/src/tools/unified/compilers/QueryCompiler.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { ReadInput, FilterValue, FlatFilterValue } from '../schemas/read-schema.js';
 import type { TaskFilter, NormalizedTaskFilter, ProjectStatus } from '../../../contracts/filters.js';
 import type { SortableField } from '../../../contracts/ast/script-builder.js';
@@ -170,10 +171,29 @@ export class QueryCompiler {
 
     if (input.NOT) {
       const notFilter = input.NOT as FlatQueryFilter;
-      if (notFilter.status === 'completed') return { completed: false };
-      if (notFilter.status === 'active') return { completed: true };
-      console.warn('[QueryCompiler] Complex NOT operator simplified. Original: ' + JSON.stringify(notFilter));
-      return {};
+      // The status special-case applies only when status is the SOLE key —
+      // otherwise the other keys would be silently dropped (OMN-131 rider).
+      if (Object.keys(notFilter).length === 1) {
+        if (notFilter.status === 'completed') return { completed: false };
+        if (notFilter.status === 'active') return { completed: true };
+      }
+      // OMN-131: every other NOT payload used to warn + return {} — an EMPTY
+      // filter, i.e. the query silently matched EVERYTHING. A caller that
+      // trusts the result set (e.g. a destructive sweep) gets the whole
+      // database. Reject loudly instead; a ZodError surfaces as
+      // VALIDATION_ERROR in the failure log and InvalidParams over MCP.
+      throw new z.ZodError([
+        {
+          code: z.ZodIssueCode.custom,
+          path: ['query', 'filters', 'NOT'],
+          message:
+            `Unsupported NOT filter: ${JSON.stringify(notFilter)}. ` +
+            "NOT supports exactly { status: 'completed' } or { status: 'active' }. " +
+            'Alternatives: tag exclusion → tags: { none: [...] }; ' +
+            'flagged exclusion → flagged: false; ' +
+            'otherwise express the condition directly without NOT.',
+        },
+      ]);
     }
 
     return null;

--- a/tests/integration/not-filter-rejection.test.ts
+++ b/tests/integration/not-filter-rejection.test.ts
@@ -1,0 +1,55 @@
+/**
+ * OMN-131 regression: unsupported NOT filters must REJECT, not silently
+ * return all tasks.
+ *
+ * The bug: `transformLogicalOperator` special-cased only NOT:{status:
+ * 'completed'|'active'}; every other NOT payload warned to the console and
+ * compiled to an EMPTY filter — so `NOT:{tags:[...]}` returned the whole
+ * database with no diagnostic. The caller trusted a silently-wrong result
+ * set (the same failure class as OMN-142's name/note over-match).
+ *
+ * Contract under test, end to end through the MCP protocol:
+ * - unsupported NOT payloads produce an InvalidParams tool error
+ * - the supported status inversions keep working
+ *
+ * Read-only — no fixtures, no sandbox, no cleanup.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getSharedClient } from './helpers/shared-server.js';
+import { MCPTestClient } from './helpers/mcp-test-client.js';
+
+const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
+const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
+
+d('OMN-131: unsupported NOT filters reject (no silent match-all)', () => {
+  let client: MCPTestClient;
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+  });
+
+  it('NOT:{tags:{any}} returns a validation error instead of ALL tasks', async () => {
+    await expect(
+      client.callTool('omnifocus_read', {
+        query: { type: 'tasks', filters: { NOT: { tags: { any: ['__test-omn131-nonexistent'] } } }, limit: 5 },
+      }),
+    ).rejects.toThrow(/NOT/);
+  }, 30000);
+
+  it('NOT:{flagged:true} returns a validation error naming the alternative', async () => {
+    await expect(
+      client.callTool('omnifocus_read', {
+        query: { type: 'tasks', filters: { NOT: { flagged: true } }, limit: 5 },
+      }),
+    ).rejects.toThrow(/flagged/);
+  }, 30000);
+
+  it("NOT:{status:'completed'} still compiles and succeeds", async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { NOT: { status: 'completed' } }, limit: 1, countOnly: true },
+    })) as { success: boolean };
+
+    expect(result.success).toBe(true);
+  }, 60000);
+});

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -361,6 +361,18 @@ describe('OmniFocusReadTool', () => {
       expect(result.summary).toBeUndefined();
     });
 
+    // OMN-131: an unsupported NOT payload used to compile to an EMPTY filter —
+    // the query silently returned ALL tasks. It must reject before any script
+    // reaches OmniFocus.
+    it('OMN-131: NOT:{tags:{any}} rejects with InvalidParams instead of matching everything', async () => {
+      await expect(
+        tool.execute({
+          query: { type: 'tasks', filters: { NOT: { tags: { any: ['someday'] } } } },
+        }),
+      ).rejects.toThrow(/Invalid parameters/);
+      expect(execJsonSpy).not.toHaveBeenCalled();
+    });
+
     // OMN-142: a projects name filter must compile to a name-only predicate.
     // The old path routed name → search → ProjectFilter.text, which also
     // matched project NOTE content.

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
 import { QueryCompiler } from '../../../../../src/tools/unified/compilers/QueryCompiler.js';
 import { isNormalizedFilter } from '../../../../../src/contracts/filters.js';
 import type { ReadInput } from '../../../../../src/tools/unified/schemas/read-schema.js';
@@ -686,32 +687,49 @@ describe('QueryCompiler', () => {
       });
     });
 
-    describe('NOT operator — non-status branches simplify to {} + warn', () => {
-      it('NOT: { flagged: true } returns {} and warns', () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const result = compiler.transformFilters({ NOT: { flagged: true } });
-        expect(result).toEqual({});
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Complex NOT operator simplified'));
-        warnSpy.mockRestore();
+    // OMN-131: unsupported NOT payloads used to warn + return {} — an EMPTY
+    // filter, i.e. match-everything. Silent wrong results are worse than an
+    // error, so they now throw a validation error with actionable
+    // alternatives instead.
+    describe('NOT operator — unsupported payloads reject loudly (OMN-131)', () => {
+      it('NOT: { flagged: true } throws, naming flagged: false as the alternative', () => {
+        expect(() => compiler.transformFilters({ NOT: { flagged: true } })).toThrowError(/flagged: false/);
       });
 
-      it('NOT with a date filter returns {} and warns', () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const result = compiler.transformFilters({ NOT: { dueDate: { before: '2026-12-31' } } });
-        expect(result).toEqual({});
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Complex NOT operator simplified'));
-        warnSpy.mockRestore();
+      it('NOT with a date filter throws a validation error', () => {
+        expect(() => compiler.transformFilters({ NOT: { dueDate: { before: '2026-12-31' } } })).toThrowError(/NOT/);
       });
 
-      it('NOT with a tag filter returns {} and warns', () => {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const result = compiler.transformFilters({ NOT: { tags: { any: ['@home'] } } });
-        expect(result).toEqual({});
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Complex NOT operator simplified'));
-        warnSpy.mockRestore();
+      it('NOT with a tag filter throws, naming tags: { none } as the alternative', () => {
+        expect(() => compiler.transformFilters({ NOT: { tags: { any: ['@home'] } } })).toThrowError(/none/);
       });
 
-      it("NOT: { status: 'active' } inverts to completed:true (no warn)", () => {
+      it('the thrown error is a ZodError (surfaces as VALIDATION_ERROR / InvalidParams)', () => {
+        try {
+          compiler.transformFilters({ NOT: { tags: { any: ['@home'] } } });
+          expect.unreachable('should have thrown');
+        } catch (e) {
+          expect(e).toBeInstanceOf(z.ZodError);
+          const issue = (e as z.ZodError).issues[0];
+          expect(issue.path).toEqual(['query', 'filters', 'NOT']);
+        }
+      });
+
+      it('multi-key NOT throws even when status is present (no silent key drop)', () => {
+        // Previously NOT:{status:'completed', flagged:true} took the status
+        // special-case and silently DROPPED the flagged key.
+        expect(() => compiler.transformFilters({ NOT: { status: 'completed', flagged: true } })).toThrowError(/NOT/);
+      });
+
+      it('empty NOT: {} throws instead of silently matching everything', () => {
+        expect(() => compiler.transformFilters({ NOT: {} })).toThrowError(/NOT/);
+      });
+
+      it("NOT: { status: 'dropped' } throws (only completed/active invert cleanly)", () => {
+        expect(() => compiler.transformFilters({ NOT: { status: 'dropped' } })).toThrowError(/NOT/);
+      });
+
+      it("NOT: { status: 'active' } still inverts to completed:true (no warn, no throw)", () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const result = compiler.transformFilters({ NOT: { status: 'active' } });
         expect(result.completed).toBe(true);


### PR DESCRIPTION
## Bug (silent wrong-results class, P2)

`transformLogicalOperator` special-cased only `NOT: { status: 'completed' | 'active' }`. Every other NOT payload — e.g. `NOT: { tags: { any: ['someday'] } }` — logged a console warning and compiled to an **empty filter**: the query silently returned ALL tasks. A caller that trusts the result set (a destructive sweep, a review workflow) gets the whole database with zero diagnostic.

## Fix (ticket pre-work option (a))

Unsupported NOT payloads throw a hand-built `ZodError` from the compiler. It rides the existing `handleExecuteError` ZodError branch — `VALIDATION_ERROR` in the failure log, `InvalidParams` over MCP, zero new error machinery — and the message names working alternatives (`tags: { none: [...] }`, `flagged: false`) so an LLM caller can self-correct in one step.

**Rider fixed:** the status special-case didn't require status to be the *sole* key, so `NOT: { status: 'completed', flagged: true }` silently dropped `flagged`. Now rejects unless status is the only key. Supported inversions unchanged.

**Deferred (per ticket pre-work):** option (b) clean translations (`NOT:{flagged:true}` → `flagged:false`, `NOT:{tags:{any}}` → `NOT_IN`). Rejection is uniformly safe; translation must be exactly right per shape; the failure log will now collect data on which NOT shapes callers actually attempt.

Tool description updated to state the NOT contract (no schema shape change — rejection is semantic, `filters` inputSchema stays an opaque object).

## Testing

- Unit (2634 passed): the three tests that **pinned the warn+`{}` fallback** now assert rejection with actionable messages; new coverage for the ZodError type/path, multi-key NOT, empty NOT, `NOT:{status:'dropped'}`; read-tool test asserts rejection happens **before any script reaches OmniFocus** (`execJson` never called)
- Integration vs real OmniFocus (141 passed): new `not-filter-rejection.test.ts` asserts end-to-end over the MCP protocol that unsupported NOT payloads produce a tool error and `NOT:{status:'completed'}` still succeeds

Closes OMN-131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)