### PR TITLE
fix(OMN-144): bulk_delete returns success:false when nothing was deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **A fully-failed `bulk_delete` reports top-level `success: false`** (OMN-144) — A bulk delete in which nothing was
+  deleted (e.g. the whole dispatch was refused by the sandbox guard, or every item failed) returned top-level
+  `success: true` with `successCount: 0` and the failures buried in `data.errors[]` — while the identical refusal on a
+  single-op delete returned `success: false`. A client checking only `success` concluded the delete worked. Zero
+  successes with errors now return `success: false` (code `BULK_DELETE_FAILED`) with per-item detail in `error.details`;
+  partial success keeps `success: true` with loud `data.errors[]`. Rider fixed: an unrecognized bulk script result shape
+  used to yield a `0 deleted / 0 errors` "success" that reported nothing at all — it is now a loud error. Project bulk
+  deletes also carry the real per-item failure message instead of a constant `Delete failed`.
 - **Unsupported NOT filters reject instead of silently returning ALL tasks** (OMN-131) — `transformLogicalOperator`
   special-cased only `NOT: { status: 'completed' | 'active' }`; every other NOT payload (e.g. `NOT: { tags: ... }`)
   logged a console warning and compiled to an _empty_ filter — the query silently matched the whole database, with no

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1004,8 +1004,7 @@ SAFETY:
       }
     }
 
-    return createSuccessResponseV2(
-      'omnifocus_write',
+    return this.bulkDeleteEnvelope(
       {
         operation: 'bulk_delete',
         successCount: deleteResults.length,
@@ -1013,8 +1012,7 @@ SAFETY:
         results: deleteResults,
         errors: deleteErrors.length > 0 ? deleteErrors : undefined,
       },
-      undefined,
-      timer.toMetadata(),
+      timer,
     );
   }
 
@@ -1044,13 +1042,54 @@ SAFETY:
       errors.push({ error: String(error) });
     }
 
-    const responseData = {
-      operation: 'bulk_delete',
-      successCount: results.length,
-      errorCount: errors.length,
-      results,
-      errors: errors.length > 0 ? errors : undefined,
-    };
+    // ids is schema-guaranteed non-empty, so a script result that reported
+    // neither deletes nor errors is an unrecognized shape — make it loud
+    // instead of returning a 0/0 "success" that says nothing happened.
+    if (results.length === 0 && errors.length === 0) {
+      errors.push({ error: 'Bulk delete script returned no per-item results (unrecognized result shape)' });
+    }
+
+    return this.bulkDeleteEnvelope(
+      {
+        operation: 'bulk_delete',
+        successCount: results.length,
+        errorCount: errors.length,
+        results,
+        errors: errors.length > 0 ? errors : undefined,
+      },
+      timer,
+    );
+  }
+
+  /**
+   * Wrap a bulk delete outcome in the honest envelope (OMN-144): zero
+   * successes with any errors is a top-level failure — matching the
+   * single-op envelope for the same refusal — while partial success stays
+   * success:true with loud errors[] (OMN-137 contract). Per-item detail
+   * rides error.details either way.
+   */
+  private bulkDeleteEnvelope(
+    responseData: {
+      operation: 'bulk_delete';
+      successCount: number;
+      errorCount: number;
+      results: unknown[];
+      errors?: unknown[];
+    },
+    timer: OperationTimerV2,
+  ): unknown {
+    if (responseData.successCount === 0 && responseData.errorCount > 0) {
+      const first = (responseData.errors?.[0] ?? {}) as { error?: unknown };
+      const firstText = typeof first.error === 'string' ? first.error : JSON.stringify(first);
+      return createErrorResponseV2(
+        'omnifocus_write',
+        'BULK_DELETE_FAILED',
+        `Bulk delete failed: 0 deleted, ${responseData.errorCount} error(s). First error: ${firstText}`,
+        'No items were deleted. Check error.details.errors for per-item failures, verify the ids, and retry.',
+        responseData,
+        timer.toMetadata(),
+      );
+    }
 
     return createSuccessResponseV2('omnifocus_write', responseData, undefined, timer.toMetadata());
   }

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -991,13 +991,16 @@ SAFETY:
 
     for (const id of ids) {
       try {
-        const deleteResult = await this.handleProjectDelete(id);
-        const success =
-          deleteResult && typeof deleteResult === 'object' && (deleteResult as { success?: boolean }).success;
-        if (success) {
+        const deleteResult = (await this.handleProjectDelete(id)) as {
+          success?: boolean;
+          error?: { message?: string };
+        } | null;
+        if (deleteResult && typeof deleteResult === 'object' && deleteResult.success) {
           deleteResults.push({ projectId: id, status: 'deleted' });
         } else {
-          deleteErrors.push({ projectId: id, error: 'Delete failed' });
+          // Carry the real per-item failure message, not a constant that
+          // discards it — the bulk envelope surfaces the first one top-level.
+          deleteErrors.push({ projectId: id, error: deleteResult?.error?.message ?? 'Delete failed' });
         }
       } catch (err) {
         deleteErrors.push({ projectId: id, error: String(err) });

--- a/tests/integration/tools/unified/complete-delete-paths.test.ts
+++ b/tests/integration/tools/unified/complete-delete-paths.test.ts
@@ -387,12 +387,11 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
   // outer try/catch → error ends up in errors[] → ENTIRE dispatch refused
   // with successCount:0.
   //
-  // NOTE ON RESPONSE SHAPE: unlike single-op guards (which surface as
-  // success:false via createErrorResponseV2), handleBulkDeleteTasks wraps ALL
-  // errors — including the thrown guard error — in its catch block and returns
-  // success:true with data.successCount:0, data.errorCount:1, data.errors[].
-  // Documented current behavior; envelope follow-up tracked in OMN-144. The
-  // test asserts this shape.
+  // NOTE ON RESPONSE SHAPE (OMN-144): a fully-refused bulk delete now returns
+  // top-level success:false with error.code BULK_DELETE_FAILED — consistent
+  // with the single-op guard envelope for the same refusal. Per-item detail
+  // (successCount/errorCount/errors) rides error.details. Partial success
+  // remains success:true with loud data.errors[] (OMN-137 contract).
   //
   // This whole-dispatch refusal IS the OMN-120 non-bypass contract (guard must
   // cover every id before any mutation executes). The unguarded per-item
@@ -402,10 +401,11 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
   // all ids.
   //
   // The test asserts:
-  //   (a) the write response carries success:true but successCount:0, with the
-  //       TEST GUARD error text in data.errors[0].error
+  //   (a) the write response is a top-level failure (success:false,
+  //       BULK_DELETE_FAILED) with the TEST GUARD error text in the error
+  //       and per-item detail in error.details (successCount:0)
   //   (b) BOTH real task fixtures still exist (read-back succeeds for each)
-  it('bulk_delete with a bogus id in the list: guard refusal surfaced in data.errors with successCount:0; both real fixtures survive', async () => {
+  it('bulk_delete with a bogus id in the list: whole-dispatch guard refusal is a top-level failure (OMN-144); both real fixtures survive', async () => {
     const idA = await createTask({ name: BULK_TASK_A_NAME });
     const idB = await createTask({ name: BULK_TASK_B_NAME });
 
@@ -417,20 +417,23 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
       },
     });
 
-    // (a) The bulk handler wraps the guard throw in its catch block, so the
-    // top-level response is success:true with zero deletes and one error entry.
-    // The guard error text is in data.errors[0].error.
-    expect(writeRes.success, `unexpected hard failure, got: ${JSON.stringify(writeRes).slice(0, 400)}`).toBe(true);
-    const data = writeRes.data;
-    expect(data.successCount, `expected zero deletes due to guard refusal, got: ${data.successCount}`).toBe(0);
-    expect(
-      data.errorCount,
-      `expected one guard error entry, got errorCount: ${data.errorCount}`,
-    ).toBeGreaterThanOrEqual(1);
-    // The guard error text is in the errors array — not the top-level response.
-    const errText = JSON.stringify(data.errors ?? []);
-    expect(errText, `guard error text not in data.errors: ${errText}`).toContain('TEST GUARD');
+    // (a) Zero deletes + errors → top-level success:false, matching the
+    // single-op envelope for the same guard refusal (OMN-144).
+    expect(writeRes.success, `expected top-level failure, got: ${JSON.stringify(writeRes).slice(0, 400)}`).toBe(false);
+    expect(writeRes.error?.code, `expected BULK_DELETE_FAILED, got: ${writeRes.error?.code}`).toBe(
+      'BULK_DELETE_FAILED',
+    );
+    // Guard error text surfaces in the top-level error (message and/or details).
+    const errText = JSON.stringify(writeRes.error ?? {});
+    expect(errText, `guard error text not in error: ${errText.slice(0, 400)}`).toContain('TEST GUARD');
     expect(errText).toContain('outside sandbox');
+    // Per-item detail preserved in error.details.
+    const details = writeRes.error?.details as { successCount?: number; errorCount?: number };
+    expect(details?.successCount, `expected zero deletes due to guard refusal, got: ${details?.successCount}`).toBe(0);
+    expect(
+      details?.errorCount,
+      `expected one guard error entry, got errorCount: ${details?.errorCount}`,
+    ).toBeGreaterThanOrEqual(1);
 
     // (b) Both real tasks survive — guard ran before any delete script.
     const taskA = await readTaskById(idA, ['name']);

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -592,6 +592,139 @@ describe('OmniFocusWriteTool task operations', () => {
     });
   });
 
+  // ─── OMN-144: bulk_delete envelope honesty ──────────────────────────
+  //
+  // A fully-refused/failed bulk delete must report top-level success:false,
+  // matching the single-op envelope for the same refusal. Partial success
+  // stays success:true with loud errors[] (OMN-137 contract).
+
+  describe('OMN-144: bulk_delete envelope honesty (tasks)', () => {
+    it('returns success:false when the whole dispatch failed (script error, zero deletes)', async () => {
+      execJsonSpy.mockResolvedValue(createScriptError('TEST GUARD: task outside sandbox', 'bulk_delete'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'bulk_delete',
+          target: 'task',
+          ids: ['id1', 'id2'],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('BULK_DELETE_FAILED');
+      // The underlying error text must surface in the top-level error, not
+      // only in a buried per-item array.
+      expect(JSON.stringify(result.error)).toContain('TEST GUARD');
+      // Per-item detail preserved for clients that want it.
+      expect(result.error.details.successCount).toBe(0);
+      expect(result.error.details.errorCount).toBe(1);
+    });
+
+    it('returns success:false when every item failed per-item (zero deletes)', async () => {
+      execJsonSpy.mockResolvedValue(
+        createScriptSuccess({
+          deleted: [],
+          errors: [
+            { taskId: 'id1', error: 'Task not found: id1' },
+            { taskId: 'id2', error: 'Task not found: id2' },
+          ],
+        }),
+      );
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'bulk_delete',
+          target: 'task',
+          ids: ['id1', 'id2'],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('BULK_DELETE_FAILED');
+      expect(result.error.details.successCount).toBe(0);
+      expect(result.error.details.errorCount).toBe(2);
+    });
+
+    it('keeps success:true with loud errors[] on partial success (OMN-137 contract)', async () => {
+      execJsonSpy.mockResolvedValue(
+        createScriptSuccess({
+          deleted: [{ id: 'id1', name: 'Task 1' }],
+          errors: [{ taskId: 'id2', error: 'Task not found: id2' }],
+        }),
+      );
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'bulk_delete',
+          target: 'task',
+          ids: ['id1', 'id2'],
+        },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.successCount).toBe(1);
+      expect(result.data.errorCount).toBe(1);
+      expect(result.data.errors).toBeDefined();
+    });
+
+    it('rider: unrecognized script result shape is loud, not a 0/0 silent success', async () => {
+      // collectBulkDeleteResults previously early-returned on a non-object
+      // result.data, yielding successCount:0/errorCount:0 with success:true —
+      // a bulk delete that reported nothing at all.
+      execJsonSpy.mockResolvedValue(createScriptSuccess('not-an-object'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'bulk_delete',
+          target: 'task',
+          ids: ['id1', 'id2'],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('BULK_DELETE_FAILED');
+      expect(result.error.details.errorCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('OMN-144: bulk_delete envelope honesty (projects)', () => {
+    it('returns success:false when every project delete failed', async () => {
+      execJsonSpy.mockResolvedValue(createScriptError('Project not found', 'delete'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'bulk_delete',
+          target: 'project',
+          ids: ['proj-1', 'proj-2'],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('BULK_DELETE_FAILED');
+      expect(result.error.details.successCount).toBe(0);
+      expect(result.error.details.errorCount).toBe(2);
+    });
+
+    it('keeps success:true with loud errors[] on partial project success', async () => {
+      execJsonSpy
+        .mockResolvedValueOnce(createScriptSuccess({ id: 'proj-1', name: 'P1' }))
+        .mockResolvedValueOnce(createScriptError('Project not found', 'delete'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'bulk_delete',
+          target: 'project',
+          ids: ['proj-1', 'proj-2'],
+        },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.successCount).toBe(1);
+      expect(result.data.errorCount).toBe(1);
+      expect(result.data.errors).toBeDefined();
+    });
+  });
+
   // ─── PROJECT OPERATIONS (inline, no ProjectsTool) ──────────────────
 
   describe('project create', () => {

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -703,6 +703,9 @@ describe('OmniFocusWriteTool task operations', () => {
       expect(result.error.code).toBe('BULK_DELETE_FAILED');
       expect(result.error.details.successCount).toBe(0);
       expect(result.error.details.errorCount).toBe(2);
+      // The per-item error text must carry the real underlying message, not a
+      // constant 'Delete failed' that discards it.
+      expect(JSON.stringify(result.error)).toContain('Project not found');
     });
 
     it('keeps success:true with loud errors[] on partial project success', async () => {


### PR DESCRIPTION
## Summary

A fully-refused/failed bulk delete (`successCount: 0` with errors) returned top-level `success: true`, while the identical guard refusal on a single-op delete returned `success: false` (OMN-144, found by the OMN-128 slice-5 integration review).

- Both `handleBulkDeleteTasks` and `handleBulkDeleteProjects` now route their outcome through a shared `bulkDeleteEnvelope`: **zero successes + any errors → `success: false`** via `createErrorResponseV2` (code `BULK_DELETE_FAILED`), with per-item detail preserved in `error.details`.
- **Partial success is unchanged**: `success: true` with loud `data.errors[]` (OMN-137 contract), pinned by new unit tests.
- Fix shape: chose the `successCount === 0 && errorCount > 0` condition over re-raising the guard throw, because it also covers the all-items-failed-per-item case in production mode (no throw to re-raise) — same envelope honesty, broader coverage.

## Rider (selection-honesty cluster rule, now 4-for-4)

`collectBulkDeleteResults` silently early-returned on an unrecognized script result shape, yielding `successCount: 0, errorCount: 0, success: true` — a bulk delete that reported nothing at all as success. Since `ids` is schema-guaranteed `.min(1)`, a no-per-item-results outcome is provably anomalous and is now a loud error (which the new envelope then turns into a top-level failure).

## Client-visible change

Response envelope only; input schema and tool description are unchanged (the description does not document envelope shapes). Clients checking only top-level `success` on bulk_delete will now correctly see failures they previously read as success.

## Tests

- 6 new unit tests (all-failed via script error, all-failed per-item, partial-success pin ×2, unrecognized-shape rider, project all-failed) — TDD, watched fail first
- Integration pin updated: `complete-delete-paths.test.ts` bulk mixed-ids test now asserts the top-level failure envelope (the ticket's "update that test when fixing")
- `npm run test:unit`: 2640 passed
- `npm run build`: clean
- Integration `complete-delete-paths.test.ts` against live guarded OmniFocus: 9/9 passed

Closes OMN-144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)