### PR TITLE
fix(OMN-141): batch stopOnError/rollback failures keep per-item results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Batch `stopOnError`/atomic-rollback failures keep per-item results** (OMN-141) — A batch create halted by
+  `stopOnError: true` (or undone by `atomicOperation` rollback) returned a single degenerate row
+  `{ operation: "unknown", id: "unknown", error: "undefined" }` instead of the per-item rows — which item succeeded,
+  which failed, and the real error message were all lost (summary counts and `tempIdMapping` were correct). Per-item
+  rows now survive in `results`, with rolled-back creates re-marked `success: false` ("Created, then rolled back")
+  rather than reported as surviving; the halt/rollback itself appears as one compact phase-level error row. Phase-level
+  error rows now carry `id: null` instead of the string `"unknown"`.
 - **A fully-failed `bulk_delete` reports top-level `success: false`** (OMN-144) — A bulk delete in which nothing was
   deleted (e.g. the whole dispatch was refused by the sandbox guard, or every item failed) returned top-level
   `success: true` with `successCount: 0` and the failures buried in `data.errors[]` — while the identical refusal on a

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1621,11 +1621,30 @@ SAFETY:
         stopOnError: compiled.stopOnError ?? true,
       });
 
+      // OMN-141: per-item rows always flatten from the created bucket — pushing
+      // the whole createResult envelope into errors degraded every row to
+      // operation:'unknown'/error:'undefined'. The halt/rollback itself is a
+      // compact phase-level error; errors[] is reserved for that shape.
       if (createResult.success === false && createResult.rolledBack) {
-        results.errors.push(createResult);
+        // Successes were undone by the rollback — mark them so the flattened
+        // rows don't claim surviving creates.
+        results.created.push({
+          ...createResult,
+          results: createResult.results.map((r) =>
+            r.success ? { ...r, success: false, error: 'Created, then rolled back (atomicOperation)' } : r,
+          ),
+        });
+        results.errors.push({
+          phase: 'create',
+          error: `Atomic batch rolled back: ${createResult.failed} of ${createResult.totalItems} creates failed; all created items were removed`,
+        });
         if (compiled.stopOnError) hadError = true;
       } else if (createResult.failed > 0 && compiled.stopOnError) {
-        results.errors.push(createResult);
+        results.created.push(createResult);
+        results.errors.push({
+          phase: 'create',
+          error: `${createResult.failed} of ${createResult.totalItems} creates failed; batch halted (stopOnError)`,
+        });
         hadError = true;
       } else {
         results.created.push(createResult);

--- a/src/tools/unified/batch-response-flatten.ts
+++ b/src/tools/unified/batch-response-flatten.ts
@@ -96,7 +96,9 @@ export function flattenBatchResults(results: NestedBatchResults): FlatBatchResul
     flat.push({
       operation: err.phase || 'unknown',
       success: false as const,
-      id: err.id || 'unknown',
+      // Phase-level errors (OMN-141: stopOnError halt, atomic rollback) have no
+      // item id — null is honest where the string 'unknown' was a lie.
+      id: err.id ?? null,
       error: errorMsg || 'Unknown error',
     });
   }

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -966,6 +966,113 @@ describe('OmniFocusWriteTool task operations', () => {
       taskSpy.mockRestore();
     });
 
+    it('OMN-141: stopOnError=true with a failing item keeps per-item rows (no operation:unknown degradation)', async () => {
+      const buildSpy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+        script: 'mock batch script',
+        operation: 'create',
+        target: 'task',
+        description: 'mock',
+      });
+      // Script halted after the failing second item — third row never produced.
+      execJsonSpy.mockResolvedValue({
+        success: true,
+        data: {
+          results: [
+            { tempId: 't1', taskId: 'real-1', success: true },
+            { tempId: 't2', taskId: null, success: false, error: 'Parent task not found: DOES_NOT_EXIST_123' },
+          ],
+        },
+      });
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          stopOnError: true,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            {
+              operation: 'create',
+              target: 'task',
+              data: { tempId: 't2', name: 'B', parentTaskId: 'DOES_NOT_EXIST_123' },
+            },
+            { operation: 'create', target: 'task', data: { tempId: 't3', name: 'C' } },
+          ],
+        },
+      })) as any;
+
+      // Halted batch is still an overall failure with a non-zero error count.
+      expect(result.success).toBe(false);
+      expect(result.data.summary.created).toBe(1);
+      expect(result.data.summary.errors).toBeGreaterThanOrEqual(1);
+      // tempIdMapping survives.
+      expect(result.data.tempIdMapping.t1).toBe('real-1');
+
+      const items = result.data.results as Array<Record<string, unknown>>;
+      // The per-item rows survive: which item succeeded, which failed, and why.
+      const ok = items.find((r) => r.tempId === 't1');
+      expect(ok).toMatchObject({ operation: 'create', success: true, id: 'real-1' });
+      const fail = items.find((r) => r.tempId === 't2');
+      expect(fail).toMatchObject({ operation: 'create', success: false });
+      expect(String(fail!.error)).toContain('Parent task not found');
+      // The degenerate flattening must be gone.
+      expect(items.some((r) => r.operation === 'unknown')).toBe(false);
+      expect(items.some((r) => r.error === 'undefined')).toBe(false);
+      buildSpy.mockRestore();
+    });
+
+    it('OMN-141 rider: atomic rollback keeps per-item rows, marking undone creates instead of degrading', async () => {
+      const buildSpy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+        script: 'mock batch script',
+        operation: 'create',
+        target: 'task',
+        description: 'mock',
+      });
+      // First call: the batch create script (one ok, one fail). Later calls
+      // (rollback deletes) get a generic success.
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'Parent task not found: DOES_NOT_EXIST_123' },
+            ],
+          },
+        })
+        .mockResolvedValue({ success: true, data: {} });
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: true,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            {
+              operation: 'create',
+              target: 'task',
+              data: { tempId: 't2', name: 'B', parentTaskId: 'DOES_NOT_EXIST_123' },
+            },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      const items = result.data.results as Array<Record<string, unknown>>;
+      // The rolled-back create must NOT flatten as a surviving success.
+      const undone = items.find((r) => r.tempId === 't1');
+      expect(undone).toBeDefined();
+      expect(undone!.success).toBe(false);
+      expect(String(undone!.error)).toContain('rolled back');
+      const fail = items.find((r) => r.tempId === 't2');
+      expect(String(fail!.error)).toContain('Parent task not found');
+      expect(items.some((r) => r.operation === 'unknown')).toBe(false);
+      expect(items.some((r) => r.error === 'undefined')).toBe(false);
+      buildSpy.mockRestore();
+    });
+
     it('slow path: batch task create passes repetitionRule to the builder with NO second script', async () => {
       // repetitionRule on an item forces the per-item path; the rule must ride
       // the create script itself (applyRepetitionRuleSilently is gone).

--- a/tests/unit/tools/unified/batch-response-shape.test.ts
+++ b/tests/unit/tools/unified/batch-response-shape.test.ts
@@ -163,6 +163,26 @@ describe('flattenBatchResults', () => {
     });
   });
 
+  it('OMN-141: phase-level errors without an id flatten with id:null, not the string "unknown"', () => {
+    const nestedResults = {
+      created: [],
+      updated: [],
+      completed: [],
+      deleted: [],
+      errors: [{ phase: 'create', error: '1 of 3 creates failed; batch halted (stopOnError)' }],
+    };
+
+    const flat = flattenBatchResults(nestedResults);
+
+    expect(flat).toHaveLength(1);
+    expect(flat[0]).toEqual({
+      operation: 'create',
+      success: false,
+      id: null,
+      error: '1 of 3 creates failed; batch halted (stopOnError)',
+    });
+  });
+
   it('should handle mixed operations preserving type ordering (creates, updates, completes, deletes, errors)', () => {
     const nestedResults = {
       created: [


### PR DESCRIPTION
## Summary

A batch create halted by `stopOnError: true` (or undone by `atomicOperation` rollback) returned a single degenerate row `{ operation: "unknown", id: "unknown", error: "undefined" }` instead of the per-item rows — which item succeeded, which failed, and the real error message were all lost, while `summary` and `tempIdMapping` stayed correct (OMN-141, found during the OMN-128 slice-2 live verify).

**Mechanism:** `executeBatchCreatePhase` pushed the *whole* `createResult` envelope into `results.errors`, whose flattener branch expects `{phase, id, error}` rows — every field lookup missed.

**Fix (the ticket's suggested shape):**
- Per-item rows always flatten from the `created` bucket (the data was there all along); `errors[]` is reserved for genuine phase-level failures.
- The halt/rollback itself becomes one compact phase-level error row (e.g. `"1 of 3 creates failed; batch halted (stopOnError)"`), which preserves the existing `success: false` + `summary.errors ≥ 1` envelope semantics with no change to the success computation.
- **Rollback rider** (same conditional): rolled-back successes are re-marked `success: false, error: "Created, then rolled back (atomicOperation)"` before flattening — otherwise the fix would trade "everything unknown" for "deleted items reported as surviving creates."
- Phase-level error rows flatten with `id: null` instead of the string `"unknown"` (`FlatBatchResult.id` already allowed null).

## Tests

- 2 new tool-level unit tests (TDD, watched RED): the ticket's discriminating case (stopOnError halt with failing middle item → `[ok-row, fail-row-with-message]`, no `unknown` rows) and the atomic-rollback case
- 1 new flattener unit test: id-less phase errors → `id: null`
- `npm run test:unit`: 2643 passed; `npm run build` clean
- `tests/integration/batch-operations.test.ts` against live OmniFocus: 10/10 passed

Part of the selection-honesty cluster envelope trio (OMN-144 ✅ → **OMN-141** → OMN-139).

Closes OMN-141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)