### PR TITLE
fix(OMN-163): conformance probe owns the Ollama lifecycle + measured num_ctx cap

### DIFF
--- a/scripts/lib/ollama-lifecycle.ts
+++ b/scripts/lib/ollama-lifecycle.ts
@@ -1,0 +1,56 @@
+/**
+ * Ollama lifecycle helpers for the conformance probe (OMN-163).
+ *
+ * Pure decision logic lives here so it is unit-testable; the probe script owns
+ * the process spawning/teardown that consumes these answers.
+ */
+
+import { URL } from 'node:url';
+
+const LOCALHOST_NAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+/**
+ * May the probe spawn `ollama serve` for this OLLAMA_HOST target?
+ *
+ * Localhost only — the probe never manages a remote server (e.g. the OMN-39
+ * Tailscale topology). Accepts both full URLs and the scheme-less host[:port]
+ * forms OLLAMA_HOST allows. Unparseable input fails closed (treated as remote).
+ */
+export function isLocalhostOllamaHost(host: string): boolean {
+  if (!host.trim()) return false;
+  const withScheme = host.includes('://') ? host : `http://${host}`;
+  try {
+    return LOCALHOST_NAMES.has(new URL(withScheme).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Default context window for the probe's chat requests, measured 2026-06-12
+ * (exact, via prompt_eval_count through each baseline model's own tokenizer):
+ *
+ *   - request side (system prompt + all 4 advertised tool schemas + case
+ *     prompt): ~4,350 tokens — today's single-turn probe needs nothing more,
+ *     so 16384 is ~3.7x headroom over actual use
+ *   - worst-case future multi-turn round-trip: request + the largest response
+ *     the server can return (limit:200 is truncated server-side to 100 rows,
+ *     ~36KB ≈ 9,900 tokens) = ~14,300 tokens — still fits
+ *   - RAM (llama3.1:8b resident): 16k → 7.9 GB vs 21 GB at the model's 131k
+ *     default (Ollama ≥0.24 sizes the KV cache to num_ctx); 32k would cost
+ *     11 GB to buy headroom for a multi-turn probe that does not exist yet
+ *
+ * Override via PROBE_NUM_CTX for experiments with larger payloads.
+ */
+export const DEFAULT_NUM_CTX = 16384;
+
+/** Resolve num_ctx from a PROBE_NUM_CTX-style env value; throws on garbage. */
+export function resolveNumCtx(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_NUM_CTX;
+  const trimmed = raw.trim();
+  const value = Number(trimmed);
+  if (!/^\d+$/.test(trimmed) || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`PROBE_NUM_CTX must be a positive integer, got ${JSON.stringify(raw)}`);
+  }
+  return value;
+}

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -24,11 +24,21 @@
  *   REAL_LLM_MODEL=llama3.1:8b npx tsx scripts/llm-conformance-probe.ts
  *   OLLAMA_HOST=http://host:11434 npx tsx scripts/llm-conformance-probe.ts llama3.1:8b > report.md
  *
+ * Ollama lifecycle (OMN-163): attaches to a running server when one is reachable; otherwise,
+ * for a localhost OLLAMA_HOST only, starts `ollama serve` itself and stops it at exit (an
+ * unreachable remote host is an error — the probe never manages a remote server). Probed
+ * models are unloaded at exit regardless of who started the server, so their RAM is
+ * recovered immediately instead of after Ollama's keep-alive. Chat requests cap the context
+ * window at a measured default (PROBE_NUM_CTX overrides; sizing rationale in
+ * scripts/lib/ollama-lifecycle.ts) — without the cap, Ollama sizes the KV cache to the
+ * model's full advertised context (131k for llama3.1 → 21 GB resident for the 8b).
+ *
  * Output: a Markdown conformance report to stdout (redirect to a file), progress to stderr.
  */
 
 import { spawn, type ChildProcess } from 'child_process';
 import { Ollama, type Tool, type ToolCall } from 'ollama';
+import { isLocalhostOllamaHost, resolveNumCtx } from './lib/ollama-lifecycle.js';
 import type { ZodTypeAny } from 'zod';
 import { ReadSchema } from '../src/tools/unified/schemas/read-schema.js';
 import { WriteSchema } from '../src/tools/unified/schemas/write-schema.js';
@@ -214,6 +224,74 @@ class McpServer {
   }
 }
 
+// ── Ollama lifecycle (OMN-163) ───────────────────────────────────────────────
+
+interface OllamaLifecycle {
+  startedByUs: boolean;
+  serveProc?: ChildProcess;
+}
+
+async function isReachable(ollama: Ollama): Promise<boolean> {
+  try {
+    await ollama.list();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attach to a running Ollama, or — for a localhost host only — start `ollama serve`
+ * ourselves and record that we own it. We never manage a remote server.
+ */
+async function ensureOllama(ollama: Ollama, host: string): Promise<OllamaLifecycle> {
+  if (await isReachable(ollama)) return { startedByUs: false };
+  if (!isLocalhostOllamaHost(host)) {
+    process.stderr.write(
+      `Ollama not reachable at ${host}. That host is remote, so the probe will not start it — ` +
+        'start it there and re-run.\n',
+    );
+    process.exit(2);
+  }
+  process.stderr.write('Ollama not running — starting `ollama serve` (will be stopped at exit) …\n');
+  const stderrTail: string[] = [];
+  const proc = spawn('ollama', ['serve'], { stdio: ['ignore', 'ignore', 'pipe'] });
+  proc.stderr?.on('data', (d: Buffer) => {
+    stderrTail.push(d.toString());
+    if (stderrTail.length > 20) stderrTail.shift();
+  });
+  let spawnError: Error | undefined;
+  proc.on('error', (err) => {
+    spawnError = err;
+  });
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline && !spawnError) {
+    if (await isReachable(ollama)) return { startedByUs: true, serveProc: proc };
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  proc.kill('SIGTERM');
+  const reason = spawnError
+    ? `${String(spawnError)} (is the ollama CLI installed and on PATH?)`
+    : `not ready after 15s. ollama serve output:\n${stderrTail.join('')}`;
+  process.stderr.write(`Failed to start ollama serve: ${reason}\n`);
+  process.exit(2);
+}
+
+/**
+ * Unload a model immediately (keep_alive: 0) so its RAM is recovered now rather than
+ * after Ollama's keep-alive window. Done regardless of who started the server — this is
+ * where most of the memory lives. (Deliberately NOT set per-request: that would reload
+ * the model between every case.)
+ */
+async function unloadModel(ollama: Ollama, model: string): Promise<void> {
+  try {
+    // An empty prompt with keep_alive: 0 unloads without generating.
+    await ollama.generate({ model, prompt: '', keep_alive: 0 });
+  } catch (err) {
+    process.stderr.write(`! failed to unload ${model}: ${String(err)} — it will unload after the keep-alive\n`);
+  }
+}
+
 // ── Grading ─────────────────────────────────────────────────────────────────
 
 type Outcome = 'pass' | 'no_tool_call' | 'wrong_tool' | 'schema_invalid' | 'model_error';
@@ -272,7 +350,7 @@ interface ModelReport {
   error?: string;
 }
 
-async function probeModel(ollama: Ollama, model: string, tools: Tool[]): Promise<ModelReport> {
+async function probeModel(ollama: Ollama, model: string, tools: Tool[], numCtx: number): Promise<ModelReport> {
   const results: CaseResult[] = [];
   for (const c of CASES) {
     process.stderr.write(`  [${model}] ${c.id} … `);
@@ -290,7 +368,9 @@ async function probeModel(ollama: Ollama, model: string, tools: Tool[]): Promise
         ],
         tools,
         stream: false,
-        options: { temperature: 0 },
+        // num_ctx caps the KV cache (OMN-163) — without it Ollama allocates for the
+        // model's full advertised context. Default + sizing rationale: lib/ollama-lifecycle.ts.
+        options: { temperature: 0, num_ctx: numCtx },
       });
       const call = res.message.tool_calls?.[0];
       const graded = gradeToolCall(c, call);
@@ -401,55 +481,86 @@ async function main(): Promise<void> {
   if (models.length === 0) {
     process.stderr.write(
       'Usage: npx tsx scripts/llm-conformance-probe.ts <model> [model ...]\n' +
-        '       (or set REAL_LLM_MODEL). Requires `npm run build` first and a running Ollama.\n',
+        '       (or set REAL_LLM_MODEL). Requires `npm run build` first; a localhost Ollama is\n' +
+        '       started automatically when not already running.\n',
     );
     process.exit(2);
   }
 
-  const ollama = new Ollama({ host: process.env.OLLAMA_HOST || 'http://localhost:11434' });
-
-  // Confirm Ollama is up and which requested models are present.
-  let installed: Set<string>;
+  let numCtx: number;
   try {
-    const list = await ollama.list();
-    installed = new Set(list.models.map((m) => m.name));
+    numCtx = resolveNumCtx(process.env.PROBE_NUM_CTX);
   } catch (err) {
-    process.stderr.write(`Ollama not reachable: ${String(err)}. Start it with \`ollama serve\`.\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(2);
   }
 
-  process.stderr.write('Starting MCP server for tools/list …\n');
-  const server = new McpServer();
-  let tools: Tool[];
-  try {
-    // Brief settle for the spawned server before the first request.
-    await new Promise((r) => setTimeout(r, 1500));
-    const mcpTools = await server.listTools();
-    tools = mcpTools.map((t) => ({
-      type: 'function',
-      function: {
-        name: t.name,
-        description: t.description,
-        parameters: t.inputSchema as Tool['function']['parameters'],
-      },
-    }));
-    process.stderr.write(`Advertised tools: ${mcpTools.map((t) => t.name).join(', ')}\n`);
-  } finally {
-    server.stop();
-  }
+  const host = process.env.OLLAMA_HOST || 'http://localhost:11434';
+  const ollama = new Ollama({ host });
+  const lifecycle = await ensureOllama(ollama, host);
 
-  const reports: ModelReport[] = [];
-  for (const model of models) {
-    if (!installed.has(model)) {
-      process.stderr.write(`! ${model} not installed (ollama pull ${model}) — skipping\n`);
-      reports.push({ model, available: false, results: [], error: 'not installed' });
-      continue;
+  // Teardown must run on normal exit AND on interrupt: unload every probed model
+  // (the RAM), then stop the server only if we started it (never the user's).
+  const probedModels = new Set<string>();
+  let toreDown = false;
+  const teardown = async (): Promise<void> => {
+    if (toreDown) return;
+    toreDown = true;
+    for (const m of probedModels) await unloadModel(ollama, m);
+    if (lifecycle.startedByUs && lifecycle.serveProc) {
+      lifecycle.serveProc.kill('SIGTERM');
+      process.stderr.write('Stopped the `ollama serve` this probe started.\n');
     }
-    process.stderr.write(`Probing ${model} …\n`);
-    reports.push(await probeModel(ollama, model, tools));
-  }
+  };
+  process.on('SIGINT', () => void teardown().finally(() => process.exit(130)));
+  process.on('SIGTERM', () => void teardown().finally(() => process.exit(143)));
+  // Last resort if we exit without teardown (uncaught throw): don't orphan a server
+  // we spawned. kill() is sync-safe in an exit handler; model unload is not possible here.
+  process.on('exit', () => {
+    if (lifecycle.startedByUs) lifecycle.serveProc?.kill('SIGTERM');
+  });
 
-  process.stdout.write(renderReport(reports) + '\n');
+  try {
+    // Which requested models are present?
+    const list = await ollama.list();
+    const installed = new Set(list.models.map((m) => m.name));
+
+    process.stderr.write('Starting MCP server for tools/list …\n');
+    const server = new McpServer();
+    let tools: Tool[];
+    try {
+      // Brief settle for the spawned server before the first request.
+      await new Promise((r) => setTimeout(r, 1500));
+      const mcpTools = await server.listTools();
+      tools = mcpTools.map((t) => ({
+        type: 'function',
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema as Tool['function']['parameters'],
+        },
+      }));
+      process.stderr.write(`Advertised tools: ${mcpTools.map((t) => t.name).join(', ')}\n`);
+    } finally {
+      server.stop();
+    }
+
+    const reports: ModelReport[] = [];
+    for (const model of models) {
+      if (!installed.has(model)) {
+        process.stderr.write(`! ${model} not installed (ollama pull ${model}) — skipping\n`);
+        reports.push({ model, available: false, results: [], error: 'not installed' });
+        continue;
+      }
+      process.stderr.write(`Probing ${model} (num_ctx=${numCtx}) …\n`);
+      probedModels.add(model);
+      reports.push(await probeModel(ollama, model, tools, numCtx));
+    }
+
+    process.stdout.write(renderReport(reports) + '\n');
+  } finally {
+    await teardown();
+  }
 }
 
 main().catch((err) => {

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -248,14 +248,18 @@ async function ensureOllama(ollama: Ollama, host: string): Promise<OllamaLifecyc
   if (await isReachable(ollama)) return { startedByUs: false };
   if (!isLocalhostOllamaHost(host)) {
     process.stderr.write(
-      `Ollama not reachable at ${host}. That host is remote, so the probe will not start it — ` +
-        'start it there and re-run.\n',
+      `Ollama not reachable at ${host}. That host is not localhost (or could not be parsed), ` +
+        'so the probe will not start a server for it — start it there and re-run.\n',
     );
     process.exit(2);
   }
   process.stderr.write('Ollama not running — starting `ollama serve` (will be stopped at exit) …\n');
   const stderrTail: string[] = [];
   const proc = spawn('ollama', ['serve'], { stdio: ['ignore', 'ignore', 'pipe'] });
+  // Backstop registered at spawn time so a crash/signal during the readiness poll
+  // cannot orphan the server. The child is ours by construction on this path, and
+  // kill() on an already-dead process is a no-op. Sync-safe in an exit handler.
+  process.on('exit', () => proc.kill('SIGTERM'));
   proc.stderr?.on('data', (d: Buffer) => {
     stderrTail.push(d.toString());
     if (stderrTail.length > 20) stderrTail.shift();
@@ -514,11 +518,8 @@ async function main(): Promise<void> {
   };
   process.on('SIGINT', () => void teardown().finally(() => process.exit(130)));
   process.on('SIGTERM', () => void teardown().finally(() => process.exit(143)));
-  // Last resort if we exit without teardown (uncaught throw): don't orphan a server
-  // we spawned. kill() is sync-safe in an exit handler; model unload is not possible here.
-  process.on('exit', () => {
-    if (lifecycle.startedByUs) lifecycle.serveProc?.kill('SIGTERM');
-  });
+  // (The orphan backstop for a server we spawned is registered at spawn time inside
+  // ensureOllama, so it also covers the readiness-poll window before we get here.)
 
   try {
     // Which requested models are present?

--- a/tests/unit/scripts/ollama-lifecycle.test.ts
+++ b/tests/unit/scripts/ollama-lifecycle.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable sonarjs/no-clear-text-protocols -- fixtures: host classification is ABOUT
+   parsing http:// URLs; nothing here makes a network request */
+import { describe, it, expect } from 'vitest';
+import { isLocalhostOllamaHost, resolveNumCtx, DEFAULT_NUM_CTX } from '../../../scripts/lib/ollama-lifecycle.js';
+
+// OMN-163: the probe may spawn `ollama serve` ONLY for a localhost target —
+// never manage a remote server. Host classification is the safety boundary.
+describe('isLocalhostOllamaHost', () => {
+  it.each([
+    'http://localhost:11434',
+    'https://localhost:11434',
+    'http://127.0.0.1:11434',
+    'http://[::1]:11434',
+    'http://localhost:11434/',
+    // OLLAMA_HOST also accepts scheme-less host:port (ollama-js normalizes it)
+    'localhost:11434',
+    '127.0.0.1:11434',
+    '127.0.0.1',
+    'localhost',
+    // 0.0.0.0 as a client target resolves to this machine
+    'http://0.0.0.0:11434',
+  ])('classifies %s as localhost', (host) => {
+    expect(isLocalhostOllamaHost(host)).toBe(true);
+  });
+
+  it.each([
+    'http://192.168.1.10:11434',
+    'http://winbox.tailnet.ts.net:11434', // OMN-39 Tailscale topology — remote
+    'http://ollama.example.com',
+    'example.com:11434',
+    // looks-like-localhost tricks must not pass
+    'http://localhost.example.com:11434',
+    'http://127.0.0.1.example.com:11434',
+  ])('classifies %s as remote', (host) => {
+    expect(isLocalhostOllamaHost(host)).toBe(false);
+  });
+
+  it('rejects unparseable hosts as non-localhost (fail closed)', () => {
+    expect(isLocalhostOllamaHost('http://[malformed')).toBe(false);
+    expect(isLocalhostOllamaHost('')).toBe(false);
+  });
+});
+
+// OMN-163: num_ctx default measured 2026-06-12 — see scripts/lib/ollama-lifecycle.ts
+// for the sizing rationale. Override via PROBE_NUM_CTX.
+describe('resolveNumCtx', () => {
+  it('defaults to the documented measured value when unset', () => {
+    expect(resolveNumCtx(undefined)).toBe(DEFAULT_NUM_CTX);
+    expect(DEFAULT_NUM_CTX).toBe(16384);
+  });
+
+  it('accepts a positive integer override', () => {
+    expect(resolveNumCtx('8192')).toBe(8192);
+    expect(resolveNumCtx(' 32768 ')).toBe(32768);
+  });
+
+  it.each(['abc', '0', '-5', '1.5', '16k', ''])('throws a clear error on %j', (raw) => {
+    expect(() => resolveNumCtx(raw)).toThrow(/PROBE_NUM_CTX/);
+  });
+});


### PR DESCRIPTION
## Why

`npm run conformance` required an externally-started `ollama serve` and left ~27 GB of models resident after finishing (llama3.1:8b alone: **21 GB**, loaded at its full 131k context window, held for the 5-minute keep-alive). OMN-163 decided the probe should own the lifecycle and recover the RAM.

## What

1. **Lifecycle ownership — start only what we'll stop.** If `OLLAMA_HOST` is unreachable AND the host is localhost, the probe spawns `ollama serve`, polls `/api/tags`-equivalent readiness (15s), and records `startedByUs`. Teardown (`finally` + SIGINT/SIGTERM handlers + a sync `exit` backstop) SIGTERMs the child **only if** `startedByUs`. An unreachable **remote** host is a hard error with a clear message — the probe never manages a remote server. Host classification (`isLocalhostOllamaHost`) is the safety boundary and is extracted to `scripts/lib/ollama-lifecycle.ts` with unit tests (25 cases, incl. `localhost.example.com` lookalikes failing closed).
2. **Immediate model unload at exit regardless of who started the server** — empty-prompt generate with `keep_alive: 0` per probed model. Deliberately NOT per-request (that would reload the model between each of the 19 cases).
3. **`num_ctx` capped at a measured default of 16384** (`PROBE_NUM_CTX` overrides). Sizing rationale recorded at the change site (`scripts/lib/ollama-lifecycle.ts`).

## The measurement (ticket's research note)

Exact tokens via `prompt_eval_count` through each baseline model's own tokenizer, 2026-06-12:

| | llama3.1:8b | qwen2.5:7b |
|---|---|---|
| Request side (system + all 4 tool schemas + case prompt) | 4,331 | 4,351 |
| 25-task default-fields response | 2,700 | 2,821 |
| Worst-case response (`limit: 200` → server truncates to **100 rows**, 36 KB) | 9,691 | 9,913 |
| Multi-turn floor (request + worst-case response) | 14,022 | 14,264 |

The server's own 100-row response cap bounds the worst case, so 16384 provably covers today's single-turn probe (3.7× headroom) AND the worst future multi-turn round-trip. RAM (llama3.1:8b resident): 8k → 6.3 GB, **16k → 7.9 GB**, 32k → 11 GB, 131k default → 21 GB.

## Verification

- Unit: 124 files / 2,873 tests pass (25 new). Lint: zero new findings (3 pre-existing probe warnings unchanged on main).
- Live, all three ownership states:
  - **Probe-owned** (Ollama stopped beforehand): probe started it, ran the full 2-model gate, unloaded both models, stopped its server — zero residual ollama processes. Mid-run `ollama ps`: llama3.1:8b **7.9 GB @ ctx 16384**.
  - **Attached** (server pre-started): probe ran, user's server pid survived, models unloaded immediately.
  - **Remote unreachable** (`OLLAMA_HOST=http://203.0.113.5:11434`): clear refusal, exit 2, no spawn.
- Support gate unchanged under the cap: **llama3.1:8b 95% (18/19), qwen2.5:7b 89% (17/19)** — identical to the 2026-06-12 baselines.

Closes OMN-163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)