### PR TITLE
fix(OMN-154): read-metadata count honesty — total_count reports the matching population (+ truncated flag)

### DIFF
--- a/docs/skills/omnifocus-assistant/SKILL.md
+++ b/docs/skills/omnifocus-assistant/SKILL.md
@@ -510,8 +510,10 @@ To **remove** a repeat rule: `{ changes: { clearRepeatRule: true } }`
 **Sort-before-limit:** When both `sort` and `limit` are specified, the server collects all matching tasks, sorts them,
 then applies the limit. This guarantees correct top-N results (e.g., "10 most overdue" works as expected).
 
-**Pagination metadata:** When sort + limit are used, the response metadata includes `total_matched` — the number of
-tasks that matched before the limit was applied. Use this to know if there are more results to page through.
+**Pagination metadata:** `metadata.total_count` always reports the full matching population (not just the returned
+rows), and `metadata.truncated: true` appears whenever `offset + returned_count < total_count`. Use these to decide
+whether to raise `limit` or page with `offset`; a separate `countOnly` query is no longer needed just to detect
+truncation.
 
 ### Logical Operators
 

--- a/docs/superpowers/plans/2026-06-12-omn-154-count-honesty.md
+++ b/docs/superpowers/plans/2026-06-12-omn-154-count-honesty.md
@@ -604,6 +604,14 @@ describe('OMN-154: tasks envelope reports population', () => {
     const result = await callReadTool({ type: 'tasks', filters: { flagged: true }, limit: 2, offset: 2 });
     expect('truncated' in result.metadata).toBe(false);
   });
+
+  it('smart_suggest mode inherits the contract (population + truncated)', async () => {
+    // Same handler path; post-script re-ranking does not change row count.
+    // Mock: 2 rows, total_matched 48, mode smart_suggest.
+    const result = await callReadTool({ type: 'tasks', mode: 'smart_suggest', limit: 2 });
+    expect(result.metadata.total_count).toBe(48);
+    expect(result.metadata.truncated).toBe(true);
+  });
 });
 ```
 
@@ -781,7 +789,8 @@ return response;
 ```
 
 (Import `applyCountHonesty` from `../../utils/response-format.js`. The folders query has no filter — pre-filter total =
-population, spec R7.)
+population, spec R7. Type note: the helper's first parameter expects `summary?: Record<string, unknown>` — apply the
+same `as` cast shown in Task 1 step 3(b) if `StandardResponseV2`'s typed summary union doesn't assign directly.)
 
 - [ ] **Step 4: Run the tool's unit file**
 
@@ -796,12 +805,13 @@ git commit -m "feat(OMN-154): folders surface total_available with truncation ho
 
 ---
 
-### Task 7: Tool description note + full unit suite
+### Task 7: Tool description note + SKILL.md contract update + full unit suite
 
 **Files:**
 
 - Modify: `src/tools/unified/OmniFocusReadTool.ts` (description string, near the countOnly COMMON QUERIES line
   ~line 223)
+- Modify: `docs/skills/omnifocus-assistant/SKILL.md` (the "Pagination metadata" paragraph, ~line 513)
 
 - [ ] **Step 1: Add one line to the tool description**
 
@@ -813,17 +823,30 @@ In the `description` string, directly under the `- Count only (fast): ...` COMMO
 
 (The MCP-facing `inputSchema` is untouched — this is response-shape documentation only, spec §5.5.)
 
-- [ ] **Step 2: Build and run the FULL unit suite**
+- [ ] **Step 2: Rewrite the SKILL.md pagination paragraph (D3)**
+
+`docs/skills/omnifocus-assistant/SKILL.md` (~line 513) documents the now-removed `metadata.total_matched` ("Pagination
+metadata: When sort + limit are used, the response metadata includes `total_matched`…"). Replace that paragraph with the
+new contract:
+
+```markdown
+**Pagination metadata:** `metadata.total_count` always reports the full matching population (not just the returned
+rows), and `metadata.truncated: true` appears whenever `offset + returned_count < total_count`. Use these to decide
+whether to raise `limit` or page with `offset`; a separate `countOnly` query is no longer needed just to detect
+truncation.
+```
+
+- [ ] **Step 3: Build and run the FULL unit suite**
 
 Run: `npm run build && npm run test:unit` Expected: ALL PASS. Pay attention to `tests/unit/docs/claude-md-paths.test.ts`
 and `tests/unit/architecture/schema-impl-parity.test.ts` — they guard description/docs drift. Fix forward if they flag
 the new line.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add src/tools/unified/OmniFocusReadTool.ts
-git commit -m "docs(OMN-154): describe total_count population semantics + truncated flag"
+git add src/tools/unified/OmniFocusReadTool.ts docs/skills/omnifocus-assistant/SKILL.md
+git commit -m "docs(OMN-154): document total_count population semantics + truncated flag"
 ```
 
 ---
@@ -863,14 +886,14 @@ d('OMN-154: read-metadata count honesty', () => {
 
   beforeAll(async () => {
     client = await getSharedClient();
-    await ensureSandboxFolder(client);
+    await ensureSandboxFolder(); // NOTE: takes no arguments (see name-filter-scope.test.ts) — same for fullCleanup()
     // Create POPULATION tasks named `${MARKER}-NN` inside a sandbox project
     // (NOT the inbox), batch-create per the sandbox-manager / name-filter-scope
     // precedent. Read back with countOnly to confirm the fixture landed.
   }, 120_000);
 
   afterAll(async () => {
-    await fullCleanup(client);
+    await fullCleanup();
   }, 120_000);
 
   it('C11: limit 5 against the 10-row population → total_count 10, truncated, countOnly agrees', async () => {

--- a/docs/superpowers/plans/2026-06-12-omn-154-count-honesty.md
+++ b/docs/superpowers/plans/2026-06-12-omn-154-count-honesty.md
@@ -1,0 +1,981 @@
+# OMN-154 Count Honesty Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `metadata.total_count` reports the full matching population (not the returned rows) on tasks, projects, and
+folders read queries, with `truncated: true` whenever rows are missing.
+
+**Architecture:** OmniJS scripts count every predicate match while still capping the rows they project (the scan already
+traverses the whole collection — the limit check is a `forEach` body-skip). The envelope consumes the population at ONE
+seam: a shared `applyCountHonesty` helper called by both response builders. Handlers pass the script's `total_matched`
+through (and into caches). See the approved spec: `docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md` —
+R1–R9 and D1–D7 are normative; read it before starting.
+
+**Tech Stack:** TypeScript, Zod, vitest (unit + live integration), OmniJS script generation in
+`src/contracts/ast/script-builder.ts`, `node:vm` for executing generated OmniJS in unit tests.
+
+**Worktree:** `/Users/kip/src/omnifocus-mcp/.claude/worktrees/omn-154-count-honesty`, branch
+`worktree-omn-154-count-honesty`. All commands run from this directory.
+
+**Conventions that bite:**
+
+- `npm run build` before anything that executes the server.
+- Unit tests: `npx vitest run <file>` (fast, safe). Integration tests: ONLY via `npm run test:integration` as a
+  background process — never kill a running vitest integration process (orphaned teardowns hit the live OmniFocus
+  database).
+- The pre-commit hook runs prettier via lint-staged; committed files may be reformatted — that's expected.
+- Metadata keys are snake_case (an ESLint rule enforces this).
+
+---
+
+### Task 1: `applyCountHonesty` helper + response-builder wiring
+
+The single envelope seam (spec §5.3, R1/R2/R3/R5/R9).
+
+**Files:**
+
+- Modify: `src/utils/response-format.ts` (helper + `createTaskResponseV2` + `createListResponseV2`)
+- Test: `tests/unit/utils/count-honesty.test.ts` (new file)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/utils/count-honesty.test.ts`:
+
+```typescript
+/**
+ * OMN-154: applyCountHonesty — the one envelope seam where population counts
+ * land. R1 (total_count = population), R2 (truncated iff offset + returned <
+ * population), R3 (summary headline counts + insight line), R5 (one truncated
+ * flag), R9 (no-population fallback preserves current behavior).
+ */
+import { describe, it, expect } from 'vitest';
+import { createTaskResponseV2, createListResponseV2 } from '../../../src/utils/response-format.js';
+
+const task = (name: string) => ({ id: `id-${name}`, name, flagged: false, completed: false });
+
+describe('OMN-154 applyCountHonesty via createTaskResponseV2', () => {
+  it('R1: total_count = population, returned_count = rows', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
+    expect(r.metadata.total_count).toBe(48);
+    expect(r.metadata.returned_count).toBe(2);
+  });
+
+  it('R2: truncated true when offset + returned < population', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
+    expect(r.metadata.truncated).toBe(true);
+  });
+
+  it('R2: complete response has NO truncated key (absent, not false)', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 2 });
+    expect(r.metadata.total_count).toBe(2);
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R2: last page of a paginated walk reads complete (offset participates)', () => {
+    // population 10, offset 8, returned 2 → 8 + 2 = 10 → complete
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 10, offset: 8 });
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R2: offset past the end reads complete', () => {
+    // population 10, offset 50, returned 0 → 50 + 0 >= 10 → complete
+    const r = createTaskResponseV2('tasks', [], {}, { population: 10, offset: 50 });
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R2: middle page reads truncated', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 10, offset: 2 });
+    expect(r.metadata.truncated).toBe(true);
+  });
+
+  it('R3: summary.total_count = population; returned_count stays rows; insight line present', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
+    expect(r.summary.total_count).toBe(48);
+    expect(r.summary.returned_count).toBe(2);
+    expect(r.summary.key_insights?.[0]).toBe('Showing 2 of 48 matching tasks (truncated)');
+  });
+
+  it('R3: complete response gets no insight line', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 2 });
+    expect(r.summary.key_insights ?? []).not.toContain('Showing 2 of 2 matching tasks (truncated)');
+  });
+
+  it('R9: no counts argument → exact current behavior (echo, no truncated)', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')]);
+    expect(r.metadata.total_count).toBe(2);
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R9: population wins over caller-supplied metadata total_count', () => {
+    // countOnly injects total_count via the metadata spread; when a population
+    // is ALSO supplied, the population is authoritative.
+    const r = createTaskResponseV2('tasks', [], { total_count: 7 }, { population: 9 });
+    expect(r.metadata.total_count).toBe(9);
+  });
+
+  it('R9: metadata spread still wins when no population (countOnly path)', () => {
+    const r = createTaskResponseV2('tasks', [], { total_count: 42 });
+    expect(r.metadata.total_count).toBe(42);
+  });
+});
+
+describe('OMN-154 applyCountHonesty via createListResponseV2 (projects)', () => {
+  const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
+
+  it('R1/R3: total_count and summary.total_projects = population', () => {
+    const r = createListResponseV2('projects', [project('p1'), project('p2')], 'projects', {}, { population: 160 });
+    expect(r.metadata.total_count).toBe(160);
+    expect(r.metadata.returned_count).toBe(2);
+    expect(r.metadata.truncated).toBe(true);
+    expect((r.summary as Record<string, unknown>).total_projects).toBe(160);
+  });
+
+  it('R3: projects key_insight gets the truncation notice prepended', () => {
+    const r = createListResponseV2('projects', [project('p1'), project('p2')], 'projects', {}, { population: 160 });
+    const insight = (r.summary as Record<string, unknown>).key_insight as string;
+    expect(insight.startsWith('Showing 2 of 160 matching projects (truncated)')).toBe(true);
+  });
+
+  it('R2: complete projects response has no truncated key', () => {
+    const r = createListResponseV2('projects', [project('p1')], 'projects', {}, { population: 1 });
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R9: no counts → echo behavior unchanged', () => {
+    const r = createListResponseV2('projects', [project('p1')], 'projects');
+    expect(r.metadata.total_count).toBe(1);
+    expect('truncated' in r.metadata).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/utils/count-honesty.test.ts` Expected: FAIL — the builders accept no 4th/5th argument
+yet, so `total_count` echoes rows (e.g. first test gets 2, not 48).
+
+- [ ] **Step 3: Implement the helper and wire the builders**
+
+In `src/utils/response-format.ts`:
+
+(a) Add the option type + helper (place near `StandardMetadataV2`):
+
+```typescript
+/**
+ * OMN-154: population counts supplied by handlers when the script reports a
+ * pre-limit match count (`total_matched`).
+ */
+export interface CountHonestyInput {
+  /** Full matching population (post-filter, pre-offset/limit). */
+  population?: number;
+  /** Offset the caller applied; participates in the truncation formula (R2/D5). */
+  offset?: number;
+}
+
+/**
+ * OMN-154 R1/R2/R3: make headline counts report the population and truncation
+ * unmistakable. Mutates the already-built response IN PLACE, after the
+ * metadata spread — population is authoritative over caller metadata.
+ * No-op when no population is supplied (R9: id-lookups, countOnly,
+ * perspectives keep current behavior).
+ */
+export function applyCountHonesty(
+  response: { summary?: Record<string, unknown>; metadata: StandardMetadataV2 },
+  counts: CountHonestyInput | undefined,
+  itemNoun: 'tasks' | 'projects' | 'folders',
+): void {
+  if (counts?.population === undefined) return;
+  const population = counts.population;
+  const offset = counts.offset ?? 0;
+  const returned = typeof response.metadata.returned_count === 'number' ? response.metadata.returned_count : 0;
+  const isTruncated = offset + returned < population;
+
+  response.metadata.total_count = population;
+  if (isTruncated) {
+    response.metadata.truncated = true;
+  }
+
+  const summary = response.summary;
+  if (!summary) return;
+  if ('total_count' in summary) summary.total_count = population;
+  if ('total_projects' in summary) summary.total_projects = population;
+  if (isTruncated) {
+    const notice = `Showing ${returned} of ${population} matching ${itemNoun} (truncated)`;
+    if (Array.isArray(summary.key_insights)) {
+      (summary.key_insights as string[]).unshift(notice);
+    } else {
+      const existing = typeof summary.key_insight === 'string' ? summary.key_insight : undefined;
+      summary.key_insight = existing ? `${notice}; ${existing}` : notice;
+    }
+  }
+}
+```
+
+(b) `createTaskResponseV2` — add the 4th parameter and apply the helper just before returning. Build the response into a
+`const response = { ... }` (the current object literal), then:
+
+```typescript
+export function createTaskResponseV2<T>(
+  operation: string,
+  tasks: T[],
+  metadata: Partial<StandardMetadataV2> = {},
+  counts?: CountHonestyInput,
+): StandardResponseV2<{ tasks: T[] }> {
+  // ... existing body unchanged, but capture the literal:
+  const response: StandardResponseV2<{ tasks: T[] }> = {
+    /* existing literal exactly as today */
+  };
+  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, 'tasks');
+  return response;
+}
+```
+
+(c) `createListResponseV2` — same pattern, 5th parameter `counts?: CountHonestyInput`, noun
+`itemType === 'projects' ? 'projects' : 'tasks'` is wrong — use:
+
+```typescript
+const noun: 'tasks' | 'projects' | 'folders' =
+  itemType === 'projects' ? 'projects' : itemType === 'folders' ? 'folders' : 'tasks';
+applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, noun);
+```
+
+Do NOT change any existing caller in this task — the new parameters are optional (R9).
+
+- [ ] **Step 4: Run the new tests and the existing response-format tests**
+
+Run: `npx vitest run tests/unit/utils/count-honesty.test.ts tests/unit/utils/response-format-utilities.test.ts`
+Expected: ALL PASS (existing tests exercise the no-counts path, which R9 keeps byte-identical).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/response-format.ts tests/unit/utils/count-honesty.test.ts
+git commit -m "feat(OMN-154): applyCountHonesty envelope seam (R1/R2/R3/R9)"
+```
+
+---
+
+### Task 2: Unsorted-tasks and inbox scripts emit `total_matched`
+
+Spec R8. The scripts already traverse the whole collection; hoist the limit short-circuit below the predicate and count
+every match.
+
+**Files:**
+
+- Modify: `src/contracts/ast/script-builder.ts` (`buildUnsortedScript` ~line 424, `buildInboxScript` ~line 600)
+- Test: `tests/unit/contracts/ast/script-builder.test.ts` (flip the pinning test at ~line 778; add vm-execution tests)
+
+- [ ] **Step 1: Flip the pinning test and add failing tests**
+
+In `tests/unit/contracts/ast/script-builder.test.ts`, find the test
+`'does not include total_matched when no sort specified'` (~line 778) and REPLACE it — the old expectation pins the bug
+(cluster pattern: tests pin bugs):
+
+```typescript
+it('includes total_matched on the unsorted path too (OMN-154)', () => {
+  const result = buildFilteredTasksScript({ flagged: true }, { limit: 5 });
+  expect(result.script).toContain('total_matched: totalMatched');
+});
+```
+
+In the same describe block (or a new `describe('OMN-154 population counting', ...)`), add vm-execution tests so the
+counting is verified by running the generated OmniJS, not by string-matching (the repo's recurring vacuous-green class —
+copy the sandbox style from `tests/unit/contracts/ast/mutation/emitter.test.ts`):
+
+```typescript
+import * as vm from 'node:vm';
+
+describe('OMN-154: generated scripts count the full population (vm-executed)', () => {
+  // Minimal stub matching what the generated predicate/projection touches.
+  // The default dropped-exclusion (OMN-157) emits a taskStatus check, so the
+  // sandbox provides Task.Status and per-task taskStatus.
+  const Task = { Status: { Dropped: 'Dropped', Active: 'Active' } };
+  const stubTask = (name: string, flagged: boolean) => ({
+    id: { primaryKey: `id-${name}` },
+    name,
+    flagged,
+    completed: false,
+    taskStatus: Task.Status.Active,
+    inInbox: false,
+    tags: [],
+    notes: '',
+  });
+
+  function runTaskScript(script: string, tasks: unknown[]): { tasks: unknown[]; count: number; total_matched: number } {
+    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string);
+  }
+
+  it('unsorted path: limit 2 against 5 matches → 2 rows, total_matched 5', () => {
+    const tasks = [
+      stubTask('a', true),
+      stubTask('b', true),
+      stubTask('c', true),
+      stubTask('d', true),
+      stubTask('e', true),
+      stubTask('f', false),
+    ];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { limit: 2 });
+    const result = runTaskScript(script, tasks);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.count).toBe(2);
+    expect(result.total_matched).toBe(5);
+  });
+
+  it('unsorted path with offset: total_matched counts offset-skipped matches too', () => {
+    const tasks = [stubTask('a', true), stubTask('b', true), stubTask('c', true), stubTask('d', true)];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { limit: 2, offset: 1 });
+    const result = runTaskScript(script, tasks);
+    expect(result.tasks).toHaveLength(2); // skipped 1, took 2
+    expect(result.total_matched).toBe(4);
+  });
+
+  it('unsorted path: population equal to limit → total_matched == count', () => {
+    const tasks = [stubTask('a', true), stubTask('b', true)];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { limit: 5 });
+    const result = runTaskScript(script, tasks);
+    expect(result.count).toBe(2);
+    expect(result.total_matched).toBe(2);
+  });
+
+  it('inbox path: limit 1 against 3 matches → total_matched 3', () => {
+    const inboxTasks = [
+      { ...stubTask('a', false), inInbox: true },
+      { ...stubTask('b', false), inInbox: true },
+      { ...stubTask('c', false), inInbox: true },
+    ];
+    const { script } = buildInboxScript({}, { limit: 1 });
+    const result = runTaskScript(script, inboxTasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.total_matched).toBe(3);
+  });
+
+  it('sorted path still reports total_matched (regression)', () => {
+    const tasks = [stubTask('b', true), stubTask('a', true), stubTask('c', true)];
+    const { script } = buildFilteredTasksScript(
+      { flagged: true },
+      { limit: 2, sort: [{ field: 'name', direction: 'asc' }] },
+    );
+    const result = runTaskScript(script, tasks);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.total_matched).toBe(3);
+  });
+});
+```
+
+NOTE for the implementer: the stub-task shape may need extra properties if the default field projection touches more
+than id/name/flagged/dueDate/deferDate/tags/project/available — run the test, read the vm error, extend the stub. Do NOT
+weaken the assertions. If `buildInboxScript`'s inbox collection or completion check differs (it iterates the `inbox`
+global), the sandbox above already provides `inbox`.
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `npx vitest run tests/unit/contracts/ast/script-builder.test.ts` Expected: the flipped pinning test and all new vm
+tests FAIL (`total_matched` undefined on unsorted/inbox paths); the sorted-path regression test PASSES.
+
+- [ ] **Step 3: Restructure the two script bodies**
+
+In `src/contracts/ast/script-builder.ts`, `buildUnsortedScript` — current loop:
+
+```javascript
+flattenedTasks.forEach(task => {
+  if (count >= limit) return;
+  ${ctx.completionCheck}
+  // Apply AST-generated filter
+  if (!matchesFilter(task)) return;
+  ${offsetCheck}
+  results.push({ ... });
+  count++;
+});
+```
+
+becomes (declare `let totalMatched = 0;` beside `let count = 0;`):
+
+```javascript
+flattenedTasks.forEach(task => {
+  ${ctx.completionCheck}
+  // Apply AST-generated filter
+  if (!matchesFilter(task)) return;
+  // OMN-154: count every match; the limit caps only the projected rows
+  totalMatched++;
+  if (count >= limit) return;
+  ${offsetCheck}
+  results.push({ ... });
+  count++;
+});
+```
+
+and the return payload gains one line:
+
+```javascript
+return JSON.stringify({
+  tasks: results,
+  count: results.length,
+  total_matched: totalMatched,
+  ${offsetMetadata}
+  ...
+});
+```
+
+Apply the identical transformation to `buildInboxScript` (same loop shape over `inbox.forEach`; its completion check is
+`${completionCheck}` before the predicate — keep it before `totalMatched++` so the population respects the completion
+default, matching countOnly's predicate).
+
+Do NOT touch `buildSortedScript` (already compliant: `total_matched: allResults.length`).
+
+- [ ] **Step 4: Run the full script-builder test file**
+
+Run: `npx vitest run tests/unit/contracts/ast/script-builder.test.ts tests/unit/contracts/ast/list-tasks-ast.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/script-builder.ts tests/unit/contracts/ast/script-builder.test.ts
+git commit -m "feat(OMN-154): unsorted + inbox task scripts count the full matching population"
+```
+
+---
+
+### Task 3: Projects script emits `total_matched`; JXA wrapper forwards it
+
+Spec R8 (projects arm). Reminder: projects has NO offset option — population math runs with offset 0 (spec R8 note).
+
+**Files:**
+
+- Modify: `src/contracts/ast/script-builder.ts` (`buildFilteredProjectsScript`, OmniJS loop ~line 1239 and JXA wrapper
+  metadata ~line 1330)
+- Test: `tests/unit/contracts/ast/script-builder.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe('OMN-154: projects script counts the full population', () => {
+  const Project = {
+    Status: { Active: 'Active', Done: 'Done', Dropped: 'Dropped', OnHold: 'OnHold' },
+  };
+  const stubProject = (name: string, status: string) => ({
+    id: { primaryKey: `id-${name}` },
+    name,
+    status,
+    flagged: false,
+    folder: null,
+    rootTask: null,
+    note: '',
+  });
+
+  it('script text includes total_matched and the wrapper forwards it', () => {
+    const result = buildFilteredProjectsScript({ status: ['active'] }, { limit: 2 });
+    expect(result.script).toContain('total_matched: totalMatched');
+    // JXA wrapper forwards it in its metadata block
+    expect(result.script).toContain('total_matched: result.total_matched');
+  });
+
+  it('vm: limit 2 against 4 active → 2 rows, total_matched 4', () => {
+    const projects = [
+      stubProject('p1', Project.Status.Active),
+      stubProject('p2', Project.Status.Active),
+      stubProject('p3', Project.Status.Active),
+      stubProject('p4', Project.Status.Active),
+      stubProject('p5', Project.Status.Done),
+    ];
+    const generated = buildFilteredProjectsScript({ status: ['active'] }, { limit: 2, performanceMode: 'lite' });
+    // Extract the inner OmniJS (the generated .script is the JXA wrapper).
+    // The OmniJS source is embedded as a template literal; instead of parsing
+    // it out, run the INNER source by rebuilding it: the builder exposes only
+    // the wrapped script, so vm-run the wrapper with an Application stub whose
+    // evaluateJavascript executes the OmniJS in the same sandbox.
+    const sandbox: Record<string, unknown> = {
+      flattenedProjects: projects,
+      Project,
+      JSON,
+      Application: () => ({
+        evaluateJavascript: (src: string) => vm.runInNewContext(src, sandbox) as string,
+      }),
+    };
+    const raw = vm.runInNewContext(generated.script, sandbox) as string;
+    const parsed = JSON.parse(raw) as {
+      projects: unknown[];
+      metadata: { total_matched: number; returned_count: number; total_available: number };
+    };
+    expect(parsed.projects).toHaveLength(2);
+    expect(parsed.metadata.returned_count).toBe(2);
+    expect(parsed.metadata.total_matched).toBe(4);
+    expect(parsed.metadata.total_available).toBe(5); // pre-filter total, unchanged
+  });
+});
+```
+
+NOTE for the implementer: `performanceMode: 'lite'` skips the rootTask/taskCounts block, keeping the stub small. The
+status helper in the script compares `project.status === Project.Status.Done` etc. — the stub's `status` values must be
+the SAME sentinels as the sandbox `Project.Status` object (they are, by construction above). If the lite projection
+touches more fields, extend the stub per the vm error. The double-vm trick (Application stub running the inner OmniJS in
+the same sandbox) keeps the test at the real seam — the full generated artifact, both layers.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/contracts/ast/script-builder.test.ts -t 'OMN-154: projects script'` Expected: FAIL (no
+`total_matched` in script text).
+
+- [ ] **Step 3: Implement**
+
+In `buildFilteredProjectsScript`'s OmniJS source — current loop:
+
+```javascript
+flattenedProjects.forEach(project => {
+  if (count >= limit) return;
+  // Apply AST-generated filter
+  if (!matchesFilter(project)) return;
+  const proj = { ... };
+  ...
+  results.push(proj);
+  count++;
+});
+```
+
+becomes (declare `let totalMatched = 0;` beside `let count = 0;`):
+
+```javascript
+flattenedProjects.forEach(project => {
+  // Apply AST-generated filter
+  if (!matchesFilter(project)) return;
+  // OMN-154: count every match; the limit caps only the projected rows
+  totalMatched++;
+  if (count >= limit) return;
+  const proj = { ... };
+  ...
+  results.push(proj);
+  count++;
+});
+```
+
+OmniJS return payload gains `total_matched: totalMatched,` (keep `total_available` — pre-filter total, unchanged, see
+spec §2). JXA wrapper metadata block gains `total_matched: result.total_matched,` beside `total_available`.
+
+- [ ] **Step 4: Run the test file**
+
+Run: `npx vitest run tests/unit/contracts/ast/script-builder.test.ts` Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contracts/ast/script-builder.ts tests/unit/contracts/ast/script-builder.test.ts
+git commit -m "feat(OMN-154): projects script counts the full matching population"
+```
+
+---
+
+### Task 4: Tasks handler passes the population; `metadata.total_matched` removed (D3)
+
+**Files:**
+
+- Modify: `src/tools/unified/OmniFocusReadTool.ts` (`handleTaskQuery` ~lines 428–473)
+- Test: `tests/unit/tools/unified/OmniFocusReadTool.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Follow the file's existing mocking pattern (it stubs `execJson`-level script results — see the countOnly tests around
+line 1404). Add:
+
+```typescript
+describe('OMN-154: tasks envelope reports population', () => {
+  it('total_count = script total_matched; truncated set; metadata.total_matched gone (D3)', async () => {
+    // Mock a script result: 2 rows, total_matched 48
+    // (shape: { tasks: [...], metadata: { total_matched: 48, sorted_in_script: false } })
+    // ... use the file's established execJson mock helper ...
+    const result = await callReadTool({ type: 'tasks', filters: { flagged: true }, limit: 2 });
+    expect(result.metadata.total_count).toBe(48);
+    expect(result.metadata.returned_count).toBe(2);
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.metadata.total_matched).toBeUndefined(); // D3
+    expect(result.summary.total_count).toBe(48);
+  });
+
+  it('script without total_matched (defensive): falls back to echo, no truncated (R9)', async () => {
+    // Mock metadata without total_matched
+    const result = await callReadTool({ type: 'tasks', filters: { flagged: true }, limit: 2 });
+    expect(result.metadata.total_count).toBe(2);
+    expect('truncated' in result.metadata).toBe(false);
+  });
+
+  it('offset rides into the truncation formula', async () => {
+    // 2 rows, total_matched 4, offset 2 → 2 + 2 = 4 → complete
+    const result = await callReadTool({ type: 'tasks', filters: { flagged: true }, limit: 2, offset: 2 });
+    expect('truncated' in result.metadata).toBe(false);
+  });
+});
+```
+
+(Exact mock invocation per the file's pattern — the implementer adapts the scaffolding, NOT the assertions.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusReadTool.test.ts -t 'OMN-154'` Expected: FAIL — `total_count`
+echoes 2; `total_matched` still in metadata.
+
+- [ ] **Step 3: Implement in `handleTaskQuery`**
+
+- Delete the `...(totalMatched !== undefined ? { total_matched: totalMatched } : {})` line from the metadata literal
+  (D3).
+- Change the return to pass counts:
+
+```typescript
+return createTaskResponseV2('tasks', tasks, metadata, {
+  population: totalMatched,
+  offset: compiled.offset || 0,
+});
+```
+
+(`totalMatched` is already extracted at ~line 434; when the script omits it — defensive only after Tasks 2–3 —
+`population: undefined` triggers R9 fallback.)
+
+Leave `executeCountOnly` and `executeIdLookup` untouched (R9 / R1 "countOnly unchanged").
+
+- [ ] **Step 4: Run the tool's full unit file**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusReadTool.test.ts` Expected: ALL PASS. If any existing test pinned
+`metadata.total_matched` or echo counts on the row path, rewrite it to the new contract (it was pinning the bug) — note
+this in the task report.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusReadTool.ts tests/unit/tools/unified/OmniFocusReadTool.test.ts
+git commit -m "feat(OMN-154): tasks envelope reports matching population, drops total_matched (D3)"
+```
+
+---
+
+### Task 5: Projects handler — stop discarding script metadata; cache the population (R6)
+
+**Files:**
+
+- Modify: `src/tools/unified/OmniFocusReadTool.ts` (`handleProjectQuery` ~lines 679–733)
+- Test: `tests/unit/tools/unified/OmniFocusReadTool.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe('OMN-154: projects envelope reports population', () => {
+  it('total_count + summary.total_projects = script total_matched; truncated set', async () => {
+    // Mock script result: { projects: [2 rows], metadata: { total_matched: 160, returned_count: 2, total_available: 200 } }
+    const result = await callReadTool({ type: 'projects', filters: { status: 'active' }, limit: 2 });
+    expect(result.metadata.total_count).toBe(160);
+    expect(result.metadata.truncated).toBe(true);
+    expect(result.summary.total_projects).toBe(160);
+  });
+
+  it('cache hit repeats the honest counts (R6)', async () => {
+    // First call populates the cache (mock as above), second call must NOT
+    // re-run the script and must still report population, not row echo.
+    const first = await callReadTool({ type: 'projects', filters: { status: 'active' }, limit: 2 });
+    const second = await callReadTool({ type: 'projects', filters: { status: 'active' }, limit: 2 });
+    expect(second.metadata.from_cache).toBe(true);
+    expect(second.metadata.total_count).toBe(160);
+    expect(second.metadata.truncated).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusReadTool.test.ts -t 'OMN-154: projects'` Expected: FAIL (echo 2;
+cached path loses everything).
+
+- [ ] **Step 3: Implement in `handleProjectQuery`**
+
+- After `const resultData = result.data as { projects?: unknown[]; items?: unknown[] };` widen the type to read the
+  wrapper metadata:
+
+```typescript
+const resultData = result.data as {
+  projects?: unknown[];
+  items?: unknown[];
+  metadata?: { total_matched?: number };
+};
+const totalMatched = resultData.metadata?.total_matched;
+```
+
+- Cache entry becomes `this.cache.set('projects', cacheKey, { projects, totalMatched });` and the cache read type
+  becomes `{ projects: unknown[]; totalMatched?: number }`.
+- Both response constructions (cached at ~line 686 and fresh at ~line 723) pass `{ population: <totalMatched> }` as the
+  new 5th argument to `createListResponseV2` (projects has no offset — omit it, spec R8 note).
+
+- [ ] **Step 4: Run the tool's unit file**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusReadTool.test.ts` Expected: ALL PASS (rewrite any echo-pinning
+projects tests; report them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusReadTool.ts tests/unit/tools/unified/OmniFocusReadTool.test.ts
+git commit -m "feat(OMN-154): projects envelope + cache carry the matching population (R6)"
+```
+
+---
+
+### Task 6: Folders rider (R7)
+
+**Files:**
+
+- Modify: `src/tools/unified/OmniFocusReadTool.ts` (`handleFolderQuery` ~lines 874–914)
+- Test: `tests/unit/tools/unified/OmniFocusReadTool.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe('OMN-154: folders surface total_available as total_count (R7)', () => {
+  it('truncated when the 100-cap hides folders', async () => {
+    // Mock script result: { success: true, folders: [100 rows], metadata: { total_available: 120 } }
+    const result = await callReadTool({ type: 'folders' });
+    expect(result.metadata.total_count).toBe(120);
+    expect(result.metadata.returned_count).toBe(100);
+    expect(result.metadata.total_folders).toBe(120); // honest alias
+    expect(result.metadata.truncated).toBe(true);
+  });
+
+  it('complete when population fits', async () => {
+    // Mock: 30 folders, total_available 30
+    const result = await callReadTool({ type: 'folders' });
+    expect(result.metadata.total_count).toBe(30);
+    expect('truncated' in result.metadata).toBe(false);
+  });
+
+  it('cached folders response repeats the counts (R6)', async () => {
+    const first = await callReadTool({ type: 'folders' });
+    const second = await callReadTool({ type: 'folders' });
+    expect(second.metadata.from_cache).toBe(true);
+    expect(second.metadata.total_count).toBe(first.metadata.total_count);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusReadTool.test.ts -t 'OMN-154: folders'` Expected: FAIL
+(`total_count` absent; cached path returns no count at all today).
+
+- [ ] **Step 3: Implement in `handleFolderQuery`**
+
+- Read the script's metadata:
+  `const resultData = result.data as { folders?: unknown[]; items?: unknown[]; metadata?: { total_available?: number } };`
+  and `const totalAvailable = resultData.metadata?.total_available;`
+- Cache entry: `this.cache.set('folders', cacheKey, { folders, totalAvailable });` (widen the cache read type to match).
+- Both return sites build metadata with `returned_count: folders.length` and `total_folders`, then use the exported
+  helper directly (folders use `createSuccessResponseV2`, which has no counts parameter):
+
+```typescript
+const response = createSuccessResponseV2('folders', { folders }, undefined, {
+  ...timer.toMetadata(),
+  operation: 'list',
+  returned_count: folders.length,
+  total_folders: folders.length,
+});
+applyCountHonesty(response, { population: totalAvailable }, 'folders');
+if (typeof response.metadata.total_count === 'number') {
+  response.metadata.total_folders = response.metadata.total_count; // honest alias (R7)
+}
+return response;
+```
+
+(Import `applyCountHonesty` from `../../utils/response-format.js`. The folders query has no filter — pre-filter total =
+population, spec R7.)
+
+- [ ] **Step 4: Run the tool's unit file**
+
+Run: `npx vitest run tests/unit/tools/unified/OmniFocusReadTool.test.ts` Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusReadTool.ts tests/unit/tools/unified/OmniFocusReadTool.test.ts
+git commit -m "feat(OMN-154): folders surface total_available with truncation honesty (R7)"
+```
+
+---
+
+### Task 7: Tool description note + full unit suite
+
+**Files:**
+
+- Modify: `src/tools/unified/OmniFocusReadTool.ts` (description string, near the countOnly COMMON QUERIES line
+  ~line 223)
+
+- [ ] **Step 1: Add one line to the tool description**
+
+In the `description` string, directly under the `- Count only (fast): ...` COMMON QUERIES line, add:
+
+```
+- metadata.total_count always reports the FULL matching population; truncated: true marks a partial result (raise limit or paginate with offset)
+```
+
+(The MCP-facing `inputSchema` is untouched — this is response-shape documentation only, spec §5.5.)
+
+- [ ] **Step 2: Build and run the FULL unit suite**
+
+Run: `npm run build && npm run test:unit` Expected: ALL PASS. Pay attention to `tests/unit/docs/claude-md-paths.test.ts`
+and `tests/unit/architecture/schema-impl-parity.test.ts` — they guard description/docs drift. Fix forward if they flag
+the new line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tools/unified/OmniFocusReadTool.ts
+git commit -m "docs(OMN-154): describe total_count population semantics + truncated flag"
+```
+
+---
+
+### Task 8: Live integration test (AC probes, C11 shape)
+
+**Files:**
+
+- Create: `tests/integration/count-honesty.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Use the harness pattern from `tests/integration/name-filter-scope.test.ts` (shared client, sandbox folder, run-unique
+markers, folder-scoped cleanup). Deterministic population: create 10 sandbox tasks named with a run-unique marker, then
+drive every assertion off filters that match exactly those 10 — this is conformance case C11's exact shape (`limit:5`
+against a 10-row population → `total_count: 10`, truncation visible).
+
+```typescript
+/**
+ * OMN-154: count honesty — total_count reports the matching population,
+ * truncated marks partial results, countOnly agrees (R1/R2/R4; C11).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getSharedClient } from './helpers/shared-server.js';
+import { MCPTestClient } from './helpers/mcp-test-client.js';
+import { ensureSandboxFolder, fullCleanup } from './helpers/sandbox-manager.js';
+import { RUN_ID } from './helpers/run-id.js';
+
+const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
+const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
+
+const MARKER = `XYZCOUNT${RUN_ID.replace(/[^a-z0-9]/gi, '')}`;
+const POPULATION = 10;
+
+d('OMN-154: read-metadata count honesty', () => {
+  let client: MCPTestClient;
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder(client);
+    // Create POPULATION tasks named `${MARKER}-NN` inside a sandbox project
+    // (NOT the inbox), batch-create per the sandbox-manager / name-filter-scope
+    // precedent. Read back with countOnly to confirm the fixture landed.
+  }, 120_000);
+
+  afterAll(async () => {
+    await fullCleanup(client);
+  }, 120_000);
+
+  it('C11: limit 5 against the 10-row population → total_count 10, truncated, countOnly agrees', async () => {
+    const rows = await readTasks({ filters: { name: { contains: MARKER } }, limit: 5 });
+    expect(rows.metadata.total_count).toBe(POPULATION);
+    expect(rows.metadata.returned_count).toBe(5);
+    expect(rows.metadata.truncated).toBe(true);
+    expect(rows.metadata.total_matched).toBeUndefined(); // D3
+    expect(rows.summary?.total_count).toBe(POPULATION);
+
+    const count = await readTasks({ filters: { name: { contains: MARKER } }, countOnly: true });
+    expect(count.metadata.total_count).toBe(POPULATION); // R4 same-predicate agreement
+  });
+
+  it('complete response: limit >= population → no truncated key', async () => {
+    const rows = await readTasks({ filters: { name: { contains: MARKER } }, limit: 50 });
+    expect(rows.metadata.total_count).toBe(POPULATION);
+    expect(rows.metadata.returned_count).toBe(POPULATION);
+    expect('truncated' in rows.metadata).toBe(false);
+  });
+
+  it('offset: the last page reads complete (R2/D5)', async () => {
+    const lastPage = await readTasks({ filters: { name: { contains: MARKER } }, limit: 5, offset: 5 });
+    expect(lastPage.metadata.total_count).toBe(POPULATION);
+    expect(lastPage.metadata.returned_count).toBe(5);
+    expect('truncated' in lastPage.metadata).toBe(false);
+  });
+
+  it('sorted path: same contract (population + truncated)', async () => {
+    const rows = await readTasks({
+      filters: { name: { contains: MARKER } },
+      limit: 3,
+      sort: [{ field: 'name', direction: 'asc' }],
+    });
+    expect(rows.metadata.total_count).toBe(POPULATION);
+    expect(rows.metadata.truncated).toBe(true);
+  });
+
+  it('projects: limit below population reports population; cache hit repeats it (R6)', async () => {
+    // Query against the live DB with a status filter and limit 1. The exact
+    // population is unknown but MUST be >= the sandbox project count (>=1)
+    // and the response must satisfy the invariants:
+    const first = await readProjects({ filters: { status: 'active' }, limit: 1 });
+    const population = first.metadata.total_count as number;
+    expect(population).toBeGreaterThanOrEqual(1);
+    expect(first.metadata.returned_count).toBe(1);
+    if (population > 1) expect(first.metadata.truncated).toBe(true);
+
+    const second = await readProjects({ filters: { status: 'active' }, limit: 1 });
+    expect(second.metadata.from_cache).toBe(true);
+    expect(second.metadata.total_count).toBe(population);
+    if (population > 1) expect(second.metadata.truncated).toBe(true);
+  });
+});
+```
+
+(`readTasks` / `readProjects` are thin wrappers over `client.callTool('omnifocus_read', { query: ... })` parsing the
+JSON text content — copy the helper shape from the existing integration files. Fixture creation: batch create via
+`omnifocus_write`, per the sandbox precedent in `name-filter-scope.test.ts`.)
+
+- [ ] **Step 2: Build, then run the integration suite in the background**
+
+```bash
+npm run build
+# Integration MUST run via npm in a BACKGROUND process; never kill it mid-run
+# (orphaned vitest teardowns hit the live OmniFocus DB).
+npm run test:integration
+```
+
+Expected: the new file passes; the whole suite stays green. OmniFocus must be running and not blocked by dialogs; if
+scripts time out, check the app.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/count-honesty.test.ts
+git commit -m "test(OMN-154): live count-honesty integration probes (C11 shape)"
+```
+
+---
+
+### Task 9: Final verification sweep
+
+- [ ] **Step 1: Full unit + integration, fresh**
+
+```bash
+npm run build && npm run test:unit
+npm run test:integration   # background, do not kill
+```
+
+Expected: both fully green.
+
+- [ ] **Step 2: Mutation-verify the core fix**
+
+Temporarily revert the `buildUnsortedScript` counting hunk (`git stash` the change or comment `totalMatched++`), run
+`npx vitest run tests/unit/contracts/ast/script-builder.test.ts` — the vm tests MUST fail. Restore (`git stash pop` /
+undo), re-run, green. State the result in the task report.
+
+- [ ] **Step 3: Check off the spec's acceptance criteria**
+
+Walk `docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md` §7 — every unchecked box must now be
+demonstrably true (cite the test that proves each).
+
+- [ ] **Step 4: Commit any stragglers; hand off to finishing-a-development-branch**
+
+Post-merge (outside this plan): deploy to `~/omnifocus-mcp` is Kip's manual step; live-verify by re-running the spec §1
+probe table on the prod buildId (all four rows flip to population counts), then update memory
+(`tooling_omnifocus_read_defaults` gotcha 6, `project_selection_honesty_cluster`) and Linear OMN-154.

--- a/docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md
+++ b/docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md
@@ -1,0 +1,164 @@
+# OMN-154: Read-metadata count honesty — design
+
+**Ticket:** OMN-154 — `total_count` must report the matching population, not the returned rows (+ `truncated` flag).
+**Cluster:** selection-honesty (last open member). Resolves Q3 of the OMN-148 filter-semantics spec (PR #85 §10), drift
+D13. Spec anchors: P4 (honest results), R10.
+
+## 1. Problem
+
+`metadata.total_count` and the `summary` headline counts echo the returned rows, so a truncated response is structurally
+indistinguishable from a complete one.
+
+Live evidence (prod buildId `64ecfcb9`, 2026-06-12):
+
+| Probe                                        | Result                                                                     |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| tasks `{flagged, completed:false}` `limit:2` | `metadata.total_count: 2`, `summary.total_count: 2`                        |
+| same filters, `countOnly:true`               | `total_count: 48` (truthful)                                               |
+| same filters, `limit:2` + `sort`             | `metadata.total_matched: 48` **and** `total_count: 2` in the same response |
+| projects `{status:active}` `limit:3`         | `total_count: 3`, `summary.total_projects: 3` (~160 active exist)          |
+
+The third probe is the design key: the sorted tasks path already computes and ships the truthful population
+(`total_matched`); the envelope ignores it for the headline counts.
+
+### Premise changes vs the ticket as written
+
+- **D5 fold-in (tool description "default 14" → 7) already shipped** as a PR #93 rider. AC item 4 is satisfied on
+  current main; dropped from this scope.
+- countOnly population measured 48, not 49 (database drift; immaterial).
+
+## 2. Current count-producer inventory (audited 2026-06-12, main `64ecfcb`)
+
+| Surface                                                                    | Producer                                                         | Counts today                                                                                                           |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| tasks `metadata.total_count`/`returned_count`                              | `createTaskResponseV2` (`src/utils/response-format.ts`)          | returned rows                                                                                                          |
+| tasks `summary.total_count` + `breakdown`                                  | `generateTaskSummary`                                            | returned rows                                                                                                          |
+| tasks `metadata.total_matched`                                             | sorted script path only, plumbed via `list-tasks-ast.ts` wrapper | matching population (truthful, sorted path only)                                                                       |
+| projects `metadata.total_count`, `summary.total_projects` + status tallies | `createListResponseV2` / `generateProjectSummary`                | returned rows; handler **discards the script's metadata block** (`total_available`, `returned_count`, `limit_applied`) |
+| projects script `total_available`                                          | `buildFilteredProjectsScript`                                    | pre-**filter** DB total (third semantic; never surfaced)                                                               |
+| folders `metadata.total_folders`                                           | `handleFolderQuery`                                              | returned rows (hardcoded limit 100); script's `total_available` ignored                                                |
+| tags `summary.total` / `metadata.total`                                    | tag scripts                                                      | full population — honest as wired (handler never passes a limit)                                                       |
+| `countOnly`                                                                | `buildTaskCountScript`                                           | truthful; same `generateFilterCode` predicate as row path                                                              |
+| export                                                                     | `limited` → `summary.truncated` + `cap`                          | already honest about limit truncation                                                                                  |
+| tasks `metadata.truncated`                                                 | `createTaskResponseV2`                                           | **character-limit** truncation only (semantic collision)                                                               |
+| `metadata.has_more`                                                        | declared in `StandardMetadataV2`, never set                      | dead field                                                                                                             |
+
+Script mechanics that make the fix cheap: the unsorted tasks, inbox, and projects scripts all use `forEach` with
+`if (count >= limit) return;` — a body-skip, not a break. The full collection is traversed regardless of limit; the only
+cost of counting all matches is predicate evaluation on the tail. The ~7-10s `flattenedTasks` materialization floor is
+paid either way; field projection (the expensive part) stays limited. The sorted path already collects all matches
+before slicing.
+
+## 3. Approach decision
+
+**A. Scripts emit the population everywhere; the envelope consumes it at one seam. (Chosen.)** Extend the proven
+`total_matched` counter to the unsorted-tasks, inbox, and projects scripts; fix the envelope once in a shared counts
+helper used by both response builders.
+
+**B. Envelope-only: re-run `countOnly` when `returned == limit`. (Rejected.)** Doubles query latency (7-10s → 15-20s)
+exactly on the queries that are truncated. The whole-DB floor is real (perf memory, OMN-57 decomposition).
+
+**C. Full typed `ResponseCounts` contract per query type. (Deferred to OMN-161.)** Right structure, wrong ticket. A's
+shared helper centralizes count semantics at one seam OMN-161 can later formalize; that keeps this fix from becoming a
+per-symptom patch without expanding scope.
+
+## 4. Normative behavior
+
+Scope: `omnifocus_read` row queries — tasks (all modes, including inbox and smart_suggest) and projects. Folders ride
+along (R7). Definitions: **population** = tasks/projects matching the compiled predicate, counted post-filter,
+pre-offset, pre-limit, within the mode's collection (inbox mode counts inbox matches).
+
+- **R1 — `metadata.total_count` = population.** `returned_count` stays the number of rows in `data`. The countOnly path
+  is unchanged (already truthful).
+- **R2 — `metadata.truncated: true` present iff `offset + returned_count < total_count`.** Omitted otherwise (AC permits
+  absent-or-false). The formula makes the last page of a paginated walk read complete, and an offset past the end
+  (`offset ≥ total`) read complete, not truncated.
+- **R3 — summary headline counts = population.** `summary.total_count` (tasks) and `summary.total_projects` (projects)
+  report the population. `summary.returned_count` stays row-scoped. Breakdown/status tallies and preview stay row-scoped
+  (computing population breakdowns would duplicate date/status logic in-script for marginal value). When truncated, the
+  summary gains an explicit insight line — `"Showing N of M matching tasks (truncated)"` in `key_insights` / the
+  projects `key_insight` — so truncation is unmistakable in the LLM-facing summary, not only in metadata.
+- **R4 — same-predicate agreement.** Row queries and `countOnly` share `generateFilterCode` (already true); an
+  integration test pins `total_count == countOnly count` for identical filters (conformance case C11).
+- **R5 — one `truncated` flag.** Limit truncation and character truncation both set `metadata.truncated: true`;
+  character truncation additionally keeps `truncation_message`. The flag means "data rows are not the full matching
+  population." `truncated` is never set without `total_count` present.
+- **R6 — caches stay honest.** The projects cache entry stores the population alongside rows; cached responses rebuild
+  counts from stored values, never from row length. (Tags/folders caches: same rule where touched.)
+- **R7 — folders rider.** `handleFolderQuery` surfaces the script's existing `total_available` as `metadata.total_count`
+  with R2 truncation semantics (`total_folders` keyed alias retained for compatibility). The folders query has no
+  filter, so pre-filter total = population. This converts the known silent-false-pass gotcha (absence checks beyond the
+  100 cap) into a visible signal.
+- **R8 — script changes.** Unsorted tasks, inbox, and projects scripts count all matches: hoist the `count >= limit`
+  short-circuit so the predicate runs for every element, increment `totalMatched` per match, and push rows only within
+  the offset/limit window. Scripts return `total_matched` beside the existing fields. Sorted tasks path already
+  complies.
+
+### Decisions recorded (alternatives not taken)
+
+- **D1: count in-script, not via a second query** — see §3 B.
+- **D2: unify on the existing `truncated` flag** rather than a new `limit_truncated` field. Two flags meaning "you don't
+  have everything" invites consumers to check the wrong one. The existing field is in additive position (optional
+  metadata), so unification is non-breaking.
+- **D3: `metadata.total_matched` is removed** once `total_count` is truthful. Alternatives: keep both (two fields, one
+  meaning — invites drift; the redundancy was live evidence in §1) or alias indefinitely. It appeared only weeks ago
+  (sort-before-limit fix), only on the sorted path, and is undocumented. The external fork sees a cleaner contract.
+- **D4: breakdown/preview stay row-scoped** (see R3) — population breakdowns would require duplicating TS date logic in
+  OmniJS; the truncation insight line covers the honesty requirement.
+- **D5: offset participates in the truncation formula** (R2) — `returned < total` alone would brand every non-first page
+  truncated.
+- **D6: `has_more` stays unset** — dead field, untouched here; candidates for OMN-161's contract.
+- **D7: tags, perspectives, export, countOnly `maxScan` are out of scope** — tags/perspectives are uncapped as wired
+  (honest), export already reports `limited`/`truncated`, countOnly's `maxScan: 10000` cap already emits `limited` +
+  warning.
+
+## 5. Implementation shape
+
+1. **Scripts** (`src/contracts/ast/script-builder.ts`): `buildUnsortedScript`, `buildInboxScript`, and
+   `buildFilteredProjectsScript` gain the `totalMatched` counter; output gains `total_matched`. The projects JXA wrapper
+   forwards it in its metadata block.
+2. **Wrapper** (`src/omnifocus/scripts/tasks/list-tasks-ast.ts`): already forwards `total_matched`; no shape change.
+3. **Envelope seam** (`src/utils/response-format.ts`): one shared helper (e.g.
+   `applyCountHonesty(metadata, summary, { totalMatched, returnedCount, offset })`) used by `createTaskResponseV2` and
+   `createListResponseV2`; sets `total_count`, `truncated` (R2), summary headline counts (R3), and the truncation
+   insight. Builders take the population via an explicit option, not metadata-spread ordering.
+4. **Handlers** (`src/tools/unified/OmniFocusReadTool.ts`): tasks handler passes the script's `total_matched` into the
+   builder; projects handler stops discarding the script metadata block and passes `total_matched` through (and into the
+   cache entry, R6); folders handler surfaces `total_available` (R7).
+5. **Schema note:** script-output Zod schemas (`listResultSchema`) type `metadata` as `z.unknown()` — no schema change
+   needed for new script fields. The MCP-facing `inputSchema` is untouched (response shape only); tool **description**
+   gains a one-line note that `total_count` is the matching population and `truncated` signals partial results.
+
+### Expected blast radius
+
+Unit tests that pin the echo behavior (`total_count == returned rows`) will go RED first and be rewritten as the
+regression guard (cluster pattern: tests pin bugs). Known pinned surface: `createTaskResponseV2`/`createListResponseV2`
+unit tests, possibly golden envelope snapshots. Rider expectation (7-for-7 in this cluster): the projects handler's
+discarded script-metadata block and the cache-entry shape are the most likely homes for a second silently-dropped-input
+bug; both are explicitly in scope (R6, step 4).
+
+## 6. Test plan
+
+- **Unit (TDD):** script builders emit `total_matched` on all three paths (assert generated script text + vm-executed
+  counts where the harness exists); counts helper math — truncated true/false/absent across (offset, limit, population)
+  including offset-past-end and exact-boundary; summary insight line; D3 removal (no `total_matched` in envelope
+  metadata).
+- **Integration (live):** AC probe pair — `limit:2` flagged query returns population `total_count`, `truncated: true`,
+  and `countOnly` agrees (R4/C11); un-truncated query reports no `truncated`; projects `limit < population` shows
+  population; projects cache-hit response repeats the honest counts (R6); folders `total_count` ≥ returned when DB
+  exceeds cap (best-effort at current DB size); offset pagination last-page reads complete.
+- **Conformance:** C11 as written in the OMN-148 spec §9.
+- **Live verify (post-deploy):** re-run the §1 probe table on prod buildId; all four rows must flip to population counts
+  with `truncated: true` on the limited probes.
+
+## 7. Acceptance criteria (restated against current main)
+
+- [ ] `limit:2` flagged tasks query: `total_count` = population (countOnly-equivalent), `truncated: true`, countOnly
+      agrees.
+- [ ] Complete responses: `truncated` absent (or false).
+- [ ] Projects `limit < population`: population in `total_count` and `summary.total_projects`; cached hit identical.
+- [ ] Inbox/sorted/offset paths follow R1/R2.
+- [ ] Folders surfaces `total_count` per R7.
+- [ ] `metadata.total_matched` no longer emitted (D3).
+- [ ] Conformance C11 passes as written.
+- [x] Tool description upcoming default = 7 (shipped in #93; verified on `64ecfcb`).

--- a/docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md
+++ b/docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md
@@ -84,7 +84,8 @@ pre-offset, pre-limit, within the mode's collection (inbox mode counts inbox mat
   character truncation additionally keeps `truncation_message`. The flag means "data rows are not the full matching
   population." `truncated` is never set without `total_count` present.
 - **R6 — caches stay honest.** The projects cache entry stores the population alongside rows; cached responses rebuild
-  counts from stored values, never from row length. (Tags/folders caches: same rule where touched.)
+  counts from stored values, never from row length. The folders cache entry likewise stores the total (the cached
+  folders response currently returns no count at all). (Tags cache: same rule where touched.)
 - **R7 — folders rider.** `handleFolderQuery` surfaces the script's existing `total_available` as `metadata.total_count`
   with R2 truncation semantics (`total_folders` keyed alias retained for compatibility). The folders query has no
   filter, so pre-filter total = population. This converts the known silent-false-pass gotcha (absence checks beyond the
@@ -92,7 +93,12 @@ pre-offset, pre-limit, within the mode's collection (inbox mode counts inbox mat
 - **R8 — script changes.** Unsorted tasks, inbox, and projects scripts count all matches: hoist the `count >= limit`
   short-circuit so the predicate runs for every element, increment `totalMatched` per match, and push rows only within
   the offset/limit window. Scripts return `total_matched` beside the existing fields. Sorted tasks path already
-  complies.
+  complies. (`buildFilteredProjectsScript` has no offset option — the projects arm of the R2 formula always runs with
+  offset 0; do not add projects pagination here.)
+- **R9 — no-population fallback.** When a caller supplies no population, the response builders keep today's behavior:
+  `total_count` = row count, no `truncated` flag, and the trailing metadata spread still wins. This is honest for the
+  0/1-row id-lookup paths and preserves the countOnly path, which injects its truthful `total_count` (and patches the
+  summary) via that spread — R1's "countOnly unchanged" depends on it.
 
 ### Decisions recorded (alternatives not taken)
 

--- a/docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md
+++ b/docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md
@@ -108,7 +108,9 @@ pre-offset, pre-limit, within the mode's collection (inbox mode counts inbox mat
   metadata), so unification is non-breaking.
 - **D3: `metadata.total_matched` is removed** once `total_count` is truthful. Alternatives: keep both (two fields, one
   meaning — invites drift; the redundancy was live evidence in §1) or alias indefinitely. It appeared only weeks ago
-  (sort-before-limit fix), only on the sorted path, and is undocumented. The external fork sees a cleaner contract.
+  (sort-before-limit fix) and only on the sorted path. Its one documentation site —
+  `docs/skills/omnifocus-assistant/SKILL.md` "Pagination metadata" — is rewritten to the `total_count`/`truncated`
+  contract as part of this change. The external fork sees a cleaner contract.
 - **D4: breakdown/preview stay row-scoped** (see R3) — population breakdowns would require duplicating TS date logic in
   OmniJS; the truncation insight line covers the honesty requirement.
 - **D5: offset participates in the truncation formula** (R2) — `returned < total` alone would brand every non-first page

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -434,17 +434,21 @@ function buildUnsortedScript(ctx: ScriptBuildContext): string {
 (() => {
   const results = [];
   let count = 0;
+  let totalMatched = 0;
   const limit = ${ctx.limit};
   ${offsetVars}
 
   ${matchesFilterBlock}
 
   flattenedTasks.forEach(task => {
-    if (count >= limit) return;
     ${ctx.completionCheck}
 
     // Apply AST-generated filter
     if (!matchesFilter(task)) return;
+
+    // OMN-154: count every match; the limit caps only the projected rows
+    totalMatched++;
+    if (count >= limit) return;
 
     ${offsetCheck}
 
@@ -459,6 +463,7 @@ function buildUnsortedScript(ctx: ScriptBuildContext): string {
   return JSON.stringify({
     tasks: results,
     count: results.length,
+    total_matched: totalMatched,
     ${offsetMetadata}
     mode: 'ast_filtered',
     filter_description: ${JSON.stringify(ctx.filterDescription)},
@@ -630,6 +635,7 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
 (() => {
   const results = [];
   let count = 0;
+  let totalMatched = 0;
   const limit = ${limit};
   ${offsetVars}
 
@@ -641,13 +647,15 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
   }
 
   inbox.forEach(task => {
-    if (count >= limit) return;
-
     // Exclude completed tasks by default
     ${completionCheck}
 
     // Apply AST-generated filter
     if (!matchesFilter(task)) return;
+
+    // OMN-154: count every match; the limit caps only the projected rows
+    totalMatched++;
+    if (count >= limit) return;
 
     ${offsetCheck}
 
@@ -660,6 +668,7 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
   return JSON.stringify({
     tasks: results,
     count: results.length,
+    total_matched: totalMatched,
     ${offsetMetadata}
     mode: 'inbox_ast',
     filter_description: ${JSON.stringify(filterDescription)}

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -420,7 +420,7 @@ function buildSortedScript(ctx: ScriptBuildContext, sort: SortSpec[]): string {
 `;
 }
 
-/** Build script for no-sort fast path: limit during iteration */
+/** Build script for no-sort fast path: full-population iteration; limit caps projected rows */
 function buildUnsortedScript(ctx: ScriptBuildContext): string {
   const useOffset = ctx.offset > 0;
   const offsetVars = useOffset ? `const offset = ${ctx.offset};\n  let skipped = 0;` : '';
@@ -1217,6 +1217,7 @@ export function buildFilteredProjectsScript(
       (() => {
         const results = [];
         let count = 0;
+        let totalMatched = 0;
         const limit = ${limit};
 
         // Helper to get project status string
@@ -1246,10 +1247,12 @@ export function buildFilteredProjectsScript(
         }
 
         flattenedProjects.forEach(project => {
-          if (count >= limit) return;
-
           // Apply AST-generated filter
           if (!matchesFilter(project)) return;
+
+          // OMN-154: count every match; the limit caps only the projected rows
+          totalMatched++;
+          if (count >= limit) return;
 
           const proj = {
             ${fieldProjection}
@@ -1321,6 +1324,7 @@ export function buildFilteredProjectsScript(
         return JSON.stringify({
           projects: results,
           count: results.length,
+          total_matched: totalMatched,
           total_available: flattenedProjects.length
         });
       })()
@@ -1340,6 +1344,7 @@ export function buildFilteredProjectsScript(
       projects: result.projects,
       metadata: {
         total_available: result.total_available,
+        total_matched: result.total_matched,
         returned_count: result.count,
         limit_applied: ${limit},
         performance_mode: '${performanceMode}',

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -683,13 +683,19 @@ PERFORMANCE:
     const cacheKey = `projects_list_${JSON.stringify(cacheParams)}`;
 
     // Check cache
-    const cached = this.cache.get<{ projects: unknown[] }>('projects', cacheKey);
+    const cached = this.cache.get<{ projects: unknown[]; totalMatched?: number }>('projects', cacheKey);
     if (cached) {
-      const cacheResult = createListResponseV2('projects', cached.projects, 'projects', {
-        ...timer.toMetadata(),
-        from_cache: true,
-        operation: 'list',
-      }) as unknown as Record<string, unknown>;
+      const cacheResult = createListResponseV2(
+        'projects',
+        cached.projects,
+        'projects',
+        {
+          ...timer.toMetadata(),
+          from_cache: true,
+          operation: 'list',
+        },
+        { population: cached.totalMatched },
+      ) as unknown as Record<string, unknown>;
 
       if (isNarrowLookup) delete cacheResult.summary;
 
@@ -718,15 +724,26 @@ PERFORMANCE:
     }
 
     // Parse dates and cache
-    const resultData = result.data as { projects?: unknown[]; items?: unknown[] };
+    const resultData = result.data as {
+      projects?: unknown[];
+      items?: unknown[];
+      metadata?: { total_matched?: number };
+    };
+    const totalMatched = resultData.metadata?.total_matched;
     const projects = this.parseProjects(resultData.projects || resultData.items || result.data);
-    this.cache.set('projects', cacheKey, { projects });
+    this.cache.set('projects', cacheKey, { projects, totalMatched });
 
-    const listResult = createListResponseV2('projects', projects, 'projects', {
-      ...timer.toMetadata(),
-      from_cache: false,
-      operation: 'list',
-    }) as unknown as Record<string, unknown>;
+    const listResult = createListResponseV2(
+      'projects',
+      projects,
+      'projects',
+      {
+        ...timer.toMetadata(),
+        from_cache: false,
+        operation: 'list',
+      },
+      { population: totalMatched },
+    ) as unknown as Record<string, unknown>;
 
     if (isNarrowLookup) delete listResult.summary;
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -455,7 +455,6 @@ PERFORMANCE:
       offset: compiled.offset || 0,
       sort_applied: sortedInScript || !!sortOptions,
       fields_mode: fieldsMode,
-      ...(totalMatched !== undefined ? { total_matched: totalMatched } : {}),
     };
 
     // Today mode: count categories BEFORE field projection
@@ -470,7 +469,10 @@ PERFORMANCE:
     // Project fields (after counting)
     tasks = projectFields(tasks, compiled.fields);
 
-    return createTaskResponseV2('tasks', tasks, metadata);
+    return createTaskResponseV2('tasks', tasks, metadata, {
+      population: totalMatched,
+      offset: compiled.offset || 0,
+    });
   }
 
   private async executeCountOnly(

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -224,6 +224,7 @@ COMMON QUERIES:
 - Upcoming (7 days): { query: { type: "tasks", mode: "upcoming", daysAhead: 7 } }
 - Smart suggestions: { query: { type: "tasks", mode: "smart_suggest", limit: 10 } }
 - Count only (fast): { query: { type: "tasks", filters: { flagged: true }, countOnly: true } }
+- metadata.total_count always reports the FULL matching population; truncated: true marks a partial result (raise limit or paginate with offset)
 - Export tasks: { query: { type: "export", exportType: "tasks", format: "json" } }
 
 MODES (tasks queries ONLY — not valid on type:"projects"):

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -31,7 +31,9 @@ import {
   createListResponseV2,
   createErrorResponseV2,
   createSuccessResponseV2,
+  applyCountHonesty,
   OperationTimerV2,
+  type StandardMetadataV2,
 } from '../../utils/response-format.js';
 import type { ExportDataV2 } from '../response-types-v2.js';
 import type { TaskFilter, ProjectFilter } from '../../contracts/filters.js';
@@ -893,15 +895,31 @@ PERFORMANCE:
   private async handleFolderQuery(_compiled: CompiledQuery): Promise<unknown> {
     const timer = new OperationTimerV2();
 
-    // Check cache first
-    const cacheKey = 'folders_list_basic';
-    const cached = this.cache.get<{ folders: unknown[] }>('folders', cacheKey);
-    if (cached) {
-      return createSuccessResponseV2('folders', { folders: cached.folders }, undefined, {
+    // Helper: build the folders response with honest counts on both paths
+    const buildFoldersResponse = (
+      folders: unknown[],
+      totalAvailable: number | undefined,
+      extraMeta: Partial<StandardMetadataV2>,
+    ) => {
+      const response = createSuccessResponseV2('folders', { folders }, undefined, {
         ...timer.toMetadata(),
         operation: 'list',
-        from_cache: true,
+        returned_count: folders.length,
+        total_folders: folders.length,
+        ...extraMeta,
       });
+      applyCountHonesty(response, { population: totalAvailable }, 'folders');
+      if (typeof response.metadata.total_count === 'number') {
+        response.metadata.total_folders = response.metadata.total_count;
+      }
+      return response;
+    };
+
+    // Check cache first
+    const cacheKey = 'folders_list_basic';
+    const cached = this.cache.get<{ folders: unknown[]; totalAvailable?: number }>('folders', cacheKey);
+    if (cached) {
+      return buildFoldersResponse(cached.folders, cached.totalAvailable, { from_cache: true });
     }
 
     // Build and execute AST-generated folder list script
@@ -919,17 +937,18 @@ PERFORMANCE:
       );
     }
 
-    const resultData = result.data as { folders?: unknown[]; items?: unknown[] };
+    const resultData = result.data as {
+      folders?: unknown[];
+      items?: unknown[];
+      metadata?: { total_available?: number };
+    };
     const folders = resultData.folders || resultData.items || [];
+    const totalAvailable = resultData.metadata?.total_available;
 
     // Cache for 5 minutes (folders change infrequently)
-    this.cache.set('folders', cacheKey, { folders });
+    this.cache.set('folders', cacheKey, { folders, totalAvailable });
 
-    return createSuccessResponseV2('folders', { folders }, undefined, {
-      ...timer.toMetadata(),
-      operation: 'list',
-      total_folders: folders.length,
-    });
+    return buildFoldersResponse(folders, totalAvailable, {});
   }
 
   // =============================================================================

--- a/src/utils/response-format.ts
+++ b/src/utils/response-format.ts
@@ -90,6 +90,55 @@ export interface AnalyticsSummary extends Record<string, unknown> {
   health_score?: number;
 }
 
+/**
+ * OMN-154: population counts supplied by handlers when the script reports a
+ * pre-limit match count (`total_matched`).
+ */
+export interface CountHonestyInput {
+  /** Full matching population (post-filter, pre-offset/limit). */
+  population?: number;
+  /** Offset the caller applied; participates in the truncation formula (R2/D5). */
+  offset?: number;
+}
+
+/**
+ * OMN-154 R1/R2/R3: make headline counts report the population and truncation
+ * unmistakable. Mutates the already-built response IN PLACE, after the
+ * metadata spread — population is authoritative over caller metadata.
+ * No-op when no population is supplied (R9: id-lookups, countOnly,
+ * perspectives keep current behavior).
+ */
+export function applyCountHonesty(
+  response: { summary?: Record<string, unknown>; metadata: StandardMetadataV2 },
+  counts: CountHonestyInput | undefined,
+  itemNoun: 'tasks' | 'projects' | 'folders',
+): void {
+  if (counts?.population === undefined) return;
+  const population = counts.population;
+  const offset = counts.offset ?? 0;
+  const returned = typeof response.metadata.returned_count === 'number' ? response.metadata.returned_count : 0;
+  const isTruncated = offset + returned < population;
+
+  response.metadata.total_count = population;
+  if (isTruncated) {
+    response.metadata.truncated = true;
+  }
+
+  const summary = response.summary;
+  if (!summary) return;
+  if ('total_count' in summary) summary.total_count = population;
+  if ('total_projects' in summary) summary.total_projects = population;
+  if (isTruncated) {
+    const notice = `Showing ${returned} of ${population} matching ${itemNoun} (truncated)`;
+    if (Array.isArray(summary.key_insights)) {
+      (summary.key_insights as string[]).unshift(notice);
+    } else {
+      const existing = typeof summary.key_insight === 'string' ? summary.key_insight : undefined;
+      summary.key_insight = existing ? `${notice}; ${existing}` : notice;
+    }
+  }
+}
+
 export interface StandardMetadataV2 {
   // Operation info
   operation: string;
@@ -526,6 +575,7 @@ export function createListResponseV2<T>(
   items: T[],
   itemType: 'tasks' | 'projects' | 'tags' | 'folders' | 'other',
   metadata: Partial<StandardMetadataV2> = {},
+  counts?: CountHonestyInput,
 ): StandardResponseV2<Record<string, T[]>> {
   // Generate summary based on item type
   let summary: TaskSummary | ProjectSummary | undefined;
@@ -538,7 +588,7 @@ export function createListResponseV2<T>(
   // Use entity-specific key, fallback to 'items' for 'other'
   const dataKey = itemType === 'other' ? 'items' : itemType;
 
-  return {
+  const response: StandardResponseV2<Record<string, T[]>> = {
     success: true,
     summary,
     data: {
@@ -553,6 +603,11 @@ export function createListResponseV2<T>(
       ...metadata,
     },
   };
+
+  const noun: 'tasks' | 'projects' | 'folders' =
+    itemType === 'projects' ? 'projects' : itemType === 'folders' ? 'folders' : 'tasks';
+  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, noun);
+  return response;
 }
 
 import { CHARACTER_LIMIT } from './constants.js';
@@ -612,6 +667,7 @@ export function createTaskResponseV2<T>(
   operation: string,
   tasks: T[],
   metadata: Partial<StandardMetadataV2> = {},
+  counts?: CountHonestyInput,
 ): StandardResponseV2<{ tasks: T[] }> {
   const summary = generateTaskSummary(tasks as unknown[]);
 
@@ -625,7 +681,7 @@ export function createTaskResponseV2<T>(
     summary.returned_count = truncatedTasks.length;
   }
 
-  return {
+  const response: StandardResponseV2<{ tasks: T[] }> = {
     success: true,
     summary,
     data: {
@@ -644,6 +700,9 @@ export function createTaskResponseV2<T>(
       ...metadata,
     },
   };
+
+  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, 'tasks');
+  return response;
 }
 
 /**

--- a/src/utils/response-format.ts
+++ b/src/utils/response-format.ts
@@ -604,8 +604,12 @@ export function createListResponseV2<T>(
     },
   };
 
-  const noun: 'tasks' | 'projects' | 'folders' =
-    itemType === 'projects' ? 'projects' : itemType === 'folders' ? 'folders' : 'tasks';
+  // 'tasks' is a fallback label only: no tags/other caller supplies counts today,
+  // so the truncation insight noun is exercised solely for projects and folders.
+  let noun: 'tasks' | 'projects' | 'folders' = 'tasks';
+  if (itemType === 'projects' || itemType === 'folders') {
+    noun = itemType;
+  }
   applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, noun);
   return response;
 }

--- a/tests/integration/count-honesty.test.ts
+++ b/tests/integration/count-honesty.test.ts
@@ -7,6 +7,7 @@
  * - R3: metadata.total_matched is NOT emitted (D3 — removed from public contract)
  * - R4: countOnly query reports same total_count as a row query with sufficient limit
  * - R6: second identical query returns from_cache: true with identical count metadata
+ * (R5 — a single truncated flag, no competing truncation keys — is covered by unit tests.)
  *
  * Deterministic fixture: 10 tasks inside a sandbox project, each named with a
  * run-unique marker. Assertions are keyed on marker-filtered counts, not live DB
@@ -81,7 +82,6 @@ interface ProjectsReadResponse {
 
 interface BatchResponse {
   success: boolean;
-  data: { tempIdMapping?: Record<string, string> };
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +145,6 @@ d('OMN-154: count-honesty contract (C11 shape)', () => {
         operations,
         createSequentially: true,
         atomicOperation: false,
-        returnMapping: true,
         stopOnError: true,
       },
     })) as BatchResponse;
@@ -282,6 +281,14 @@ d('OMN-154: count-honesty contract (C11 shape)', () => {
     for (const name of returnedNames) {
       expect(name, `"${name}" must contain the run marker`).toContain(MARKER);
     }
+
+    // Exact check: runScopedName puts the run-id as a PREFIX, so every fixture
+    // name ENDS with its sequence suffix. The lexicographically first 3 must be
+    // exactly -01, -02, -03 (sort-before-limit sanity).
+    expect(
+      returnedNames.map((n) => n.slice(-3)),
+      'returned names must be the first 3 sequence suffixes',
+    ).toEqual(['-01', '-02', '-03']);
   }, 60_000);
 
   // ---------------------------------------------------------------------------
@@ -299,6 +306,10 @@ d('OMN-154: count-honesty contract (C11 shape)', () => {
 
     expect(firstResult.success, 'first projects query must succeed').toBe(true);
     const firstMeta = firstResult.metadata;
+
+    // Cache was just cleared — the first call must be a genuine fresh query
+    // (the fresh projects path sets from_cache: false explicitly).
+    expect(firstMeta.from_cache, 'first call must be a cache miss').toBe(false);
 
     // Basic invariants on the first call
     expect(firstMeta.returned_count, 'returned_count must be 1 (limit=1)').toBe(1);

--- a/tests/integration/count-honesty.test.ts
+++ b/tests/integration/count-honesty.test.ts
@@ -1,0 +1,331 @@
+/**
+ * OMN-154: Count-honesty contract live integration probes (C11 shape).
+ *
+ * Contract under test:
+ * - R1: metadata.total_count = full matching population (post-filter, pre-offset/limit)
+ * - R2: metadata.truncated = true iff offset + returned_count < total_count
+ * - R3: metadata.total_matched is NOT emitted (D3 — removed from public contract)
+ * - R4: countOnly query reports same total_count as a row query with sufficient limit
+ * - R6: second identical query returns from_cache: true with identical count metadata
+ *
+ * Deterministic fixture: 10 tasks inside a sandbox project, each named with a
+ * run-unique marker. Assertions are keyed on marker-filtered counts, not live DB
+ * population, so they are stable across any OmniFocus state.
+ *
+ * Follows the patterns established in name-filter-scope.test.ts:
+ * - getSharedClient / sandbox isolation / fullCleanup / RUN_ID markers
+ * - Tasks created inside a sandbox project (NOT the inbox)
+ * - Tool responses called+parsed via client.callTool
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getSharedClient } from './helpers/shared-server.js';
+import { MCPTestClient } from './helpers/mcp-test-client.js';
+import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from './helpers/sandbox-manager.js';
+import { runScopedName, RUN_ID } from './helpers/run-id.js';
+
+const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
+const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+interface TaskRow {
+  id: string;
+  name: string;
+}
+
+interface TasksMetadata {
+  total_count?: number;
+  returned_count?: number;
+  truncated?: boolean;
+  from_cache?: boolean;
+  total_matched?: number; // Must NOT be present per D3
+  [key: string]: unknown;
+}
+
+interface TasksSummary {
+  total_count?: number;
+  returned_count?: number;
+  [key: string]: unknown;
+}
+
+interface TasksReadResponse {
+  success: boolean;
+  data?: { tasks?: TaskRow[] };
+  metadata: TasksMetadata;
+  summary?: TasksSummary;
+}
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+interface ProjectsMetadata {
+  total_count?: number;
+  returned_count?: number;
+  truncated?: boolean;
+  from_cache?: boolean;
+  [key: string]: unknown;
+}
+
+interface ProjectsReadResponse {
+  success: boolean;
+  data?: { projects?: ProjectRow[] };
+  metadata: ProjectsMetadata;
+  summary?: { total_projects?: number; [key: string]: unknown };
+}
+
+interface BatchResponse {
+  success: boolean;
+  data: { tempIdMapping?: Record<string, string> };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+d('OMN-154: count-honesty contract (C11 shape)', () => {
+  let client: MCPTestClient;
+
+  // Run-unique marker — never appears in any real task name, so marker-filtered
+  // result sets are exactly the 10 probe records created in beforeAll.
+  const MARKER = `XYZCOUNT${RUN_ID.replace(/[^a-z0-9]/gi, '')}`;
+  const TASK_COUNT = 10;
+
+  async function readTasks(query: Record<string, unknown>): Promise<TasksReadResponse> {
+    return (await client.callTool('omnifocus_read', { query: { type: 'tasks', ...query } })) as TasksReadResponse;
+  }
+
+  async function readProjects(query: Record<string, unknown>): Promise<ProjectsReadResponse> {
+    return (await client.callTool('omnifocus_read', { query: { type: 'projects', ...query } })) as ProjectsReadResponse;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fixture setup
+  // ---------------------------------------------------------------------------
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+
+    // Build batch: one holder project + TASK_COUNT tasks inside it.
+    const operations: unknown[] = [
+      {
+        operation: 'create',
+        target: 'project',
+        data: {
+          tempId: 'holder',
+          name: runScopedName(`CountHonesty_Holder`),
+          folder: SANDBOX_FOLDER_NAME,
+        },
+      },
+    ];
+
+    for (let i = 1; i <= TASK_COUNT; i++) {
+      const seq = String(i).padStart(2, '0');
+      operations.push({
+        operation: 'create',
+        target: 'task',
+        data: {
+          tempId: `task${seq}`,
+          name: runScopedName(`CountHonesty_${MARKER}-${seq}`),
+          parentTempId: 'holder',
+        },
+      });
+    }
+
+    const batchResponse = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations,
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+
+    expect(batchResponse.success, 'batch create must succeed').toBe(true);
+
+    // Fail-fast check: confirm all 10 tasks landed via countOnly before tests run.
+    const countCheck = await readTasks({
+      filters: { name: { contains: MARKER } },
+      countOnly: true,
+    });
+    expect(
+      countCheck.metadata.total_count,
+      `Fixture setup: expected ${TASK_COUNT} tasks with marker "${MARKER}" in OmniFocus, got ${countCheck.metadata.total_count}. Fixture may not have landed — aborting.`,
+    ).toBe(TASK_COUNT);
+  }, 120_000);
+
+  afterAll(async () => {
+    await fullCleanup();
+  }, 120_000);
+
+  // ---------------------------------------------------------------------------
+  // C11 shape: truncated page — the core count-honesty scenario
+  // ---------------------------------------------------------------------------
+
+  it('C11: limit < population → total_count=population, returned_count=limit, truncated=true, total_matched absent', async () => {
+    const result = await readTasks({
+      filters: { name: { contains: MARKER } },
+      limit: 5,
+    });
+
+    expect(result.success).toBe(true);
+    const meta = result.metadata;
+
+    // R1: total_count must equal the full matching population (10)
+    expect(meta.total_count, 'metadata.total_count must equal full population').toBe(TASK_COUNT);
+
+    // Returned rows
+    const returnedRows = result.data?.tasks?.length ?? 0;
+    expect(returnedRows, 'returned row count must equal limit').toBe(5);
+    expect(meta.returned_count, 'metadata.returned_count must equal returned rows').toBe(5);
+
+    // R2: truncated=true because 0 + 5 < 10
+    expect(meta.truncated, 'metadata.truncated must be true when limit < population').toBe(true);
+
+    // D3: total_matched must NOT be present
+    expect('total_matched' in meta, 'metadata.total_matched must be absent (D3)').toBe(false);
+
+    // summary.total_count alignment
+    expect(result.summary?.total_count, 'summary.total_count must equal full population').toBe(TASK_COUNT);
+  }, 60_000);
+
+  it('R4 agreement: countOnly reports same total_count as full query', async () => {
+    const countResult = await readTasks({
+      filters: { name: { contains: MARKER } },
+      countOnly: true,
+    });
+
+    expect(countResult.success).toBe(true);
+    expect(countResult.metadata.total_count, 'countOnly total_count must match population').toBe(TASK_COUNT);
+  }, 60_000);
+
+  // ---------------------------------------------------------------------------
+  // Complete fetch — no truncation
+  // ---------------------------------------------------------------------------
+
+  it('complete fetch: limit > population → total_count=population, returned_count=population, no truncated key', async () => {
+    const result = await readTasks({
+      filters: { name: { contains: MARKER } },
+      limit: 50,
+    });
+
+    expect(result.success).toBe(true);
+    const meta = result.metadata;
+
+    expect(meta.total_count, 'total_count must equal full population').toBe(TASK_COUNT);
+    expect(meta.returned_count, 'returned_count must equal full population').toBe(TASK_COUNT);
+    expect(result.data?.tasks?.length, 'data.tasks.length must equal full population').toBe(TASK_COUNT);
+
+    // R2: NOT truncated → truncated key must be absent
+    expect('truncated' in meta, 'truncated key must be absent when all rows fit').toBe(false);
+  }, 60_000);
+
+  // ---------------------------------------------------------------------------
+  // Offset last page
+  // ---------------------------------------------------------------------------
+
+  it('offset last page: offset=5 limit=5 → total_count=10, returned_count=5, no truncated key', async () => {
+    const result = await readTasks({
+      filters: { name: { contains: MARKER } },
+      limit: 5,
+      offset: 5,
+    });
+
+    expect(result.success).toBe(true);
+    const meta = result.metadata;
+
+    expect(meta.total_count, 'total_count must equal full population').toBe(TASK_COUNT);
+    expect(meta.returned_count, 'returned_count must equal 5 (last page)').toBe(5);
+    expect(result.data?.tasks?.length, 'data.tasks.length must equal 5 (last page)').toBe(5);
+
+    // R2: offset(5) + returned(5) == population(10) → NOT truncated
+    expect('truncated' in meta, 'truncated key must be absent on last page').toBe(false);
+  }, 60_000);
+
+  // ---------------------------------------------------------------------------
+  // Sorted path
+  // ---------------------------------------------------------------------------
+
+  it('sorted path: sort asc + limit=3 → total_count=10, truncated=true, first 3 are lexicographically earliest', async () => {
+    const result = await readTasks({
+      filters: { name: { contains: MARKER } },
+      limit: 3,
+      sort: [{ field: 'name', direction: 'asc' }],
+    });
+
+    expect(result.success).toBe(true);
+    const meta = result.metadata;
+
+    expect(meta.total_count, 'total_count must equal full population').toBe(TASK_COUNT);
+    expect(meta.truncated, 'truncated must be true (3 < 10)').toBe(true);
+
+    // Returned names should be the 3 lexicographically first of the 10 fixture names.
+    // All fixture names share the same MARKER prefix with sequence suffix -01 … -10.
+    // Lexicographic order puts -01, -02, -03 first (digit comparison on equal prefix length).
+    const returnedNames = (result.data?.tasks ?? []).map((t) => t.name);
+    expect(returnedNames.length, 'must have 3 returned rows').toBe(3);
+
+    // Verify they are sorted ascending
+    const sortedCopy = [...returnedNames].sort();
+    expect(returnedNames, 'returned names must be in ascending lexicographic order').toEqual(sortedCopy);
+
+    // The three returned names must be a subset of the fixture names
+    for (const name of returnedNames) {
+      expect(name, `"${name}" must contain the run marker`).toContain(MARKER);
+    }
+  }, 60_000);
+
+  // ---------------------------------------------------------------------------
+  // R6: Projects + cache consistency
+  // ---------------------------------------------------------------------------
+
+  it('R6 projects + cache: second call returns from_cache=true with same total_count and truncated state', async () => {
+    // Clear cache before first call so we get a fresh query.
+    await client.clearCache();
+
+    const firstResult = await readProjects({
+      filters: { status: 'active' },
+      limit: 1,
+    });
+
+    expect(firstResult.success, 'first projects query must succeed').toBe(true);
+    const firstMeta = firstResult.metadata;
+
+    // Basic invariants on the first call
+    expect(firstMeta.returned_count, 'returned_count must be 1 (limit=1)').toBe(1);
+    expect(typeof firstMeta.total_count, 'total_count must be a number').toBe('number');
+    expect((firstMeta.total_count as number) >= 1, 'total_count must be >= 1 (at least our holder project exists)').toBe(
+      true,
+    );
+
+    // If there are more projects than the limit, truncated must be true
+    if ((firstMeta.total_count as number) > 1) {
+      expect(firstMeta.truncated, 'truncated must be true when total_count > limit').toBe(true);
+    }
+
+    // Second call — should hit the cache
+    const secondResult = await readProjects({
+      filters: { status: 'active' },
+      limit: 1,
+    });
+
+    expect(secondResult.success, 'second projects query must succeed').toBe(true);
+    const secondMeta = secondResult.metadata;
+
+    // R6: cache hit
+    expect(secondMeta.from_cache, 'second call must be from cache').toBe(true);
+
+    // Count metadata must be identical across cache hit
+    expect(secondMeta.total_count, 'cached total_count must match fresh total_count').toBe(firstMeta.total_count);
+    expect(secondMeta.truncated, 'cached truncated state must match fresh truncated state').toBe(firstMeta.truncated);
+  }, 60_000);
+});

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import * as vm from 'node:vm';
 import {
   buildFilteredTasksScript,
   buildInboxScript,
@@ -775,10 +776,9 @@ describe('buildFilteredTasksScript sort-before-limit', () => {
       expect(result.script).toContain('total_matched: allResults.length');
     });
 
-    it('does not include total_matched when no sort specified', () => {
-      const result = buildFilteredTasksScript({}, { limit: 10 });
-
-      expect(result.script).not.toContain('total_matched');
+    it('includes total_matched on the unsorted path too (OMN-154)', () => {
+      const result = buildFilteredTasksScript({ flagged: true }, { limit: 5 });
+      expect(result.script).toContain('total_matched: totalMatched');
     });
   });
 
@@ -827,6 +827,95 @@ describe('buildFilteredTasksScript sort-before-limit', () => {
       expect(result.script).toContain('return 1'); // null -> end
       expect(result.script).toContain('return -1'); // non-null -> before null
     });
+  });
+});
+
+// =============================================================================
+// OMN-154: VM-EXECUTED POPULATION COUNT TESTS
+// =============================================================================
+
+describe('OMN-154: generated scripts count the full population (vm-executed)', () => {
+  // Minimal stub matching what the generated predicate/projection touches.
+  // The default dropped-exclusion (OMN-157) emits a taskStatus check, so the
+  // sandbox provides Task.Status and per-task taskStatus.
+  const Task = { Status: { Dropped: 'Dropped', Active: 'Active' } };
+  const stubTask = (name: string, flagged: boolean) => ({
+    id: { primaryKey: `id-${name}` },
+    name,
+    flagged,
+    completed: false,
+    taskStatus: Task.Status.Active,
+    inInbox: false,
+    tags: [],
+    notes: '',
+    dueDate: null,
+    deferDate: null,
+    estimatedMinutes: null,
+    effectiveDueDate: null,
+    effectiveDeferDate: null,
+    containingProject: null,
+    available: true,
+    blocked: false,
+  });
+
+  function runTaskScript(script: string, tasks: unknown[]): { tasks: unknown[]; count: number; total_matched: number } {
+    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string);
+  }
+
+  it('unsorted path: limit 2 against 5 matches → 2 rows, total_matched 5', () => {
+    const tasks = [
+      stubTask('a', true),
+      stubTask('b', true),
+      stubTask('c', true),
+      stubTask('d', true),
+      stubTask('e', true),
+      stubTask('f', false),
+    ];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { limit: 2 });
+    const result = runTaskScript(script, tasks);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.count).toBe(2);
+    expect(result.total_matched).toBe(5);
+  });
+
+  it('unsorted path with offset: total_matched counts offset-skipped matches too', () => {
+    const tasks = [stubTask('a', true), stubTask('b', true), stubTask('c', true), stubTask('d', true)];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { limit: 2, offset: 1 });
+    const result = runTaskScript(script, tasks);
+    expect(result.tasks).toHaveLength(2); // skipped 1, took 2
+    expect(result.total_matched).toBe(4);
+  });
+
+  it('unsorted path: population equal to limit → total_matched == count', () => {
+    const tasks = [stubTask('a', true), stubTask('b', true)];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { limit: 5 });
+    const result = runTaskScript(script, tasks);
+    expect(result.count).toBe(2);
+    expect(result.total_matched).toBe(2);
+  });
+
+  it('inbox path: limit 1 against 3 matches → total_matched 3', () => {
+    const inboxTasks = [
+      { ...stubTask('a', false), inInbox: true },
+      { ...stubTask('b', false), inInbox: true },
+      { ...stubTask('c', false), inInbox: true },
+    ];
+    const { script } = buildInboxScript({}, { limit: 1 });
+    const result = runTaskScript(script, inboxTasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.total_matched).toBe(3);
+  });
+
+  it('sorted path still reports total_matched (regression)', () => {
+    const tasks = [stubTask('b', true), stubTask('a', true), stubTask('c', true)];
+    const { script } = buildFilteredTasksScript(
+      { flagged: true },
+      { limit: 2, sort: [{ field: 'name', direction: 'asc' }] },
+    );
+    const result = runTaskScript(script, tasks);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.total_matched).toBe(3);
   });
 });
 

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -1175,6 +1175,63 @@ describe('buildFilteredTasksScript preamble and warning injection', () => {
   });
 });
 
+// =============================================================================
+// OMN-154: PROJECTS SCRIPT POPULATION COUNT TESTS
+// =============================================================================
+
+describe('OMN-154: projects script counts the full population', () => {
+  const Project = {
+    Status: { Active: 'Active', Done: 'Done', Dropped: 'Dropped', OnHold: 'OnHold' },
+  };
+  const stubProject = (name: string, status: string) => ({
+    id: { primaryKey: `id-${name}` },
+    name,
+    status,
+    flagged: false,
+    folder: null,
+    rootTask: null,
+    note: '',
+  });
+
+  it('script text includes total_matched and the wrapper forwards it', () => {
+    const result = buildFilteredProjectsScript({ status: ['active'] }, { limit: 2 });
+    expect(result.script).toContain('total_matched: totalMatched');
+    // JXA wrapper forwards it in its metadata block
+    expect(result.script).toContain('total_matched: result.total_matched');
+  });
+
+  it('vm: limit 2 against 4 active → 2 rows, total_matched 4', () => {
+    const projects = [
+      stubProject('p1', Project.Status.Active),
+      stubProject('p2', Project.Status.Active),
+      stubProject('p3', Project.Status.Active),
+      stubProject('p4', Project.Status.Active),
+      stubProject('p5', Project.Status.Done),
+    ];
+    const generated = buildFilteredProjectsScript({ status: ['active'] }, { limit: 2, performanceMode: 'lite' });
+    // Double-vm: the generated artifact is a JXA wrapper embedding OmniJS via
+    // app.evaluateJavascript. Stub Application so evaluateJavascript runs the
+    // inner OmniJS in the same sandbox — exercising BOTH layers as generated.
+    const sandbox: Record<string, unknown> = {
+      flattenedProjects: projects,
+      Project,
+      JSON,
+      Application: () => ({
+        evaluateJavascript: (src: string) => vm.runInNewContext(src, sandbox) as string,
+      }),
+    };
+    const raw = vm.runInNewContext(generated.script, sandbox) as string;
+    const parsed = JSON.parse(raw) as {
+      projects: unknown[];
+      metadata: { total_matched: number; returned_count: number; total_available: number };
+    };
+    expect(parsed.projects).toHaveLength(2);
+    expect(parsed.metadata.returned_count).toBe(2);
+    expect(parsed.metadata.total_matched).toBe(4);
+    expect(parsed.metadata.total_available).toBe(5); // pre-filter total, unchanged
+  });
+});
+
 // OMN-142: the export path threads `name` through ExportFilter as a
 // name-scoped predicate; only `search` (the documented full-text param)
 // may read task.note.

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1716,4 +1716,67 @@ describe('OmniFocusReadTool', () => {
       expect(result.metadata.truncated).toBe(true);
     });
   });
+
+  describe('OMN-154: projects envelope reports population', () => {
+    it('total_count + summary.total_projects = script total_matched; truncated set', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [
+            { id: 'pp1', name: 'Alpha Project', status: 'active' },
+            { id: 'pp2', name: 'Beta Project', status: 'active' },
+          ],
+          metadata: { total_matched: 160, returned_count: 2, total_available: 200 },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', filters: { status: 'active' }, limit: 2 },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.total_count).toBe(160);
+      expect(result.metadata.truncated).toBe(true);
+      expect(result.summary.total_projects).toBe(160);
+    });
+
+    it('cache hit repeats the honest counts (R6)', async () => {
+      // First call — mock script result with total_matched
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          projects: [
+            { id: 'pp3', name: 'Gamma Project', status: 'active' },
+            { id: 'pp4', name: 'Delta Project', status: 'active' },
+          ],
+          metadata: { total_matched: 160, returned_count: 2, total_available: 200 },
+        },
+      } satisfies ScriptResult);
+
+      // Distinct limit so cache key doesn't collide with the previous test
+      (mockCache.get as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
+
+      const first = (await tool.execute({
+        query: { type: 'projects', filters: { status: 'active' }, limit: 2 },
+      })) as any;
+
+      // Capture what was stored in the cache
+      const cacheSetCall = (mockCache.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      const cachedValue = cacheSetCall[2];
+
+      // Second call — simulate a cache hit with the cached value (includes totalMatched)
+      (mockCache.get as ReturnType<typeof vi.fn>).mockReturnValueOnce(cachedValue);
+
+      const second = (await tool.execute({
+        query: { type: 'projects', filters: { status: 'active' }, limit: 2 },
+      })) as any;
+
+      expect(first.metadata.total_count).toBe(160);
+      expect(second.metadata.from_cache).toBe(true);
+      expect(second.metadata.total_count).toBe(160);
+      expect(second.metadata.truncated).toBe(true);
+      // execJson only called once (for the first query; second is cache hit)
+      expect(execJsonSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1400,6 +1400,71 @@ describe('OmniFocusReadTool', () => {
     });
   });
 
+  describe('OMN-154: folders surface total_available as total_count (R7)', () => {
+    it('truncated when the 100-cap hides folders', async () => {
+      const folders100 = Array.from({ length: 100 }, (_, i) => ({ id: `f${i}`, name: `Folder ${i}` }));
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          folders: folders100,
+          metadata: { total_available: 120 },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({ query: { type: 'folders' } })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.total_count).toBe(120);
+      expect(result.metadata.returned_count).toBe(100);
+      expect(result.metadata.total_folders).toBe(120);
+      expect(result.metadata.truncated).toBe(true);
+    });
+
+    it('complete when population fits', async () => {
+      const folders30 = Array.from({ length: 30 }, (_, i) => ({ id: `f${i}`, name: `Folder ${i}` }));
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          folders: folders30,
+          metadata: { total_available: 30 },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({ query: { type: 'folders' } })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.total_count).toBe(30);
+      expect('truncated' in result.metadata).toBe(false);
+    });
+
+    it('cached folders response repeats the counts (R6)', async () => {
+      const folders30 = Array.from({ length: 30 }, (_, i) => ({ id: `f${i}`, name: `Folder ${i}` }));
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          folders: folders30,
+          metadata: { total_available: 30 },
+        },
+      } satisfies ScriptResult);
+
+      const first = (await tool.execute({ query: { type: 'folders' } })) as any;
+
+      // Capture what was stored in the cache
+      const cacheSetCall = (mockCache.set as ReturnType<typeof vi.fn>).mock.calls[0];
+      const cachedValue = cacheSetCall[2];
+
+      // Second call — simulate a cache hit with the cached value (includes totalAvailable)
+      (mockCache.get as ReturnType<typeof vi.fn>).mockReturnValueOnce(cachedValue);
+
+      const second = (await tool.execute({ query: { type: 'folders' } })) as any;
+
+      expect(second.metadata.from_cache).toBe(true);
+      expect(second.metadata.total_count).toBe(first.metadata.total_count);
+      // execJson only called once (for the first query; second is cache hit)
+      expect(execJsonSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('countOnly through execute() (OMN-35 gap 2)', () => {
     it('returns count + metadata flags + overrides summary.total_count from JXA', async () => {
       execJsonSpy.mockResolvedValueOnce({
@@ -1753,9 +1818,6 @@ describe('OmniFocusReadTool', () => {
         },
       } satisfies ScriptResult);
 
-      // Distinct limit so cache key doesn't collide with the previous test
-      (mockCache.get as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
-
       const first = (await tool.execute({
         query: { type: 'projects', filters: { status: 'active' }, limit: 2 },
       })) as any;
@@ -1775,6 +1837,7 @@ describe('OmniFocusReadTool', () => {
       expect(second.metadata.from_cache).toBe(true);
       expect(second.metadata.total_count).toBe(160);
       expect(second.metadata.truncated).toBe(true);
+      expect(second.summary.total_projects).toBe(160);
       // execJson only called once (for the first query; second is cache hit)
       expect(execJsonSpy).toHaveBeenCalledTimes(1);
     });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1622,4 +1622,98 @@ describe('OmniFocusReadTool', () => {
       expect(task.dueDate).toBeInstanceOf(Date);
     });
   });
+
+  describe('OMN-154: tasks envelope reports population', () => {
+    it('total_count = script total_matched; truncated set; metadata.total_matched gone (D3)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [
+            { id: 't1', name: 'Alpha', flagged: true, completed: false },
+            { id: 't2', name: 'Beta', flagged: true, completed: false },
+          ],
+          metadata: { total_matched: 48, sorted_in_script: false },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { flagged: true }, limit: 2 },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.total_count).toBe(48);
+      expect(result.metadata.returned_count).toBe(2);
+      expect(result.metadata.truncated).toBe(true);
+      expect(result.metadata.total_matched).toBeUndefined(); // D3
+      expect(result.summary.total_count).toBe(48);
+    });
+
+    it('script without total_matched (defensive): falls back to echo, no truncated (R9)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [
+            { id: 't1', name: 'Alpha', flagged: true, completed: false },
+            { id: 't2', name: 'Beta', flagged: true, completed: false },
+          ],
+          // metadata without total_matched
+          metadata: { sorted_in_script: false },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { flagged: true }, limit: 2 },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      // Falls back to echo: total_count = returned count (2)
+      expect(result.metadata.total_count).toBe(2);
+      // No truncated flag when no population is known
+      expect('truncated' in result.metadata).toBe(false);
+    });
+
+    it('offset rides into the truncation formula', async () => {
+      // offset=2, limit=2, total_matched=4 → offset + returned = 2 + 2 = 4 = population → not truncated
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [
+            { id: 't3', name: 'Gamma', flagged: true, completed: false },
+            { id: 't4', name: 'Delta', flagged: true, completed: false },
+          ],
+          metadata: { total_matched: 4, sorted_in_script: false },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { flagged: true }, limit: 2, offset: 2 },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.total_count).toBe(4);
+      // offset(2) + returned(2) = population(4) → not truncated
+      expect('truncated' in result.metadata).toBe(false);
+    });
+
+    it('smart_suggest mode inherits the contract (population + truncated)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [
+            { id: 't1', name: 'Alpha', flagged: false, completed: false },
+            { id: 't2', name: 'Beta', flagged: false, completed: false },
+          ],
+          metadata: { total_matched: 48, sorted_in_script: false },
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', mode: 'smart_suggest', limit: 2 },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.total_count).toBe(48);
+      expect(result.metadata.truncated).toBe(true);
+    });
+  });
 });

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -1,0 +1,105 @@
+/**
+ * OMN-154: applyCountHonesty — the one envelope seam where population counts
+ * land. R1 (total_count = population), R2 (truncated iff offset + returned <
+ * population), R3 (summary headline counts + insight line), R5 (one truncated
+ * flag), R9 (no-population fallback preserves current behavior).
+ */
+import { describe, it, expect } from 'vitest';
+import { createTaskResponseV2, createListResponseV2 } from '../../../src/utils/response-format.js';
+
+const task = (name: string) => ({ id: `id-${name}`, name, flagged: false, completed: false });
+
+describe('OMN-154 applyCountHonesty via createTaskResponseV2', () => {
+  it('R1: total_count = population, returned_count = rows', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
+    expect(r.metadata.total_count).toBe(48);
+    expect(r.metadata.returned_count).toBe(2);
+  });
+
+  it('R2: truncated true when offset + returned < population', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
+    expect(r.metadata.truncated).toBe(true);
+  });
+
+  it('R2: complete response has NO truncated key (absent, not false)', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 2 });
+    expect(r.metadata.total_count).toBe(2);
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R2: last page of a paginated walk reads complete (offset participates)', () => {
+    // population 10, offset 8, returned 2 → 8 + 2 = 10 → complete
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 10, offset: 8 });
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R2: offset past the end reads complete', () => {
+    // population 10, offset 50, returned 0 → 50 + 0 >= 10 → complete
+    const r = createTaskResponseV2('tasks', [], {}, { population: 10, offset: 50 });
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R2: middle page reads truncated', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 10, offset: 2 });
+    expect(r.metadata.truncated).toBe(true);
+  });
+
+  it('R3: summary.total_count = population; returned_count stays rows; insight line present', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
+    expect(r.summary.total_count).toBe(48);
+    expect(r.summary.returned_count).toBe(2);
+    expect(r.summary.key_insights?.[0]).toBe('Showing 2 of 48 matching tasks (truncated)');
+  });
+
+  it('R3: complete response gets no insight line', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 2 });
+    expect(r.summary.key_insights ?? []).not.toContain('Showing 2 of 2 matching tasks (truncated)');
+  });
+
+  it('R9: no counts argument → exact current behavior (echo, no truncated)', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')]);
+    expect(r.metadata.total_count).toBe(2);
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R9: population wins over caller-supplied metadata total_count', () => {
+    // countOnly injects total_count via the metadata spread; when a population
+    // is ALSO supplied, the population is authoritative.
+    const r = createTaskResponseV2('tasks', [], { total_count: 7 }, { population: 9 });
+    expect(r.metadata.total_count).toBe(9);
+  });
+
+  it('R9: metadata spread still wins when no population (countOnly path)', () => {
+    const r = createTaskResponseV2('tasks', [], { total_count: 42 });
+    expect(r.metadata.total_count).toBe(42);
+  });
+});
+
+describe('OMN-154 applyCountHonesty via createListResponseV2 (projects)', () => {
+  const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
+
+  it('R1/R3: total_count and summary.total_projects = population', () => {
+    const r = createListResponseV2('projects', [project('p1'), project('p2')], 'projects', {}, { population: 160 });
+    expect(r.metadata.total_count).toBe(160);
+    expect(r.metadata.returned_count).toBe(2);
+    expect(r.metadata.truncated).toBe(true);
+    expect((r.summary as Record<string, unknown>).total_projects).toBe(160);
+  });
+
+  it('R3: projects key_insight gets the truncation notice prepended', () => {
+    const r = createListResponseV2('projects', [project('p1'), project('p2')], 'projects', {}, { population: 160 });
+    const insight = (r.summary as Record<string, unknown>).key_insight as string;
+    expect(insight.startsWith('Showing 2 of 160 matching projects (truncated)')).toBe(true);
+  });
+
+  it('R2: complete projects response has no truncated key', () => {
+    const r = createListResponseV2('projects', [project('p1')], 'projects', {}, { population: 1 });
+    expect('truncated' in r.metadata).toBe(false);
+  });
+
+  it('R9: no counts → echo behavior unchanged', () => {
+    const r = createListResponseV2('projects', [project('p1')], 'projects');
+    expect(r.metadata.total_count).toBe(1);
+    expect('truncated' in r.metadata).toBe(false);
+  });
+});

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -46,14 +46,15 @@ describe('OMN-154 applyCountHonesty via createTaskResponseV2', () => {
 
   it('R3: summary.total_count = population; returned_count stays rows; insight line present', () => {
     const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 });
-    expect(r.summary.total_count).toBe(48);
-    expect(r.summary.returned_count).toBe(2);
-    expect(r.summary.key_insights?.[0]).toBe('Showing 2 of 48 matching tasks (truncated)');
+    expect(r.summary?.total_count).toBe(48);
+    expect(r.summary?.returned_count).toBe(2);
+    const insights = r.summary?.key_insights as string[] | undefined;
+    expect(insights?.[0]).toBe('Showing 2 of 48 matching tasks (truncated)');
   });
 
   it('R3: complete response gets no insight line', () => {
     const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 2 });
-    expect(r.summary.key_insights ?? []).not.toContain('Showing 2 of 2 matching tasks (truncated)');
+    expect(r.summary?.key_insights ?? []).not.toContain('Showing 2 of 2 matching tasks (truncated)');
   });
 
   it('R9: no counts argument → exact current behavior (echo, no truncated)', () => {


### PR DESCRIPTION
## Summary

`metadata.total_count` (and the summary headline counts) echoed the returned rows, making a truncated response structurally indistinguishable from a complete one — the mechanism behind the May projects-audit near-miss. Live evidence: `limit:2` flagged query returned `total_count: 2` while the same filters via `countOnly` returned 48.

- **Scripts count the full matching population**: the unsorted-tasks, inbox, and projects OmniJS scripts now run the filter predicate over the whole (already fully-traversed) collection and return `total_matched`; field projection stays limit-gated, so the marginal cost is predicate evaluation on the tail (~8% on live probes — the sorted path has shipped this pattern since the sort-before-limit fix).
- **One envelope seam consumes it**: a shared `applyCountHonesty` helper sets `metadata.total_count` = population, `truncated: true` iff `offset + returned_count < total_count` (absent otherwise), realigns `summary.total_count` / `summary.total_projects`, and prepends a "Showing N of M matching … (truncated)" insight. No-population callers (countOnly, id-lookups, perspectives) keep today's behavior byte-for-byte (R9).
- **Caches stay honest** (R6): projects and folders cache entries store the population, so cache hits report the same truthful counts.
- **Folders rider** (R7): the script's `total_available` (previously discarded) now surfaces as `total_count`/`total_folders` with the same truncation semantics — the silent 100-cap false-pass gotcha becomes a visible signal.
- **D3**: `metadata.total_matched` is no longer emitted (replaced by the now-truthful `total_count`); tool description + omnifocus-assistant SKILL.md updated to the new contract.

Spec: `docs/superpowers/specs/2026-06-12-omn-154-count-honesty-design.md` (R1–R9, D1–D7 decision records). Plan: `docs/superpowers/plans/2026-06-12-omn-154-count-honesty.md`.

## Test plan

- [x] Unit: 2904/2904 (new: envelope seam math incl. offset edges, vm-executed script counting on all three paths incl. double-vm through the projects JXA wrapper, handler wiring incl. smart_suggest, cache honesty, folders rider)
- [x] Mutation-verify: counter removal caught per-builder (unsorted 3-fail / inbox 1-fail / projects two-layer), envelope population-loss caught on tasks+projects cached/fresh paths, folders alias caught — all restores confirmed clean
- [x] Live integration: full suite 154/154 twice (incl. new `count-honesty.test.ts`: C11 shape — limit 5 vs 10-row sandbox population → `total_count: 10`, `truncated: true`, countOnly agreement, offset last-page complete, sorted path, projects cache-hit honesty); zero leaked fixtures per dry-run scan
- [ ] Post-deploy live verify: re-run the spec §1 probe table on prod buildId (all rows flip to population counts) + `query_time_ms` comparison against this morning's pre-change baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)