### PR TITLE
feat(OMN-173): suite-timing baseline — persisted integration + conformance time-series

### DIFF
--- a/docs/dev/SUITE_TIMING_LOG.md
+++ b/docs/dev/SUITE_TIMING_LOG.md
@@ -1,0 +1,49 @@
+# Suite Timing Log
+
+**Purpose (OMN-173):** a persisted, per-run time-series of how long the **integration** and **conformance** suites take,
+so "is the suite getting slower as it grows?" and "did a model-load regression creep in?" are answerable from a **git
+diff**, not from scraping old logs. Mirrors the cold-start reconnect baseline convention
+(`project_mcp_cold_start_reconnect`: "drift is a diff, not a memory").
+
+This is the **time-series**. For the curated, per-test breakdown snapshot see
+[`INTEGRATION_TEST_TIMING_BASELINE.md`](INTEGRATION_TEST_TIMING_BASELINE.md).
+
+## How to record a row
+
+```bash
+# Conformance: the probe writes a timing artifact when PROBE_TIMING_JSON is set.
+PROBE_TIMING_JSON=/tmp/conf.json npm run conformance -- llama3.1:8b qwen2.5:7b
+npm run baseline:record -- --conformance-json /tmp/conf.json --notes "post-merge"
+
+# Integration: capture the reported wall (seconds) and test count.
+npm run baseline:record -- --integration-wall 529 --integration-tests 159
+
+# Both halves of one run, or --dry-run to preview the row without writing.
+```
+
+Date + build (`git rev-parse --short HEAD`) are auto-filled. Either suite may be omitted in a given run — the absent
+column renders `—`.
+
+## How to check for drift
+
+```bash
+npm run baseline:check          # newest row vs rolling median of prior 5; ±25% default
+npm run baseline:check -- --threshold 20 --window 8
+```
+
+Exits non-zero when a measured metric (integration wall, conformance total, or per-model conformance elapsed) deviates
+beyond the threshold. Metrics with no prior history are reported as skipped, not failed.
+
+## Cell format (machine-parseable, no literal pipes)
+
+- **Integration wall** — `529s` · **Tests** — `159`
+- **Conformance** — `model score% elapsed/load`, one per model, `; `-separated:
+  `llama3.1:8b 100% 31.2s/8.1s; qwen2.5:7b 84% 41.8s/7.0s`. `n/a` where unmeasured.
+- **Conf total** — total probe wall incl. Ollama start + model loads.
+
+## Runs (newest first)
+
+| Date       | Build   | Integration wall | Tests | Conformance (model score elapsed/load)                 | Conf total | Notes                                                                                                                              |
+| ---------- | ------- | ---------------- | ----- | ------------------------------------------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-13 | 7403e72 | —                | —     | llama3.1:8b 100% 16.6s/2.5s; qwen2.5:7b 84% 17.0s/2.9s | 37.8s      | first instrumented run (OMN-173); warm 8B loads                                                                                    |
+| 2026-06-13 | 7403e72 | 529s             | 159   | llama3.1:8b 100% n/a; qwen2.5:7b 84% n/a               | n/a        | pre-instrumentation seed (OMN-173 ticket): conformance ~55s incl. cold 8B loads — timing n/a (not instrumented), scores comparable |

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "analyze-tokens": "npx tsx scripts/analyze-token-usage.ts",
     "setup-real-llm": "npx tsx scripts/setup-real-llm-testing.ts",
     "conformance": "npm run build && npx tsx scripts/llm-conformance-probe.ts",
+    "baseline:record": "npx tsx scripts/record-suite-timing.ts",
+    "baseline:check": "npx tsx scripts/check-suite-timing.ts",
     "prompts:list": "npx tsx scripts/list-prompts.ts",
     "benchmark": "npm run build && npx tsx scripts/benchmark-performance.ts",
     "ci:local": "./scripts/ci-local.sh"

--- a/scripts/check-suite-timing.ts
+++ b/scripts/check-suite-timing.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env tsx
+/**
+ * Check the newest suite-timing row against the rolling baseline (OMN-173).
+ *
+ * Reads docs/dev/SUITE_TIMING_LOG.md, compares the newest row's metrics (integration wall,
+ * conformance total, per-model conformance elapsed) to the median of the prior N rows, and
+ * exits non-zero if any metric deviates by more than the threshold. This turns "is the suite
+ * getting slower as it grows" from a memory question into a CI-gateable diff.
+ *
+ * Usage:
+ *   npm run baseline:check
+ *   npx tsx scripts/check-suite-timing.ts --threshold 25 --window 5 --log docs/dev/SUITE_TIMING_LOG.md
+ *
+ * Exit codes: 0 = within tolerance (or insufficient history), 1 = a metric exceeded threshold.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { parseRows, checkDeviation } from './lib/suite-timing.js';
+
+const DEFAULT_LOG = 'docs/dev/SUITE_TIMING_LOG.md';
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+function main(): void {
+  const logPath = arg('log') ?? DEFAULT_LOG;
+  const thresholdPct = arg('threshold') ? Number(arg('threshold')) : 25;
+  const window = arg('window') ? Number(arg('window')) : 5;
+
+  // Guard NaN explicitly: a bad `--threshold abc` would make every `> NaN` comparison false
+  // (silently passing real regressions), and a bad `--window abc` would empty the baseline
+  // (silently skipping everything). Either way the check would falsely go green — fail loud.
+  if (!Number.isFinite(thresholdPct) || thresholdPct < 0) {
+    process.stderr.write('check-suite-timing: --threshold must be a non-negative number (percent)\n');
+    process.exit(2);
+  }
+  if (!Number.isFinite(window) || window < 1) {
+    process.stderr.write('check-suite-timing: --window must be a positive integer (rows)\n');
+    process.exit(2);
+  }
+
+  if (!existsSync(logPath)) {
+    process.stderr.write(`check-suite-timing: log not found: ${logPath}\n`);
+    process.exit(2);
+  }
+
+  const rows = parseRows(readFileSync(logPath, 'utf8'));
+  if (rows.length === 0) {
+    process.stdout.write('No recorded rows yet — nothing to check.\n');
+    return;
+  }
+
+  const result = checkDeviation(rows, { thresholdPct, window });
+  const latest = rows[0];
+  process.stdout.write(
+    `Checking newest row (${latest.date} ${latest.build}) vs prior ${window}, threshold ±${thresholdPct}%\n`,
+  );
+
+  if (result.skipped.length) {
+    process.stdout.write(`  (no baseline yet for: ${result.skipped.join(', ')})\n`);
+  }
+
+  if (result.ok) {
+    process.stdout.write('✅ All measured metrics within tolerance.\n');
+    return;
+  }
+
+  process.stderr.write('🚨 Suite-timing regression(s):\n');
+  for (const f of result.findings) {
+    const dir = f.deltaPct > 0 ? 'slower' : 'faster';
+    process.stderr.write(
+      `  - ${f.metric}: ${f.latest} vs baseline ${f.baseline} (${f.deltaPct > 0 ? '+' : ''}${f.deltaPct}%, ${dir})\n`,
+    );
+  }
+  process.exit(1);
+}
+
+main();

--- a/scripts/lib/suite-timing.ts
+++ b/scripts/lib/suite-timing.ts
@@ -1,0 +1,272 @@
+/**
+ * Suite-timing baseline (OMN-173) — pure row/parse/deviation logic.
+ *
+ * The canonical store is a tracked Markdown table (docs/dev/SUITE_TIMING_LOG.md), one row
+ * per recorded run, newest first. A Markdown table was chosen over JSONL on purpose: the
+ * ticket's framing is "drift is a diff, not a memory", and a table makes every regression a
+ * readable git diff while staying machine-parseable (fixed columns, no pipes inside cells).
+ *
+ * This module holds the side-effect-free logic (build a row, render it, insert it, parse the
+ * table back, flag deviation) so it can be unit-tested without running Ollama or the suite.
+ * The CLIs (record-suite-timing.ts, check-suite-timing.ts) are thin wrappers over it.
+ */
+
+/** Per-model conformance result for one run. Elapsed/load are null when unmeasured (e.g. a pre-instrumentation seed). */
+export interface ConformanceModel {
+  model: string;
+  scorePct: number | null;
+  elapsedS: number | null;
+  loadS: number | null;
+}
+
+/** One recorded run. Any suite not run in a given invocation is null (rendered "—"). */
+export interface RunRow {
+  date: string;
+  build: string;
+  integrationWallS: number | null;
+  integrationTests: number | null;
+  conformance: ConformanceModel[];
+  conformanceTotalS: number | null;
+  notes: string;
+}
+
+/** The conformance timing artifact the probe writes when PROBE_TIMING_JSON is set. */
+export interface ConformanceArtifact {
+  schema: string;
+  ollama: { startedByUs: boolean; startMs: number };
+  totalWallMs: number;
+  models: Array<{
+    model: string;
+    available: boolean;
+    passed: number;
+    cases: number;
+    scorePct: number | null;
+    elapsedMs: number | null;
+    loadMs: number | null;
+    caseExecMs: number | null;
+  }>;
+}
+
+export const ARTIFACT_SCHEMA = 'omn-173-conformance-timing@1';
+
+export const TABLE_HEADER =
+  '| Date | Build | Integration wall | Tests | Conformance (model score elapsed/load) | Conf total | Notes |';
+export const TABLE_SEPARATOR =
+  '|------|-------|------------------|-------|----------------------------------------|-----------|-------|';
+
+const SENTINEL = '—';
+
+function num(v: number | null, suffix = ''): string {
+  return v === null ? SENTINEL : `${v}${suffix}`;
+}
+
+/** One decimal for sub-minute seconds; markdown cells must never contain a literal `|`. */
+function sec1(v: number | null): string {
+  return v === null ? 'n/a' : `${v.toFixed(1)}s`;
+}
+
+/** Render the conformance cell: `llama3.1:8b 100% 31.2s/8.1s; qwen2.5:7b 84% 41.8s/7.0s`. */
+export function formatConformanceCell(models: ConformanceModel[]): string {
+  if (models.length === 0) return SENTINEL;
+  return models
+    .map((m) => {
+      const score = m.scorePct === null ? 'n/a' : `${m.scorePct}%`;
+      const elapsed = m.elapsedS === null && m.loadS === null ? 'n/a' : `${sec1(m.elapsedS)}/${sec1(m.loadS)}`;
+      return `${m.model} ${score} ${elapsed}`;
+    })
+    .join('; ');
+}
+
+/** Parse the conformance cell back into models. Tolerates the `n/a` placeholders. */
+export function parseConformanceCell(cell: string): ConformanceModel[] {
+  const trimmed = cell.trim();
+  if (trimmed === SENTINEL || trimmed === '') return [];
+  return trimmed
+    .split(';')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      // model  score%|n/a  elapsed/load. `\S+` then literal-space backtracks linearly, and
+      // the input is our own fixed-format table cell (not external/adversarial), so slow-regex
+      // does not apply here.
+      // eslint-disable-next-line sonarjs/slow-regex -- bounded, non-adversarial input (see above)
+      const m = /^(\S+) +(\d+%|n\/a) +(.+)$/.exec(entry);
+      if (!m) return { model: entry, scorePct: null, elapsedS: null, loadS: null };
+      const [, model, scoreTok, timeTok] = m;
+      const scorePct = scoreTok === 'n/a' ? null : parseInt(scoreTok, 10);
+      let elapsedS: number | null = null;
+      let loadS: number | null = null;
+      if (timeTok !== 'n/a') {
+        const [eTok, lTok] = timeTok.split('/');
+        elapsedS = parseSecTok(eTok);
+        loadS = parseSecTok(lTok);
+      }
+      return { model, scorePct, elapsedS, loadS };
+    });
+}
+
+function parseSecTok(tok: string | undefined): number | null {
+  if (!tok) return null;
+  const t = tok.trim();
+  if (t === 'n/a') return null;
+  const n = parseFloat(t.replace(/s$/, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Render a row as one Markdown table line. Cells are guaranteed pipe-free. */
+export function renderRow(row: RunRow): string {
+  const cells = [
+    row.date,
+    row.build,
+    num(row.integrationWallS, 's'),
+    num(row.integrationTests),
+    formatConformanceCell(row.conformance),
+    num(row.conformanceTotalS, 's'),
+    row.notes.replace(/\|/g, '/').trim() || SENTINEL,
+  ];
+  return `| ${cells.join(' | ')} |`;
+}
+
+/** Insert a new row immediately under the table separator (newest first). Throws if the table is absent. */
+export function insertRow(markdown: string, row: RunRow): string {
+  const lines = markdown.split('\n');
+  const sepIdx = lines.findIndex((l) => l.replace(/\s/g, '').startsWith('|---'));
+  if (sepIdx === -1) {
+    throw new Error('suite-timing log has no Markdown table separator (|---…) — cannot insert a row');
+  }
+  lines.splice(sepIdx + 1, 0, renderRow(row));
+  return lines.join('\n');
+}
+
+/** Parse all data rows from the log (skips the header + separator). */
+export function parseRows(markdown: string): RunRow[] {
+  const lines = markdown.split('\n');
+  const rows: RunRow[] = [];
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t.startsWith('|')) continue;
+    if (t.replace(/\s/g, '').startsWith('|---')) continue;
+    const cells = splitCells(t);
+    // header row
+    if (cells[0] === 'Date') continue;
+    if (cells.length < 7) continue;
+    rows.push({
+      date: cells[0],
+      build: cells[1],
+      integrationWallS: parseSecTok(cells[2] === SENTINEL ? undefined : cells[2]),
+      integrationTests: cells[3] === SENTINEL ? null : intOrNull(cells[3]),
+      conformance: parseConformanceCell(cells[4]),
+      conformanceTotalS: parseSecTok(cells[5] === SENTINEL ? undefined : cells[5]),
+      notes: cells[6] === SENTINEL ? '' : cells[6],
+    });
+  }
+  return rows;
+}
+
+function intOrNull(s: string): number | null {
+  const n = parseInt(s, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function splitCells(line: string): string[] {
+  // Strip the leading/trailing pipe, then split. Cells never contain `|` by construction.
+  return line
+    .replace(/^\s*\|/, '')
+    .replace(/\|\s*$/, '')
+    .split('|')
+    .map((c) => c.trim());
+}
+
+/** Map a probe artifact into the conformance half of a row. */
+export function conformanceFromArtifact(art: ConformanceArtifact): {
+  conformance: ConformanceModel[];
+  conformanceTotalS: number;
+} {
+  return {
+    conformance: art.models.map((m) => ({
+      model: m.model,
+      scorePct: m.scorePct,
+      elapsedS: m.elapsedMs === null ? null : round1(m.elapsedMs / 1000),
+      loadS: m.loadMs === null ? null : round1(m.loadMs / 1000),
+    })),
+    conformanceTotalS: round1(art.totalWallMs / 1000),
+  };
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+// ── Deviation check ───────────────────────────────────────────────────────────
+
+export interface DeviationFinding {
+  metric: string;
+  latest: number;
+  baseline: number;
+  deltaPct: number;
+}
+
+export interface DeviationResult {
+  ok: boolean;
+  findings: DeviationFinding[];
+  /** Metrics skipped because there was no prior history to baseline against. */
+  skipped: string[];
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+/**
+ * Flag metrics where the newest row deviates from the rolling median of the prior `window`
+ * rows by more than `thresholdPct`. Rows are newest-first (as stored). A metric with no
+ * prior data points is reported as skipped, not failed — a baseline needs history.
+ */
+export function checkDeviation(rows: RunRow[], opts: { thresholdPct?: number; window?: number } = {}): DeviationResult {
+  const thresholdPct = opts.thresholdPct ?? 25;
+  const window = opts.window ?? 5;
+  const findings: DeviationFinding[] = [];
+  const skipped: string[] = [];
+  if (rows.length === 0) return { ok: true, findings, skipped };
+
+  const latest = rows[0];
+  const prior = rows.slice(1, 1 + window);
+
+  const evaluate = (metric: string, latestVal: number | null, priorVals: (number | null)[]): void => {
+    if (latestVal === null) return; // suite not run this time — nothing to compare
+    const hist = priorVals.filter((v): v is number => v !== null && v > 0);
+    if (hist.length === 0) {
+      skipped.push(metric);
+      return;
+    }
+    const baseline = median(hist);
+    const deltaPct = baseline === 0 ? 0 : Math.round(((latestVal - baseline) / baseline) * 100);
+    if (Math.abs(deltaPct) > thresholdPct) {
+      findings.push({ metric, latest: latestVal, baseline: round1(baseline), deltaPct });
+    }
+  };
+
+  evaluate(
+    'integration_wall_s',
+    latest.integrationWallS,
+    prior.map((r) => r.integrationWallS),
+  );
+  evaluate(
+    'conformance_total_s',
+    latest.conformanceTotalS,
+    prior.map((r) => r.conformanceTotalS),
+  );
+
+  // Per-model conformance elapsed, keyed by model name.
+  for (const m of latest.conformance) {
+    evaluate(
+      `conformance_elapsed_s[${m.model}]`,
+      m.elapsedS,
+      prior.map((r) => r.conformance.find((x) => x.model === m.model)?.elapsedS ?? null),
+    );
+  }
+
+  return { ok: findings.length === 0, findings, skipped };
+}

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -34,9 +34,16 @@
  * model's full advertised context (131k for llama3.1 → 21 GB resident for the 8b).
  *
  * Output: a Markdown conformance report to stdout (redirect to a file), progress to stderr.
+ *
+ * Timing (OMN-173): the report carries a "## Timing" section — Ollama server-start time
+ * (when the probe started it), per-model model-load vs case-execution split, per-model
+ * elapsed, and total wall. Set PROBE_TIMING_JSON=<path> to also write a machine-readable
+ * timing+scores JSON for `npm run baseline:record` to append to the suite-timing log.
  */
 
 import { spawn, type ChildProcess } from 'child_process';
+import { writeFileSync } from 'fs';
+import { performance } from 'perf_hooks';
 import { Ollama, type Tool, type ToolCall } from 'ollama';
 import { isLocalhostOllamaHost, resolveNumCtx } from './lib/ollama-lifecycle.js';
 import type { ZodTypeAny } from 'zod';
@@ -229,6 +236,8 @@ class McpServer {
 interface OllamaLifecycle {
   startedByUs: boolean;
   serveProc?: ChildProcess;
+  /** Wall time spent waiting for the server we started to become reachable (0 if attached). */
+  startMs: number;
 }
 
 async function isReachable(ollama: Ollama): Promise<boolean> {
@@ -245,7 +254,7 @@ async function isReachable(ollama: Ollama): Promise<boolean> {
  * ourselves and record that we own it. We never manage a remote server.
  */
 async function ensureOllama(ollama: Ollama, host: string): Promise<OllamaLifecycle> {
-  if (await isReachable(ollama)) return { startedByUs: false };
+  if (await isReachable(ollama)) return { startedByUs: false, startMs: 0 };
   if (!isLocalhostOllamaHost(host)) {
     process.stderr.write(
       `Ollama not reachable at ${host}. That host is not localhost (or could not be parsed), ` +
@@ -254,6 +263,7 @@ async function ensureOllama(ollama: Ollama, host: string): Promise<OllamaLifecyc
     process.exit(2);
   }
   process.stderr.write('Ollama not running — starting `ollama serve` (will be stopped at exit) …\n');
+  const startedAt = performance.now();
   const stderrTail: string[] = [];
   const proc = spawn('ollama', ['serve'], { stdio: ['ignore', 'ignore', 'pipe'] });
   // Backstop registered at spawn time so a crash/signal during the readiness poll
@@ -270,7 +280,9 @@ async function ensureOllama(ollama: Ollama, host: string): Promise<OllamaLifecyc
   });
   const deadline = Date.now() + 15000;
   while (Date.now() < deadline && !spawnError) {
-    if (await isReachable(ollama)) return { startedByUs: true, serveProc: proc };
+    if (await isReachable(ollama)) {
+      return { startedByUs: true, serveProc: proc, startMs: performance.now() - startedAt };
+    }
     await new Promise((r) => setTimeout(r, 500));
   }
   proc.kill('SIGTERM');
@@ -347,15 +359,29 @@ function gradeToolCall(c: ConformanceCase, call: ToolCall | undefined): CaseResu
 
 // ── Per-model run ────────────────────────────────────────────────────────────
 
+/** Per-model timing (OMN-173). All values in milliseconds. */
+interface ModelTiming {
+  /** Wall from before the first case to after the last (load + all inference). */
+  elapsedMs: number;
+  /** Model-load time, taken from the first case's Ollama `load_duration` (lazy load on first chat). */
+  loadMs: number;
+  /** Inference wall only: elapsedMs minus loadMs. */
+  caseExecMs: number;
+}
+
 interface ModelReport {
   model: string;
   available: boolean;
   results: CaseResult[];
   error?: string;
+  timing?: ModelTiming;
 }
 
 async function probeModel(ollama: Ollama, model: string, tools: Tool[], numCtx: number): Promise<ModelReport> {
   const results: CaseResult[] = [];
+  let loadMs = 0;
+  let firstCase = true;
+  const startedAt = performance.now();
   for (const c of CASES) {
     process.stderr.write(`  [${model}] ${c.id} … `);
     try {
@@ -376,6 +402,14 @@ async function probeModel(ollama: Ollama, model: string, tools: Tool[], numCtx: 
         // model's full advertised context. Default + sizing rationale: lib/ollama-lifecycle.ts.
         options: { temperature: 0, num_ctx: numCtx },
       });
+      // The model loads lazily on the first chat that completes; `load_duration` (ns) on that
+      // response is the load cost. If an earlier case threw (network/timeout, not a load), the
+      // model never loaded, so the first *successful* case still carries the true load cost.
+      // Subsequent cases reuse the loaded model (load_duration ≈ 0).
+      if (firstCase) {
+        loadMs = (res.load_duration ?? 0) / 1e6;
+        firstCase = false;
+      }
       const call = res.message.tool_calls?.[0];
       const graded = gradeToolCall(c, call);
       results.push(graded);
@@ -385,7 +419,9 @@ async function probeModel(ollama: Ollama, model: string, tools: Tool[], numCtx: 
       process.stderr.write('model_error\n');
     }
   }
-  return { model, available: true, results };
+  const elapsedMs = performance.now() - startedAt;
+  const timing: ModelTiming = { elapsedMs, loadMs, caseExecMs: Math.max(0, elapsedMs - loadMs) };
+  return { model, available: true, results, timing };
 }
 
 // ── Reporting ────────────────────────────────────────────────────────────────
@@ -394,7 +430,80 @@ function pct(n: number, d: number): string {
   return d === 0 ? '0%' : `${Math.round((100 * n) / d)}%`;
 }
 
-function renderReport(reports: ModelReport[]): string {
+/** Compact seconds with one decimal, e.g. 1234ms → "1.2s". */
+function secs(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Run-level timing the per-model reports don't carry (OMN-173). */
+interface ProbeTiming {
+  ollamaStartedByUs: boolean;
+  ollamaStartMs: number;
+  totalWallMs: number;
+}
+
+/** Passed / total / score% for a model report. */
+function scoreOf(r: ModelReport): { passed: number; cases: number } {
+  return { passed: r.results.filter((x) => x.outcome === 'pass').length, cases: CASES.length };
+}
+
+/**
+ * Machine-readable timing + scores (OMN-173) for `npm run baseline:record` to append to
+ * the suite-timing log. Stable `schema` tag so the consumer can reject a drifted shape.
+ */
+function buildTimingArtifact(reports: ModelReport[], timing: ProbeTiming) {
+  return {
+    schema: 'omn-173-conformance-timing@1',
+    ollama: { startedByUs: timing.ollamaStartedByUs, startMs: Math.round(timing.ollamaStartMs) },
+    totalWallMs: Math.round(timing.totalWallMs),
+    models: reports.map((r) => {
+      const { passed, cases } = scoreOf(r);
+      return {
+        model: r.model,
+        available: r.available,
+        passed,
+        cases,
+        scorePct: r.available ? Math.round((100 * passed) / cases) : null,
+        elapsedMs: r.timing ? Math.round(r.timing.elapsedMs) : null,
+        loadMs: r.timing ? Math.round(r.timing.loadMs) : null,
+        caseExecMs: r.timing ? Math.round(r.timing.caseExecMs) : null,
+      };
+    }),
+  };
+}
+
+/** The "## Timing" section (OMN-173), split out to keep renderReport's complexity down. */
+function renderTimingSection(reports: ModelReport[], timing: ProbeTiming): string[] {
+  const lines: string[] = [];
+  lines.push('## Timing');
+  lines.push('');
+  const ollamaNote = timing.ollamaStartedByUs
+    ? ` · Ollama server-start: ${secs(timing.ollamaStartMs)} (started by probe)`
+    : ' · Ollama: attached to a running server (no start cost)';
+  lines.push(`Total wall: **${secs(timing.totalWallMs)}**${ollamaNote}`);
+  lines.push('');
+  lines.push('| Model | Elapsed | Model-load | Case-exec | Per-case avg |');
+  lines.push('|-------|---------|-----------|-----------|--------------|');
+  for (const r of reports) {
+    if (!r.available || !r.timing) {
+      lines.push(`| ${r.model} | — | — | — | — |`);
+      continue;
+    }
+    const avg = r.timing.caseExecMs / CASES.length;
+    lines.push(
+      `| ${r.model} | ${secs(r.timing.elapsedMs)} | ${secs(r.timing.loadMs)} | ${secs(r.timing.caseExecMs)} | ${secs(avg)} |`,
+    );
+  }
+  lines.push('');
+  lines.push(
+    '> Model-load is the first-case `load_duration`; case-exec is the remaining inference wall. ' +
+      'Wall times depend on hardware, RAM pressure, and whether the model was already resident — ' +
+      'compare against a same-machine baseline, not across hosts.',
+  );
+  return lines;
+}
+
+function renderReport(reports: ModelReport[], timing: ProbeTiming): string {
   const lines: string[] = [];
   lines.push('# LLM Conformance Probe Report');
   lines.push('');
@@ -426,6 +535,10 @@ function renderReport(reports: ModelReport[]): string {
       `| ${r.model} | ${pass} | ${normalized} | ${tally('wrong_tool')} | ${tally('schema_invalid')} | ${tally('no_tool_call')} | ${tally('model_error')} | **${pct(pass, CASES.length)}** |`,
     );
   }
+  lines.push('');
+
+  // Timing (OMN-173) — drift becomes a diff once recorded to the suite-timing log.
+  lines.push(...renderTimingSection(reports, timing));
   lines.push('');
 
   // Per-model detail
@@ -499,6 +612,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  const runStartedAt = performance.now();
   const host = process.env.OLLAMA_HOST || 'http://localhost:11434';
   const ollama = new Ollama({ host });
   const lifecycle = await ensureOllama(ollama, host);
@@ -558,7 +672,19 @@ async function main(): Promise<void> {
       reports.push(await probeModel(ollama, model, tools, numCtx));
     }
 
-    process.stdout.write(renderReport(reports) + '\n');
+    const timing: ProbeTiming = {
+      ollamaStartedByUs: lifecycle.startedByUs,
+      ollamaStartMs: lifecycle.startMs,
+      totalWallMs: performance.now() - runStartedAt,
+    };
+    process.stdout.write(renderReport(reports, timing) + '\n');
+
+    // Machine-readable timing+scores for `npm run baseline:record` (OMN-173).
+    const timingJsonPath = process.env.PROBE_TIMING_JSON;
+    if (timingJsonPath) {
+      writeFileSync(timingJsonPath, JSON.stringify(buildTimingArtifact(reports, timing), null, 2) + '\n');
+      process.stderr.write(`Wrote timing artifact → ${timingJsonPath}\n`);
+    }
   } finally {
     await teardown();
   }

--- a/scripts/record-suite-timing.ts
+++ b/scripts/record-suite-timing.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+/**
+ * Record a suite-timing row (OMN-173).
+ *
+ * Appends one row to docs/dev/SUITE_TIMING_LOG.md from a conformance timing artifact
+ * (written by the probe via PROBE_TIMING_JSON) and/or a measured integration wall. Either
+ * half may be omitted — the absent suite renders as "—". Date and build (git rev-parse) are
+ * auto-filled. So drift is a diff, not a memory ([[project_mcp_cold_start_reconnect]]).
+ *
+ * Usage:
+ *   # conformance only (the probe wrote /tmp/conf.json)
+ *   PROBE_TIMING_JSON=/tmp/conf.json npm run conformance -- llama3.1:8b qwen2.5:7b
+ *   npx tsx scripts/record-suite-timing.ts --conformance-json /tmp/conf.json --notes "post-merge"
+ *
+ *   # integration only
+ *   npx tsx scripts/record-suite-timing.ts --integration-wall 529 --integration-tests 159
+ *
+ *   # both, dry-run (print the row, don't write)
+ *   npx tsx scripts/record-suite-timing.ts --conformance-json /tmp/conf.json --integration-wall 529 --dry-run
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import {
+  ARTIFACT_SCHEMA,
+  conformanceFromArtifact,
+  insertRow,
+  renderRow,
+  type ConformanceArtifact,
+  type RunRow,
+} from './lib/suite-timing.js';
+
+const DEFAULT_LOG = 'docs/dev/SUITE_TIMING_LOG.md';
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+function flag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function gitShort(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function todayLocal(): string {
+  // Local calendar date; the suite-timing log is a per-machine record, not a UTC ledger.
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+function die(msg: string): never {
+  process.stderr.write(`record-suite-timing: ${msg}\n`);
+  process.exit(2);
+}
+
+function main(): void {
+  const confJsonPath = arg('conformance-json') ?? process.env.PROBE_TIMING_JSON;
+  const intWallRaw = arg('integration-wall');
+  const intTestsRaw = arg('integration-tests');
+  const notes = arg('notes') ?? '';
+  const logPath = arg('log') ?? DEFAULT_LOG;
+  const dryRun = flag('dry-run');
+
+  if (!confJsonPath && intWallRaw === undefined) {
+    die('nothing to record — pass --conformance-json and/or --integration-wall');
+  }
+
+  let conformance: RunRow['conformance'] = [];
+  let conformanceTotalS: number | null = null;
+  if (confJsonPath) {
+    if (!existsSync(confJsonPath)) die(`conformance JSON not found: ${confJsonPath}`);
+    let art: ConformanceArtifact;
+    try {
+      art = JSON.parse(readFileSync(confJsonPath, 'utf8')) as ConformanceArtifact;
+    } catch (e) {
+      die(`conformance JSON is not valid JSON: ${String(e)}`);
+    }
+    // `art` is definitely assigned here: die() returns `never`, so the catch path cannot fall through.
+    if (art.schema !== ARTIFACT_SCHEMA) {
+      die(
+        `conformance JSON schema is "${art.schema}", expected "${ARTIFACT_SCHEMA}" — regenerate with the current probe`,
+      );
+    }
+    const c = conformanceFromArtifact(art);
+    conformance = c.conformance;
+    conformanceTotalS = c.conformanceTotalS;
+  }
+
+  const integrationWallS = intWallRaw === undefined ? null : Number(intWallRaw);
+  if (integrationWallS !== null && !Number.isFinite(integrationWallS))
+    die('--integration-wall must be a number (seconds)');
+  const integrationTests = intTestsRaw === undefined ? null : Number(intTestsRaw);
+  if (integrationTests !== null && !Number.isFinite(integrationTests)) die('--integration-tests must be a number');
+
+  const row: RunRow = {
+    date: arg('date') ?? todayLocal(),
+    build: arg('build') ?? gitShort(),
+    integrationWallS,
+    integrationTests,
+    conformance,
+    conformanceTotalS,
+    notes,
+  };
+
+  if (dryRun) {
+    process.stdout.write(renderRow(row) + '\n');
+    return;
+  }
+
+  if (!existsSync(logPath)) die(`log not found: ${logPath} (create it from the template first)`);
+  const updated = insertRow(readFileSync(logPath, 'utf8'), row);
+  writeFileSync(logPath, updated);
+  process.stderr.write(`Recorded row → ${logPath}\n`);
+  process.stdout.write(renderRow(row) + '\n');
+}
+
+main();

--- a/tests/unit/scripts/suite-timing.test.ts
+++ b/tests/unit/scripts/suite-timing.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ARTIFACT_SCHEMA,
+  TABLE_HEADER,
+  TABLE_SEPARATOR,
+  formatConformanceCell,
+  parseConformanceCell,
+  renderRow,
+  insertRow,
+  parseRows,
+  conformanceFromArtifact,
+  checkDeviation,
+  type RunRow,
+  type ConformanceArtifact,
+} from '../../../scripts/lib/suite-timing.js';
+
+const emptyLog = `# Suite Timing Log\n\n${TABLE_HEADER}\n${TABLE_SEPARATOR}\n`;
+
+function row(overrides: Partial<RunRow> = {}): RunRow {
+  return {
+    date: '2026-06-13',
+    build: 'abc1234',
+    integrationWallS: 529,
+    integrationTests: 159,
+    conformance: [{ model: 'llama3.1:8b', scorePct: 100, elapsedS: 31.2, loadS: 8.1 }],
+    conformanceTotalS: 55,
+    notes: '',
+    ...overrides,
+  };
+}
+
+describe('formatConformanceCell / parseConformanceCell round-trip', () => {
+  it('round-trips a measured multi-model run', () => {
+    const models = [
+      { model: 'llama3.1:8b', scorePct: 100, elapsedS: 31.2, loadS: 8.1 },
+      { model: 'qwen2.5:7b', scorePct: 84, elapsedS: 41.8, loadS: 7.0 },
+    ];
+    const parsed = parseConformanceCell(formatConformanceCell(models));
+    expect(parsed).toEqual(models);
+  });
+
+  it('round-trips a pre-instrumentation seed (elapsed/load unknown)', () => {
+    const models = [{ model: 'llama3.1:8b', scorePct: 100, elapsedS: null, loadS: null }];
+    const parsed = parseConformanceCell(formatConformanceCell(models));
+    expect(parsed).toEqual(models);
+  });
+
+  it('treats the em-dash sentinel as no models', () => {
+    expect(parseConformanceCell('—')).toEqual([]);
+    expect(formatConformanceCell([])).toBe('—');
+  });
+});
+
+describe('renderRow', () => {
+  it('renders a single pipe-delimited line with the right cell count', () => {
+    const line = renderRow(row());
+    // 7 columns → 8 pipes
+    expect(line.match(/\|/g)?.length).toBe(8);
+    expect(line).toContain('2026-06-13');
+    expect(line).toContain('529s');
+    expect(line).toContain('llama3.1:8b 100% 31.2s/8.1s');
+  });
+
+  it('renders "—" for absent suites', () => {
+    const line = renderRow(
+      row({ integrationWallS: null, integrationTests: null, conformance: [], conformanceTotalS: null }),
+    );
+    expect(line).toContain('| — |');
+  });
+
+  it('never lets a note break the table (pipes are replaced)', () => {
+    const line = renderRow(row({ notes: 'has | a | pipe' }));
+    // exactly the 8 structural pipes, none from the note
+    expect(line.match(/\|/g)?.length).toBe(8);
+    expect(line).toContain('has / a / pipe');
+  });
+});
+
+describe('insertRow', () => {
+  it('inserts newest-first directly under the separator', () => {
+    const withOne = insertRow(emptyLog, row({ date: '2026-06-13', build: 'old' }));
+    const withTwo = insertRow(withOne, row({ date: '2026-06-14', build: 'new' }));
+    const rows = parseRows(withTwo);
+    expect(rows.map((r) => r.build)).toEqual(['new', 'old']);
+  });
+
+  it('throws when the table separator is missing', () => {
+    expect(() => insertRow('# no table here\n', row())).toThrow(/separator/);
+  });
+});
+
+describe('parseRows round-trip', () => {
+  it('parses back what renderRow wrote', () => {
+    const original = row({
+      conformance: [
+        { model: 'llama3.1:8b', scorePct: 100, elapsedS: 31.2, loadS: 8.1 },
+        { model: 'qwen2.5:7b', scorePct: 84, elapsedS: 41.8, loadS: 7.0 },
+      ],
+      notes: 'post-merge baseline',
+    });
+    const parsed = parseRows(insertRow(emptyLog, original));
+    expect(parsed).toEqual([original]);
+  });
+
+  it('skips the header and separator lines', () => {
+    expect(parseRows(emptyLog)).toEqual([]);
+  });
+});
+
+describe('conformanceFromArtifact', () => {
+  it('converts ms→s with one decimal and carries scores', () => {
+    const art: ConformanceArtifact = {
+      schema: ARTIFACT_SCHEMA,
+      ollama: { startedByUs: true, startMs: 2000 },
+      totalWallMs: 55400,
+      models: [
+        {
+          model: 'llama3.1:8b',
+          available: true,
+          passed: 19,
+          cases: 19,
+          scorePct: 100,
+          elapsedMs: 31234,
+          loadMs: 8120,
+          caseExecMs: 23114,
+        },
+      ],
+    };
+    const out = conformanceFromArtifact(art);
+    expect(out.conformanceTotalS).toBe(55.4);
+    expect(out.conformance[0]).toEqual({ model: 'llama3.1:8b', scorePct: 100, elapsedS: 31.2, loadS: 8.1 });
+  });
+
+  it('passes through nulls for an unavailable model', () => {
+    const art: ConformanceArtifact = {
+      schema: ARTIFACT_SCHEMA,
+      ollama: { startedByUs: false, startMs: 0 },
+      totalWallMs: 1000,
+      models: [
+        {
+          model: 'ghost:7b',
+          available: false,
+          passed: 0,
+          cases: 19,
+          scorePct: null,
+          elapsedMs: null,
+          loadMs: null,
+          caseExecMs: null,
+        },
+      ],
+    };
+    expect(conformanceFromArtifact(art).conformance[0]).toEqual({
+      model: 'ghost:7b',
+      scorePct: null,
+      elapsedS: null,
+      loadS: null,
+    });
+  });
+});
+
+describe('checkDeviation', () => {
+  const baselineRows = (vals: number[]): RunRow[] =>
+    vals.map((v, i) =>
+      row({ date: `2026-06-${10 + i}`, integrationWallS: v, conformance: [], conformanceTotalS: null }),
+    );
+
+  it('passes when the newest is within tolerance of the prior median', () => {
+    // newest 540, prior median 530 → +1.9%
+    const rows = [
+      row({ integrationWallS: 540, conformance: [], conformanceTotalS: null }),
+      ...baselineRows([530, 520, 540]),
+    ];
+    const res = checkDeviation(rows, { thresholdPct: 25 });
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual([]);
+  });
+
+  it('flags a slow regression beyond threshold', () => {
+    // newest 800, prior median 530 → +51%
+    const rows = [
+      row({ integrationWallS: 800, conformance: [], conformanceTotalS: null }),
+      ...baselineRows([530, 520, 540]),
+    ];
+    const res = checkDeviation(rows, { thresholdPct: 25 });
+    expect(res.ok).toBe(false);
+    expect(res.findings[0]).toMatchObject({ metric: 'integration_wall_s', latest: 800, deltaPct: 51 });
+  });
+
+  it('flags a faster outlier too (signed delta)', () => {
+    const rows = [
+      row({ integrationWallS: 300, conformance: [], conformanceTotalS: null }),
+      ...baselineRows([530, 520, 540]),
+    ];
+    const res = checkDeviation(rows, { thresholdPct: 25 });
+    expect(res.ok).toBe(false);
+    expect(res.findings[0].deltaPct).toBeLessThan(0);
+  });
+
+  it('skips metrics with no prior history rather than failing', () => {
+    const res = checkDeviation([row()], { thresholdPct: 25 });
+    expect(res.ok).toBe(true);
+    expect(res.skipped).toContain('integration_wall_s');
+  });
+
+  it('keys per-model conformance elapsed independently', () => {
+    const mk = (llamaElapsed: number): RunRow =>
+      row({
+        integrationWallS: null,
+        conformance: [{ model: 'llama3.1:8b', scorePct: 100, elapsedS: llamaElapsed, loadS: 8 }],
+        conformanceTotalS: null,
+      });
+    const rows = [mk(60), mk(31), mk(30), mk(32)]; // newest 60 vs median 31 → +94%
+    const res = checkDeviation(rows, { thresholdPct: 25 });
+    expect(res.findings.some((f) => f.metric === 'conformance_elapsed_s[llama3.1:8b]')).toBe(true);
+  });
+
+  it('does not compare a suite that was not run this time (null latest)', () => {
+    const rows = [
+      row({ integrationWallS: null, conformance: [], conformanceTotalS: null }),
+      ...baselineRows([530, 520, 540]),
+    ];
+    const res = checkDeviation(rows, { thresholdPct: 25 });
+    expect(res.ok).toBe(true);
+    expect(res.findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds a persisted, per-run time-series of how long the **integration** and **conformance** suites take, so "is the suite getting slower as it grows?" and "did a model-load regression creep in?" are answerable from a **git diff**, not from scraping old logs. Mirrors the cold-start reconnect convention: *drift is a diff, not a memory*.

## Pieces

| File | Role |
|------|------|
| `scripts/lib/suite-timing.ts` | Side-effect-free row/render/parse/deviation logic (unit-testable without Ollama or the suite) |
| `scripts/record-suite-timing.ts` (`npm run baseline:record`) | Append a row from a conformance timing artifact and/or a measured integration wall; date + build auto-filled; either suite may be omitted (renders `—`); `--dry-run` preview |
| `scripts/check-suite-timing.ts` (`npm run baseline:check`) | Newest row vs rolling median of prior N rows, ±threshold; exits non-zero on deviation; NaN args fail loud |
| `scripts/llm-conformance-probe.ts` | New `## Timing` report section (Ollama start, per-model load vs case-exec split, total wall) + a schema-tagged machine-readable artifact when `PROBE_TIMING_JSON` is set |
| `docs/dev/SUITE_TIMING_LOG.md` | The canonical store (Markdown table, newest-first) + how-to |
| `tests/unit/scripts/suite-timing.test.ts` | 18 unit tests over the pure logic |

## Why a Markdown table (not JSONL)

The ticket's framing is "drift is a diff." A fixed-column Markdown table makes every regression a readable git diff while staying machine-parseable (cells guaranteed pipe-free). The pure logic round-trips render ↔ parse.

## Verification

- `npm run build` (tsc) — clean
- 18/18 unit tests pass
- `baseline:record --dry-run` — renders a valid row
- ESLint — 0 errors (3 sonarjs *warnings* in the probe; `scripts/` is not covered by CI `npm run lint`)
- Rebased onto current `main` (`a8ffd69`, post-OMN-161 S1–S4) — no conflicts; premise-checked that S1–S4 touched none of these files
- Code-review subagent verdict: **SAFE**, zero must-fix (verified parse/render round-trip, deviation math, `load_duration` attribution, silent-failure audit)

Post-merge, the first integration-wall + conformance-wall rows at the merged build SHA will be recorded to the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)