### PR TITLE
fix(OMN-177): strip internal __normalized__ brand from filters_applied

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -14,7 +14,7 @@
  */
 
 import type { TaskFilter, ProjectFilter, NormalizedTaskFilter, TextOperator, FolderFilter } from '../filters.js';
-import { normalizeFilter } from '../filters.js';
+import { normalizeFilter, stripNormalizedBrand } from '../filters.js';
 import {
   generateFilterCode,
   generateProjectFilterCode,
@@ -2113,7 +2113,7 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
     const endTime = Date.now();
     return JSON.stringify({
       count: count,
-      filters_applied: ${JSON.stringify(filter)},
+      filters_applied: ${JSON.stringify(stripNormalizedBrand(filter))},
       query_time_ms: endTime - startTime,
       optimization: 'omnijs_count${needsTags ? '_with_tags' : '_no_tags'}',
       filter_description: ${JSON.stringify(filterDescription)},

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -515,6 +515,20 @@ export function isNormalizedFilter(filter: TaskFilter | NormalizedTaskFilter): f
   return (filter as Record<string, unknown>)[NORMALIZED_FILTER_BRAND] === true;
 }
 
+/**
+ * Return a brand-free shallow copy of a filter (OMN-177).
+ *
+ * The `__normalized__` brand is an internal NormalizedTaskFilter marker, not a
+ * filter the user applied. Echo sites that surface a filter in user-facing
+ * metadata (`filters_applied`) must route it through this helper so the brand
+ * never reaches the wire. Does not mutate the input.
+ */
+export function stripNormalizedBrand(filter: TaskFilter | NormalizedTaskFilter): Record<string, unknown> {
+  const rest = { ...(filter as Record<string, unknown>) };
+  delete rest[NORMALIZED_FILTER_BRAND];
+  return rest;
+}
+
 // =============================================================================
 // NORMALIZATION
 // =============================================================================

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -45,6 +45,7 @@ import {
 } from '../../utils/response-format.js';
 import type { ExportDataV2 } from '../response-types-v2.js';
 import type { TaskFilter, ProjectFilter } from '../../contracts/filters.js';
+import { stripNormalizedBrand } from '../../contracts/filters.js';
 import {
   augmentFilterForMode,
   getDefaultSort,
@@ -541,7 +542,7 @@ PERFORMANCE:
       mode: mode || 'count_only',
       count_only: true,
       total_count: count,
-      filters_applied: countFilter as unknown as Record<string, unknown>,
+      filters_applied: stripNormalizedBrand(countFilter),
       optimization: data.optimization || 'ast_omnijs_bridge',
       filter_description: data.filter_description,
       warning: data.warning,

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -18,6 +18,7 @@ import {
   resolveEffectiveProjectFields,
 } from '../../../../src/contracts/ast/script-builder.js';
 import type { TaskFilter } from '../../../../src/contracts/filters.js';
+import { normalizeFilter } from '../../../../src/contracts/filters.js';
 
 describe('buildFilteredTasksScript', () => {
   describe('basic script generation', () => {
@@ -538,6 +539,24 @@ describe('buildTaskCountScript', () => {
 
       expect(result.script).toContain('task.taskStatus === Task.Status.Dropped');
       expect(result.script).not.toContain('task.taskStatus !== Task.Status.Dropped');
+    });
+  });
+
+  // OMN-177: the count script echoes the raw input filter into filters_applied.
+  // When the caller passes an already-normalized (branded) filter — as the count
+  // path does — JSON.stringify must not carry the internal __normalized__ brand
+  // onto the wire.
+  describe('filters_applied brand leak (OMN-177)', () => {
+    it('omits the __normalized__ brand from a branded input filter', () => {
+      const branded = normalizeFilter({ deferBefore: '2026-12-31' });
+      // sanity: the input really is branded
+      expect((branded as Record<string, unknown>).__normalized__).toBe(true);
+
+      const { script } = buildTaskCountScript(branded);
+
+      expect(script).not.toContain('__normalized__');
+      // the real filter key is still echoed
+      expect(script).toContain('deferBefore');
     });
   });
 

--- a/tests/unit/contracts/filters.test.ts
+++ b/tests/unit/contracts/filters.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeFilter, stripNormalizedBrand } from '../../../src/contracts/filters.js';
+
+// OMN-177: the __normalized__ brand is an internal NormalizedTaskFilter marker.
+// It must never reach user-facing metadata (filters_applied). stripNormalizedBrand
+// returns a brand-free shallow copy for echo sites.
+describe('OMN-177: stripNormalizedBrand', () => {
+  it('removes the __normalized__ brand key from a normalized filter', () => {
+    const branded = normalizeFilter({ deferBefore: '2026-12-31' });
+    // sanity: it really is branded
+    expect((branded as Record<string, unknown>).__normalized__).toBe(true);
+
+    const stripped = stripNormalizedBrand(branded);
+
+    expect(Object.keys(stripped)).not.toContain('__normalized__');
+    // real filter keys survive
+    expect(stripped.deferBefore).toBe('2026-12-31');
+  });
+
+  it('returns an equivalent object for a non-branded filter', () => {
+    const stripped = stripNormalizedBrand({ flagged: true });
+    expect(stripped).toEqual({ flagged: true });
+  });
+
+  it('does not mutate the input filter', () => {
+    const branded = normalizeFilter({ flagged: true });
+    stripNormalizedBrand(branded);
+    expect((branded as Record<string, unknown>).__normalized__).toBe(true);
+  });
+});

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -904,6 +904,29 @@ describe('OmniFocusReadTool', () => {
       });
     });
 
+    // OMN-177: countOnly tasks queries echoed metadata.filters_applied built from
+    // the branded (normalized) filter, leaking the internal __normalized__ marker
+    // onto the wire. The echo must be brand-free.
+    describe('OMN-177: countOnly does not leak the __normalized__ brand', () => {
+      it('strips __normalized__ from metadata.filters_applied', async () => {
+        execJsonSpy.mockResolvedValueOnce({
+          success: true,
+          data: {
+            count: 5,
+            filter_description: 'defer before 2026-12-31',
+            optimization: 'omnijs_count_no_tags',
+          },
+        } satisfies ScriptResult);
+
+        const result = (await tool.execute({
+          query: { type: 'tasks', filters: { deferDate: { before: '2026-12-31' } }, countOnly: true },
+        })) as any;
+
+        expect(result.metadata.filters_applied).toBeDefined();
+        expect(Object.keys(result.metadata.filters_applied)).not.toContain('__normalized__');
+      });
+    });
+
     // OMN-44: tasks export silently dropped records and ignored includeCompleted.
     // Two distinct bugs in handleTaskExport: outputDirectory was never read
     // (only handleBulkExport consumed it), and includeCompleted was never


### PR DESCRIPTION
**Wave 1, item 3.** Closes OMN-177.

## Problem
A `countOnly` tasks query returned `metadata.filters_applied` carrying the internal `NormalizedTaskFilter` brand (found during OMN-172 live-verify, prod `a8ffd692`):

```json
"filters_applied": { "deferBefore": "2026-12-31", "__normalized__": true }
```

`__normalized__` is an implementation marker (`NORMALIZED_FILTER_BRAND`), not a filter the user applied — an internal key surfacing in user-facing metadata, the exact class the selection-honesty cluster targets. Pre-existing (not an OMN-172 regression).

## Fix
- New `stripNormalizedBrand()` in `src/contracts/filters.ts` — non-mutating, returns a brand-free shallow copy.
- Routed both count-path echo sites through it:
  - `OmniFocusReadTool.ts` `executeCountOnly` (tool response metadata) — was the wire leak.
  - `script-builder.ts` `buildTaskCountScript` (generated OmniJS count script) — defense in depth on the script's own `filters_applied`.

## Sibling audit
The three `OmniFocusAnalyzeTool` `filters_applied` sites echo analyze **options** (`analyzeOptions`/`patternsOptions`/`args`), not normalized filters — they carry no brand, so they're out of scope.

## Tests (TDD)
- `tests/unit/contracts/filters.test.ts` — helper unit coverage (strips brand, keeps real keys, no mutation).
- `script-builder.test.ts` — branded input → generated script contains no `__normalized__`.
- `OmniFocusReadTool.test.ts` — count path → `metadata.filters_applied` has no `__normalized__` (reproduces the exact live-verify output, then asserts it's gone).

Full unit suite green (3250 tests). No schema change. Stretch (an F10-style forcing function asserting `filters_applied` carries no internal-only keys) deferred — noted on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)