### PR TITLE
refactor(OMN-129): read-side JXA→OmniJS boundary to JSON.stringify; retire escapeTemplateString

### DIFF
--- a/src/contracts/ast/bridge-escape.ts
+++ b/src/contracts/ast/bridge-escape.ts
@@ -1,27 +1,32 @@
 /**
- * Escape ONLY the JS template-literal hazards (backtick and ${) — NOT
- * backslash. Use on a value already produced by JSON.stringify (whose
- * backslashes are final); adding backslash-escaping here would double-escape
- * and corrupt the literal. For raw (non-JSON-stringified) text use
- * escapeTemplateString instead.
+ * OMN-129: the read side now crosses the JXA→OmniJS boundary exactly as the write
+ * side does — `app.evaluateJavascript(${JSON.stringify(program)})` — so the program
+ * rides inside a single JSON string literal. JSON.stringify escapes every quote,
+ * backslash, newline, control char, and unicode per the JS spec, which deletes the
+ * nested-backtick + hand-rolled-escaper mechanism behind OMN-111/113 outright. The
+ * old `escapeTemplateString` / `escapeTemplateLiteralHazards` helpers are therefore
+ * retired; this module now carries only the comment-line guard below.
+ *
+ * sanitizeForScriptComment is STILL load-bearing after the boundary fix: the
+ * boundary JSON.stringify protects the OUTER JS string literal, but the inner OmniJS
+ * that OmniFocus compiles sees the separator restored. A raw line terminator inside a
+ * `// Filter:` comment would split it into live code even with the JSON.stringify
+ * boundary in place — so line terminators must still be scrubbed before they reach a
+ * comment line.
  */
-export function escapeTemplateLiteralHazards(s: string): string {
-  return s.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
-}
-
-/** Escape a string for safe embedding inside a JXA backtick template literal. */
-export function escapeTemplateString(str: string): string {
-  return escapeTemplateLiteralHazards(str.replace(/\\/g, '\\\\'));
-}
 
 /**
- * Make a human filter description safe inside a single-line `//` comment within
- * a bridge template. escapeTemplateString handles backtick/${ /backslash but
- * NOT newlines; a CR/LF (or other control char) would split the `//` line and
- * break the OmniJS parse even after whole-source escaping. Collapse any run of
- * C0 control chars (incl. CR/LF/tab) and DEL to one space; trim.
+ * Make a human filter description safe inside a single-line `//` comment within a
+ * bridge program. Any JS LineTerminator would split the `//` line and break (or
+ * inject into) the OmniJS the bridge compiles — and JS has FOUR: CR, LF, U+2028
+ * (line separator) and U+2029 (paragraph separator). JSON.stringify at the boundary
+ * leaves U+2028/U+2029 literal (they are not JSON control chars) and they are valid
+ * inside the OUTER string literal, so they slip past the boundary and only bite when
+ * OmniFocus compiles the inner program — exactly the OMN-111/113 comment channel via
+ * a Unicode separator (surfaced by the OMN-129 fuzz). Collapse any run of C0 control
+ * chars (incl. CR/LF/tab), DEL, and U+2028/U+2029 to one space; trim.
  */
 export function sanitizeForScriptComment(desc: string): string {
   // eslint-disable-next-line no-control-regex
-  return desc.replace(/[\x00-\x1f\x7f]+/g, ' ').trim();
+  return desc.replace(/[\x00-\x1f\x7f\u2028\u2029]+/g, ' ').trim();
 }

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -1833,8 +1833,8 @@ export function buildFilteredFoldersScript(options: FolderScriptOptions = {}): G
 
   const isEmpty = isEmptyFolderFilter(filter);
   const filterDescription = describeFolderFilter(filter);
-  // OMN-170 S2: generated inside the OmniJS body; value terms injected via
-  // JSON.stringify and the whole source escaped by escapeTemplateString below.
+  // OMN-170 S2 / OMN-129: generated inside the OmniJS body; value terms injected via
+  // JSON.stringify, and the whole source crosses the boundary via JSON.stringify below.
   const folderPredicate = generateFolderFilterCode(filter);
 
   const omniJsSource = `

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -25,7 +25,7 @@ import {
   describeFolderFilter,
 } from './filter-generator.js';
 import { buildAST } from './builder.js';
-import { escapeTemplateString, escapeTemplateLiteralHazards, sanitizeForScriptComment } from './bridge-escape.js';
+import { sanitizeForScriptComment } from './bridge-escape.js';
 
 // =============================================================================
 // TYPES
@@ -1375,9 +1375,7 @@ export function buildFilteredProjectsScript(
   const app = Application('OmniFocus');
 
   try {
-    const omniJsScript = \`${escapeTemplateString(omniJsSource)}\`;
-
-    const resultJson = app.evaluateJavascript(omniJsScript);
+    const resultJson = app.evaluateJavascript(${JSON.stringify(omniJsSource)});
     const result = JSON.parse(resultJson);
 
     return JSON.stringify({
@@ -1390,7 +1388,7 @@ export function buildFilteredProjectsScript(
         performance_mode: '${performanceMode}',
         stats_included: ${includeStats},
         optimization: 'ast_filtered',
-        filter_description: ${escapeTemplateLiteralHazards(JSON.stringify(filterDescription))}
+        filter_description: ${JSON.stringify(filterDescription)}
       }
     });
 
@@ -1462,9 +1460,7 @@ export function buildProjectByIdScript(projectId: string, fields: string[] = [])
   const app = Application('OmniFocus');
 
   try {
-    const omniJsScript = \`${escapeTemplateString(omniJsSource)}\`;
-
-    const resultJson = app.evaluateJavascript(omniJsScript);
+    const resultJson = app.evaluateJavascript(${JSON.stringify(omniJsSource)});
     return resultJson;
 
   } catch (error) {
@@ -1661,9 +1657,7 @@ export function buildExportTasksScript(filter: ExportFilter = {}, options: Expor
     const startTime = Date.now();
 
     // Use OmniJS bridge for fast bulk property access
-    const omniJsScript = \`${escapeTemplateString(omniJsSource)}\`;
-
-    const bridgeResult = app.evaluateJavascript(omniJsScript);
+    const bridgeResult = app.evaluateJavascript(${JSON.stringify(omniJsSource)});
     const parsed = JSON.parse(bridgeResult);
     const tasks = parsed.tasks;
     const tasksAdded = parsed.tasksCollected;
@@ -1768,7 +1762,7 @@ export function buildExportTasksScript(filter: ExportFilter = {}, options: Expor
         debug: {
           totalTasksProcessed: parsed.totalProcessed,
           maxTasksAllowed: maxTasks,
-          filterDescription: ${escapeTemplateLiteralHazards(JSON.stringify(filterDescription))},
+          filterDescription: ${JSON.stringify(filterDescription)},
           fieldsRequested: allFields,
           optimizationUsed: 'AST filter + OmniJS bridge'
         },
@@ -1989,9 +1983,7 @@ export function buildFilteredFoldersScript(options: FolderScriptOptions = {}): G
   const app = Application('OmniFocus');
 
   try {
-    const omniJsScript = \`${escapeTemplateString(omniJsSource)}\`;
-
-    const result = app.evaluateJavascript(omniJsScript);
+    const result = app.evaluateJavascript(${JSON.stringify(omniJsSource)});
     return result;
 
   } catch (error) {
@@ -2132,8 +2124,7 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
   const app = Application('OmniFocus');
 
   try {
-    const omniJsScript = \`${escapeTemplateString(omniJsSource)}\`;
-    return app.evaluateJavascript(omniJsScript);
+    return app.evaluateJavascript(${JSON.stringify(omniJsSource)});
   } catch (e) {
     return JSON.stringify({ error: true, message: e.message || String(e), context: 'task_count_omnijs' });
   }

--- a/src/contracts/ast/tag-script-builder.ts
+++ b/src/contracts/ast/tag-script-builder.ts
@@ -16,7 +16,6 @@
 import type { TagQueryOptions, TagSortBy } from '../tag-options.js';
 import type { TextOperator } from '../filters.js';
 import type { GeneratedScript } from './script-builder.js';
-import { escapeTemplateString } from './bridge-escape.js';
 
 // =============================================================================
 // MAIN TAG SCRIPT BUILDER
@@ -82,14 +81,7 @@ function buildTagNamesScript(options: TagScriptOptions = {}): GeneratedScript {
   const limitClause = limit ? `const limitCount = ${limit};` : '';
   const limitCheck = limit ? 'if (count >= limitCount) return;' : '';
 
-  const script = `
-(() => {
-  const app = Application('OmniFocus');
-
-  try {
-    const startTime = Date.now();
-
-    const omniJsScript = \`
+  const namesOmniJsSource = `
       (() => {
         const tagNames = [];
         ${limitClause}
@@ -109,9 +101,17 @@ function buildTagNamesScript(options: TagScriptOptions = {}): GeneratedScript {
           total: tagNames.length
         });
       })()
-    \`;
+    `;
 
-    const resultJson = app.evaluateJavascript(omniJsScript);
+  const script = `
+(() => {
+  const app = Application('OmniFocus');
+
+  try {
+    const startTime = Date.now();
+
+    // OMN-129: program crosses the JXA→OmniJS boundary as a JSON string literal.
+    const resultJson = app.evaluateJavascript(${JSON.stringify(namesOmniJsSource)});
     const result = JSON.parse(resultJson);
 
     // Sort by name (only option for names mode)
@@ -166,10 +166,11 @@ function buildBasicTagsScript(options: TagScriptOptions = {}): GeneratedScript {
   const namePredicate = tagNamePredicate(name, nameOperator);
   const hasFilter = !!name;
 
-  // OMN-170 S2: build the inner OmniJS as a plain source string, then wrap it via
-  // escapeTemplateString — the established nested-backtick safety mechanism. The
-  // name term lands inside this source (via namePredicate's JSON.stringify); the
-  // whole-source escape neutralizes any backtick/${ in the term (OMN-111/113).
+  // OMN-170 S2 / OMN-129: build the inner OmniJS as a plain source string, then
+  // hand it across the JXA→OmniJS boundary as a single JSON.stringify'd string
+  // literal (no nested backtick). The name term lands inside this source via
+  // namePredicate's JSON.stringify; JSON.stringify at the boundary neutralizes any
+  // backtick/${ in the term — killing the OMN-111/113 class outright.
   const tagsOmniJsSource = `
       (() => {
         const tags = [];
@@ -208,9 +209,7 @@ function buildBasicTagsScript(options: TagScriptOptions = {}): GeneratedScript {
   try {
     const startTime = Date.now();
 
-    const omniJsScript = \`${escapeTemplateString(tagsOmniJsSource)}\`;
-
-    const resultJson = app.evaluateJavascript(omniJsScript);
+    const resultJson = app.evaluateJavascript(${JSON.stringify(tagsOmniJsSource)});
     const result = JSON.parse(resultJson);
 
     // Sort by name
@@ -269,18 +268,7 @@ function buildFullTagsScript(options: FullTagScriptOptions = {}): GeneratedScrip
 
   const limitClause = limit ? `const limitCount = ${limit};` : '';
 
-  const script = `
-(() => {
-  const app = Application('OmniFocus');
-
-  try {
-    const startTime = Date.now();
-    const includeUsageStats = ${includeUsageStats};
-    const includeEmpty = ${includeEmpty};
-    const sortBy = '${sortBy}';
-    ${limitClause}
-
-    const omniJsScript = \`
+  const fullOmniJsSource = `
       (() => {
         const tagDataMap = {};
         const tagUsageByName = {};
@@ -370,9 +358,21 @@ function buildFullTagsScript(options: FullTagScriptOptions = {}): GeneratedScrip
           total: tagsArray.length
         });
       })()
-    \`;
+    `;
 
-    const resultJson = app.evaluateJavascript(omniJsScript);
+  const script = `
+(() => {
+  const app = Application('OmniFocus');
+
+  try {
+    const startTime = Date.now();
+    const includeUsageStats = ${includeUsageStats};
+    const includeEmpty = ${includeEmpty};
+    const sortBy = '${sortBy}';
+    ${limitClause}
+
+    // OMN-129: program crosses the JXA→OmniJS boundary as a JSON string literal.
+    const resultJson = app.evaluateJavascript(${JSON.stringify(fullOmniJsSource)});
     const result = JSON.parse(resultJson);
 
     // Filter empty tags if requested (only meaningful with usage stats)
@@ -443,15 +443,7 @@ function buildFullTagsScript(options: FullTagScriptOptions = {}): GeneratedScrip
  * Build script to get active tags only (tags with at least one incomplete task)
  */
 export function buildActiveTagsScript(): GeneratedScript {
-  const script = `
-(() => {
-  const app = Application('OmniFocus');
-
-  try {
-    const startTime = Date.now();
-
-    // Pure OmniJS bridge to get active tags
-    const omniJsScript = \`
+  const activeOmniJsSource = `
       (() => {
         const tagUsage = {};
 
@@ -474,9 +466,18 @@ export function buildActiveTagsScript(): GeneratedScript {
           total: activeTags.length
         });
       })()
-    \`;
+    `;
 
-    const resultJson = app.evaluateJavascript(omniJsScript);
+  const script = `
+(() => {
+  const app = Application('OmniFocus');
+
+  try {
+    const startTime = Date.now();
+
+    // Pure OmniJS bridge to get active tags (OMN-129: program crosses the
+    // JXA→OmniJS boundary as a JSON string literal, not a nested backtick).
+    const resultJson = app.evaluateJavascript(${JSON.stringify(activeOmniJsSource)});
     const result = JSON.parse(resultJson);
 
     // Sort alphabetically

--- a/src/omnifocus/scripts/tasks/list-tasks-ast.ts
+++ b/src/omnifocus/scripts/tasks/list-tasks-ast.ts
@@ -24,7 +24,6 @@ import {
   buildInboxScript,
   buildTaskByIdScript,
 } from '../../../contracts/ast/script-builder.js';
-import { escapeTemplateString } from '../../../contracts/ast/bridge-escape.js';
 
 /**
  * Build a V4 task query script using AST-generated filters
@@ -85,9 +84,10 @@ export function buildListTasksScriptV4(params: {
   const app = Application('OmniFocus');
 
   try {
-    // Execute AST-generated OmniJS script
-    const omniJsScript = \`${escapeTemplateString(generatedScript.script)}\`;
-    const resultJson = app.evaluateJavascript(omniJsScript);
+    // Execute AST-generated OmniJS script (OMN-129: the program crosses the
+    // JXA→OmniJS boundary as a single JSON.stringify'd string literal — no nested
+    // backtick, no hand-rolled escaper — which kills the OMN-111/113 class outright).
+    const resultJson = app.evaluateJavascript(${JSON.stringify(generatedScript.script)});
     const result = JSON.parse(resultJson);
 
     // Return with metadata

--- a/tests/unit/contracts/ast/bridge-escape.test.ts
+++ b/tests/unit/contracts/ast/bridge-escape.test.ts
@@ -1,37 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import {
-  escapeTemplateString,
-  escapeTemplateLiteralHazards,
-  sanitizeForScriptComment,
-} from '../../../../src/contracts/ast/bridge-escape.js';
+import { sanitizeForScriptComment } from '../../../../src/contracts/ast/bridge-escape.js';
 
-describe('escapeTemplateString', () => {
-  it('escapes backslash, backtick, and ${', () => {
-    expect(escapeTemplateString('a\\b')).toBe('a\\\\b');
-    expect(escapeTemplateString('a`b')).toBe('a\\`b');
-    expect(escapeTemplateString('a${x}b')).toBe('a\\${x}b');
-  });
-  it('is identity on benign input', () => {
-    expect(escapeTemplateString('plain text 123 _-.')).toBe('plain text 123 _-.');
-  });
-  it("does NOT alter newlines (that is sanitizeForScriptComment's job)", () => {
-    expect(escapeTemplateString('a\nb')).toBe('a\nb');
-  });
-});
-
-describe('escapeTemplateLiteralHazards', () => {
-  it('escapes backtick and ${ but NOT backslash', () => {
-    expect(escapeTemplateLiteralHazards('a`b')).toBe('a\\`b');
-    expect(escapeTemplateLiteralHazards('a${x}b')).toBe('a\\${x}b');
-    // backslash is left untouched (caller already JSON.stringify'd it)
-    expect(escapeTemplateLiteralHazards('a\\b')).toBe('a\\b');
-    expect(escapeTemplateLiteralHazards('a\\\\b')).toBe('a\\\\b');
-  });
-  it('is identity on benign input', () => {
-    expect(escapeTemplateLiteralHazards('plain text 123 _-.')).toBe('plain text 123 _-.');
-  });
-});
-
+// OMN-129 retired escapeTemplateString / escapeTemplateLiteralHazards: the read
+// side now crosses the JXA→OmniJS boundary via JSON.stringify(program) (see
+// bridge-injection.test.ts), so the hand-rolled template-literal escapers no longer
+// exist. sanitizeForScriptComment survives — JSON.stringify guards the outer string
+// literal, but a raw CR/LF inside a `// Filter:` comment still splits the inner
+// OmniJS that OmniFocus compiles, so control chars must be scrubbed from comments.
 describe('sanitizeForScriptComment', () => {
   it('collapses CR/LF/tab/control runs to a single space and trims', () => {
     expect(sanitizeForScriptComment('a\r\n\tb')).toBe('a b');
@@ -40,5 +15,17 @@ describe('sanitizeForScriptComment', () => {
   });
   it('is identity on benign single-line input', () => {
     expect(sanitizeForScriptComment('text: "abc" AND flagged')).toBe('text: "abc" AND flagged');
+  });
+
+  it('collapses U+2028/U+2029 — JS line/paragraph separators (OMN-129 fuzz)', () => {
+    // These are NOT C0 control chars, so JSON.stringify leaves them literal and they
+    // pass the boundary; but they ARE JS LineTerminators, so an un-scrubbed one would
+    // split the `// Filter:` comment in the compiled OmniJS. Constructed via charCode
+    // so no raw line terminator lands in this test's source.
+    const LS = String.fromCharCode(0x2028);
+    const PS = String.fromCharCode(0x2029);
+    expect(sanitizeForScriptComment(`a${LS}b`)).toBe('a b');
+    expect(sanitizeForScriptComment(`a${PS}b`)).toBe('a b');
+    expect(sanitizeForScriptComment(`a${LS}${PS}\nb`)).toBe('a b');
   });
 });

--- a/tests/unit/contracts/ast/bridge-injection.test.ts
+++ b/tests/unit/contracts/ast/bridge-injection.test.ts
@@ -21,37 +21,78 @@ function parses(script: string): boolean {
   }
 }
 
-// A parse-only check (`new Function`) only sees the OUTER JXA wrapper — the
-// inner OmniJS is an opaque string to it, so it ONLY catches the backtick
-// structural break. The ${x} (eval-time) and newline (comment-split) channels
-// are invisible to parse alone. So additionally assert the hostile payload
-// never appears RAW in the generated script — only in escaped/sanitized form.
-// That assertion is what gives genuine RED→GREEN for the ${ and \n channels.
-function assertSafe(script: string, v: string) {
-  expect(parses(script)).toBe(true); // backtick structural channel
-  if (v === 'a`b') {
-    expect(script.includes('a`b')).toBe(false); // no raw unescaped backtick payload
-    expect(script.includes('a\\`b')).toBe(true); // present only as \`
-  } else if (v === 'a${x}b') {
-    expect(script.includes('a${x}b')).toBe(false); // no raw live ${x}
-    expect(script.includes('a\\${x}b')).toBe(true); // present only as \${x}
-  } else if (v.includes(NL)) {
-    expect(script.includes('a' + NL + 'b')).toBe(false); // no raw LF-bearing payload
-    // (comment channel → sanitized to "a b"; predicate channel → JSON-escaped "a\\nb")
-  } else if (v === BS) {
-    // A literal backslash round-trips through TWO correct escape layers:
-    //   1. JSON.stringify(predicate value)  : a\b   → a\\b   (JSON doubling)
-    //   2. escapeTemplateString(whole src)  : a\\b  → a\\\\b (template doubling)
-    // So quadruple-backslash in the generated TEXT is the CORRECT single-pass
-    // result, not corruption. The double-escape *bug* signature would be a
-    // further doubling to EIGHT backslashes — assert that never appears.
-    // `parses()` above is the load-bearing check: any escape that unbalanced
-    // the outer template literal would have thrown there.
-    expect(script.includes('a\\\\\\\\\\\\\\\\b')).toBe(false); // no 8x (double-escape)
+// OMN-129: the read side now crosses the JXA→OmniJS boundary the same way the
+// write side does — `app.evaluateJavascript(${JSON.stringify(program)})` — so the
+// program rides inside a JSON string literal, not a hand-escaped nested backtick.
+// Recover every program string that the generated JXA hands across the boundary
+// (recursing, since list-tasks nests one program inside another). A JSON-string
+// argument is the proof the retrofit landed; the old backtick boundary passed an
+// `omniJsScript` identifier and yields nothing here.
+function recoverInnerPrograms(script: string): string[] {
+  const out: string[] = [];
+  const marker = 'evaluateJavascript(';
+  let i = 0;
+  while ((i = script.indexOf(marker, i)) !== -1) {
+    let j = i + marker.length;
+    while (j < script.length && /\s/.test(script[j]!)) j++;
+    if (script[j] !== '"') {
+      i = j; // not a JSON-string argument (e.g. the old `evaluateJavascript(omniJsScript)`)
+      continue;
+    }
+    // Read one JSON string literal starting at j, honoring \" escapes.
+    let k = j + 1;
+    let lit = '"';
+    while (k < script.length) {
+      const ch = script[k]!;
+      lit += ch;
+      if (ch === '\\') {
+        lit += script[k + 1] ?? '';
+        k += 2;
+        continue;
+      }
+      if (ch === '"') {
+        k++;
+        break;
+      }
+      k++;
+    }
+    try {
+      const inner = JSON.parse(lit);
+      out.push(inner);
+      out.push(...recoverInnerPrograms(inner)); // nested boundary (list-tasks)
+    } catch {
+      // not a recoverable JSON string; skip
+    }
+    i = k;
+  }
+  return out;
+}
+
+// Under the JSON.stringify(program) boundary, backtick and ${ are inert — they
+// live inside a JSON string literal and again inside an OmniJS string literal, so
+// neither can break structure. `parses` is therefore the structural oracle for
+// those channels. The newline/comment channel still has teeth: the boundary
+// JSON.stringify escapes the OUTER string, but the inner OmniJS that OmniFocus
+// compiles sees the LF restored — a raw LF in a `// Filter:` comment would split
+// it into live code. sanitizeForScriptComment is what keeps that payload
+// single-line, so we assert it against the RECOVERED inner program (where the LF
+// is unescaped), not the outer text (where the boundary escaping hides it).
+function assertSafe(script: string, _v: string) {
+  expect(parses(script)).toBe(true); // outer structural validity (all channels)
+
+  const inners = recoverInnerPrograms(script);
+  expect(inners.length).toBeGreaterThan(0); // boundary is the JSON-string form
+
+  for (const inner of inners) {
+    expect(parses(inner)).toBe(true); // each recovered program is itself valid JS
+    // OMN-111/113 comment channel: the hostile LF-bearing payload must not survive
+    // contiguously into the compiled program (sanitized to a space in the comment,
+    // JSON-escaped to `a\nb` in the predicate string).
+    expect(inner.includes('a' + NL + 'b')).toBe(false);
   }
 }
 
-describe('OMN-65: bridge builders survive hostile filter strings', () => {
+describe('OMN-65/OMN-129: bridge builders survive hostile filter strings', () => {
   for (const v of [...HOSTILE, 'benign_abc']) {
     const tag = JSON.stringify(v);
     // comment-channel + predicate-channel builders (free text via `text`):
@@ -62,23 +103,20 @@ describe('OMN-65: bridge builders survive hostile filter strings', () => {
     // predicate-only builders (no in-body comment channel):
     // OMN-170 S2: folders filter free text via `filter.name` (the old `search`
     // string option was removed; the name predicate routes through the same
-    // escapeTemplateString-wrapped omniJsSource).
+    // omniJsSource that now crosses via JSON.stringify).
     it(`buildFilteredFoldersScript name=${tag}`, () =>
       assertSafe(buildFilteredFoldersScript({ filter: { name: v, nameOperator: 'CONTAINS' } }).script, v));
     it(`buildProjectByIdScript projectId=${tag}`, () => assertSafe(buildProjectByIdScript(v).script, v));
   }
 });
 
-// OMN-66: the list-tasks-ast.ts path was scoped OUT of OMN-65 because its
-// backtick/${ vectors are already neutralized by the whole-source
-// escapeTemplateString wrap at list-tasks-ast.ts:89. But that wrap
-// deliberately does NOT touch CR/LF/control chars — so a raw newline in
-// the user `text` filter could still split the `// Filter:` comment line.
-// Exercise the production entry point (buildListTasksScriptV4) so the test
-// runs against the wrapped form OmniFocus actually executes, not the
-// inner unwrapped builder output. Covers both the general-filter and
-// inbox routes since they share generateMatchesFilterBlock.
-describe('OMN-66: list-tasks-ast comment channel survives hostile filter strings', () => {
+// OMN-66: the list-tasks-ast.ts path nests one program inside another (the JXA
+// wrapper hands buildFilteredTasksScript's output across the boundary, and that
+// output crosses a second boundary internally). recoverInnerPrograms recurses, so
+// both levels are validated. The newline/comment channel is the live concern:
+// JSON.stringify guards the outer literals, sanitizeForScriptComment guards the
+// `// Filter:` line. Covers the general-filter and inbox routes.
+describe('OMN-66/OMN-129: list-tasks-ast survives hostile filter strings', () => {
   for (const v of [...HOSTILE, 'benign_abc']) {
     const tag = JSON.stringify(v);
     it(`buildListTasksScriptV4 general filter text=${tag}`, () =>

--- a/tests/unit/contracts/ast/bridge-injection.test.ts
+++ b/tests/unit/contracts/ast/bridge-injection.test.ts
@@ -7,6 +7,13 @@ import {
   buildTaskCountScript,
 } from '../../../../src/contracts/ast/script-builder.js';
 import { buildListTasksScriptV4 } from '../../../../src/omnifocus/scripts/tasks/list-tasks-ast.js';
+// OMN-129: the read side now crosses the JXA→OmniJS boundary the same way the write
+// side does — `app.evaluateJavascript(${JSON.stringify(program)})` — so the program
+// rides inside a JSON string literal, not a hand-escaped nested backtick. The shared
+// recoverInnerPrograms decodes each boundary (recursing for list-tasks' nested
+// program); a JSON-string argument is the proof the retrofit landed (the old backtick
+// boundary passed an `omniJsScript` identifier and yields nothing).
+import { recoverInnerPrograms } from '../../../utils/recover-bridge-program.js';
 
 const NL = String.fromCharCode(10); // a real newline
 const BS = 'a\\b'; // literal single backslash: the 3-char string a \ b
@@ -21,53 +28,6 @@ function parses(script: string): boolean {
   }
 }
 
-// OMN-129: the read side now crosses the JXA→OmniJS boundary the same way the
-// write side does — `app.evaluateJavascript(${JSON.stringify(program)})` — so the
-// program rides inside a JSON string literal, not a hand-escaped nested backtick.
-// Recover every program string that the generated JXA hands across the boundary
-// (recursing, since list-tasks nests one program inside another). A JSON-string
-// argument is the proof the retrofit landed; the old backtick boundary passed an
-// `omniJsScript` identifier and yields nothing here.
-function recoverInnerPrograms(script: string): string[] {
-  const out: string[] = [];
-  const marker = 'evaluateJavascript(';
-  let i = 0;
-  while ((i = script.indexOf(marker, i)) !== -1) {
-    let j = i + marker.length;
-    while (j < script.length && /\s/.test(script[j]!)) j++;
-    if (script[j] !== '"') {
-      i = j; // not a JSON-string argument (e.g. the old `evaluateJavascript(omniJsScript)`)
-      continue;
-    }
-    // Read one JSON string literal starting at j, honoring \" escapes.
-    let k = j + 1;
-    let lit = '"';
-    while (k < script.length) {
-      const ch = script[k]!;
-      lit += ch;
-      if (ch === '\\') {
-        lit += script[k + 1] ?? '';
-        k += 2;
-        continue;
-      }
-      if (ch === '"') {
-        k++;
-        break;
-      }
-      k++;
-    }
-    try {
-      const inner = JSON.parse(lit);
-      out.push(inner);
-      out.push(...recoverInnerPrograms(inner)); // nested boundary (list-tasks)
-    } catch {
-      // not a recoverable JSON string; skip
-    }
-    i = k;
-  }
-  return out;
-}
-
 // Under the JSON.stringify(program) boundary, backtick and ${ are inert — they
 // live inside a JSON string literal and again inside an OmniJS string literal, so
 // neither can break structure. `parses` is therefore the structural oracle for
@@ -77,7 +37,7 @@ function recoverInnerPrograms(script: string): string[] {
 // it into live code. sanitizeForScriptComment is what keeps that payload
 // single-line, so we assert it against the RECOVERED inner program (where the LF
 // is unescaped), not the outer text (where the boundary escaping hides it).
-function assertSafe(script: string, _v: string) {
+function assertSafe(script: string) {
   expect(parses(script)).toBe(true); // outer structural validity (all channels)
 
   const inners = recoverInnerPrograms(script);
@@ -96,17 +56,17 @@ describe('OMN-65/OMN-129: bridge builders survive hostile filter strings', () =>
   for (const v of [...HOSTILE, 'benign_abc']) {
     const tag = JSON.stringify(v);
     // comment-channel + predicate-channel builders (free text via `text`):
-    it(`buildTaskCountScript text=${tag}`, () => assertSafe(buildTaskCountScript({ text: v }).script, v));
-    it(`buildFilteredProjectsScript text=${tag}`, () => assertSafe(buildFilteredProjectsScript({ text: v }).script, v));
+    it(`buildTaskCountScript text=${tag}`, () => assertSafe(buildTaskCountScript({ text: v }).script));
+    it(`buildFilteredProjectsScript text=${tag}`, () => assertSafe(buildFilteredProjectsScript({ text: v }).script));
     // ExportFilter exposes free text as `search` (NOT `text` — TS2353 otherwise):
-    it(`buildExportTasksScript search=${tag}`, () => assertSafe(buildExportTasksScript({ search: v }).script, v));
+    it(`buildExportTasksScript search=${tag}`, () => assertSafe(buildExportTasksScript({ search: v }).script));
     // predicate-only builders (no in-body comment channel):
     // OMN-170 S2: folders filter free text via `filter.name` (the old `search`
     // string option was removed; the name predicate routes through the same
     // omniJsSource that now crosses via JSON.stringify).
     it(`buildFilteredFoldersScript name=${tag}`, () =>
-      assertSafe(buildFilteredFoldersScript({ filter: { name: v, nameOperator: 'CONTAINS' } }).script, v));
-    it(`buildProjectByIdScript projectId=${tag}`, () => assertSafe(buildProjectByIdScript(v).script, v));
+      assertSafe(buildFilteredFoldersScript({ filter: { name: v, nameOperator: 'CONTAINS' } }).script));
+    it(`buildProjectByIdScript projectId=${tag}`, () => assertSafe(buildProjectByIdScript(v).script));
   }
 });
 
@@ -120,8 +80,8 @@ describe('OMN-66/OMN-129: list-tasks-ast survives hostile filter strings', () =>
   for (const v of [...HOSTILE, 'benign_abc']) {
     const tag = JSON.stringify(v);
     it(`buildListTasksScriptV4 general filter text=${tag}`, () =>
-      assertSafe(buildListTasksScriptV4({ filter: { text: v } }), v));
+      assertSafe(buildListTasksScriptV4({ filter: { text: v } })));
     it(`buildListTasksScriptV4 inbox mode text=${tag}`, () =>
-      assertSafe(buildListTasksScriptV4({ filter: { text: v }, mode: 'inbox' }), v));
+      assertSafe(buildListTasksScriptV4({ filter: { text: v }, mode: 'inbox' })));
   }
 });

--- a/tests/unit/contracts/ast/folder-builders.test.ts
+++ b/tests/unit/contracts/ast/folder-builders.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildFilteredFoldersScript } from '../../../../src/contracts/ast/script-builder.js';
+import { recoverInnerProgram } from '../../../utils/recover-bridge-program.js';
 
 describe('buildFilteredFoldersScript', () => {
   describe('basic script generation', () => {
@@ -111,19 +112,22 @@ describe('buildFilteredFoldersScript', () => {
 
     it('name CONTAINS → case-insensitive substring predicate on folder.name', () => {
       const result = buildFilteredFoldersScript({ filter: { name: 'Work', nameOperator: 'CONTAINS' } });
-      expect(result.script).toContain('(folder.name || \'\').toLowerCase().includes("work")');
+      // OMN-129: assert on the recovered (decoded) program where quotes are unescaped.
+      const inner = recoverInnerProgram(result.script);
+      expect(inner).toContain('(folder.name || \'\').toLowerCase().includes("work")');
       expect(result.filterDescription).toContain('name contains "Work"');
     });
 
     it('name MATCHES → safe RegExp predicate (no raw interpolation)', () => {
       const result = buildFilteredFoldersScript({ filter: { name: 'Wo.k', nameOperator: 'MATCHES' } });
-      expect(result.script).toContain('new RegExp("Wo.k", \'i\').test');
+      expect(recoverInnerProgram(result.script)).toContain('new RegExp("Wo.k", \'i\').test');
     });
 
     it('parentName → null-guarded substring on folder.parent.name', () => {
       const result = buildFilteredFoldersScript({ filter: { parentName: 'Bills' } });
-      expect(result.script).toContain('folder.parent');
-      expect(result.script).toContain('(folder.parent.name || \'\').toLowerCase().includes("bills")');
+      const inner = recoverInnerProgram(result.script);
+      expect(inner).toContain('folder.parent');
+      expect(inner).toContain('(folder.parent.name || \'\').toLowerCase().includes("bills")');
     });
 
     it('topLevelOnly → !folder.parent', () => {
@@ -143,12 +147,16 @@ describe('buildFilteredFoldersScript', () => {
       expect(result.script).not.toContain('total_available: flattenedFolders.length');
     });
 
-    it('backtick-bearing name does not leave a raw backtick in the final script (escapeTemplateString)', () => {
+    it('backtick-bearing name rides safely across the JSON.stringify boundary (OMN-129)', () => {
       const result = buildFilteredFoldersScript({ filter: { name: 'a`b', nameOperator: 'CONTAINS' } });
-      // The inner OmniJS source is wrapped in a backtick literal; any backtick in
-      // the term must be escaped (\\`) so it does not terminate the template.
-      expect(result.script).not.toMatch(/includes\("a`b"/);
-      expect(result.script).toContain('a\\`b');
+      // OMN-129: the program crosses as a JSON string literal, so a backtick in the
+      // term is inert — it lives inside an OmniJS double-quoted string and cannot
+      // break structure. The whole script parses, and the recovered program both
+      // parses and carries the term as a plain string value.
+      expect(() => new Function(result.script)).not.toThrow();
+      const inner = recoverInnerProgram(result.script);
+      expect(() => new Function(inner)).not.toThrow();
+      expect(inner).toContain('includes("a`b")');
     });
   });
 

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../src/contracts/ast/script-builder.js';
 import type { TaskFilter } from '../../../../src/contracts/filters.js';
 import { normalizeFilter } from '../../../../src/contracts/filters.js';
+import { recoverInnerProgram } from '../../../utils/recover-bridge-program.js';
 
 describe('buildFilteredTasksScript', () => {
   describe('basic script generation', () => {
@@ -1142,7 +1143,9 @@ describe('note truncation in project field projection', () => {
       },
     );
 
-    expect(result.script).toContain('note: project.note || ""');
+    // OMN-129: buildFilteredProjectsScript crosses the JSON.stringify boundary, so
+    // assert on the recovered (decoded) program where the double quotes are unescaped.
+    expect(recoverInnerProgram(result.script)).toContain('note: project.note || ""');
   });
 
   it('emits a reviewInterval projection when the reviewInterval field is requested (OMN-60)', () => {

--- a/tests/unit/contracts/ast/tag-name-filter.test.ts
+++ b/tests/unit/contracts/ast/tag-name-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildTagsScript } from '../../../../src/contracts/ast/tag-script-builder.js';
+import { recoverInnerProgram } from '../../../utils/recover-bridge-program.js';
 
 /**
  * OMN-170 S2: tags-by-name filtering on the basic mode (the only mode the read
@@ -18,12 +19,13 @@ describe('buildTagsScript basic mode — name filter (OMN-170 S2)', () => {
 
   it('name CONTAINS → case-insensitive substring predicate on tag.name', () => {
     const { script } = buildTagsScript({ mode: 'basic', name: 'Home', nameOperator: 'CONTAINS' });
-    expect(script).toContain('(tag.name || \'\').toLowerCase().includes("home")');
+    // OMN-129: assert on the recovered (decoded) program where quotes are unescaped.
+    expect(recoverInnerProgram(script)).toContain('(tag.name || \'\').toLowerCase().includes("home")');
   });
 
   it('name MATCHES → safe RegExp predicate (OMN-149 pattern)', () => {
     const { script } = buildTagsScript({ mode: 'basic', name: '^Home$', nameOperator: 'MATCHES' });
-    expect(script).toContain("new RegExp(\"^Home$\", 'i').test((tag.name || ''))");
+    expect(recoverInnerProgram(script)).toContain("new RegExp(\"^Home$\", 'i').test((tag.name || ''))");
   });
 
   it('emits total_matched separately from total (OMN-154 count honesty)', () => {
@@ -32,12 +34,15 @@ describe('buildTagsScript basic mode — name filter (OMN-170 S2)', () => {
     expect(script).toContain('total_matched:');
   });
 
-  it('backtick-bearing name does not leave a raw backtick in the inner template', () => {
+  it('backtick-bearing name rides safely across the JSON.stringify boundary (OMN-129)', () => {
     const { script } = buildTagsScript({ mode: 'basic', name: 'a`b', nameOperator: 'CONTAINS' });
-    // The whole inner OmniJS source is escapeTemplateString-wrapped, so any
-    // backtick in the term is escaped (\`) and cannot terminate the template.
-    expect(script).not.toMatch(/includes\("a`b"/);
-    expect(script).toContain('a\\`b');
+    // OMN-129: the program crosses as a JSON string literal, so a backtick in the
+    // term is inert (it lives inside an OmniJS double-quoted string). The whole
+    // script and the recovered program both parse; the term rides as a plain value.
+    expect(() => new Function(script)).not.toThrow();
+    const inner = recoverInnerProgram(script);
+    expect(() => new Function(inner)).not.toThrow();
+    expect(inner).toContain('includes("a`b")');
   });
 
   it('filterDescription reflects the name filter', () => {

--- a/tests/unit/contracts/ast/unicode-boundary-fuzz.test.ts
+++ b/tests/unit/contracts/ast/unicode-boundary-fuzz.test.ts
@@ -67,8 +67,13 @@ describe('OMN-129: read boundary survives Unicode direction-control / zero-width
         // Outer JXA wrapper parses (structural channel).
         expect(parses(script)).toBe(true);
         // Every recovered OmniJS program parses and carries the term verbatim — the
-        // char survived as a string value, not as code that broke the program. This
-        // is the assertion that bit on U+2028/U+2029 before the sanitize fix.
+        // char survived as a string value, not as code that broke the program. For the
+        // comment-bearing builders (FilteredProjects/TaskCount/ListTasks) parses(inner)
+        // is the assertion that bit on U+2028/U+2029 before the sanitize fix: an
+        // unscrubbed separator split the `// Filter:` line, orphaning the closing quote
+        // into a syntax error. For the predicate-only builders (folders/tags) there is
+        // no comment channel, so parses(inner) confirms inertness inside string literals
+        // and the round-trip below is the load-bearing data-fidelity check.
         const inners = recoverInnerPrograms(script);
         expect(inners.length).toBeGreaterThan(0);
         for (const inner of inners) {

--- a/tests/unit/contracts/ast/unicode-boundary-fuzz.test.ts
+++ b/tests/unit/contracts/ast/unicode-boundary-fuzz.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFilteredProjectsScript,
+  buildTaskCountScript,
+  buildFilteredFoldersScript,
+} from '../../../../src/contracts/ast/script-builder.js';
+import { buildTagsScript } from '../../../../src/contracts/ast/tag-script-builder.js';
+import { buildListTasksScriptV4 } from '../../../../src/omnifocus/scripts/tasks/list-tasks-ast.js';
+import { dispatchMutation, emitProgram } from '../../../../src/contracts/ast/mutation/index.js';
+import { SNIPPETS } from '../../../../src/contracts/ast/mutation/snippets.js';
+import { recoverInnerPrograms } from '../../../utils/recover-bridge-program.js';
+
+// OMN-129 (JesKingDev CONCERNS.md, Security Considerations): JSON.stringify escapes
+// quoting/structural hazards but does NOT strip Unicode direction-control or
+// zero-width characters — they survive into generated source. Existing coverage
+// (bridge-injection.test.ts) targets the backtick/${/newline vectors; this file
+// covers the directional / zero-width / line-separator class across the read
+// boundary and the tag-path parsers that feed script generation. The safety
+// contract is: these chars must ride as inert string DATA (script parses, recovered
+// program parses, char round-trips) — never break structure or become code.
+//
+// This file surfaced a real, pre-existing gap: U+2028/U+2029 (the JS line/paragraph
+// separators) are not C0 control chars, so JSON.stringify leaves them literal and
+// they pass the boundary, but they ARE JS LineTerminators — an un-scrubbed one in a
+// `// Filter:` comment splits it into live code when OmniFocus compiles the program.
+// The fix extended sanitizeForScriptComment to strip them (see bridge-escape.ts).
+
+// Built via charCode so no invisible / irregular-whitespace literals live in this
+// source file (and the chars survive editing/transform unchanged).
+const cc = (hex: number): string => String.fromCharCode(hex);
+const HAZARDS: ReadonlyArray<readonly [string, string]> = [
+  ['RLO U+202E', cc(0x202e)], // right-to-left override (directional)
+  ['LRI U+2066', cc(0x2066)], // left-to-right isolate (directional)
+  ['ZWSP U+200B', cc(0x200b)], // zero-width space
+  ['ZWJ U+200D', cc(0x200d)], // zero-width joiner
+  ['BOM U+FEFF', cc(0xfeff)], // zero-width no-break space
+  ['LS U+2028', cc(0x2028)], // line separator
+  ['PS U+2029', cc(0x2029)], // paragraph separator
+];
+
+function parses(script: string): boolean {
+  try {
+    new Function(script);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('OMN-129: read boundary survives Unicode direction-control / zero-width chars', () => {
+  for (const [label, ch] of HAZARDS) {
+    const term = 'a' + ch + 'b';
+
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ['buildFilteredProjectsScript', buildFilteredProjectsScript({ text: term }).script],
+      ['buildTaskCountScript', buildTaskCountScript({ text: term }).script],
+      [
+        'buildFilteredFoldersScript',
+        buildFilteredFoldersScript({ filter: { name: term, nameOperator: 'CONTAINS' } }).script,
+      ],
+      ['buildTagsScript(basic)', buildTagsScript({ mode: 'basic', name: term, nameOperator: 'CONTAINS' }).script],
+      ['buildListTasksScriptV4', buildListTasksScriptV4({ filter: { text: term } })],
+    ];
+
+    for (const [builder, script] of cases) {
+      it(`${builder} — ${label} rides as inert data`, () => {
+        // Outer JXA wrapper parses (structural channel).
+        expect(parses(script)).toBe(true);
+        // Every recovered OmniJS program parses and carries the term verbatim — the
+        // char survived as a string value, not as code that broke the program. This
+        // is the assertion that bit on U+2028/U+2029 before the sanitize fix.
+        const inners = recoverInnerPrograms(script);
+        expect(inners.length).toBeGreaterThan(0);
+        for (const inner of inners) {
+          expect(parses(inner)).toBe(true);
+        }
+        // At least one recovered program preserves the exact term (data fidelity).
+        expect(inners.some((p) => p.includes(term))).toBe(true);
+      });
+    }
+  }
+});
+
+describe('OMN-129: parseTagPath runtime snippet handles Unicode hazards without injection', () => {
+  // The snippet runs inside OmniFocus; it uses no OmniFocus globals, so it can be
+  // exercised directly in Node via `new Function`.
+  const parseTagPath = new Function(`${SNIPPETS.parseTagPath!.source}\nreturn parseTagPath;`)() as (
+    input: string,
+  ) => string[] | null;
+
+  for (const [label, ch] of HAZARDS) {
+    it(`splits a path whose segment carries ${label} and preserves the char`, () => {
+      const segs = parseTagPath('Parent : Chi' + ch + 'ld');
+      expect(segs).toEqual(['Parent', 'Chi' + ch + 'ld']);
+    });
+  }
+
+  it('a non-whitespace zero-width segment is not treated as empty', () => {
+    // ZWSP is a real codepoint, not stripped by .trim(), so the segment is non-empty.
+    const zwsp = cc(0x200b);
+    const segs = parseTagPath('Parent : ' + zwsp);
+    expect(segs).toEqual(['Parent', zwsp]);
+  });
+});
+
+describe('OMN-129: build-time tag-path parsing emits hazard chars as inert data', () => {
+  for (const [label, ch] of HAZARDS) {
+    it(`create/tag with a ${label}-bearing name emits a parseable program carrying the char`, async () => {
+      const name = 'a' + ch + 'b';
+      const program = await dispatchMutation('create/tag', { tagName: name });
+      const omnijs = emitProgram(program);
+      // The emitted OmniJS parses (the char is inside JSON.stringify'd string literals).
+      expect(parses(omnijs)).toBe(true);
+      expect(omnijs.includes(name)).toBe(true);
+    });
+  }
+});

--- a/tests/utils/recover-bridge-program.ts
+++ b/tests/utils/recover-bridge-program.ts
@@ -49,7 +49,12 @@ export function recoverInnerPrograms(script: string): string[] {
   return out;
 }
 
-/** Convenience: the single recovered OmniJS program (throws if not exactly one). */
+/**
+ * Convenience for single-boundary builders: the first recovered OmniJS program.
+ * Throws if none was found. NOTE: for the nested list-tasks path (which yields the
+ * intermediate program at [0] and the innermost predicate at [1]) this returns the
+ * OUTER program — use recoverInnerPrograms there and pick the level you mean.
+ */
 export function recoverInnerProgram(script: string): string {
   const programs = recoverInnerPrograms(script);
   if (programs.length === 0) throw new Error('no JSON.stringify bridge program found in script');

--- a/tests/utils/recover-bridge-program.ts
+++ b/tests/utils/recover-bridge-program.ts
@@ -1,0 +1,57 @@
+/**
+ * Test helper for the OMN-129 JSON.stringify boundary.
+ *
+ * Since OMN-129 the read side hands its OmniJS program across the JXA→OmniJS
+ * boundary as `app.evaluateJavascript(${JSON.stringify(program)})` — a JSON string
+ * literal, not a nested backtick. Builder unit tests that want to assert on the
+ * generated PREDICATE text should assert against the recovered (decoded) program,
+ * where quotes are unescaped, rather than the doubly-encoded outer script text.
+ *
+ * Returns every OmniJS program recovered from a generated JXA script, recursing for
+ * the list-tasks path which nests one program inside another.
+ */
+export function recoverInnerPrograms(script: string): string[] {
+  const out: string[] = [];
+  const marker = 'evaluateJavascript(';
+  let i = 0;
+  while ((i = script.indexOf(marker, i)) !== -1) {
+    let j = i + marker.length;
+    while (j < script.length && /\s/.test(script[j]!)) j++;
+    if (script[j] !== '"') {
+      i = j;
+      continue;
+    }
+    let k = j + 1;
+    let lit = '"';
+    while (k < script.length) {
+      const ch = script[k]!;
+      lit += ch;
+      if (ch === '\\') {
+        lit += script[k + 1] ?? '';
+        k += 2;
+        continue;
+      }
+      if (ch === '"') {
+        k++;
+        break;
+      }
+      k++;
+    }
+    try {
+      const inner = JSON.parse(lit) as string;
+      out.push(inner);
+      out.push(...recoverInnerPrograms(inner));
+    } catch {
+      // not a recoverable JSON string; skip
+    }
+    i = k;
+  }
+  return out;
+}
+
+/** Convenience: the single recovered OmniJS program (throws if not exactly one). */
+export function recoverInnerProgram(script: string): string {
+  const programs = recoverInnerPrograms(script);
+  if (programs.length === 0) throw new Error('no JSON.stringify bridge program found in script');
+  return programs[0]!;
+}


### PR DESCRIPTION
## Summary

Retrofits the **read-side** JXA→OmniJS boundary to the same `app.evaluateJavascript(${JSON.stringify(program)})` mechanism the write side adopted in OMN-128 (`wrapInLauncher`), and retires the hand-rolled `escapeTemplateString` / `escapeTemplateLiteralHazards` helpers. This closes the latent OMN-111/113 injection class on the read path **before** Wave 3/4 read-side features build on the boundary.

Premise re-verified against fresh `origin/main` (`a140a46e`): the read side still crossed the boundary via a nested backtick template + 3-replace escaper — the exact OMN-111/113 mechanism. Exposure was latent (leaf values already `JSON.stringify`'d by the AST emitter), so this is a behavior-preserving structural fix.

## Changes
- **All 10 read-side nested-backtick boundaries** → `JSON.stringify(source)`: 5 in `script-builder.ts` (projects, project-by-id, export, folders, task-count), 1 in `list-tasks-ast.ts`, 4 in `tag-script-builder.ts` (names/basic/full/active — incl. the 3 bare nested backticks, for full structural closure).
- 2 `escapeTemplateLiteralHazards(JSON.stringify(filterDescription))` outer-template sites → bare `JSON.stringify` (the hazard escape was redundant inside a double-quoted JXA string).
- Retire `escapeTemplateString` + `escapeTemplateLiteralHazards`.
- **Keep `sanitizeForScriptComment`** — still load-bearing for the `// Filter:` comment channel.

## Fuzz finding (folded in per the OMN-129 comment / JesKingDev CONCERNS.md)
`sanitizeForScriptComment` now also strips **U+2028 / U+2029**. They are JS LineTerminators but *not* C0 control chars, so `JSON.stringify` left them literal and they passed the boundary — an un-scrubbed one in a `// Filter:` comment split it into live code when OmniFocus compiled the program (the OMN-111/113 comment channel via a Unicode separator). Pre-existing; the old escaper never handled it either.

## Tests
- `bridge-injection.test.ts` rewritten to the JSON.stringify boundary: recovers each inner program (now cleanly JSON-decodable), asserts each parses and that no hostile newline payload survives contiguously into the compiled program.
- New `unicode-boundary-fuzz.test.ts`: direction-control / zero-width / line-separator chars across all read builders + `parseTagPath` (runtime snippet) + build-time tag-path parsing.
- New `tests/utils/recover-bridge-program.ts` shared helper.

## Verification
- `npm run test:unit` — **138 files / 3305 tests green**
- `tsc` + `tsc -p tsconfig.test.json` clean; eslint clean on changed files
- **Live**: all 15 read builders executed against OmniFocus — incl. backtick / `${}` / U+2028 hostile filters — returning valid JSON, no errors (avoids the OMN-125 "wiring passes, artifact broken" trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)