### PR TITLE
test(OMN-147): osascript child-process timeouts in integration helpers (wedge-orphan hygiene)

### DIFF
--- a/tests/integration/helpers/sandbox-manager.ts
+++ b/tests/integration/helpers/sandbox-manager.ts
@@ -11,10 +11,17 @@
  * @see docs/plans/2025-12-11-test-sandbox-design.md
  */
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 
-const execAsync = promisify(exec);
+// OMN-147: args-array execFile (not shell `exec`) so the script is passed as an
+// argv element — no shell quoting to get wrong — and every spawn carries a child
+// timeout (see OSASCRIPT_TIMEOUT_MS) so a TCC-wedged AppleEvent can't leave an
+// orphaned osascript child that re-poisons later runs.
+const execFileAsync = promisify(execFile);
+
+/** Child-process timeout for every osascript spawn (wedge-orphan hygiene). */
+const OSASCRIPT_TIMEOUT_MS = 30_000;
 
 // Enable sandbox guard when this module is imported
 // This ensures integration tests that use the sandbox are protected
@@ -97,7 +104,9 @@ async function executeJXA<T>(script: string): Promise<T> {
   `;
 
   try {
-    const { stdout } = await execAsync(`osascript -l JavaScript -e '${wrappedScript.replace(/'/g, "'\"'\"'")}'`);
+    const { stdout } = await execFileAsync('osascript', ['-l', 'JavaScript', '-e', wrappedScript], {
+      timeout: OSASCRIPT_TIMEOUT_MS,
+    });
     return JSON.parse(stdout.trim()) as T;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/tests/integration/tools/unified/tag-paths.test.ts
+++ b/tests/integration/tools/unified/tag-paths.test.ts
@@ -53,6 +53,11 @@ import { RUN_NAME_PREFIX, RUN_TAG_PREFIX, runScopedName, runScopedTag } from '..
 
 const execFileAsync = promisify(execFile);
 
+// OMN-147: every osascript spawn carries a child timeout so a TCC-wedged
+// AppleEvent can't leave an orphaned osascript child that re-poisons later runs
+// (vitest's hook timeout bounds the SUITE, not the abandoned child).
+const OSASCRIPT_TIMEOUT_MS = 30_000;
+
 const TS = Date.now();
 
 // 'OMN138T' (tags) — must not contain 'OMN138D', 'OMN138U', or 'OMN-138'.
@@ -118,7 +123,9 @@ async function probeTagByName(tagName: string): Promise<TagProbe | null> {
     '})()',
   ].join('\n');
   const jxa = `(() => { const app = Application('OmniFocus'); return app.evaluateJavascript(${JSON.stringify(omniJs)}); })()`;
-  const { stdout } = await execFileAsync('osascript', ['-l', 'JavaScript', '-e', jxa]);
+  const { stdout } = await execFileAsync('osascript', ['-l', 'JavaScript', '-e', jxa], {
+    timeout: OSASCRIPT_TIMEOUT_MS,
+  });
   const matches = JSON.parse(stdout.trim()) as TagProbe[];
   if (matches.length > 1) {
     throw new Error(`probeTagByName('${tagName}'): ${matches.length} tags share this name — ambiguous oracle`);
@@ -145,7 +152,7 @@ async function osascriptDeleteTagByExactName(tagName: string): Promise<void> {
     '})()',
   ].join('\n');
   const jxa = `(() => { const app = Application('OmniFocus'); return app.evaluateJavascript(${JSON.stringify(omniJs)}); })()`;
-  await execFileAsync('osascript', ['-l', 'JavaScript', '-e', jxa]);
+  await execFileAsync('osascript', ['-l', 'JavaScript', '-e', jxa], { timeout: OSASCRIPT_TIMEOUT_MS });
 }
 
 describe('OMN-128 slice 6: live tag mutation paths (AST lowerings, persisted read-backs)', () => {


### PR DESCRIPTION
## Summary
No integration-side osascript spawn set a child-process timeout. When the AppleEvent bridge wedges (TCC consent re-prompt after a Claude Code binary update — pending events block silently), vitest's hook timeout bounds the *suite*, but the abandoned osascript child keeps running — and orphaned osascripts are exactly what re-poison subsequent runs (`tooling_omnifocus_applevent_wedge`).

## Changes
- `tests/integration/helpers/sandbox-manager.ts` `executeJXA`: migrated from shell `exec` (with hand-rolled single-quote escaping) → args-array `execFile` + `{ timeout: 30_000 }`. Args-array is a strict improvement (no shell quoting to get wrong); this is the shared spawn path for **all** sandbox setup/cleanup, so the timeout now guards every integration file.
- `tests/integration/tools/unified/tag-paths.test.ts` `probeTagByName` / `osascriptDeleteTagByExactName`: added `{ timeout: 30_000 }` to both `execFile` spawns.

## Verification
- `tsc -p tsconfig.test.json` clean · eslint 0 errors
- `executeJXA` live-exercised via `getSandboxInfo()` against OmniFocus through the new args-array path (valid JSON)
- **Full integration suite green: 166 passed / 0 failed** (2 files skipped), ~21 min, "No orphaned test data found" — confirms the shared-helper migration doesn't break setup/teardown for any file
- Opus inline review (main loop): SAFE — additive `{timeout}` options + a live-verified migration; superpowers reviewer is disabled on Sonnet, and a 7-angle fan-out is disproportionate for a 3-site additive diff

Origin: OMN-128 slice 6 Task 9 review (minor 1). Pairs with OMN-146 (same files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)