### PR TITLE
docs: route pre-merge review gate to /code-review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,9 @@ multiple machines or sessions).
 ## Workflow norms
 
 - PRs target `kip-d/omnifocus-mcp` (use `--repo kip-d/omnifocus-mcp`), not any upstream fork.
-- Run a code-review subagent before merge; gate the merge on a Safe/Approved verdict.
+- Before merge, **stop and have Kip run `/code-review`** (user-invoked slash command → main-loop Opus); gate the merge
+  on a Safe/Approved verdict. Do **not** dispatch a `superpowers:code-reviewer` subagent — `/code-review` can't be
+  model-dispatched, and a `~/.claude` hook blocks the old reviewer (which would also run on the pinned Sonnet model).
 - Merge via `gh pr merge --squash --auto` — never `--admin`.
 - `git pull --rebase` before `git push` (work spans multiple machines/sessions).
 


### PR DESCRIPTION
## What

Updates the **Workflow norms** gate in `CLAUDE.md` to direct the pre-merge review to a **Kip-run `/code-review`** instead of a model-dispatched `superpowers:code-reviewer` subagent.

Before:
> Run a code-review subagent before merge; gate the merge on a Safe/Approved verdict.

After:
> Before merge, **stop and have Kip run `/code-review`** (user-invoked slash command → main-loop Opus); gate the merge on a Safe/Approved verdict. Do **not** dispatch a `superpowers:code-reviewer` subagent — `/code-review` can't be model-dispatched, and a `~/.claude` hook blocks the old reviewer (which would also run on the pinned Sonnet model).

## Why

The old wording made the model satisfy the gate by dispatching `superpowers:code-reviewer`, which is now (a) pinned to **Sonnet** via `CLAUDE_CODE_SUBAGENT_MODEL` and (b) blocked by a `~/.claude` PreToolUse hook (`block-superpowers-reviewer.sh`). `/code-review` is a **user-invoked** slash command running main-loop **Opus** and cannot be model-dispatched — so the gate now says "stop and hand off to Kip."

A prior attempt installed the block-hook but never updated the instruction files the model actually reads, so the old reviewer kept getting dispatched. This closes that gap.

## Scope

- One bullet in `CLAUDE.md` (prettier soft-wrapped it to 3 lines; content unchanged).
- Mirrors an in-place update to the session-loaded memory `feedback_review_gates.md` (not in this repo).

## Verification

- `tests/unit/docs/claude-md-paths.test.ts` — 8/8 pass (CLAUDE.md path/stable-anchor guard).
- No volatile references (line numbers / versions / counts) added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)