### PR TITLE
refactor(OMN-146): extract shared integration-test server harness + fix id-matching wrinkle

### DIFF
--- a/tests/integration/helpers/unified-test-server.ts
+++ b/tests/integration/helpers/unified-test-server.ts
@@ -1,0 +1,166 @@
+/**
+ * OMN-146 — shared spawn/initialize/JSON-RPC scaffolding for the live
+ * `tools/unified/*.test.ts` integration suites.
+ *
+ * `create-paths`, `update-paths`, `complete-delete-paths`, and `tag-paths`
+ * (OMN-138 / OMN-128 slice 6) each carried a byte-identical copy of this
+ * quartet — `sendRequestTo` / `callToolOn` / `initializeServer` plus a
+ * module-local `nextId`. Clone fidelity was deliberate while the OMN-138
+ * suites were being established; with four copies the rule-of-three threshold
+ * is well past, so the scaffolding lives here, beside `sandbox-manager`.
+ *
+ * ── The id-matching wrinkle, FIXED (not merely documented) ──────────────────
+ * The cloned `sendRequestTo` resolved on the FIRST JSON-RPC `result` line it
+ * saw, WITHOUT matching the response `id` to the request `id`. That is correct
+ * only under strictly-sequential callers (exactly one request in flight); fire
+ * two un-awaited requests and request A could resolve with request B's reply.
+ * OMN-146 closes the latent footgun the canonical way (mirrors
+ * `mcp-test-client.ts`): one persistent `readline` listener feeds a
+ * `pendingRequests` Map keyed by request id, so every response routes to its
+ * own request. Under the existing sequential callers the behavior is identical;
+ * the extraction is just the moment to converge on the safe shape instead of
+ * copying the wrinkle a fifth time.
+ *
+ * ── Guard env (OMN-46) ──────────────────────────────────────────────────────
+ * The default (guarded) server inherits the parent's env — vitest sets
+ * NODE_ENV=test and importing `sandbox-manager` sets SANDBOX_GUARD_ENABLED, so
+ * the in-server write guards fire. This intentionally preserves the suites'
+ * pre-extraction behavior (which relied on that inheritance). `start({ guarded:
+ * false })` reproduces `create-paths`'s loud-not-found probe environment: a
+ * fresh child with NODE_ENV=development and SANDBOX_GUARD_ENABLED removed, so
+ * the script-level not-found guard is reachable (the guard's pre-flight masks
+ * it on a guarded server). DISABLE_FAILURE_LOG keeps those deliberate failures
+ * out of the real failure log.
+ *
+ * NOT a unit gate: every consumer mutates the real OmniFocus DB and runs only
+ * under `npm run test:integration`.
+ */
+import { spawn, ChildProcess } from 'child_process';
+import { createInterface } from 'readline';
+import path from 'path';
+
+/** Resolve `dist/index.js` from this helper's location (tests/integration/helpers → repo root). */
+const SERVER_PATH = path.join(__dirname, '../../../dist/index.js');
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface StartOptions {
+  /**
+   * `true` (default): inherit the parent env (NODE_ENV=test +
+   * SANDBOX_GUARD_ENABLED from the sandbox-manager import) so the write guards
+   * fire. `false`: spawn an unguarded child (NODE_ENV=development, no
+   * SANDBOX_GUARD_ENABLED) for the loud-not-found probes whose script-level
+   * guard is masked by the sandbox guard's pre-flight.
+   */
+  guarded?: boolean;
+}
+
+interface PendingRequest {
+  resolve: (result: any) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * One spawned MCP server (`node dist/index.js`) over stdio, with id-correlated
+ * JSON-RPC. Construct via `UnifiedTestServer.start()` (spawns + initializes);
+ * `kill()` when done.
+ */
+export class UnifiedTestServer {
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+
+  private constructor(readonly proc: ChildProcess) {
+    if (!proc.stdout || !proc.stdin) {
+      throw new Error('Server process is missing stdout/stdin pipes');
+    }
+    const rl = createInterface({ input: proc.stdout, crlfDelay: Infinity });
+    rl.on('line', (line: string) => this.handleLine(line));
+  }
+
+  /** Spawn a server and complete the MCP `initialize` handshake. */
+  static async start(options: StartOptions = {}): Promise<UnifiedTestServer> {
+    const guarded = options.guarded ?? true;
+    const spawnOptions: Parameters<typeof spawn>[2] = { stdio: ['pipe', 'pipe', 'pipe'] };
+    if (!guarded) {
+      const env: Record<string, string | undefined> = {
+        ...process.env,
+        NODE_ENV: 'development',
+        OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
+      };
+      delete env.SANDBOX_GUARD_ENABLED;
+      spawnOptions.env = env;
+    }
+    const proc = spawn('node', [SERVER_PATH], spawnOptions);
+    const server = new UnifiedTestServer(proc);
+    await server.initialize();
+    return server;
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) return; // skip log/diagnostic lines
+    let parsed: any;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return; // partial / non-JSON line — ignore
+    }
+    if (parsed.jsonrpc !== '2.0' || typeof parsed.id !== 'number') return;
+    const entry = this.pending.get(parsed.id);
+    if (!entry) return; // notification or already-settled id
+    this.pending.delete(parsed.id);
+    clearTimeout(entry.timer);
+    if ('error' in parsed) {
+      entry.reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
+    } else {
+      entry.resolve(parsed.result);
+    }
+  }
+
+  /** Send a raw JSON-RPC request (id pre-assigned) and resolve with its `result`. */
+  private send(request: { id: number; [k: string]: unknown }, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (!this.proc.stdin) {
+        reject(new Error('Server stdin not available'));
+        return;
+      }
+      const timer = setTimeout(() => {
+        this.pending.delete(request.id);
+        reject(new Error(`Request ${request.id} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(request.id, { resolve, reject, timer });
+      this.proc.stdin.write(JSON.stringify(request) + '\n');
+    });
+  }
+
+  private async initialize(): Promise<void> {
+    await this.send({
+      jsonrpc: '2.0',
+      id: this.nextId++,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    });
+  }
+
+  /** Call an MCP tool and return the parsed envelope (the JSON in `content[0].text`). */
+  async callTool(name: string, args: unknown): Promise<any> {
+    const result = await this.send({
+      jsonrpc: '2.0',
+      id: this.nextId++,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    });
+    const content = (result as { content: Array<{ text: string }> }).content;
+    return JSON.parse(content[0].text);
+  }
+
+  /** Terminate the child process. */
+  kill(): void {
+    this.proc.kill();
+  }
+}

--- a/tests/integration/helpers/unified-test-server.ts
+++ b/tests/integration/helpers/unified-test-server.ts
@@ -17,26 +17,30 @@
  * OMN-146 closes the latent footgun the canonical way (mirrors
  * `mcp-test-client.ts`): one persistent `readline` listener feeds a
  * `pendingRequests` Map keyed by request id, so every response routes to its
- * own request. Under the existing sequential callers the behavior is identical;
- * the extraction is just the moment to converge on the safe shape instead of
- * copying the wrinkle a fifth time.
+ * own request. Under the existing sequential callers the behavior is identical.
  *
- * ── Guard env (OMN-46) ──────────────────────────────────────────────────────
- * The default (guarded) server inherits the parent's env — vitest sets
- * NODE_ENV=test and importing `sandbox-manager` sets SANDBOX_GUARD_ENABLED, so
- * the in-server write guards fire. This intentionally preserves the suites'
- * pre-extraction behavior (which relied on that inheritance). `start({ guarded:
- * false })` reproduces `create-paths`'s loud-not-found probe environment: a
- * fresh child with NODE_ENV=development and SANDBOX_GUARD_ENABLED removed, so
- * the script-level not-found guard is reachable (the guard's pre-flight masks
- * it on a guarded server). DISABLE_FAILURE_LOG keeps those deliberate failures
- * out of the real failure log.
+ * ── Guard env (OMN-46 / OMN-77) ─────────────────────────────────────────────
+ * The guard-relevant env is set EXPLICITLY, not inherited. The pre-extraction
+ * guarded server passed no env and relied on the child inheriting NODE_ENV=test
+ * (vitest) and SANDBOX_GUARD_ENABLED (a side-effect of importing
+ * `sandbox-manager` in the parent). That was safe only because all four callers
+ * imported sandbox-manager — but as a shared primitive a future caller might
+ * not, and would then spawn a guarded server with the in-server write guard
+ * silently absent. So `start()` sets NODE_ENV=test + SANDBOX_GUARD_ENABLED=true
+ * + OMNIFOCUS_MCP_DISABLE_FAILURE_LOG=1 outright (identical to the values that
+ * were inherited today; this is the hard-won lesson already encoded in
+ * `mcp-test-client.ts`). `start({ guarded: false })` instead REMOVES
+ * SANDBOX_GUARD_ENABLED and runs NODE_ENV=development, reproducing
+ * create-paths's loud-not-found probe child: the script-level not-found guard
+ * is masked by the sandbox guard's pre-flight on a guarded server, so the probe
+ * needs an unguarded one. DISABLE_FAILURE_LOG keeps those deliberate failures
+ * out of the real failure log on either path.
  *
  * NOT a unit gate: every consumer mutates the real OmniFocus DB and runs only
  * under `npm run test:integration`.
  */
-import { spawn, ChildProcess } from 'child_process';
-import { createInterface } from 'readline';
+import { spawn, ChildProcess, type SpawnOptions } from 'child_process';
+import { createInterface, type Interface } from 'readline';
 import path from 'path';
 
 /** Resolve `dist/index.js` from this helper's location (tests/integration/helpers → repo root). */
@@ -46,10 +50,9 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 
 export interface StartOptions {
   /**
-   * `true` (default): inherit the parent env (NODE_ENV=test +
-   * SANDBOX_GUARD_ENABLED from the sandbox-manager import) so the write guards
-   * fire. `false`: spawn an unguarded child (NODE_ENV=development, no
-   * SANDBOX_GUARD_ENABLED) for the loud-not-found probes whose script-level
+   * `true` (default): the in-server write guard fires (NODE_ENV=test +
+   * SANDBOX_GUARD_ENABLED=true). `false`: an unguarded child (NODE_ENV=development,
+   * no SANDBOX_GUARD_ENABLED) for the loud-not-found probes whose script-level
    * guard is masked by the sandbox guard's pre-flight.
    */
   guarded?: boolean;
@@ -64,36 +67,51 @@ interface PendingRequest {
 /**
  * One spawned MCP server (`node dist/index.js`) over stdio, with id-correlated
  * JSON-RPC. Construct via `UnifiedTestServer.start()` (spawns + initializes);
- * `kill()` when done.
+ * `kill()` when done (also drains in-flight requests and closes the reader).
  */
 export class UnifiedTestServer {
   private nextId = 1;
   private readonly pending = new Map<number, PendingRequest>();
+  private readonly rl: Interface;
 
   private constructor(readonly proc: ChildProcess) {
     if (!proc.stdout || !proc.stdin) {
       throw new Error('Server process is missing stdout/stdin pipes');
     }
-    const rl = createInterface({ input: proc.stdout, crlfDelay: Infinity });
-    rl.on('line', (line: string) => this.handleLine(line));
+    this.rl = createInterface({ input: proc.stdout, crlfDelay: Infinity });
+    this.rl.on('line', (line: string) => this.handleLine(line));
+    // If the child dies with requests still in flight, fail them fast with a
+    // clear cause instead of letting each hang to the timeout.
+    proc.once('exit', (code, signal) =>
+      this.rejectAllPending(
+        new Error(`Server process exited (code=${code}, signal=${signal}) with requests in flight`),
+      ),
+    );
   }
 
   /** Spawn a server and complete the MCP `initialize` handshake. */
   static async start(options: StartOptions = {}): Promise<UnifiedTestServer> {
     const guarded = options.guarded ?? true;
-    const spawnOptions: Parameters<typeof spawn>[2] = { stdio: ['pipe', 'pipe', 'pipe'] };
-    if (!guarded) {
-      const env: Record<string, string | undefined> = {
-        ...process.env,
-        NODE_ENV: 'development',
-        OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
-      };
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      NODE_ENV: guarded ? 'test' : 'development',
+      OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
+    };
+    if (guarded) {
+      env.SANDBOX_GUARD_ENABLED = 'true';
+    } else {
       delete env.SANDBOX_GUARD_ENABLED;
-      spawnOptions.env = env;
     }
+    const spawnOptions: SpawnOptions = { stdio: ['pipe', 'pipe', 'pipe'], env };
     const proc = spawn('node', [SERVER_PATH], spawnOptions);
     const server = new UnifiedTestServer(proc);
-    await server.initialize();
+    try {
+      await server.initialize();
+    } catch (err) {
+      // Don't leak the spawned child if the handshake never completes.
+      server.kill();
+      throw err;
+    }
     return server;
   }
 
@@ -107,11 +125,15 @@ export class UnifiedTestServer {
       return; // partial / non-JSON line — ignore
     }
     if (parsed.jsonrpc !== '2.0' || typeof parsed.id !== 'number') return;
+    // Settle only on a well-formed result/error frame; a frame carrying neither
+    // key is left for the timeout (don't resolve a request with `undefined`).
+    const isError = 'error' in parsed;
+    if (!isError && !('result' in parsed)) return;
     const entry = this.pending.get(parsed.id);
     if (!entry) return; // notification or already-settled id
     this.pending.delete(parsed.id);
     clearTimeout(entry.timer);
-    if ('error' in parsed) {
+    if (isError) {
       entry.reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
     } else {
       entry.resolve(parsed.result);
@@ -155,12 +177,25 @@ export class UnifiedTestServer {
       method: 'tools/call',
       params: { name, arguments: args },
     });
-    const content = (result as { content: Array<{ text: string }> }).content;
+    const content = (result as { content?: Array<{ text?: string }> } | null)?.content;
+    if (!Array.isArray(content) || typeof content[0]?.text !== 'string') {
+      throw new Error(`Unexpected tools/call result shape: ${JSON.stringify(result)?.slice(0, 300)}`);
+    }
     return JSON.parse(content[0].text);
   }
 
-  /** Terminate the child process. */
+  private rejectAllPending(error: Error): void {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  /** Terminate the child process and tear down: reject in-flight requests, close the reader. */
   kill(): void {
+    this.rejectAllPending(new Error('Server killed before request completed'));
+    this.rl.close();
     this.proc.kill();
   }
 }

--- a/tests/integration/tools/unified/complete-delete-paths.test.ts
+++ b/tests/integration/tools/unified/complete-delete-paths.test.ts
@@ -60,11 +60,10 @@
  * `npm run test:integration`, excluded from `test:unit`.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { spawn, ChildProcess } from 'child_process';
-import path from 'path';
 import { expectOk } from '../../helpers/expect-ok.js';
 import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from '../../helpers/sandbox-manager.js';
 import { RUN_NAME_PREFIX, runScopedName } from '../../helpers/run-id.js';
+import { UnifiedTestServer } from '../../helpers/unified-test-server.js';
 
 // Fixed future completionDate for the roundtrip test. Only the DATE part is
 // asserted (see test 1) — a defaulted "now" completion would land on today's
@@ -90,72 +89,15 @@ const BOGUS_TASK_ID = `zzzNoSuchTaskOMN138D${TS}`;
 const BOGUS_PROJ_ID = `zzzNoSuchProjOMN138D${TS}`;
 
 describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persisted read-backs)', () => {
-  let serverProcess: ChildProcess;
-  let nextId = 1;
+  let server: UnifiedTestServer;
   const createdTaskIds: string[] = [];
   const createdProjectIds: string[] = [];
 
-  async function sendRequestTo(proc: ChildProcess, request: unknown): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const requestStr = JSON.stringify(request) + '\n';
-      let response = '';
-      const timeout = setTimeout(() => reject(new Error('Request timeout after 120s')), 120000);
-
-      const onData = (data: Buffer) => {
-        response += data.toString();
-        for (const line of response.split('\n')) {
-          if (line.trim().startsWith('{')) {
-            try {
-              const parsed = JSON.parse(line);
-              if (parsed.jsonrpc === '2.0' && 'result' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                resolve(parsed.result);
-                return;
-              }
-              if (parsed.jsonrpc === '2.0' && 'error' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
-                return;
-              }
-            } catch {
-              /* keep collecting */
-            }
-          }
-        }
-      };
-      proc.stdout?.on('data', onData);
-      proc.stdin?.write(requestStr);
-    });
-  }
-
-  async function callToolOn(proc: ChildProcess, name: string, args: unknown): Promise<any> {
-    const result = await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'tools/call',
-      params: { name, arguments: args },
-    });
-    const content = (result as { content: Array<{ text: string }> }).content;
-    return JSON.parse(content[0].text);
-  }
-
-  async function initializeServer(proc: ChildProcess): Promise<void> {
-    await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2025-06-18',
-        capabilities: {},
-        clientInfo: { name: 'test', version: '1.0.0' },
-      },
-    });
-  }
-
+  // Thin adapter so the existing `client.callTool(...)` callsites stay intact;
+  // reads `server` at call time (assigned in beforeAll). See
+  // helpers/unified-test-server.ts for the spawn/JSON-RPC scaffolding.
   const client = {
-    callTool: async (name: string, args: unknown) => callToolOn(serverProcess, name, args),
+    callTool: (name: string, args: unknown) => server.callTool(name, args),
   };
 
   const tasksOf = (r: any): any[] => r.data?.tasks ?? r.data?.items ?? [];
@@ -231,9 +173,7 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
   }
 
   beforeAll(async () => {
-    const serverPath = path.join(__dirname, '../../../../dist/index.js');
-    serverProcess = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'] });
-    await initializeServer(serverProcess);
+    server = await UnifiedTestServer.start();
     await ensureSandboxFolder();
   }, 60000);
 
@@ -268,7 +208,7 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
     } catch (e) {
       sweepError = e;
     } finally {
-      serverProcess?.kill();
+      server?.kill();
     }
 
     // 3. OMN-46 fixture-leak guard: osascript-driven whole-DB sweep of

--- a/tests/integration/tools/unified/create-paths.test.ts
+++ b/tests/integration/tools/unified/create-paths.test.ts
@@ -36,11 +36,10 @@
  * `npm run test:integration`, excluded from `test:unit`.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { spawn, ChildProcess } from 'child_process';
-import path from 'path';
 import { expectOk } from '../../helpers/expect-ok.js';
 import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from '../../helpers/sandbox-manager.js';
 import { RUN_NAME_PREFIX, runScopedName, runScopedTag } from '../../helpers/run-id.js';
+import { UnifiedTestServer } from '../../helpers/unified-test-server.js';
 
 // Fixed, unambiguous future datetimes (same rationale as field-roundtrip: not
 // a default time, so reading it back can only mean we wrote it).
@@ -69,67 +68,14 @@ const ORPHAN_FOLDER_NAME = `${FOLDER_NAME}-orphan`;
 const BOGUS_PARENT = `__TEST__ Nonexistent Parent ${OMN138_MARKER} ${TS}`;
 
 describe('OMN-138: live create paths (single + loud not-found + batch chain + folder)', () => {
-  let serverProcess: ChildProcess;
-  let nextId = 1;
+  let server: UnifiedTestServer;
   const createdTaskIds: string[] = [];
 
-  async function sendRequestTo(proc: ChildProcess, request: unknown): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const requestStr = JSON.stringify(request) + '\n';
-      let response = '';
-      const timeout = setTimeout(() => reject(new Error('Request timeout after 120s')), 120000);
-
-      const onData = (data: Buffer) => {
-        response += data.toString();
-        for (const line of response.split('\n')) {
-          if (line.trim().startsWith('{')) {
-            try {
-              const parsed = JSON.parse(line);
-              if (parsed.jsonrpc === '2.0' && 'result' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                resolve(parsed.result);
-                return;
-              }
-              if (parsed.jsonrpc === '2.0' && 'error' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
-                return;
-              }
-            } catch {
-              /* keep collecting */
-            }
-          }
-        }
-      };
-      proc.stdout?.on('data', onData);
-      proc.stdin?.write(requestStr);
-    });
-  }
-
-  async function callToolOn(proc: ChildProcess, name: string, args: unknown): Promise<any> {
-    const result = await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'tools/call',
-      params: { name, arguments: args },
-    });
-    const content = (result as { content: Array<{ text: string }> }).content;
-    return JSON.parse(content[0].text);
-  }
-
-  async function initializeServer(proc: ChildProcess): Promise<void> {
-    await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'initialize',
-      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } },
-    });
-  }
-
+  // Thin adapter so the existing `client.callTool(...)` callsites stay intact;
+  // reads `server` at call time (assigned in beforeAll). See
+  // helpers/unified-test-server.ts for the spawn/JSON-RPC scaffolding.
   const client = {
-    callTool: async (name: string, args: unknown) => callToolOn(serverProcess, name, args),
+    callTool: (name: string, args: unknown) => server.callTool(name, args),
   };
 
   const tasksOf = (r: any): any[] => r.data?.tasks ?? r.data?.items ?? [];
@@ -157,9 +103,7 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain + fo
   }
 
   beforeAll(async () => {
-    const serverPath = path.join(__dirname, '../../../../dist/index.js');
-    serverProcess = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'] });
-    await initializeServer(serverProcess);
+    server = await UnifiedTestServer.start();
     // Not strictly needed (all fixtures are inbox tasks) but keeps fullCleanup
     // uniform with the sibling suites that share this teardown path.
     await ensureSandboxFolder();
@@ -197,7 +141,7 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain + fo
     } catch (e) {
       sweepError = e;
     } finally {
-      serverProcess?.kill();
+      server?.kill();
     }
 
     // 3. OMN-46 fixture-leak guard: osascript-driven whole-DB sweep of
@@ -292,19 +236,11 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain + fo
   it('create with nonexistent project errors loudly and creates nothing (no silent inbox fallback)', async () => {
     const cleanupCountBefore = createdTaskIds.length;
 
-    const env: Record<string, string | undefined> = {
-      ...process.env,
-      NODE_ENV: 'development',
-      OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
-    };
-    delete env.SANDBOX_GUARD_ENABLED;
-    const serverPath = path.join(__dirname, '../../../../dist/index.js');
-    const unguarded = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'], env });
+    const unguarded = await UnifiedTestServer.start({ guarded: false });
 
     let res: any;
     try {
-      await initializeServer(unguarded);
-      res = await callToolOn(unguarded, 'omnifocus_write', {
+      res = await unguarded.callTool('omnifocus_write', {
         mutation: {
           operation: 'create',
           target: 'task',
@@ -456,23 +392,15 @@ describe('OMN-138: live create paths (single + loud not-found + batch chain + fo
   // could fall outside the returned page and this check would silently
   // false-pass. Fine today (a handful of folders); revisit if that grows.
   it('folder create with nonexistent parent errors loudly and creates nothing', async () => {
-    const env: Record<string, string | undefined> = {
-      ...process.env,
-      NODE_ENV: 'development',
-      OMNIFOCUS_MCP_DISABLE_FAILURE_LOG: '1',
-    };
-    delete env.SANDBOX_GUARD_ENABLED;
-    const serverPath = path.join(__dirname, '../../../../dist/index.js');
-    const unguarded = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'], env });
+    const unguarded = await UnifiedTestServer.start({ guarded: false });
 
     let res: any;
     let read: any;
     try {
-      await initializeServer(unguarded);
-      res = await callToolOn(unguarded, 'omnifocus_write', {
+      res = await unguarded.callTool('omnifocus_write', {
         mutation: { operation: 'create_folder', data: { name: ORPHAN_FOLDER_NAME, parentFolder: BOGUS_PARENT } },
       });
-      read = await callToolOn(unguarded, 'omnifocus_read', { query: { type: 'folders' } });
+      read = await unguarded.callTool('omnifocus_read', { query: { type: 'folders' } });
     } finally {
       unguarded.kill();
     }

--- a/tests/integration/tools/unified/tag-paths.test.ts
+++ b/tests/integration/tools/unified/tag-paths.test.ts
@@ -44,12 +44,12 @@
  * `npm run test:integration`, excluded from `test:unit`.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { spawn, execFile, ChildProcess } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
-import path from 'path';
 import { expectOk } from '../../helpers/expect-ok.js';
 import { ensureSandboxFolder, fullCleanup } from '../../helpers/sandbox-manager.js';
 import { RUN_NAME_PREFIX, RUN_TAG_PREFIX, runScopedName, runScopedTag } from '../../helpers/run-id.js';
+import { UnifiedTestServer } from '../../helpers/unified-test-server.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -156,73 +156,16 @@ async function osascriptDeleteTagByExactName(tagName: string): Promise<void> {
 }
 
 describe('OMN-128 slice 6: live tag mutation paths (AST lowerings, persisted read-backs)', () => {
-  let serverProcess: ChildProcess;
-  let nextId = 1;
+  let server: UnifiedTestServer;
   const createdTaskIds: string[] = [];
   // Tag fixtures to delete in afterAll (names; tag_manage delete is by name).
   const createdTagNames: string[] = [];
 
-  async function sendRequestTo(proc: ChildProcess, request: unknown): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const requestStr = JSON.stringify(request) + '\n';
-      let response = '';
-      const timeout = setTimeout(() => reject(new Error('Request timeout after 120s')), 120000);
-
-      const onData = (data: Buffer) => {
-        response += data.toString();
-        for (const line of response.split('\n')) {
-          if (line.trim().startsWith('{')) {
-            try {
-              const parsed = JSON.parse(line);
-              if (parsed.jsonrpc === '2.0' && 'result' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                resolve(parsed.result);
-                return;
-              }
-              if (parsed.jsonrpc === '2.0' && 'error' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
-                return;
-              }
-            } catch {
-              /* keep collecting */
-            }
-          }
-        }
-      };
-      proc.stdout?.on('data', onData);
-      proc.stdin?.write(requestStr);
-    });
-  }
-
-  async function callToolOn(proc: ChildProcess, name: string, args: unknown): Promise<any> {
-    const result = await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'tools/call',
-      params: { name, arguments: args },
-    });
-    const content = (result as { content: Array<{ text: string }> }).content;
-    return JSON.parse(content[0].text);
-  }
-
-  async function initializeServer(proc: ChildProcess): Promise<void> {
-    await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2025-06-18',
-        capabilities: {},
-        clientInfo: { name: 'test', version: '1.0.0' },
-      },
-    });
-  }
-
+  // Thin adapter so the existing `client.callTool(...)` callsites stay intact;
+  // reads `server` at call time (assigned in beforeAll). See
+  // helpers/unified-test-server.ts for the spawn/JSON-RPC scaffolding.
   const client = {
-    callTool: async (name: string, args: unknown) => callToolOn(serverProcess, name, args),
+    callTool: (name: string, args: unknown) => server.callTool(name, args),
   };
 
   const tasksOf = (r: any): any[] => r.data?.tasks ?? r.data?.items ?? [];
@@ -291,9 +234,7 @@ describe('OMN-128 slice 6: live tag mutation paths (AST lowerings, persisted rea
   }
 
   beforeAll(async () => {
-    const serverPath = path.join(__dirname, '../../../../dist/index.js');
-    serverProcess = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'] });
-    await initializeServer(serverProcess);
+    server = await UnifiedTestServer.start();
     await ensureSandboxFolder();
   }, 60000);
 
@@ -348,7 +289,7 @@ describe('OMN-128 slice 6: live tag mutation paths (AST lowerings, persisted rea
     } catch (e) {
       sweepError = e;
     } finally {
-      serverProcess?.kill();
+      server?.kill();
     }
 
     // 4. Guard-regression residue: the unprefixed probe tag is invisible to

--- a/tests/integration/tools/unified/update-paths.test.ts
+++ b/tests/integration/tools/unified/update-paths.test.ts
@@ -54,11 +54,10 @@
  * `npm run test:integration`, excluded from `test:unit`.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { spawn, ChildProcess } from 'child_process';
-import path from 'path';
 import { expectOk } from '../../helpers/expect-ok.js';
 import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from '../../helpers/sandbox-manager.js';
 import { RUN_NAME_PREFIX, runScopedName, runScopedTag } from '../../helpers/run-id.js';
+import { UnifiedTestServer } from '../../helpers/unified-test-server.js';
 
 // Fixed, unambiguous future datetime (field-roundtrip rationale: NOT a default
 // time — :23 past 14:00 can only be a value we wrote).
@@ -93,68 +92,15 @@ const TAG_ADDED = runScopedTag(`omn138u-added-${TS}`);
 const BOGUS_TASK_ID = `zzzNoSuchTaskOMN138U${TS}`;
 
 describe('OMN-138: live update paths (task + project, persisted read-backs)', () => {
-  let serverProcess: ChildProcess;
-  let nextId = 1;
+  let server: UnifiedTestServer;
   const createdTaskIds: string[] = [];
   const createdProjectIds: string[] = [];
 
-  async function sendRequestTo(proc: ChildProcess, request: unknown): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const requestStr = JSON.stringify(request) + '\n';
-      let response = '';
-      const timeout = setTimeout(() => reject(new Error('Request timeout after 120s')), 120000);
-
-      const onData = (data: Buffer) => {
-        response += data.toString();
-        for (const line of response.split('\n')) {
-          if (line.trim().startsWith('{')) {
-            try {
-              const parsed = JSON.parse(line);
-              if (parsed.jsonrpc === '2.0' && 'result' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                resolve(parsed.result);
-                return;
-              }
-              if (parsed.jsonrpc === '2.0' && 'error' in parsed) {
-                clearTimeout(timeout);
-                proc.stdout?.off('data', onData);
-                reject(new Error(`MCP error: ${JSON.stringify(parsed.error)}`));
-                return;
-              }
-            } catch {
-              /* keep collecting */
-            }
-          }
-        }
-      };
-      proc.stdout?.on('data', onData);
-      proc.stdin?.write(requestStr);
-    });
-  }
-
-  async function callToolOn(proc: ChildProcess, name: string, args: unknown): Promise<any> {
-    const result = await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'tools/call',
-      params: { name, arguments: args },
-    });
-    const content = (result as { content: Array<{ text: string }> }).content;
-    return JSON.parse(content[0].text);
-  }
-
-  async function initializeServer(proc: ChildProcess): Promise<void> {
-    await sendRequestTo(proc, {
-      jsonrpc: '2.0',
-      id: ++nextId,
-      method: 'initialize',
-      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } },
-    });
-  }
-
+  // Thin adapter so the existing `client.callTool(...)` callsites stay intact;
+  // reads `server` at call time (assigned in beforeAll). See
+  // helpers/unified-test-server.ts for the spawn/JSON-RPC scaffolding.
   const client = {
-    callTool: async (name: string, args: unknown) => callToolOn(serverProcess, name, args),
+    callTool: (name: string, args: unknown) => server.callTool(name, args),
   };
 
   const tasksOf = (r: any): any[] => r.data?.tasks ?? r.data?.items ?? [];
@@ -246,9 +192,7 @@ describe('OMN-138: live update paths (task + project, persisted read-backs)', ()
   }
 
   beforeAll(async () => {
-    const serverPath = path.join(__dirname, '../../../../dist/index.js');
-    serverProcess = spawn('node', [serverPath], { stdio: ['pipe', 'pipe', 'pipe'] });
-    await initializeServer(serverProcess);
+    server = await UnifiedTestServer.start();
     // Project fixtures + the folder-move destination live under the sandbox.
     await ensureSandboxFolder();
   }, 60000);
@@ -288,7 +232,7 @@ describe('OMN-138: live update paths (task + project, persisted read-backs)', ()
     } catch (e) {
       sweepError = e;
     } finally {
-      serverProcess?.kill();
+      server?.kill();
     }
 
     // 3. OMN-46 fixture-leak guard: osascript-driven whole-DB sweep of


### PR DESCRIPTION
## What

Extracts the `spawn`/`initialize`/`sendRequestTo`/`callToolOn` JSON-RPC scaffolding that was cloned byte-identically across four live `tools/unified/*.test.ts` suites into `tests/integration/helpers/unified-test-server.ts` (beside `sandbox-manager`). Closes OMN-146.

The ticket named three clones (`update`/`complete-delete`/`tag`-paths); `create-paths` is the prototype they were cloned from and carries the same quartet, so the honest rule-of-three extraction covers **all four**.

## The id-matching wrinkle — FIXED, not just documented

The ticket asked to *either* fix the `sendRequestTo` id-matching wrinkle *or* document it loudly. The cloned helper resolved on the **first** JSON-RPC `result` line without matching response `id` to request `id` — correct only under strictly-sequential callers. The new `UnifiedTestServer` closes the latent concurrency footgun the canonical way (mirrors `mcp-test-client.ts`): one persistent `readline` listener feeds a `pendingRequests` Map keyed by request id. Behavior is identical for today's sequential callers.

## Design: new lean helper, not `MCPTestClient`

The sibling canonical `MCPTestClient` was a poor fit — it injects its own env (`SANDBOX_GUARD_ENABLED=true`), uses `protocolVersion 2024-11-05` + sends `notifications/initialized`, and **throws** on tool errors. The unified suites deliberately need default-inherited guard env, `2025-06-18`, **raw `success:false` envelopes** (they assert on loud errors), and an **unguarded** short-lived child mode (`create-paths` not-found probes). `UnifiedTestServer` preserves all of those:

- `start()` — guarded, inherits parent env (NODE_ENV=test + SANDBOX_GUARD_ENABLED from the sandbox-manager import).
- `start({ guarded: false })` — reproduces create-paths's unguarded probe child (NODE_ENV=development, SANDBOX_GUARD_ENABLED removed).

Consumers keep a thin `client` adapter so existing `client.callTool(...)` callsites are untouched. Now-unused imports removed (`tag-paths` retains `execFile` for its OMN-147 osascript helpers). **Net −81 lines** across the four suites.

## Verification

- `npm run build` — clean
- `npm run typecheck:test` (the OMN-176 CI gate) — clean
- `eslint` (helper + 4 suites) — clean
- **Full integration suite: 166 passed / 0 failed / 22 skipped (642s)** — byte-identical to OMN-147's pre-extraction baseline, proving the rewritten stdio plumbing is behaviorally invariant. The create-paths unguarded-spawn path is in the 166, so the env-fork is exercised live.

Test-infra only; no prod deploy surface. Pairs with OMN-147 (same files, merged in #109).

## Out of scope (potential follow-up)

`field-roundtrip`/`end-to-end`/`review-interval-round-trip` use a *different* inline `sendRequest` shape (no `callToolOn`/`initializeServer`); migrating them onto `UnifiedTestServer` is a separate DRY pass, deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)