### PR TITLE
fix(OMN-178): decouple conformance probe's MCP boot from OmniFocus cache-warm

### DIFF
--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -191,9 +191,12 @@ class McpServer {
     // AppleEvent channel, blowing past this probe's 30s init window (the parallel-run failure).
     // NO_CACHE_WARMING=true makes the server skip the warm; the only residual OF touch is the
     // permission check's hard 3s-bounded osascript, which fits the window even under contention.
+    // Also neutralize an inherited ENABLE_CACHE_WARMING — it short-circuits NO_CACHE_WARMING in
+    // the server's shouldWarmCache (forceCacheWarming || …), so a combined baseline runner that
+    // exports it for the integration side would otherwise silently re-enable the warm here.
     this.proc = spawn('node', ['dist/index.js'], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, NO_CACHE_WARMING: 'true' },
+      env: { ...process.env, NO_CACHE_WARMING: 'true', ENABLE_CACHE_WARMING: '' },
     });
     this.proc.stdout?.on('data', (d: Buffer) => {
       this.buf += d.toString();

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -183,7 +183,18 @@ class McpServer {
   private pending = new Map<number, (msg: Record<string, unknown>) => void>();
 
   constructor() {
-    this.proc = spawn('node', ['dist/index.js'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    // OMN-178: decouple the probe's server boot from OmniFocus. The probe only ever calls
+    // tools/list (schema grading, no execution), so it needs zero OF access — but the real
+    // server warms its OmniFocus cache (projects/tags/tasks/perspectives, a 240s-budget burst
+    // of serialized AppleEvents) BEFORE the transport answers `initialize`. Run conformance
+    // alongside the live integration suite and that warm contends on the single OmniFocus app's
+    // AppleEvent channel, blowing past this probe's 30s init window (the parallel-run failure).
+    // NO_CACHE_WARMING=true makes the server skip the warm; the only residual OF touch is the
+    // permission check's hard 3s-bounded osascript, which fits the window even under contention.
+    this.proc = spawn('node', ['dist/index.js'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, NO_CACHE_WARMING: 'true' },
+    });
     this.proc.stdout?.on('data', (d: Buffer) => {
       this.buf += d.toString();
       const lines = this.buf.split('\n');


### PR DESCRIPTION
## What

The conformance probe (`scripts/llm-conformance-probe.ts`) spawns its MCP server with `NO_CACHE_WARMING=true` so the server skips the OmniFocus cache warm at boot.

## Why (OMN-178)

The probe grades **schema only** — it calls `tools/list`, never `tools/call`, and needs zero OmniFocus access. But it spawns the real `node dist/index.js`, whose `runServer()` warms the OF cache (projects/tags/tasks/perspectives — a 240s-budget burst of serialized AppleEvents) **before the transport answers `initialize`**.

Run conformance alongside the live integration suite and that warm contends on the single OmniFocus app's AppleEvent channel, exceeding the probe's 30s init window → the observed `MCP initialize timed out` (surfaced during the OMN-173 post-merge baseline, build `3346b05`).

`NO_CACHE_WARMING=true` skips the warm. The only residual OF touch is the permission check's hard 3s-bounded `osascript`.

## Empirical before/after (idle machine, this branch)

| Variant | `initialize` round-trip | Warming log line |
|---|---|---|
| CONTROL (no flag) | **23.8s** | "Warming cache before accepting requests…" |
| WITH `NO_CACHE_WARMING=true` (fix) | **3.6s** | "Cache warming disabled for benchmark mode" |

Both return the identical 4 tools — grading integrity unchanged. The 23.8s control is already perilous against the 30s window even uncontended; the fix gives a **6.6× margin**, making parallel integration+conformance runs safe.

## Scope

Dev/CI tooling only — no server behavior change, **no prod redeploy**. Decoupling at the source dominates the ticket's other levers (raise the timeout / serialize the suites); both become unnecessary.

## Tests

- `npm run test:unit` — 3304 passed
- `npm run build` — clean; eslint clean on the changed file (3 pre-existing warnings unrelated to this hunk)
- Behavioral verification harness (the table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)