### PR TITLE
perf(OMN-185): task id-lookup fast path via Task.byIdentifier (O(n)→O(1))

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -694,7 +694,12 @@ export function buildTaskByIdScript(taskId: string, fields: string[] = []): Gene
 
   // OMN-185: resolve the task directly via Task.byIdentifier (O(1)) instead of
   // iterating flattenedTasks (O(n), pays the ~7-10s materialization floor for a
-  // single known id). Mirrors OMN-40's Project.byIdentifier fast path above.
+  // single known id). Mirrors OMN-40's Project.byIdentifier fast-path PATTERN.
+  // NOTE the layering differs from buildProjectByIdScript: this builder returns
+  // only the inner OmniJS body — the caller (list-tasks-ast.ts) wraps it in
+  // app.evaluateJavascript — whereas buildProjectByIdScript self-wraps. `Task`
+  // is an OmniJS global and is defined ONLY inside that evaluateJavascript
+  // wrapper; running this script as bare JXA would throw `Task is not defined`.
   // Task.byIdentifier returns null for an unknown/deleted id, so the guard keeps
   // the {tasks:[], count:0} shape that NOT_FOUND read-backs depend on. The id
   // filter is the sole selector (sibling keys are ignored — unchanged routing in

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -692,18 +692,24 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
 export function buildTaskByIdScript(taskId: string, fields: string[] = []): GeneratedScript {
   const fieldProjection = generateFieldProjection(fields);
 
+  // OMN-185: resolve the task directly via Task.byIdentifier (O(1)) instead of
+  // iterating flattenedTasks (O(n), pays the ~7-10s materialization floor for a
+  // single known id). Mirrors OMN-40's Project.byIdentifier fast path above.
+  // Task.byIdentifier returns null for an unknown/deleted id, so the guard keeps
+  // the {tasks:[], count:0} shape that NOT_FOUND read-backs depend on. The id
+  // filter is the sole selector (sibling keys are ignored — unchanged routing in
+  // list-tasks-ast.ts), and Task.byIdentifier resolves completed tasks too.
   const script = `
 (() => {
   const results = [];
   const targetId = ${JSON.stringify(taskId)};
 
-  flattenedTasks.forEach(task => {
-    if (task.id.primaryKey === targetId) {
-      results.push({
-        ${fieldProjection}
-      });
-    }
-  });
+  const task = Task.byIdentifier(targetId);
+  if (task) {
+    results.push({
+      ${fieldProjection}
+    });
+  }
 
   return JSON.stringify({
     tasks: results,

--- a/tests/unit/contracts/ast/list-tasks-ast.test.ts
+++ b/tests/unit/contracts/ast/list-tasks-ast.test.ts
@@ -54,7 +54,10 @@ describe('buildListTasksScriptV4', () => {
       });
 
       expect(script).toContain('task-123');
-      expect(script).toContain('task.id.primaryKey === targetId');
+      // OMN-185: the id path resolves via Task.byIdentifier (O(1)), not a
+      // flattenedTasks scan.
+      expect(script).toContain('Task.byIdentifier(targetId)');
+      expect(script).not.toContain('flattenedTasks');
     });
 
     it('uses flattenedTasks for general queries', () => {

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -371,6 +371,44 @@ describe('buildTaskByIdScript', () => {
   });
 });
 
+describe('buildTaskByIdScript (vm-executed, OMN-185)', () => {
+  // Execute the generated OmniJS body with a stubbed Task.byIdentifier. This is a
+  // behavioral oracle the string-contains tests cannot be: a casing typo
+  // (`task.byIdentifier`), a dropped `mode` key, or a broken projection would pass
+  // the toContain checks but fail here. Mirrors the OMN-154 runTaskScript harness.
+  function runById(
+    script: string,
+    tasksById: Record<string, unknown>,
+  ): { tasks: any[]; count: number; mode: string; targetId: string } {
+    const Task = { byIdentifier: (id: string) => tasksById[id] ?? null };
+    const sandbox: Record<string, unknown> = { Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string);
+  }
+
+  it('found: returns the single task with id_lookup shape', () => {
+    const { script } = buildTaskByIdScript('id-abc', ['id', 'name', 'flagged']);
+    const result = runById(script, {
+      'id-abc': { id: { primaryKey: 'id-abc' }, name: 'Found', flagged: true },
+    });
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({ id: 'id-abc', name: 'Found', flagged: true });
+    expect(result.count).toBe(1);
+    expect(result.mode).toBe('id_lookup');
+    expect(result.targetId).toBe('id-abc');
+  });
+
+  it('not found: null from byIdentifier yields empty results (count 0)', () => {
+    const { script } = buildTaskByIdScript('missing', ['id', 'name']);
+    const result = runById(script, {}); // no entry → byIdentifier returns null
+
+    expect(result.tasks).toHaveLength(0);
+    expect(result.count).toBe(0);
+    expect(result.mode).toBe('id_lookup');
+    expect(result.targetId).toBe('missing');
+  });
+});
+
 describe('inInbox field projection', () => {
   it('should use task.inInbox for inInbox field projection (not containingProject)', () => {
     const result = buildFilteredTasksScript(

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -327,12 +327,33 @@ describe('buildInboxScript', () => {
 });
 
 describe('buildTaskByIdScript', () => {
-  it('generates script to find task by ID', () => {
+  it('uses Task.byIdentifier for O(1) lookup, never iterates flattenedTasks (OMN-185)', () => {
     const result = buildTaskByIdScript('abc123');
 
+    // OMN-185: mirror OMN-40's project fast path. A task id-lookup must resolve
+    // directly via Task.byIdentifier — iterating flattenedTasks pays the ~7-10s
+    // materialization floor for a single known id.
+    expect(result.script).toContain('Task.byIdentifier(targetId)');
+    expect(result.script).not.toContain('flattenedTasks');
+    expect(result.script).not.toContain('task.id.primaryKey === targetId');
     expect(result.script).toContain('targetId');
     expect(result.script).toContain('abc123');
-    expect(result.script).toContain('task.id.primaryKey === targetId');
+  });
+
+  it('guards the not-found case so a null task yields empty results (OMN-185)', () => {
+    const result = buildTaskByIdScript('abc123');
+
+    // Task.byIdentifier returns null for an unknown/deleted id; the guard keeps
+    // the {tasks:[], count:0} shape that NOT_FOUND read-back assertions rely on.
+    expect(result.script).toContain('if (task)');
+  });
+
+  it('preserves the id_lookup result shape', () => {
+    const result = buildTaskByIdScript('abc123');
+
+    expect(result.script).toContain("mode: 'id_lookup'");
+    expect(result.script).toContain('count: results.length');
+    expect(result.script).toContain('targetId: targetId');
   });
 
   it('generates field projections', () => {


### PR DESCRIPTION
## What

`buildTaskByIdScript` resolved a single task by id with `flattenedTasks.forEach(task => task.id.primaryKey === targetId)` — an O(n) whole-DB scan that pays the full ~7-10s `flattenedTasks` materialization floor for a *known* id. Projects got an O(1) `Project.byIdentifier` read fast path in **OMN-40**; the task read path was the lone laggard (the mutation path `buildUpdateTaskScript` and the recurring path already use `Task.byIdentifier`).

This rewrites it to resolve directly via `Task.byIdentifier(targetId)` with an `if (task)` guard, mirroring the project fast path verbatim.

```js
// before
flattenedTasks.forEach(task => { if (task.id.primaryKey === targetId) results.push({...}); });
// after
const task = Task.byIdentifier(targetId);
if (task) { results.push({...}); }
```

- **Same output shape** (`{tasks, count, mode:'id_lookup', targetId}`), same field projection, same not-found semantics (null → empty `tasks`, preserving NOT_FOUND read-back assertions), same routing (`list-tasks-ast.ts` dispatches on `filter.id`, ignoring sibling keys — unchanged).
- **Zero assertion change.** Every already-id-based integration read-back and every production task id-lookup gets O(1).

## Why

Surfaced by the OMN-165 integration-suite duration audit. The ticket's premise ("id-lookup is already ~ms via `Task.byIdentifier`") was **false** — the read path never got OMN-40's treatment. OMN-165 (test conversions + floor documentation) rides on top of this.

## Verification

- **Unit:** TDD RED→GREEN on `buildTaskByIdScript` (asserts `Task.byIdentifier` usage, no `flattenedTasks`, not-found guard, unchanged shape) + routing test in `list-tasks-ast.test.ts`. Full unit suite **3306 green**.
- **Integration (external seam):** full live suite **166 passed / 0 failed** on the new build — every id-based read-back still asserts identically.
- **Before/after (per-test, same code, two live runs):** the targeted id-read-back file `update-operations` dropped **107s → 41s (−62%)** (each ~8s read-back → sub-second). `field-roundtrip` −21s, `update-paths` −13s. (Suite *wall* is noise-dominated by transient OmniFocus state — the AFTER run inflated floor-bound whole-DB reads in files this change can't touch, e.g. `end-to-end` +65s; the per-test diff isolates the real signal. See OMN-154 cold-start analysis.)

## Deploy

Read-path source change → needs prod redeploy + `/mcp` reconnect + live-verify (id-lookup returns correct task; before/after latency).

Closes OMN-185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)