### PR TITLE
docs(OMN-165): integration-suite duration audit — fixture-bound wall + serial rationale + justified floor

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -692,18 +692,29 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
 export function buildTaskByIdScript(taskId: string, fields: string[] = []): GeneratedScript {
   const fieldProjection = generateFieldProjection(fields);
 
+  // OMN-185: resolve the task directly via Task.byIdentifier (O(1)) instead of
+  // iterating flattenedTasks (O(n), pays the ~7-10s materialization floor for a
+  // single known id). Mirrors OMN-40's Project.byIdentifier fast-path PATTERN.
+  // NOTE the layering differs from buildProjectByIdScript: this builder returns
+  // only the inner OmniJS body — the caller (list-tasks-ast.ts) wraps it in
+  // app.evaluateJavascript — whereas buildProjectByIdScript self-wraps. `Task`
+  // is an OmniJS global and is defined ONLY inside that evaluateJavascript
+  // wrapper; running this script as bare JXA would throw `Task is not defined`.
+  // Task.byIdentifier returns null for an unknown/deleted id, so the guard keeps
+  // the {tasks:[], count:0} shape that NOT_FOUND read-backs depend on. The id
+  // filter is the sole selector (sibling keys are ignored — unchanged routing in
+  // list-tasks-ast.ts), and Task.byIdentifier resolves completed tasks too.
   const script = `
 (() => {
   const results = [];
   const targetId = ${JSON.stringify(taskId)};
 
-  flattenedTasks.forEach(task => {
-    if (task.id.primaryKey === targetId) {
-      results.push({
-        ${fieldProjection}
-      });
-    }
-  });
+  const task = Task.byIdentifier(targetId);
+  if (task) {
+    results.push({
+      ${fieldProjection}
+    });
+  }
 
   return JSON.stringify({
     tasks: results,

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -8,21 +8,22 @@
 
 - The full integration suite runs **serially against the live OmniFocus app** (`singleFork`). This is required, not
   incidental — see [Why serial](#why-serial-singlefork-and-no-parallel-live-lane).
-- Measured wall: **~1016–1196 s (~17–20 min)** for **166 tests across 20 live files** (2026-06-14).
-- **The wall is fixture-bound, not test-body-bound.** Only ~526 s is test bodies; **~400–490 s (40–48 %) is per-file
-  fixture setup/teardown + the shared-server OmniFocus warm**, and that overhead swings ±90 s run-to-run independent of
-  any code change.
+- Measured wall: **~1016–1196 s (~17–20 min)** across the audit runs for **166 tests across 20 live files**
+  (2026-06-14); **~1019 s post-fix on a quiet host**.
+- **The wall is fixture-bound, not test-body-bound.** Only ~526 s is test bodies; the rest — **~400–570 s (39–48 %),
+  computed as wall minus test-body** — is per-file fixture setup/teardown + the shared-server OmniFocus warm, and it
+  swings ±90 s run-to-run independent of any code change.
 - **Do not track this suite by wall-clock delta.** A single wall number is dominated by fixture noise and OmniFocus
   cache state; it cannot reflect a test-body optimization. Track the **per-class test-body subtotal** instead (see
   [Measuring](#measuring--detecting-drift)).
 
 ## Where the time goes (measured 2026-06-14, quiet host)
 
-| Layer                              | Time           | Notes                                                                                                                                                                                                                                      |
-| ---------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Test bodies**                    | **~526 s**     | The `duration` vitest reports per test.                                                                                                                                                                                                    |
-| Fixture setup + teardown + OF warm | **~400–490 s** | Wall minus test-body. Per-file `beforeAll` sandbox + `afterAll` `fullCleanup` (~7 sequential `osascript`/AppleEvent calls + straggler sweeps) × 20 files, plus the shared-server cache warm (~13 s). Not counted in any test's `duration`. |
-| **Wall**                           | **~1016 s**    | What you wait for.                                                                                                                                                                                                                         |
+| Layer                              | Time        | Notes                                                                                                                                                                                                                                                              |
+| ---------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Test bodies**                    | **~526 s**  | The `duration` vitest reports per test.                                                                                                                                                                                                                            |
+| Fixture setup + teardown + OF warm | **~493 s**  | Wall minus test-body (this run; ~400–570 s across runs). Per-file `beforeAll` sandbox + `afterAll` `fullCleanup` (~7 sequential `osascript`/AppleEvent calls + straggler sweeps) × 20 files, plus the shared-server cache warm (~13 s). Not counted in `duration`. |
+| **Wall**                           | **~1019 s** | What you wait for (526 + 493).                                                                                                                                                                                                                                     |
 
 ### Test-body breakdown by class
 
@@ -33,20 +34,20 @@
 
 ## The ~7–10 s floor and the OMN-185 fix
 
-Any **filtered whole-DB task read** materialises `flattenedTasks` — a ~7–10 s floor on a large database
-([`perf_whole_db_count_floor`]). The audit's premise was that write-side read-backs paid this floor unnecessarily and
-could use a cheap `Task.byIdentifier` id-lookup. Investigation **inverted the premise**: the id-lookup path
-(`buildTaskByIdScript`) did _not_ use `Task.byIdentifier` — it iterated `flattenedTasks.forEach`, paying the _same_
+Any **filtered whole-DB task read** materialises `flattenedTasks` — a ~7–10 s floor on a large database (the
+`flattenedTasks` materialisation floor). The audit's premise was that write-side read-backs paid this floor
+unnecessarily and could use a cheap `Task.byIdentifier` id-lookup. Investigation **inverted the premise**: the id-lookup
+path (`buildTaskByIdScript`) did _not_ use `Task.byIdentifier` — it iterated `flattenedTasks.forEach`, paying the _same_
 floor. Projects got an O(1) `Project.byIdentifier` read fast path in OMN-40; tasks were the lone laggard.
 
 **OMN-185** gives task id-lookups the same O(1) path. Measured effect, reproduced across two runs at ~6× different host
 load (so it is host-independent, not noise):
 
-|                                            | pre-fix | post-fix | Δ                   |
-| ------------------------------------------ | ------- | -------- | ------------------- |
-| `update-operations` (≈100 % id read-backs) | 107 s   | 39–41 s  | **−62 to −64 %**    |
-| id-read-back files (subtotal)              | ~259 s  | ~152 s   | **~−105 s (−41 %)** |
-| floor-bound / other files                  | —       | —        | +noise only         |
+|                                            | pre-fix | post-fix | Δ                  |
+| ------------------------------------------ | ------- | -------- | ------------------ |
+| `update-operations` (≈100 % id read-backs) | 107 s   | ~40 s    | **−62 to −64 %**   |
+| id-read-back files (subtotal)              | ~259 s  | ~152 s   | **−107 s (−41 %)** |
+| floor-bound / other files                  | —       | —        | +noise only        |
 
 The **suite wall did not drop**, because the −92 s test-body win was absorbed by a +92 s swing in fixture overhead that
 run — the structural reason the wall is the wrong metric here.
@@ -61,7 +62,8 @@ project read materialises only the handful of projects in the sandbox folder, no
 
 ## Why serial (`singleFork`) and no parallel live lane
 
-Configured in `vitest.config.ts` (`pool: 'forks'`, `poolOptions.forks.singleFork: true`):
+Configured in `vitest.config.ts` (`pool: 'forks'`, `poolOptions.forks.singleFork: true` — applied whenever the run isn't
+unit-only, i.e. for every integration run):
 
 1. **One OmniFocus app; AppleEvents serialise.** Every live test drives the single OmniFocus instance over
    `osascript`/AppleEvents, which the app processes one at a time. Concurrent workers do not gain parallelism — they
@@ -69,7 +71,7 @@ Configured in `vitest.config.ts` (`pool: 'forks'`, `poolOptions.forks.singleFork
 2. **Orphaned-worker hazard (OMN-143).** Parallel forks against the live app have historically orphaned vitest workers
    whose teardowns then fire against live sessions. `singleFork` + the worker-guard
    (`tests/support/setup-worker-guard.ts`) exist specifically to prevent this. Any change here must preserve both. Run
-   the suite **only via `run_in_background`, never kill it** ([`tooling_integration_run_orphan_class`]).
+   the suite **only via `run_in_background`, never kill it** (orphaned-worker hazard).
 3. **The three non-OmniFocus files don't justify a second lane.** `mcp-protocol`, `http-transport`, `startup-timing`
    (~41 s combined) don't contend for AppleEvents and _could_ run in a parallel lane, but the saving is small and
    splitting the pool risks the `singleFork` guarantee the live files depend on. Not worth it.
@@ -82,7 +84,7 @@ within-suite serialisation above.)
 
 > **~400–490 s of the wall is irreducible per-file OmniFocus fixture overhead** (sandbox setup + `fullCleanup`
 > teardown + cache warm), and **~374 s of test-body time is load-bearing floor-bound filter/count/analytics work** that
-> must scan the real population to assert what it asserts. The remaining test-body lever — task id read-backs (~105 s) —
+> must scan the real population to assert what it asserts. The remaining test-body lever — task id read-backs (~107 s) —
 > was taken by **OMN-185**. The next lever on the wall is **fixture economics** (sharing a per-run sandbox/teardown
 > instead of per-file), tracked as **OMN-186**; it is deferred from this audit because it touches the OMN-143
 > leak-sensitive cleanup machinery and must keep cleanup folder-scoped.

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -1,0 +1,107 @@
+# Integration-suite performance & execution model
+
+> Audit deliverable for **OMN-165** (2026-06-14). Documents where the ~17-minute wall goes, which work is load-bearing,
+> why the suite runs serially, and a justified floor so future drift is detectable against a measured baseline rather
+> than a guess.
+
+## TL;DR
+
+- The full integration suite runs **serially against the live OmniFocus app** (`singleFork`). This is required, not
+  incidental — see [Why serial](#why-serial-singlefork-and-no-parallel-live-lane).
+- Measured wall: **~1016–1196 s (~17–20 min)** for **166 tests across 20 live files** (2026-06-14).
+- **The wall is fixture-bound, not test-body-bound.** Only ~526 s is test bodies; **~400–490 s (40–48 %) is per-file
+  fixture setup/teardown + the shared-server OmniFocus warm**, and that overhead swings ±90 s run-to-run independent of
+  any code change.
+- **Do not track this suite by wall-clock delta.** A single wall number is dominated by fixture noise and OmniFocus
+  cache state; it cannot reflect a test-body optimization. Track the **per-class test-body subtotal** instead (see
+  [Measuring](#measuring--detecting-drift)).
+
+## Where the time goes (measured 2026-06-14, quiet host)
+
+| Layer                              | Time           | Notes                                                                                                                                                                                                                                      |
+| ---------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Test bodies**                    | **~526 s**     | The `duration` vitest reports per test.                                                                                                                                                                                                    |
+| Fixture setup + teardown + OF warm | **~400–490 s** | Wall minus test-body. Per-file `beforeAll` sandbox + `afterAll` `fullCleanup` (~7 sequential `osascript`/AppleEvent calls + straggler sweeps) × 20 files, plus the shared-server cache warm (~13 s). Not counted in any test's `duration`. |
+| **Wall**                           | **~1016 s**    | What you wait for.                                                                                                                                                                                                                         |
+
+### Test-body breakdown by class
+
+| Class                                                                                | Test-body           | Load-bearing?                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Floor-bound** (filter / count / analytics — the filter _is_ the system under test) | ~374 s              | **Yes.** Each whole-DB read asserts a filter predicate / count-honesty / analytics calc over the real population. An id-lookup cannot test these. Files: `filter-results`, `count-honesty`, `name-filter-scope`, `dropped-task-exclusion`, `analytics-validation`, `*-filter-rejection`, plus the read/pagination tests in `end-to-end`, `mcp-protocol`, `http-transport`. |
+| **Task id read-backs** (verify a created/mutated task)                               | ~152 s (was ~259 s) | **Captured by [OMN-185](https://github.com/kip-d/omnifocus-mcp/pull/115).** These resolve a known id, so they never needed the whole-DB scan.                                                                                                                                                                                                                              |
+
+## The ~7–10 s floor and the OMN-185 fix
+
+Any **filtered whole-DB task read** materialises `flattenedTasks` — a ~7–10 s floor on a large database
+([`perf_whole_db_count_floor`]). The audit's premise was that write-side read-backs paid this floor unnecessarily and
+could use a cheap `Task.byIdentifier` id-lookup. Investigation **inverted the premise**: the id-lookup path
+(`buildTaskByIdScript`) did _not_ use `Task.byIdentifier` — it iterated `flattenedTasks.forEach`, paying the _same_
+floor. Projects got an O(1) `Project.byIdentifier` read fast path in OMN-40; tasks were the lone laggard.
+
+**OMN-185** gives task id-lookups the same O(1) path. Measured effect, reproduced across two runs at ~6× different host
+load (so it is host-independent, not noise):
+
+|                                            | pre-fix | post-fix | Δ                   |
+| ------------------------------------------ | ------- | -------- | ------------------- |
+| `update-operations` (≈100 % id read-backs) | 107 s   | 39–41 s  | **−62 to −64 %**    |
+| id-read-back files (subtotal)              | ~259 s  | ~152 s   | **~−105 s (−41 %)** |
+| floor-bound / other files                  | —       | —        | +noise only         |
+
+The **suite wall did not drop**, because the −92 s test-body win was absorbed by a +92 s swing in fixture overhead that
+run — the structural reason the wall is the wrong metric here.
+
+### Project read-backs: convertible but not worth it
+
+`field-roundtrip` and `update-paths` verify project mutations via `filters:{folder}` (folder-scoped) rather than
+`filters:{id}`. These _look_ like the task case, but they are **already cheap** (~2–3 s total per test): a folder-scoped
+project read materialises only the handful of projects in the sandbox folder, not the whole DB. Converting them to
+`filters:{id}` would save ~0 s while adding diff and risk, so the audit **deliberately leaves them** (the
+`flattenedTasks` floor is task-specific).
+
+## Why serial (`singleFork`) and no parallel live lane
+
+Configured in `vitest.config.ts` (`pool: 'forks'`, `poolOptions.forks.singleFork: true`):
+
+1. **One OmniFocus app; AppleEvents serialise.** Every live test drives the single OmniFocus instance over
+   `osascript`/AppleEvents, which the app processes one at a time. Concurrent workers do not gain parallelism — they
+   queue on the same channel and instead cause **timeouts and intermittent failures**.
+2. **Orphaned-worker hazard (OMN-143).** Parallel forks against the live app have historically orphaned vitest workers
+   whose teardowns then fire against live sessions. `singleFork` + the worker-guard
+   (`tests/support/setup-worker-guard.ts`) exist specifically to prevent this. Any change here must preserve both. Run
+   the suite **only via `run_in_background`, never kill it** ([`tooling_integration_run_orphan_class`]).
+3. **The three non-OmniFocus files don't justify a second lane.** `mcp-protocol`, `http-transport`, `startup-timing`
+   (~41 s combined) don't contend for AppleEvents and _could_ run in a parallel lane, but the saving is small and
+   splitting the pool risks the `singleFork` guarantee the live files depend on. Not worth it.
+
+(Separately, OMN-178 established that the **conformance** probe and this suite can't share a warm window without
+decoupling the probe's MCP boot from OmniFocus — fixed there. That's cross-suite contention, distinct from the
+within-suite serialisation above.)
+
+## The floor statement
+
+> **~400–490 s of the wall is irreducible per-file OmniFocus fixture overhead** (sandbox setup + `fullCleanup`
+> teardown + cache warm), and **~374 s of test-body time is load-bearing floor-bound filter/count/analytics work** that
+> must scan the real population to assert what it asserts. The remaining test-body lever — task id read-backs (~105 s) —
+> was taken by **OMN-185**. The next lever on the wall is **fixture economics** (sharing a per-run sandbox/teardown
+> instead of per-file), tracked as **OMN-186**; it is deferred from this audit because it touches the OMN-143
+> leak-sensitive cleanup machinery and must keep cleanup folder-scoped.
+
+So the justified floor today is roughly **fixture overhead (~400–490 s) + load-bearing floor-bound test bodies (~374 s)
+≈ 13–14 min**, with the rest being the now-optimised id read-backs and the small rejection/protocol tests. Duration
+meaningfully above that band (on a quiet host) signals real drift, not the baseline.
+
+## Measuring & detecting drift
+
+The suite auto-records one per-machine timing row per full integration run (`tests/support/suite-timing-reporter.ts` →
+`~/.local/state/of-mcp-suite-timing/runs.jsonl`, OMN-182). For a per-test profile (the artifact this audit was built
+from):
+
+```bash
+npm run build   # required — the suite spawns dist/index.js
+npx vitest tests/integration --run --reporter=json --outputFile.json=/tmp/pertest.json
+# then aggregate per-file / per-class from /tmp/pertest.json
+```
+
+Because the wall is fixture-noise-dominated, **compare the per-class test-body subtotal on a quiet host** (check
+`loadavg`), not the raw wall. The id-read-back subtotal (~152 s post-OMN-185) is the most stable, attributable signal.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,5 +1,8 @@
 # LLM Assistant Simulation Tests
 
+> **Suite execution model, timing, and why it runs serially:** see [`PERFORMANCE.md`](./PERFORMANCE.md). Run the
+> integration suite only via `run_in_background`, never kill it (orphaned-worker hazard, OMN-143).
+
 This directory contains integration tests that simulate how an LLM assistant (like Claude) would interact with our
 OmniFocus MCP server. These tests provide valuable insights into the real-world usage patterns and help ensure our tools
 work correctly in practice.

--- a/tests/unit/contracts/ast/list-tasks-ast.test.ts
+++ b/tests/unit/contracts/ast/list-tasks-ast.test.ts
@@ -54,7 +54,10 @@ describe('buildListTasksScriptV4', () => {
       });
 
       expect(script).toContain('task-123');
-      expect(script).toContain('task.id.primaryKey === targetId');
+      // OMN-185: the id path resolves via Task.byIdentifier (O(1)), not a
+      // flattenedTasks scan.
+      expect(script).toContain('Task.byIdentifier(targetId)');
+      expect(script).not.toContain('flattenedTasks');
     });
 
     it('uses flattenedTasks for general queries', () => {

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -327,12 +327,33 @@ describe('buildInboxScript', () => {
 });
 
 describe('buildTaskByIdScript', () => {
-  it('generates script to find task by ID', () => {
+  it('uses Task.byIdentifier for O(1) lookup, never iterates flattenedTasks (OMN-185)', () => {
     const result = buildTaskByIdScript('abc123');
 
+    // OMN-185: mirror OMN-40's project fast path. A task id-lookup must resolve
+    // directly via Task.byIdentifier — iterating flattenedTasks pays the ~7-10s
+    // materialization floor for a single known id.
+    expect(result.script).toContain('Task.byIdentifier(targetId)');
+    expect(result.script).not.toContain('flattenedTasks');
+    expect(result.script).not.toContain('task.id.primaryKey === targetId');
     expect(result.script).toContain('targetId');
     expect(result.script).toContain('abc123');
-    expect(result.script).toContain('task.id.primaryKey === targetId');
+  });
+
+  it('guards the not-found case so a null task yields empty results (OMN-185)', () => {
+    const result = buildTaskByIdScript('abc123');
+
+    // Task.byIdentifier returns null for an unknown/deleted id; the guard keeps
+    // the {tasks:[], count:0} shape that NOT_FOUND read-back assertions rely on.
+    expect(result.script).toContain('if (task)');
+  });
+
+  it('preserves the id_lookup result shape', () => {
+    const result = buildTaskByIdScript('abc123');
+
+    expect(result.script).toContain("mode: 'id_lookup'");
+    expect(result.script).toContain('count: results.length');
+    expect(result.script).toContain('targetId: targetId');
   });
 
   it('generates field projections', () => {
@@ -347,6 +368,44 @@ describe('buildTaskByIdScript', () => {
     const result = buildTaskByIdScript('abc123');
 
     expect(result.filterDescription).toBe('id = abc123');
+  });
+});
+
+describe('buildTaskByIdScript (vm-executed, OMN-185)', () => {
+  // Execute the generated OmniJS body with a stubbed Task.byIdentifier. This is a
+  // behavioral oracle the string-contains tests cannot be: a casing typo
+  // (`task.byIdentifier`), a dropped `mode` key, or a broken projection would pass
+  // the toContain checks but fail here. Mirrors the OMN-154 runTaskScript harness.
+  function runById(
+    script: string,
+    tasksById: Record<string, unknown>,
+  ): { tasks: any[]; count: number; mode: string; targetId: string } {
+    const Task = { byIdentifier: (id: string) => tasksById[id] ?? null };
+    const sandbox: Record<string, unknown> = { Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string);
+  }
+
+  it('found: returns the single task with id_lookup shape', () => {
+    const { script } = buildTaskByIdScript('id-abc', ['id', 'name', 'flagged']);
+    const result = runById(script, {
+      'id-abc': { id: { primaryKey: 'id-abc' }, name: 'Found', flagged: true },
+    });
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({ id: 'id-abc', name: 'Found', flagged: true });
+    expect(result.count).toBe(1);
+    expect(result.mode).toBe('id_lookup');
+    expect(result.targetId).toBe('id-abc');
+  });
+
+  it('not found: null from byIdentifier yields empty results (count 0)', () => {
+    const { script } = buildTaskByIdScript('missing', ['id', 'name']);
+    const result = runById(script, {}); // no entry → byIdentifier returns null
+
+    expect(result.tasks).toHaveLength(0);
+    expect(result.count).toBe(0);
+    expect(result.mode).toBe('id_lookup');
+    expect(result.targetId).toBe('missing');
   });
 });
 


### PR DESCRIPTION
## What

The OMN-165 audit deliverable: a measured report on where the ~17-min integration wall goes, which work is load-bearing, why the suite is serial, and a justified floor so future drift is detectable against a baseline rather than a guess. Adds `tests/integration/PERFORMANCE.md` + a pointer from the integration README.

**Stacked on [#115 (OMN-185)](https://github.com/kip-d/omnifocus-mcp/pull/115)** — base is the OMN-185 branch so this shows only the doc diff. Rebases onto `main` cleanly once #115 merges. Docs-only; no test/source changes.

## The audit's headline findings

1. **The wall is fixture-bound, not test-body-bound.** Measured (quiet host): ~526s test bodies + **~400–490s (40–48%) per-file fixture setup/teardown + OF warm**, swinging ±90s/run independent of code. A single wall delta *structurally cannot* measure a test-body optimization here — track the per-class test-body subtotal instead.
2. **The ticket's premise inverted → OMN-185.** Avenue 1 assumed task `filters:{id}` was already ~ms; it wasn't (`buildTaskByIdScript` scanned `flattenedTasks`). Projects got the O(1) fast path in OMN-40; tasks were the lone laggard. Fixed in #115 — ~−105s (−41%) on id-read-back files, reproduced cross-host.
3. **Every >5s test classified** (AC): floor-bound filter/count/analytics (~374s, load-bearing — the filter *is* the system under test) vs task id read-backs (captured by OMN-185).
4. **Project read-backs: convertible but not worth it.** Folder-scoped reads of the tiny sandbox folder are already ~2–3s (the `flattenedTasks` floor is task-specific), so converting to `filters:{id}` saves ~0s — deliberately left, documented.
5. **Serial rationale** (AC): one OmniFocus app + AppleEvent serialization; OMN-143 orphan hazard; the 3 non-OF files don't justify a second lane.

## Acceptance criteria

- [x] Per-test timing profile produced (attached to the OMN-165 Linear ticket; methodology in the doc)
- [x] Every >5s test classified floor-bound vs convertible
- [x] Convertible cases handled: task id read-backs → OMN-185 (with before/after, zero assertions weakened); project reads documented as not-worth-it with data
- [x] Serial-execution rationale documented in `tests/integration`
- [x] Updated duration/scaling baseline (MEMORY.md + this doc) matches the measured 2026-06-14 numbers

## Deferred (own ticket)

The remaining **wall** lever — fixture economics (shared per-run sandbox vs per-file teardown) — is **OMN-186** (deferred: touches the OMN-143 leak-sensitive cleanup machinery; cleanup must stay folder-scoped).

Closes OMN-165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)