### PR TITLE
test(OMN-183): freeze clock in planned-dates summary test to kill 23:59 flake

### DIFF
--- a/tests/unit/utils/response-format-utilities.test.ts
+++ b/tests/unit/utils/response-format-utilities.test.ts
@@ -421,28 +421,39 @@ describe('Response Format Utilities', () => {
     });
 
     it('should count tasks with planned dates', () => {
-      const now = new Date();
-      const yesterday = new Date(now);
-      yesterday.setDate(yesterday.getDate() - 1);
-      // Use end of today to ensure it's counted as "today" not "past"
-      const todayEnd = new Date(now);
-      todayEnd.setHours(23, 59, 0, 0);
-      const nextWeek = new Date(now);
-      nextWeek.setDate(nextWeek.getDate() + 5);
+      // OMN-183: freeze the clock to a fixed midday instant. The "Planned today"
+      // sentinel below is built at 23:59 today; against a real wall-clock now this
+      // buckets as planned_past whenever the runner is in the 23:59:00–23:59:59
+      // window (it was already < now). Freezing now to midday makes the sentinel
+      // always strictly future-but-today, deterministic at any real time of day.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 5, 15, 12, 0, 0));
+      try {
+        const now = new Date();
+        const yesterday = new Date(now);
+        yesterday.setDate(yesterday.getDate() - 1);
+        // Use end of today to ensure it's counted as "today" not "past"
+        const todayEnd = new Date(now);
+        todayEnd.setHours(23, 59, 0, 0);
+        const nextWeek = new Date(now);
+        nextWeek.setDate(nextWeek.getDate() + 5);
 
-      const tasks = [
-        { id: '1', name: 'Planned past', completed: false, plannedDate: yesterday.toISOString() },
-        { id: '2', name: 'Planned today', completed: false, plannedDate: todayEnd.toISOString() },
-        { id: '3', name: 'Planned future', completed: false, plannedDate: nextWeek.toISOString() },
-        { id: '4', name: 'No planned date', completed: false },
-      ];
+        const tasks = [
+          { id: '1', name: 'Planned past', completed: false, plannedDate: yesterday.toISOString() },
+          { id: '2', name: 'Planned today', completed: false, plannedDate: todayEnd.toISOString() },
+          { id: '3', name: 'Planned future', completed: false, plannedDate: nextWeek.toISOString() },
+          { id: '4', name: 'No planned date', completed: false },
+        ];
 
-      const summary = generateTaskSummary(tasks);
+        const summary = generateTaskSummary(tasks);
 
-      expect(summary.breakdown?.planned_past).toBe(1);
-      expect(summary.breakdown?.planned_today).toBe(1);
-      expect(summary.breakdown?.planned_upcoming).toBe(1);
-      expect(summary.breakdown?.has_planned_date).toBe(3);
+        expect(summary.breakdown?.planned_past).toBe(1);
+        expect(summary.breakdown?.planned_today).toBe(1);
+        expect(summary.breakdown?.planned_upcoming).toBe(1);
+        expect(summary.breakdown?.has_planned_date).toBe(3);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should handle tasks with no planned dates', () => {


### PR DESCRIPTION
## Summary
Fixes the time-of-day flaky unit test `response-format-utilities "generateTaskSummary > should count tasks with planned dates"` (OMN-183), discovered red in the OMN-140 / PR #112 CI run at 23:59:13 UTC.

## Root cause (verified empirically)
The test built its "Planned today" sentinel at `23:59:00` today, then let `generateTaskSummary` bucket it against a **real wall-clock** `now`. In the `23:59:00–23:59:59` window the sentinel is already `< now`, so it buckets as `planned_past` → `planned_past=2`, assertion `toBe(1)` fails with `expected 2 to be 1`.

Reproduced deterministically: pinning the clock to `23:59:13` → **RED** (exact CI signature); pinning to midday → **GREEN**.

## Fix
Freeze the test clock to a fixed midday instant via `vi.setSystemTime`, restored in `finally`. The sentinel is then always strictly future-but-today — deterministic at any real time of day. The `forecast_past` over `dueDate` etc. SUT logic is unchanged; this is a test-only fix.

## Sibling audit
Audited every date-relative test in the file. This is the **only** time-of-day-flaky one — the others use ≥1-day offsets (360/405/534/567) or assert ordering/presence only (380), which a partial-day clock position cannot flip.

## Verification
- Targeted test: GREEN (pre- and post-prettier)
- Full file: 39/39 GREEN
- Full unit suite: 138 files / 3308 tests GREEN
- ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)