### PR TITLE
feat(OMN-152): compile-time build stamping + stale-process self-detection

### DIFF
--- a/docs/superpowers/plans/2026-06-15-omn-152-compile-time-build-stamp.md
+++ b/docs/superpowers/plans/2026-06-15-omn-152-compile-time-build-stamp.md
@@ -1,0 +1,717 @@
+# OMN-152 Compile-Time Build Stamping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the version endpoint's `buildId` reflect the code the running process actually loaded (frozen at process
+start), and self-detect a stale process by comparing against the request-time checkout hash.
+
+**Architecture:** A `postbuild` script writes `dist/build-info.json`. A new `src/utils/build-info.ts` reads it **once,
+memoized** (warmed at process start), so the loaded build is frozen for the process lifetime. `src/utils/version.ts`
+composes that frozen build with a request-time `git rev-parse` (`checkout.hash`); when they differ it emits
+`stale: true` + a "restart the server" warning. Adds `process.startedAt`/`uptimeSeconds`.
+
+**Tech Stack:** TypeScript (ESM, NodeNext), vitest, plain Node ESM build script.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-omn-152-compile-time-build-stamp-design.md`
+
+---
+
+## File Structure
+
+- **Create** `src/utils/build-info.ts` — owns reading/parsing `dist/build-info.json` into a frozen `LoadedBuild`
+  (memoized read + `buildId` derivation + dev sentinel). One responsibility: "what build is loaded?"
+- **Create** `scripts/stamp-build-info.js` — build-time git capture → `dist/build-info.json`. Plain ESM, no compile
+  dependency.
+- **Modify** `src/utils/version.ts` — import `readLoadedBuild`, warm it at module load, compose `VersionInfo` with
+  `checkout`/`stale`/`warning`/`process`. Extend the `VersionInfo` interface.
+- **Modify** `package.json` — add `postbuild` script.
+- **Create** `tests/unit/utils/build-info.test.ts` — unit tests for the fs read/parse logic (path-aware fs mock).
+- **Create** `tests/unit/utils/version.test.ts` — unit tests for composition/staleness (mocks `build-info.js` +
+  `child_process`).
+- **Modify** `tests/unit/tools/system-v2.test.ts` — extend the mock `VersionInfo` with the new fields (the `toEqual`
+  blocker).
+
+---
+
+## Task 1: `build-info.ts` — frozen loaded-build reader
+
+**Files:**
+
+- Create: `src/utils/build-info.ts`
+- Test: `tests/unit/utils/build-info.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/utils/build-info.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Path-aware fs mock: only intercept build-info.json; defer everything else to real fs.
+let buildInfoExists = true;
+let buildInfoRaw = '';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn((p: string) => (String(p).endsWith('build-info.json') ? buildInfoExists : actual.existsSync(p))),
+    readFileSync: vi.fn((p: string, enc?: unknown) =>
+      String(p).endsWith('build-info.json') ? buildInfoRaw : (actual.readFileSync as any)(p, enc),
+    ),
+  };
+});
+
+import { readLoadedBuild, __resetBuildInfoCacheForTests, DEV_SENTINEL } from '../../../src/utils/build-info.js';
+
+beforeEach(() => {
+  __resetBuildInfoCacheForTests();
+  buildInfoExists = true;
+  buildInfoRaw = '';
+});
+
+describe('readLoadedBuild', () => {
+  it('reads a stamped build-info.json and derives a clean buildId', () => {
+    buildInfoRaw = JSON.stringify({
+      hash: 'abc1234',
+      branch: 'main',
+      commitDate: '2026-06-15 10:00:00 -0400',
+      commitMessage: 'feat: x',
+      dirty: false,
+      timestamp: '2026-06-15T14:00:00.000Z',
+    });
+    const b = readLoadedBuild();
+    expect(b.hash).toBe('abc1234');
+    expect(b.buildId).toBe('abc1234');
+    expect(b.dirty).toBe(false);
+    expect(b.timestamp).toBe('2026-06-15T14:00:00.000Z');
+  });
+
+  it('appends -dirty to buildId when the stamp is dirty', () => {
+    buildInfoRaw = JSON.stringify({ hash: 'abc1234', dirty: true });
+    expect(readLoadedBuild().buildId).toBe('abc1234-dirty');
+  });
+
+  it('returns the dev sentinel when build-info.json is missing', () => {
+    buildInfoExists = false;
+    expect(readLoadedBuild()).toEqual(DEV_SENTINEL);
+  });
+
+  it('returns the dev sentinel when build-info.json is unparseable', () => {
+    buildInfoRaw = '{ not json';
+    expect(readLoadedBuild()).toEqual(DEV_SENTINEL);
+  });
+
+  it('memoizes: a second call does not re-read the file', () => {
+    buildInfoRaw = JSON.stringify({ hash: 'first' });
+    expect(readLoadedBuild().hash).toBe('first');
+    buildInfoRaw = JSON.stringify({ hash: 'second' }); // changed on disk
+    expect(readLoadedBuild().hash).toBe('first'); // still cached
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/unit/utils/build-info.test.ts` Expected: FAIL — cannot resolve
+`../../../src/utils/build-info.js` (module not created yet).
+
+- [ ] **Step 3: Implement `src/utils/build-info.ts`**
+
+```ts
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+export interface LoadedBuild {
+  hash: string;
+  branch: string;
+  commitDate: string;
+  commitMessage: string;
+  dirty: boolean;
+  timestamp: string;
+  buildId: string;
+}
+
+export const DEV_SENTINEL: LoadedBuild = {
+  hash: 'dev-unstamped',
+  branch: 'unknown',
+  commitDate: 'unknown',
+  commitMessage: 'unknown',
+  dirty: false,
+  timestamp: 'unknown',
+  buildId: 'dev-unstamped',
+};
+
+let cache: LoadedBuild | undefined;
+
+function doRead(): LoadedBuild {
+  try {
+    // build-info.json sits beside this module's compiled output: dist/build-info.json.
+    // This module compiles to dist/utils/build-info.js → one level up is dist/.
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
+    const buildInfoPath = join(scriptDir, '..', 'build-info.json');
+    if (!existsSync(buildInfoPath)) return DEV_SENTINEL;
+    const raw = JSON.parse(readFileSync(buildInfoPath, 'utf8')) as Partial<LoadedBuild>;
+    const hash = raw.hash ?? 'unknown';
+    const dirty = Boolean(raw.dirty);
+    return {
+      hash,
+      branch: raw.branch ?? 'unknown',
+      commitDate: raw.commitDate ?? 'unknown',
+      commitMessage: raw.commitMessage ?? 'unknown',
+      dirty,
+      timestamp: raw.timestamp ?? 'unknown',
+      buildId: `${hash}${dirty ? '-dirty' : ''}`,
+    };
+  } catch {
+    return DEV_SENTINEL;
+  }
+}
+
+/**
+ * Returns the build metadata stamped into dist/ at compile time, read ONCE and
+ * memoized. The first call (warmed at process start by version.ts) captures the
+ * loaded artifact; later disk rebuilds do not change the returned value — that is
+ * what lets the version endpoint detect a stale process.
+ */
+export function readLoadedBuild(): LoadedBuild {
+  if (cache) return cache;
+  cache = doRead();
+  return cache;
+}
+
+/** Test-only: clear the memoized value so each test reads fresh. */
+export function __resetBuildInfoCacheForTests(): void {
+  cache = undefined;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/unit/utils/build-info.test.ts` Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/build-info.ts tests/unit/utils/build-info.test.ts
+git commit -m "feat(OMN-152): build-info.ts — frozen, memoized loaded-build reader"
+```
+
+---
+
+## Task 2: `version.ts` — interface + staleness composition
+
+**Files:**
+
+- Modify: `src/utils/version.ts`
+- Test: `tests/unit/utils/version.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/utils/version.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LoadedBuild } from '../../../src/utils/build-info.js';
+
+// Control the loaded build per test.
+vi.mock('../../../src/utils/build-info.js', () => ({
+  readLoadedBuild: vi.fn(),
+  DEV_SENTINEL: {
+    hash: 'dev-unstamped',
+    branch: 'unknown',
+    commitDate: 'unknown',
+    commitMessage: 'unknown',
+    dirty: false,
+    timestamp: 'unknown',
+    buildId: 'dev-unstamped',
+  },
+}));
+
+// Control request-time git (checkout hash + dev fallback git).
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
+
+import { readLoadedBuild } from '../../../src/utils/build-info.js';
+import { execSync } from 'child_process';
+import { getVersionInfo } from '../../../src/utils/version.js';
+
+const STAMPED: LoadedBuild = {
+  hash: 'abc1234',
+  branch: 'main',
+  commitDate: '2026-06-15 10:00:00 -0400',
+  commitMessage: 'feat: x',
+  dirty: false,
+  timestamp: '2026-06-15T14:00:00.000Z',
+  buildId: 'abc1234',
+};
+
+// Route execSync by the git subcommand so we can simulate checkout hash + dev git.
+function gitMock(map: Record<string, string>, fail = false) {
+  vi.mocked(execSync).mockImplementation((cmd: string) => {
+    if (fail) throw new Error('not a git repo');
+    for (const [needle, out] of Object.entries(map)) if (cmd.includes(needle)) return out as never;
+    return '' as never;
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getVersionInfo staleness', () => {
+  it('stamped build, checkout matches → not stale, no warning', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({ 'rev-parse --short HEAD': 'abc1234' });
+    const v = getVersionInfo();
+    expect(v.build.buildId).toBe('abc1234');
+    expect(v.checkout.hash).toBe('abc1234');
+    expect(v.stale).toBe(false);
+    expect(v.warning).toBeUndefined();
+  });
+
+  it('stamped build, checkout differs → stale with warning', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({ 'rev-parse --short HEAD': 'def5678' });
+    const v = getVersionInfo();
+    expect(v.stale).toBe(true);
+    expect(v.warning).toContain('abc1234');
+    expect(v.warning).toContain('def5678');
+    expect(v.warning).toContain('restart');
+  });
+
+  it('dev sentinel → buildId dev-unstamped, never stale', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue({ ...STAMPED, hash: 'dev-unstamped', buildId: 'dev-unstamped' });
+    gitMock({ 'rev-parse --short HEAD': 'anything', 'abbrev-ref': 'feature', '%ci': 'date', '%s': 'msg' });
+    const v = getVersionInfo();
+    expect(v.build.buildId).toBe('dev-unstamped');
+    expect(v.stale).toBe(false);
+  });
+
+  it('checkout git failure → checkout unknown, not stale', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({}, true);
+    const v = getVersionInfo();
+    expect(v.checkout.hash).toBe('unknown');
+    expect(v.stale).toBe(false);
+  });
+
+  it('always reports process uptime + startedAt', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({ 'rev-parse --short HEAD': 'abc1234' });
+    const v = getVersionInfo();
+    expect(typeof v.process.uptimeSeconds).toBe('number');
+    expect(typeof v.process.startedAt).toBe('string');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/unit/utils/version.test.ts` Expected: FAIL — `v.checkout`/`v.stale`/`v.process` undefined
+(fields not added yet).
+
+- [ ] **Step 3: Rewrite `src/utils/version.ts`**
+
+Replace the file contents with:
+
+```ts
+import { execSync } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { readLoadedBuild } from './build-info.js';
+
+export interface VersionInfo {
+  name: string;
+  version: string;
+  description: string;
+  build: {
+    hash: string;
+    branch: string;
+    commitDate: string;
+    commitMessage: string;
+    dirty: boolean;
+    timestamp: string;
+    buildId: string;
+  };
+  runtime: {
+    node: string;
+    platform: string;
+    arch: string;
+  };
+  git: {
+    repository: string;
+    homepage: string;
+  };
+  checkout: { hash: string };
+  stale: boolean;
+  warning?: string;
+  process: { startedAt: string; uptimeSeconds: number };
+}
+
+interface PackageJson {
+  name: string;
+  version: string;
+  description: string;
+  repository?: { url?: string };
+  homepage?: string;
+}
+
+// Captured once, at process start: makes buildId reflect load-time, not first-request time.
+const PROCESS_STARTED_AT = new Date(Date.now() - process.uptime() * 1000).toISOString();
+// Warm the memoized loaded-build read at module load (process start).
+readLoadedBuild();
+
+function resolveProjectRoot(): string {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  // dist/utils/version.js → project root is two levels up.
+  return join(scriptDir, '..', '..');
+}
+
+function readCheckoutHash(projectRoot: string): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8', cwd: projectRoot }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+// Request-time git, used ONLY for the dev fallback so dev output stays useful.
+function readRequestTimeBuild(projectRoot: string): VersionInfo['build'] {
+  const opt = { encoding: 'utf8' as const, cwd: projectRoot };
+  let hash = 'unknown';
+  let branch = 'unknown';
+  let commitDate = 'unknown';
+  let commitMessage = 'unknown';
+  let dirty = false;
+  try {
+    hash = execSync('git rev-parse --short HEAD', opt).trim();
+    branch = execSync('git rev-parse --abbrev-ref HEAD', opt).trim();
+    commitDate = execSync('git show -s --format=%ci HEAD', opt).trim();
+    commitMessage = execSync('git show -s --format=%s HEAD', opt).trim();
+    try {
+      dirty = execSync('git status --porcelain', opt).trim().length > 0;
+    } catch {
+      /* assume clean */
+    }
+  } catch {
+    /* defaults */
+  }
+  return {
+    hash,
+    branch,
+    commitDate,
+    commitMessage,
+    dirty,
+    timestamp: new Date().toISOString(),
+    buildId: 'dev-unstamped',
+  };
+}
+
+export function getVersionInfo(): VersionInfo {
+  const projectRoot = resolveProjectRoot();
+  const packagePath = join(projectRoot, 'package.json');
+  if (!existsSync(packagePath)) {
+    throw new Error(`Cannot find package.json at ${packagePath}.`);
+  }
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as PackageJson;
+
+  const loaded = readLoadedBuild();
+  const isDev = loaded.buildId === 'dev-unstamped';
+
+  const build: VersionInfo['build'] = isDev
+    ? readRequestTimeBuild(projectRoot)
+    : {
+        hash: loaded.hash,
+        branch: loaded.branch,
+        commitDate: loaded.commitDate,
+        commitMessage: loaded.commitMessage,
+        dirty: loaded.dirty,
+        timestamp: loaded.timestamp,
+        buildId: loaded.buildId,
+      };
+
+  const checkoutHash = readCheckoutHash(projectRoot);
+  const stale = !isDev && checkoutHash !== 'unknown' && loaded.hash !== checkoutHash;
+  const warning = stale
+    ? `stale process: loaded build ${loaded.hash} but checkout is ${checkoutHash} — restart the server`
+    : undefined;
+
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+    description: packageJson.description,
+    build,
+    runtime: { node: process.version, platform: process.platform, arch: process.arch },
+    git: {
+      repository: packageJson.repository?.url || 'unknown',
+      homepage: packageJson.homepage || 'unknown',
+    },
+    checkout: { hash: checkoutHash },
+    stale,
+    ...(warning ? { warning } : {}),
+    process: { startedAt: PROCESS_STARTED_AT, uptimeSeconds: process.uptime() },
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/unit/utils/version.test.ts` Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/version.ts tests/unit/utils/version.test.ts
+git commit -m "feat(OMN-152): version.ts composes frozen build + request-time checkout → stale detection"
+```
+
+---
+
+## Task 3: `stamp-build-info.js` + postbuild wiring
+
+**Files:**
+
+- Create: `scripts/stamp-build-info.js`
+- Modify: `package.json`
+
+- [ ] **Step 1: Implement `scripts/stamp-build-info.js`**
+
+```js
+#!/usr/bin/env node
+// Build-time stamp: capture git metadata into dist/build-info.json so the version
+// endpoint reports the LOADED artifact, not the request-time checkout. Never fails
+// the build — git errors degrade to "unknown".
+import { execSync } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const opt = { encoding: 'utf8', cwd: projectRoot };
+const git = (cmd) => execSync(cmd, opt).trim();
+
+let info;
+try {
+  let dirty = false;
+  try {
+    dirty = git('git status --porcelain').length > 0;
+  } catch {
+    /* assume clean */
+  }
+  info = {
+    hash: git('git rev-parse --short HEAD'),
+    branch: git('git rev-parse --abbrev-ref HEAD'),
+    commitDate: git('git show -s --format=%ci HEAD'),
+    commitMessage: git('git show -s --format=%s HEAD'),
+    dirty,
+    timestamp: new Date().toISOString(),
+  };
+} catch {
+  info = {
+    hash: 'unknown',
+    branch: 'unknown',
+    commitDate: 'unknown',
+    commitMessage: 'unknown',
+    dirty: false,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const distDir = join(projectRoot, 'dist');
+mkdirSync(distDir, { recursive: true });
+writeFileSync(join(distDir, 'build-info.json'), JSON.stringify(info, null, 2) + '\n');
+console.log(`Stamped dist/build-info.json: ${info.hash}${info.dirty ? '-dirty' : ''}`);
+```
+
+- [ ] **Step 2: Add the `postbuild` script to `package.json`**
+
+Change line 16 from:
+
+```json
+    "build": "tsc",
+```
+
+to:
+
+```json
+    "build": "tsc",
+    "postbuild": "node scripts/stamp-build-info.js",
+```
+
+- [ ] **Step 3: Run the build and verify the stamp is written**
+
+Run: `npm run build && cat dist/build-info.json` Expected: build completes, `dist/build-info.json` prints valid JSON
+with a real `hash`, `branch`, `timestamp`, and `dirty` boolean.
+
+- [ ] **Step 4: Verify the loaded buildId now flows end-to-end**
+
+Run:
+`node -e "import('./dist/utils/version.js').then(m => { const v = m.getVersionInfo(); console.log(JSON.stringify({ buildId: v.build.buildId, checkout: v.checkout.hash, stale: v.stale, uptime: v.process.uptimeSeconds }, null, 2)); })"`
+Expected: `buildId` equals the stamped short hash, `checkout` equals the same hash, `stale: false`, `uptime` a small
+number.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/stamp-build-info.js package.json
+git commit -m "feat(OMN-152): postbuild stamps dist/build-info.json"
+```
+
+---
+
+## Task 4: Fix the existing `system-v2.test.ts` mock (the toEqual blocker)
+
+**Files:**
+
+- Modify: `tests/unit/tools/system-v2.test.ts`
+
+- [ ] **Step 1: Confirm the type error that forces this change**
+
+The runtime test still passes on its own — `version.js` is fully mocked (`vi.mock('../../../src/utils/version.js')`) and
+`getVersionInfo` returns `mockVersionInfo` verbatim, so `expect(result.data).toEqual(mockVersionInfo)` is reflexive. The
+real forcing function is **TypeScript**: `vi.mocked(versionUtils.getVersionInfo).mockReturnValue(mockVersionInfo)`
+requires `mockVersionInfo` to satisfy the `VersionInfo` type, which now has new **required** fields (`checkout`,
+`stale`, `process`).
+
+Run: `npm run typecheck:test` Expected: FAIL — `mockVersionInfo` is missing properties `checkout`, `stale`, `process`
+(not assignable to `VersionInfo`).
+
+- [ ] **Step 2: Extend the mock `VersionInfo` object**
+
+In `tests/unit/tools/system-v2.test.ts`, replace the `git` block's closing of the `mockVersionInfo` object (lines
+~75-79):
+
+```ts
+        git: {
+          repository: 'https://github.com/example/omnifocus-mcp',
+          homepage: 'https://example.com',
+        },
+      };
+```
+
+with:
+
+```ts
+        git: {
+          repository: 'https://github.com/example/omnifocus-mcp',
+          homepage: 'https://example.com',
+        },
+        checkout: { hash: 'abc123' },
+        stale: false,
+        process: { startedAt: '2024-01-01T11:00:00Z', uptimeSeconds: 42 },
+      };
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/tools/system-v2.test.ts` Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/tools/system-v2.test.ts
+git commit -m "test(OMN-152): extend system-v2 version mock with checkout/stale/process fields"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck (src AND tests)**
+
+Run: `npm run typecheck && npm run typecheck:test` Expected: no errors. `typecheck` confirms the additive `VersionInfo`
+fields and `build-info.ts` compile and `SystemTool`'s `StandardResponseV2<VersionInfo>` still satisfies;
+`typecheck:test` confirms the updated `system-v2.test.ts` mock now satisfies `VersionInfo` (the Task 4 fix).
+
+- [ ] **Step 2: Full unit suite**
+
+Run: `npm run test:unit` Expected: all green, including the two new files and the updated `system-v2.test.ts`.
+
+- [ ] **Step 3: Lint**
+
+Run:
+`npx eslint src/utils/build-info.ts src/utils/version.ts scripts/stamp-build-info.js tests/unit/utils/build-info.test.ts tests/unit/utils/version.test.ts`
+Expected: clean (exit 0).
+
+- [ ] **Step 4: Commit (only if lint/format auto-fixed anything)**
+
+```bash
+git add -A && git commit -m "chore(OMN-152): lint/format pass" || echo "nothing to commit"
+```
+
+---
+
+## Task 6: Live acceptance — prove staleness is self-detected (`/verify`)
+
+**Files:** none (manual acceptance; the ticket's core acceptance criterion)
+
+- [ ] **Step 1: Build and capture the current buildId**
+
+Run:
+`npm run build && node -e "import('./dist/utils/version.js').then(m=>console.log(m.getVersionInfo().build.buildId))"`
+Record the buildId (call it `OLD`).
+
+- [ ] **Step 2: Start a long-lived process that loaded this build**
+
+Run (background): `node dist/index.js` via the MCP test harness, or simply hold an open
+`node --input-type=module -e "import('./dist/utils/version.js').then(m => { globalThis.v = m; setInterval(()=>{}, 1e9); })"`
+REPL that imported version.js (warming the cache).
+
+- [ ] **Step 3: Make a new commit and rebuild dist WITHOUT restarting that process**
+
+Run: make any trivial commit (or `git commit --allow-empty -m "stale test"`), then `npm run build`.
+`dist/build-info.json` now holds the NEW hash.
+
+- [ ] **Step 4: Query the still-running process**
+
+In the same long-lived process, call `getVersionInfo()` again. Expected: `build.buildId === OLD` (frozen — memoized at
+load), `checkout.hash === NEW`, `stale === true`, `warning` contains "restart the server". **This is the 2026-06-11
+incident, now caught by the probe alone.**
+
+- [ ] **Step 5: Restart the process and confirm it clears**
+
+Restart, call `getVersionInfo()`. Expected: `build.buildId === NEW`, `stale === false`, no warning.
+
+- [ ] **Step 6: Clean up** the empty test commit if made (`git reset --soft HEAD~1` before the real work, or drop it
+      during the final rebase) so it does not ship.
+
+---
+
+## Task 7: Update the deploy-check runbook memory (post-merge)
+
+**Files:** none in repo — memory file outside the worktree.
+
+- [ ] **Step 1:** After merge + prod redeploy, update
+      `~/.claude/projects/-Users-kip-src-omnifocus-mcp/memory/reference_version_endpoint_deploy_check.md` to record that
+      `buildId` now reflects the LOADED process and the endpoint self-reports `stale`, so the separate behavioral-probe
+      requirement is dropped (replaced by "check `stale === false` on the first post-deploy version probe"). Update the
+      `MEMORY.md` hook line accordingly.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Component 1 (stamp script) → Task 3. ✓
+- Component 2 (postbuild) → Task 3 Step 2. ✓
+- Component 3 (module-load capture, dev fallback, checkout, stale, warning, process) → Tasks 1 + 2. ✓ (capture is
+  memoized + warmed at module load, functionally equivalent to a top-level const and unit-testable.)
+- Component 4 (VersionInfo additive fields) → Task 2 Step 3. ✓
+- Error handling (never throws) → readCheckoutHash/readRequestTimeBuild/doRead all try-catch to `unknown`/sentinel. ✓
+- Testing scenarios 1-5 → Task 2 tests + Task 1 tests. ✓
+- Testing scenario 6 (system-v2 mock) → Task 4. ✓
+- Live acceptance → Task 6. ✓
+- Runbook update → Task 7. ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"; every code step shows full code. ✓
+
+**Type consistency:** `LoadedBuild` (build-info.ts) used by `readLoadedBuild` and mocked identically in version.test.ts;
+`VersionInfo` fields (`checkout`/`stale`/`warning?`/`process`) consistent across interface, getVersionInfo return, and
+the system-v2 mock. `buildId` derived in build-info.ts and consumed (never re-derived) in version.ts. ✓
+
+**Note on the request-time git in dev fallback:** `readRequestTimeBuild` sets `buildId: 'dev-unstamped'` directly, so
+dev never reports a misleading stamped-looking id. ✓

--- a/docs/superpowers/specs/2026-06-15-omn-152-compile-time-build-stamp-design.md
+++ b/docs/superpowers/specs/2026-06-15-omn-152-compile-time-build-stamp-design.md
@@ -1,0 +1,130 @@
+# OMN-152 — Compile-time build stamping + staleness detection
+
+**Status:** Approved design (2026-06-15) **Ticket:** OMN-152 — version endpoint buildId is request-time `git rev-parse`;
+stamp real build metadata at compile time so it reflects the LOADED code.
+
+## Problem
+
+`src/utils/version.ts` computes `build.hash`/`buildId` by running `git rev-parse --short HEAD` (and friends) via
+`execSync` **at request time**, from the project root on disk. So the version endpoint reports _the checkout on disk_,
+not _the code the running process actually loaded_.
+
+**Incident (2026-06-11, during the OMN-131 prod deploy):** the prod tree was pulled and rebuilt, but the MCP server
+process (spawned ~48 min earlier) kept serving the previous build. The version probe reported the new `buildId` while
+live behavior was demonstrably the old code — the canonical "is prod current?" probe passed on a stale process.
+Compounding factors: `/mcp` reconnect re-attached without respawning the stdio child, and orphaned `node dist/index.js`
+processes accumulated.
+
+### Root insight
+
+The fix is **not** merely "move git to build time." If we write `dist/build-info.json` and read it _per request_, a
+stale process would read the _freshly rebuilt_ JSON and report the new buildId — reproducing the exact bug. The stamped
+value must be **captured at process-load time** (a top-level module read, frozen for the process lifetime) so an old
+process keeps reporting its own old build even after `dist/` is rebuilt under it. A separate **request-time** checkout
+hash is then compared against the frozen loaded hash to _detect_ staleness.
+
+## Goals
+
+1. `build.*` / `buildId` provably describe the **loaded artifact**, frozen at process start.
+2. The version payload **self-detects** a stale process (`loaded ≠ checkout`) and says "restart the server."
+3. Stale-process diagnosis is one probe, not `ps` archaeology (process start time + uptime).
+4. The version endpoint never throws — all git/fs access degrades gracefully.
+
+## Non-goals
+
+- Respawning the stdio child on `/mcp` reconnect (separate concern).
+- Reaping orphaned processes (covered by the `of-mcp-redeploy` PPID-1 sweep already).
+- Changing the four callers' use of `build.*` (new fields are additive).
+
+## Design
+
+### Component 1 — `scripts/stamp-build-info.js` (new)
+
+Plain ESM Node script (matches existing `scripts/check-script-sizes.js` convention; no `tsx`/compile dependency so it
+can run as a build step). Captures, reusing the exact git commands currently in `version.ts`:
+
+| Field            | Source                             |
+| ---------------- | ---------------------------------- |
+| `hash`           | `git rev-parse --short HEAD`       |
+| `branch`         | `git rev-parse --abbrev-ref HEAD`  |
+| `commitDate`     | `git show -s --format=%ci HEAD`    |
+| `commitMessage`  | `git show -s --format=%s HEAD`     |
+| `dirty`          | `git status --porcelain` non-empty |
+| `buildTimestamp` | ISO timestamp at build time        |
+
+Writes `dist/build-info.json`. On any git failure, writes a record with `hash: "unknown"` (and other fields
+`"unknown"`/`false`) — **never** fails the build (exit 0).
+
+### Component 2 — `package.json`
+
+Add `"postbuild": "node scripts/stamp-build-info.js"`. npm runs `postbuild` automatically after `build` (`tsc`), so
+`dist/` exists when the script writes into it. `build` itself is unchanged. `dist/build-info.json` is already gitignored
+(lives under `dist/`).
+
+### Component 3 — `src/utils/version.ts` (modified)
+
+**Module-load capture (top-level, runs once at process start):**
+
+- `readLoadedBuild()` — resolve `dist/build-info.json` relative to `import.meta.url` (`dist/utils/version.js` →
+  `../build-info.json`), parse into a frozen `LOADED_BUILD` const.
+  - File missing or unparseable (dev/source run via `tsx`, or pre-stamp) → sentinel `{ hash: "dev-unstamped", … }`.
+- `PROCESS_STARTED_AT` — computed once: `new Date(Date.now() - process.uptime() * 1000).toISOString()`.
+
+**`getVersionInfo()` (per request):**
+
+- `build.*` sourced from `LOADED_BUILD` (frozen — reflects the loaded artifact).
+- **Dev fallback:** when `LOADED_BUILD.hash === "dev-unstamped"`, populate `build.*` from request-time git (keeps dev
+  output useful) and force `buildId: "dev-unstamped"`, `stale: false`.
+- `checkout.hash` — `readCheckoutHash()`: request-time `git rev-parse --short HEAD` from project root; failure →
+  `"unknown"`.
+- `stale` — `true` iff `LOADED_BUILD` is stamped (not dev) AND `checkout.hash !== "unknown"` AND
+  `LOADED_BUILD.hash !== checkout.hash`.
+- `warning` — when `stale`: `"stale process: loaded build <X> but checkout is <Y> — restart the server"`.
+- `process` — `{ startedAt: PROCESS_STARTED_AT, uptimeSeconds: process.uptime() }` (uptime live per call).
+
+`readLoadedBuild()` and `readCheckoutHash()` are small internal seams so unit tests can stub `fs`/`child_process`.
+
+### Component 4 — `VersionInfo` interface
+
+Additive fields (existing `build.*`, `runtime.*`, `git.*` unchanged):
+
+```ts
+checkout: { hash: string };
+stale: boolean;
+warning?: string;
+process: { startedAt: string; uptimeSeconds: number };
+```
+
+The four callers (`SystemTool`, `http-server`, `index`, `session-manager`) read `build.*` and keep working unchanged.
+
+## Error handling
+
+Every git and fs access is wrapped to degrade to `"unknown"`/fallback. The version endpoint must never throw — it is the
+diagnostic of last resort and must work even on a broken checkout.
+
+## Testing
+
+**Unit (vitest, mocking `fs` + `child_process`):**
+
+1. Stamped `build-info.json` present → `build.hash`/`buildId` reflect the stamped SHA.
+2. `checkout.hash` differs from loaded → `stale: true` and `warning` present and correctly formatted.
+3. `checkout.hash` equals loaded → `stale: false`, no `warning`.
+4. No `build-info.json` (dev) → `buildId: "dev-unstamped"`, `stale: false`, `build.*` from request-time git fallback.
+5. git failure on checkout read → `checkout.hash: "unknown"`, `stale: false` (cannot assert staleness without a known
+   checkout).
+
+**Live acceptance (`/verify`):** rebuild `dist/` **without** restarting the process → version probe reports the **OLD**
+buildId AND a stale-process warning. This reproduces the 2026-06-11 incident and proves the probe now catches it
+unaided.
+
+## Acceptance criteria (from ticket)
+
+- [ ] Version probe on a deliberately stale process (rebuild dist, don't restart) reports the OLD buildId / explicit
+      staleness warning.
+- [ ] `reference_version_endpoint_deploy_check` memory/runbook updated to drop the behavioral-probe requirement once
+      shipped.
+
+## Rollout note
+
+After merge + prod redeploy (Kip's manual step), the _first_ version probe post-deploy is itself the verification: if
+`stale: true`, the redeploy didn't respawn the child. This is exactly the signal that was missing on 2026-06-11.

--- a/docs/superpowers/specs/2026-06-15-omn-152-compile-time-build-stamp-design.md
+++ b/docs/superpowers/specs/2026-06-15-omn-152-compile-time-build-stamp-design.md
@@ -34,7 +34,11 @@ hash is then compared against the frozen loaded hash to _detect_ staleness.
 
 - Respawning the stdio child on `/mcp` reconnect (separate concern).
 - Reaping orphaned processes (covered by the `of-mcp-redeploy` PPID-1 sweep already).
-- Changing the four callers' use of `build.*` (new fields are additive).
+- Changing the **production** callers' use of `build.*`. The three that read individual fields
+  (`http-server`/`session-manager` → `.version`, `index` → `.name`/`.version`/`.build.buildId`) are additive-safe. But
+  `SystemTool.getVersion()` returns the whole `VersionInfo` as `result.data`, and `tests/unit/tools/system-v2.test.ts`
+  asserts it with `toEqual(mockVersionInfo)` (exact structural equality) — so its mock MUST be extended with the new
+  fields (see Testing). This is the one non-additive consequence.
 
 ## Design
 
@@ -43,17 +47,22 @@ hash is then compared against the frozen loaded hash to _detect_ staleness.
 Plain ESM Node script (matches existing `scripts/check-script-sizes.js` convention; no `tsx`/compile dependency so it
 can run as a build step). Captures, reusing the exact git commands currently in `version.ts`:
 
-| Field            | Source                             |
-| ---------------- | ---------------------------------- |
-| `hash`           | `git rev-parse --short HEAD`       |
-| `branch`         | `git rev-parse --abbrev-ref HEAD`  |
-| `commitDate`     | `git show -s --format=%ci HEAD`    |
-| `commitMessage`  | `git show -s --format=%s HEAD`     |
-| `dirty`          | `git status --porcelain` non-empty |
-| `buildTimestamp` | ISO timestamp at build time        |
+| Field           | Source                             |
+| --------------- | ---------------------------------- |
+| `hash`          | `git rev-parse --short HEAD`       |
+| `branch`        | `git rev-parse --abbrev-ref HEAD`  |
+| `commitDate`    | `git show -s --format=%ci HEAD`    |
+| `commitMessage` | `git show -s --format=%s HEAD`     |
+| `dirty`         | `git status --porcelain` non-empty |
+| `timestamp`     | ISO timestamp at build time        |
+
+The JSON key is `timestamp` (matching the existing `VersionInfo.build.timestamp` field name — no rename). `buildId` is
+**not** stored in the JSON; it is derived at read time (see Component 3) from `hash` + `dirty`, keeping a single source
+of truth.
 
 Writes `dist/build-info.json`. On any git failure, writes a record with `hash: "unknown"` (and other fields
-`"unknown"`/`false`) — **never** fails the build (exit 0).
+`"unknown"`/`false`) — **never** fails the build (exit 0). Note: `dist/build-info.json` is matched by the
+`"files": ["dist/**/*"]` allowlist in `package.json`, so it ships in any npm publish — harmless and arguably useful.
 
 ### Component 2 — `package.json`
 
@@ -66,8 +75,10 @@ Add `"postbuild": "node scripts/stamp-build-info.js"`. npm runs `postbuild` auto
 **Module-load capture (top-level, runs once at process start):**
 
 - `readLoadedBuild()` — resolve `dist/build-info.json` relative to `import.meta.url` (`dist/utils/version.js` →
-  `../build-info.json`), parse into a frozen `LOADED_BUILD` const.
-  - File missing or unparseable (dev/source run via `tsx`, or pre-stamp) → sentinel `{ hash: "dev-unstamped", … }`.
+  `../build-info.json`), parse into a frozen `LOADED_BUILD` const. Derive `buildId = `${hash}${dirty ? '-dirty' : ''}``
+  here (it is not in the JSON).
+  - File missing or unparseable (dev/source run via `tsx`, or pre-stamp) → sentinel
+    `{ hash: "dev-unstamped", buildId: "dev-unstamped", … }`.
 - `PROCESS_STARTED_AT` — computed once: `new Date(Date.now() - process.uptime() * 1000).toISOString()`.
 
 **`getVersionInfo()` (per request):**
@@ -76,13 +87,19 @@ Add `"postbuild": "node scripts/stamp-build-info.js"`. npm runs `postbuild` auto
 - **Dev fallback:** when `LOADED_BUILD.hash === "dev-unstamped"`, populate `build.*` from request-time git (keeps dev
   output useful) and force `buildId: "dev-unstamped"`, `stale: false`.
 - `checkout.hash` — `readCheckoutHash()`: request-time `git rev-parse --short HEAD` from project root; failure →
-  `"unknown"`.
+  `"unknown"`. Populated in **all** modes including dev-fallback (so the field is always present); only the `stale` flag
+  is suppressed in dev.
 - `stale` — `true` iff `LOADED_BUILD` is stamped (not dev) AND `checkout.hash !== "unknown"` AND
-  `LOADED_BUILD.hash !== checkout.hash`.
+  `LOADED_BUILD.hash !== checkout.hash`. Forced `false` in dev-fallback regardless of `checkout.hash`.
 - `warning` — when `stale`: `"stale process: loaded build <X> but checkout is <Y> — restart the server"`.
 - `process` — `{ startedAt: PROCESS_STARTED_AT, uptimeSeconds: process.uptime() }` (uptime live per call).
 
 `readLoadedBuild()` and `readCheckoutHash()` are small internal seams so unit tests can stub `fs`/`child_process`.
+
+**Semantics change — `build.timestamp`:** today it is `new Date().toISOString()` computed at **request time** inside
+`getVersionInfo()` (despite its `build.` label). After this change it is sourced from `LOADED_BUILD`, i.e. the time the
+**build** ran. This is intentional and more correct, but any consumer that used `build.timestamp` as a request clock
+must move to `process.startedAt`/`uptimeSeconds`. (No current caller does — verified.)
 
 ### Component 4 — `VersionInfo` interface
 
@@ -112,6 +129,9 @@ diagnostic of last resort and must work even on a broken checkout.
 4. No `build-info.json` (dev) → `buildId: "dev-unstamped"`, `stale: false`, `build.*` from request-time git fallback.
 5. git failure on checkout read → `checkout.hash: "unknown"`, `stale: false` (cannot assert staleness without a known
    checkout).
+6. **Update `tests/unit/tools/system-v2.test.ts`** — its mock `VersionInfo` and the `toEqual(mockVersionInfo)` assertion
+   (line ~86) must be extended with the new `checkout`/`stale`/`process` fields, or the existing test fails on
+   exact-equality. This is required, not optional.
 
 **Live acceptance (`/verify`):** rebuild `dist/` **without** restarting the process → version probe reports the **OLD**
 buildId AND a stale-process warning. This reproduces the 2026-06-11 incident and proves the probe now catches it

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -177,6 +177,19 @@ export default [
     },
   },
 
+  // Node.js build/utility scripts (plain .js, ESM, run directly with node).
+  // The base TS config only wires globals.node for *.ts files; explicit-path
+  // lint calls (e.g. from lint-staged) bypass the top-level ignores glob, so
+  // we must declare globals here rather than relying on the ignore.
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
   // Ignore patterns
   {
     ignores: [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "postbuild": "node scripts/stamp-build-info.js",
     "dev": "tsc --watch",
     "start": "node ./dist/index.js",
     "test:unit": "vitest tests/unit --run",

--- a/scripts/stamp-build-info.js
+++ b/scripts/stamp-build-info.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Build-time stamp: capture git metadata into dist/build-info.json so the version
+// endpoint reports the LOADED artifact, not the request-time checkout. Never fails
+// the build — git errors degrade to "unknown".
+import { execSync } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const opt = { encoding: 'utf8', cwd: projectRoot };
+// eslint-disable-next-line sonarjs/os-command -- hardcoded git commands, no user input
+const git = (cmd) => execSync(cmd, opt).trim();
+
+let info;
+try {
+  let dirty = false;
+  try {
+    dirty = git('git status --porcelain').length > 0;
+  } catch {
+    /* assume clean */
+  }
+  info = {
+    hash: git('git rev-parse --short HEAD'),
+    branch: git('git rev-parse --abbrev-ref HEAD'),
+    commitDate: git('git show -s --format=%ci HEAD'),
+    commitMessage: git('git show -s --format=%s HEAD'),
+    dirty,
+    timestamp: new Date().toISOString(),
+  };
+} catch {
+  info = {
+    hash: 'unknown',
+    branch: 'unknown',
+    commitDate: 'unknown',
+    commitMessage: 'unknown',
+    dirty: false,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const distDir = join(projectRoot, 'dist');
+mkdirSync(distDir, { recursive: true });
+writeFileSync(join(distDir, 'build-info.json'), JSON.stringify(info, null, 2) + '\n');
+console.log(`Stamped dist/build-info.json: ${info.hash}${info.dirty ? '-dirty' : ''}`);

--- a/src/tools/system/SystemTool.ts
+++ b/src/tools/system/SystemTool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { BaseTool } from '../base.js';
-import { getVersionInfo } from '../../utils/version.js';
+import { getVersionInfo, type VersionInfo } from '../../utils/version.js';
 import { getVersionInfo as getOmniFocusVersionInfo } from '../../omnifocus/version-detection.js';
 import { DiagnosticOmniAutomation } from '../../omnifocus/DiagnosticOmniAutomation.js';
 import {
@@ -50,30 +50,6 @@ export const SystemToolSchema = z
       .describe('Cache action: stats to get statistics, clear to invalidate all cached data'),
   })
   .strict();
-
-interface VersionInfo {
-  name: string;
-  version: string;
-  description: string;
-  build: {
-    hash: string;
-    branch: string;
-    commitDate: string;
-    commitMessage: string;
-    dirty: boolean;
-    timestamp: string;
-    buildId: string;
-  };
-  runtime: {
-    node: string;
-    platform: string;
-    arch: string;
-  };
-  git: {
-    repository: string;
-    homepage: string;
-  };
-}
 
 interface DiagnosticsResult {
   timestamp: string;

--- a/src/utils/build-info.ts
+++ b/src/utils/build-info.ts
@@ -1,0 +1,66 @@
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+export interface LoadedBuild {
+  hash: string;
+  branch: string;
+  commitDate: string;
+  commitMessage: string;
+  dirty: boolean;
+  timestamp: string;
+  buildId: string;
+}
+
+export const DEV_SENTINEL: LoadedBuild = {
+  hash: 'dev-unstamped',
+  branch: 'unknown',
+  commitDate: 'unknown',
+  commitMessage: 'unknown',
+  dirty: false,
+  timestamp: 'unknown',
+  buildId: 'dev-unstamped',
+};
+
+let cache: LoadedBuild | undefined;
+
+function doRead(): LoadedBuild {
+  try {
+    // build-info.json sits beside this module's compiled output: dist/build-info.json.
+    // This module compiles to dist/utils/build-info.js → one level up is dist/.
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
+    const buildInfoPath = join(scriptDir, '..', 'build-info.json');
+    if (!existsSync(buildInfoPath)) return DEV_SENTINEL;
+    const raw = JSON.parse(readFileSync(buildInfoPath, 'utf8')) as Partial<LoadedBuild>;
+    const hash = raw.hash ?? 'unknown';
+    const dirty = Boolean(raw.dirty);
+    return {
+      hash,
+      branch: raw.branch ?? 'unknown',
+      commitDate: raw.commitDate ?? 'unknown',
+      commitMessage: raw.commitMessage ?? 'unknown',
+      dirty,
+      timestamp: raw.timestamp ?? 'unknown',
+      buildId: `${hash}${dirty ? '-dirty' : ''}`,
+    };
+  } catch {
+    return DEV_SENTINEL;
+  }
+}
+
+/**
+ * Returns the build metadata stamped into dist/ at compile time, read ONCE and
+ * memoized. The first call (warmed at process start by version.ts) captures the
+ * loaded artifact; later disk rebuilds do not change the returned value — that is
+ * what lets the version endpoint detect a stale process.
+ */
+export function readLoadedBuild(): LoadedBuild {
+  if (cache) return cache;
+  cache = doRead();
+  return cache;
+}
+
+/** Test-only: clear the memoized value so each test reads fresh. */
+export function __resetBuildInfoCacheForTests(): void {
+  cache = undefined;
+}

--- a/src/utils/build-info.ts
+++ b/src/utils/build-info.ts
@@ -12,7 +12,7 @@ export interface LoadedBuild {
   buildId: string;
 }
 
-export const DEV_SENTINEL: LoadedBuild = {
+export const DEV_SENTINEL: LoadedBuild = Object.freeze({
   hash: 'dev-unstamped',
   branch: 'unknown',
   commitDate: 'unknown',
@@ -20,7 +20,7 @@ export const DEV_SENTINEL: LoadedBuild = {
   dirty: false,
   timestamp: 'unknown',
   buildId: 'dev-unstamped',
-};
+});
 
 let cache: LoadedBuild | undefined;
 

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { readLoadedBuild } from './build-info.js';
 
 export interface VersionInfo {
   name: string;
@@ -25,101 +26,113 @@ export interface VersionInfo {
     repository: string;
     homepage: string;
   };
+  checkout: { hash: string };
+  stale: boolean;
+  warning?: string;
+  process: { startedAt: string; uptimeSeconds: number };
 }
 
 interface PackageJson {
   name: string;
   version: string;
   description: string;
-  repository?: {
-    url?: string;
-  };
+  repository?: { url?: string };
   homepage?: string;
 }
 
-export function getVersionInfo(): VersionInfo {
-  // Get package.json version - find project root using script location
-  // This works regardless of what working directory the process was started from
-  const scriptPath = fileURLToPath(import.meta.url);
-  const scriptDir = dirname(scriptPath);
+// Captured once, at process start: makes buildId reflect load-time, not first-request time.
+const PROCESS_STARTED_AT = new Date(Date.now() - process.uptime() * 1000).toISOString();
+// Warm the memoized loaded-build read at module load (process start).
+readLoadedBuild();
 
-  // From dist/utils/version.js, go up to project root
-  // script location: dist/utils/version.js
-  // project root: go up 2 levels (../.. from dist/utils)
-  const projectRoot = join(scriptDir, '..', '..');
-  const packagePath = join(projectRoot, 'package.json');
+function resolveProjectRoot(): string {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  // dist/utils/version.js → project root is two levels up.
+  return join(scriptDir, '..', '..');
+}
 
-  if (!existsSync(packagePath)) {
-    throw new Error(`Cannot find package.json at ${packagePath}. Script location: ${scriptPath}`);
-  }
-
-  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as PackageJson;
-
-  // Get git information
-  let gitCommitHash = 'unknown';
-  let gitBranch = 'unknown';
-  let gitCommitDate = 'unknown';
-  let gitCommitMessage = 'unknown';
-  let gitDirty = false;
-
+function readCheckoutHash(projectRoot: string): string {
   try {
-    // Run git commands from the project root directory
-    const gitOptions = { encoding: 'utf8' as const, cwd: projectRoot };
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8', cwd: projectRoot }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
 
-    // Get short commit hash
-    gitCommitHash = execSync('git rev-parse --short HEAD', gitOptions).trim();
-
-    // Get current branch
-    gitBranch = execSync('git rev-parse --abbrev-ref HEAD', gitOptions).trim();
-
-    // Get commit date
-    gitCommitDate = execSync('git show -s --format=%ci HEAD', gitOptions).trim();
-
-    // Get commit message
-    gitCommitMessage = execSync('git show -s --format=%s HEAD', gitOptions).trim();
-
-    // Check if working directory is dirty
+// Request-time git, used ONLY for the dev fallback so dev output stays useful.
+function readRequestTimeBuild(projectRoot: string): VersionInfo['build'] {
+  const opt = { encoding: 'utf8' as const, cwd: projectRoot };
+  let hash = 'unknown';
+  let branch = 'unknown';
+  let commitDate = 'unknown';
+  let commitMessage = 'unknown';
+  let dirty = false;
+  try {
+    hash = execSync('git rev-parse --short HEAD', opt).trim();
+    branch = execSync('git rev-parse --abbrev-ref HEAD', opt).trim();
+    commitDate = execSync('git show -s --format=%ci HEAD', opt).trim();
+    commitMessage = execSync('git show -s --format=%s HEAD', opt).trim();
     try {
-      const status = execSync('git status --porcelain', gitOptions).trim();
-      gitDirty = status.length > 0;
+      dirty = execSync('git status --porcelain', opt).trim().length > 0;
     } catch {
-      // If git status fails, assume clean
+      /* assume clean */
     }
   } catch {
-    // If git commands fail, use defaults
+    /* defaults */
   }
+  return {
+    hash,
+    branch,
+    commitDate,
+    commitMessage,
+    dirty,
+    timestamp: new Date().toISOString(),
+    buildId: 'dev-unstamped',
+  };
+}
 
-  // Get build timestamp
-  const buildTimestamp = new Date().toISOString();
+export function getVersionInfo(): VersionInfo {
+  const projectRoot = resolveProjectRoot();
+  const packagePath = join(projectRoot, 'package.json');
+  if (!existsSync(packagePath)) {
+    throw new Error(`Cannot find package.json at ${packagePath}.`);
+  }
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as PackageJson;
 
-  // Get Node.js version
-  const nodeVersion = process.version;
+  const loaded = readLoadedBuild();
+  const isDev = loaded.buildId === 'dev-unstamped';
 
-  // Get platform information
-  const platform = process.platform;
-  const arch = process.arch;
+  const build: VersionInfo['build'] = isDev
+    ? readRequestTimeBuild(projectRoot)
+    : {
+        hash: loaded.hash,
+        branch: loaded.branch,
+        commitDate: loaded.commitDate,
+        commitMessage: loaded.commitMessage,
+        dirty: loaded.dirty,
+        timestamp: loaded.timestamp,
+        buildId: loaded.buildId,
+      };
+
+  const checkoutHash = readCheckoutHash(projectRoot);
+  const stale = !isDev && checkoutHash !== 'unknown' && loaded.hash !== checkoutHash;
+  const warning = stale
+    ? `stale process: loaded build ${loaded.hash} but checkout is ${checkoutHash} — restart the server`
+    : undefined;
 
   return {
     name: packageJson.name,
     version: packageJson.version,
     description: packageJson.description,
-    build: {
-      hash: gitCommitHash,
-      branch: gitBranch,
-      commitDate: gitCommitDate,
-      commitMessage: gitCommitMessage,
-      dirty: gitDirty,
-      timestamp: buildTimestamp,
-      buildId: `${gitCommitHash}${gitDirty ? '-dirty' : ''}`,
-    },
-    runtime: {
-      node: nodeVersion,
-      platform: platform,
-      arch: arch,
-    },
+    build,
+    runtime: { node: process.version, platform: process.platform, arch: process.arch },
     git: {
       repository: packageJson.repository?.url || 'unknown',
       homepage: packageJson.homepage || 'unknown',
     },
+    checkout: { hash: checkoutHash },
+    stale,
+    ...(warning ? { warning } : {}),
+    process: { startedAt: PROCESS_STARTED_AT, uptimeSeconds: process.uptime() },
   };
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -115,7 +115,7 @@ export function getVersionInfo(): VersionInfo {
       };
 
   const checkoutHash = readCheckoutHash(projectRoot);
-  const stale = !isDev && checkoutHash !== 'unknown' && loaded.hash !== checkoutHash;
+  const stale = !isDev && loaded.hash !== 'unknown' && checkoutHash !== 'unknown' && loaded.hash !== checkoutHash;
   const warning = stale
     ? `stale process: loaded build ${loaded.hash} but checkout is ${checkoutHash} — restart the server`
     : undefined;

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,21 +2,13 @@ import { execSync } from 'child_process';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { readLoadedBuild } from './build-info.js';
+import { readLoadedBuild, type LoadedBuild } from './build-info.js';
 
 export interface VersionInfo {
   name: string;
   version: string;
   description: string;
-  build: {
-    hash: string;
-    branch: string;
-    commitDate: string;
-    commitMessage: string;
-    dirty: boolean;
-    timestamp: string;
-    buildId: string;
-  };
+  build: LoadedBuild;
   runtime: {
     node: string;
     platform: string;

--- a/tests/unit/tools/system-v2.test.ts
+++ b/tests/unit/tools/system-v2.test.ts
@@ -76,6 +76,9 @@ describe('SystemTool', () => {
           repository: 'https://github.com/example/omnifocus-mcp',
           homepage: 'https://example.com',
         },
+        checkout: { hash: 'abc123' },
+        stale: false,
+        process: { startedAt: '2024-01-01T11:00:00Z', uptimeSeconds: 42 },
       };
 
       vi.mocked(versionUtils.getVersionInfo).mockReturnValue(mockVersionInfo);

--- a/tests/unit/utils/build-info.test.ts
+++ b/tests/unit/utils/build-info.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Path-aware fs mock: only intercept build-info.json; defer everything else to real fs.
+let buildInfoExists = true;
+let buildInfoRaw = '';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn((p: string) => (String(p).endsWith('build-info.json') ? buildInfoExists : actual.existsSync(p))),
+    readFileSync: vi.fn((p: string, enc?: unknown) =>
+      String(p).endsWith('build-info.json') ? buildInfoRaw : (actual.readFileSync as any)(p, enc),
+    ),
+  };
+});
+
+import { readLoadedBuild, __resetBuildInfoCacheForTests, DEV_SENTINEL } from '../../../src/utils/build-info.js';
+
+beforeEach(() => {
+  __resetBuildInfoCacheForTests();
+  buildInfoExists = true;
+  buildInfoRaw = '';
+});
+
+describe('readLoadedBuild', () => {
+  it('reads a stamped build-info.json and derives a clean buildId', () => {
+    buildInfoRaw = JSON.stringify({
+      hash: 'abc1234',
+      branch: 'main',
+      commitDate: '2026-06-15 10:00:00 -0400',
+      commitMessage: 'feat: x',
+      dirty: false,
+      timestamp: '2026-06-15T14:00:00.000Z',
+    });
+    const b = readLoadedBuild();
+    expect(b.hash).toBe('abc1234');
+    expect(b.buildId).toBe('abc1234');
+    expect(b.dirty).toBe(false);
+    expect(b.timestamp).toBe('2026-06-15T14:00:00.000Z');
+  });
+
+  it('appends -dirty to buildId when the stamp is dirty', () => {
+    buildInfoRaw = JSON.stringify({ hash: 'abc1234', dirty: true });
+    expect(readLoadedBuild().buildId).toBe('abc1234-dirty');
+  });
+
+  it('returns the dev sentinel when build-info.json is missing', () => {
+    buildInfoExists = false;
+    expect(readLoadedBuild()).toEqual(DEV_SENTINEL);
+  });
+
+  it('returns the dev sentinel when build-info.json is unparseable', () => {
+    buildInfoRaw = '{ not json';
+    expect(readLoadedBuild()).toEqual(DEV_SENTINEL);
+  });
+
+  it('memoizes: a second call does not re-read the file', () => {
+    buildInfoRaw = JSON.stringify({ hash: 'first' });
+    expect(readLoadedBuild().hash).toBe('first');
+    buildInfoRaw = JSON.stringify({ hash: 'second' }); // changed on disk
+    expect(readLoadedBuild().hash).toBe('first'); // still cached
+  });
+});

--- a/tests/unit/utils/version.test.ts
+++ b/tests/unit/utils/version.test.ts
@@ -80,6 +80,14 @@ describe('getVersionInfo staleness', () => {
     expect(v.stale).toBe(false);
   });
 
+  it('unknown stamp (build-time git failed) → not stale even if checkout is known', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue({ ...STAMPED, hash: 'unknown', buildId: 'unknown' });
+    gitMock({ 'rev-parse --short HEAD': 'abc1234' });
+    const v = getVersionInfo();
+    expect(v.stale).toBe(false);
+    expect(v.warning).toBeUndefined();
+  });
+
   it('always reports process uptime + startedAt', () => {
     vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
     gitMock({ 'rev-parse --short HEAD': 'abc1234' });

--- a/tests/unit/utils/version.test.ts
+++ b/tests/unit/utils/version.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LoadedBuild } from '../../../src/utils/build-info.js';
+
+// Control the loaded build per test.
+vi.mock('../../../src/utils/build-info.js', () => ({
+  readLoadedBuild: vi.fn(),
+  DEV_SENTINEL: {
+    hash: 'dev-unstamped',
+    branch: 'unknown',
+    commitDate: 'unknown',
+    commitMessage: 'unknown',
+    dirty: false,
+    timestamp: 'unknown',
+    buildId: 'dev-unstamped',
+  },
+}));
+
+// Control request-time git (checkout hash + dev fallback git).
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
+
+import { readLoadedBuild } from '../../../src/utils/build-info.js';
+import { execSync } from 'child_process';
+import { getVersionInfo } from '../../../src/utils/version.js';
+
+const STAMPED: LoadedBuild = {
+  hash: 'abc1234',
+  branch: 'main',
+  commitDate: '2026-06-15 10:00:00 -0400',
+  commitMessage: 'feat: x',
+  dirty: false,
+  timestamp: '2026-06-15T14:00:00.000Z',
+  buildId: 'abc1234',
+};
+
+// Route execSync by the git subcommand so we can simulate checkout hash + dev git.
+function gitMock(map: Record<string, string>, fail = false) {
+  vi.mocked(execSync).mockImplementation((cmd: string) => {
+    if (fail) throw new Error('not a git repo');
+    for (const [needle, out] of Object.entries(map)) if (cmd.includes(needle)) return out as never;
+    return '' as never;
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getVersionInfo staleness', () => {
+  it('stamped build, checkout matches → not stale, no warning', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({ 'rev-parse --short HEAD': 'abc1234' });
+    const v = getVersionInfo();
+    expect(v.build.buildId).toBe('abc1234');
+    expect(v.checkout.hash).toBe('abc1234');
+    expect(v.stale).toBe(false);
+    expect(v.warning).toBeUndefined();
+  });
+
+  it('stamped build, checkout differs → stale with warning', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({ 'rev-parse --short HEAD': 'def5678' });
+    const v = getVersionInfo();
+    expect(v.stale).toBe(true);
+    expect(v.warning).toContain('abc1234');
+    expect(v.warning).toContain('def5678');
+    expect(v.warning).toContain('restart');
+  });
+
+  it('dev sentinel → buildId dev-unstamped, never stale', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue({ ...STAMPED, hash: 'dev-unstamped', buildId: 'dev-unstamped' });
+    gitMock({ 'rev-parse --short HEAD': 'anything', 'abbrev-ref': 'feature', '%ci': 'date', '%s': 'msg' });
+    const v = getVersionInfo();
+    expect(v.build.buildId).toBe('dev-unstamped');
+    expect(v.stale).toBe(false);
+  });
+
+  it('checkout git failure → checkout unknown, not stale', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({}, true);
+    const v = getVersionInfo();
+    expect(v.checkout.hash).toBe('unknown');
+    expect(v.stale).toBe(false);
+  });
+
+  it('always reports process uptime + startedAt', () => {
+    vi.mocked(readLoadedBuild).mockReturnValue(STAMPED);
+    gitMock({ 'rev-parse --short HEAD': 'abc1234' });
+    const v = getVersionInfo();
+    expect(typeof v.process.uptimeSeconds).toBe('number');
+    expect(typeof v.process.startedAt).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
Makes the version endpoint's `buildId` reflect the code the running process **actually loaded** (frozen at process start), and self-detect a stale process by comparing against the request-time checkout hash. Closes the 2026-06-11 blind spot where the "is prod current?" probe passed on a stale process (OMN-152).

## Approach
- **`scripts/stamp-build-info.js`** (`postbuild`) writes `dist/build-info.json` (git hash/branch/commitDate/message/dirty + build timestamp). Never fails the build — git errors degrade to `"unknown"`.
- **`src/utils/build-info.ts`** reads that file **once, memoized**, warmed at process start — so an old process keeps reporting its own old build even after `dist/` is rebuilt under it.
- **`src/utils/version.ts`** composes the frozen loaded build with a request-time `git rev-parse` (`checkout.hash`); when they differ it emits `stale: true` + a `"restart the server"` warning. Adds `process.startedAt`/`uptimeSeconds`. Dev/source runs (no stamp) fall back to request-time git and are never marked stale.

## Live acceptance (the core criterion — verified)
In one un-restarted process:
- baseline: `buildId a4bb5a0`, `checkout a4bb5a0`, `stale false`
- after HEAD → `2b2799f` + dist rebuilt under it: `buildId a4bb5a0` (frozen), `checkout 2b2799f`, **`stale: true`**, warning *"stale process: loaded build a4bb5a0 but checkout is 2b2799f — restart the server"*
- fresh process: `stale: false` (clears on restart)

## VersionInfo changes (additive)
New: `checkout: { hash }`, `stale: boolean`, `warning?: string`, `process: { startedAt, uptimeSeconds }`. Existing `build.*`/`runtime.*`/`git.*` unchanged; the 4 callers are unaffected. `system-v2.test.ts` mock extended (typecheck forcing function).

## Verification
- New unit tests: `build-info.test.ts` (5), `version.test.ts` (6, incl. stale-true/false, dev fallback, git-failure, unknown-stamp guard)
- Full unit suite: 140 files / 3319 tests green; `typecheck` + `typecheck:test` clean; ESLint clean
- `eslint.config.js`: added a `scripts/**/*.js` node-globals block (legitimate gap fix); `execSync` suppression scoped inline to the one seam (not the whole dir)

## Reviews already run
Per-task spec+quality reviews + a holistic final review (all approved). Two findings caught and fixed pre-PR: over-broad eslint suppression → scoped inline; false-positive stale on unknown stamp → guarded.

## Follow-up (post-deploy)
Update the `reference_version_endpoint_deploy_check` runbook to drop the behavioral-probe requirement (replaced by "check `stale === false` on the first post-deploy probe").

Spec: `docs/superpowers/specs/2026-06-15-omn-152-compile-time-build-stamp-design.md`
Plan: `docs/superpowers/plans/2026-06-15-omn-152-compile-time-build-stamp.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)