### PR TITLE
test(OMN-184): harden unguarded .data access + kill vacuous-pass in analytics-validation

### DIFF
--- a/tests/integration/validation/analytics-validation.test.ts
+++ b/tests/integration/validation/analytics-validation.test.ts
@@ -167,24 +167,7 @@ describe('Analytics Validation - Actual Calculations', () => {
       expectOk(overdueCreate, 'create Overdue Task Test');
       expectOk(futureCreate, 'create Future Task Test');
 
-      // OMN-184: force a cache-COLD overdue_analysis. The analytics cache has a
-      // 1h TTL and is NOT invalidated by task creates, and the shared server is
-      // a single module-level instance reused across the whole integration run.
-      // overdue_analysis caches under a FIXED key (params are hardcoded:
-      // includeRecentlyCompleted/groupBy/limit), so a sibling test that calls
-      // overdue_analysis first (e.g. the LLM-simulation suites) would leave a
-      // pre-seed snapshot that this test would otherwise read — making `>= 1`
-      // pass on stale data (or fail on a clean DB) instead of verifying OUR
-      // seed. Clearing the cache here guarantees the next call does a live
-      // OmniJS query that sees the task we just created. (Costs a re-warm of
-      // the shared caches — accepted: valid testing over speed.)
-      const cacheClear = await client.callTool('system', {
-        operation: 'cache',
-        cacheAction: 'clear',
-      });
-      expectOk(cacheClear, 'cache clear before overdue_analysis');
-
-      // Run overdue analysis (cache-cold → live query → reflects the seed)
+      // Run overdue analysis
       const result = await client.callTool('omnifocus_analyze', {
         analysis: {
           type: 'overdue_analysis',
@@ -200,11 +183,14 @@ describe('Analytics Validation - Actual Calculations', () => {
       // Validate summary contains required fields
       expect(typeof result.data.stats.summary.totalOverdue).toBe('number');
       expect(typeof result.data.stats.summary.overduePercentage).toBe('number');
-      // OMN-184: we seeded a 7-days-overdue task (expectOk above proves it
-      // exists) and the cache clear above guarantees this analysis is a live
-      // query against that world, so it MUST count at least one. `>= 0`
-      // accepted the empty world a silent seed failure would have produced —
-      // the vacuous pass; `>= 1` now genuinely verifies the seed is seen.
+      // OMN-184: we seeded a 7-days-overdue task and expectOk above proves the
+      // create succeeded. A successful create invalidates the analytics cache
+      // (omnifocus_write create → CacheManager.invalidateForTaskChange, which
+      // unconditionally clears the 'analytics' category), so this
+      // overdue_analysis is a guaranteed cache miss → live OmniJS query against
+      // the world that now contains our seed. The old `>= 0` accepted the empty
+      // world a silent seed failure would have produced — the vacuous pass;
+      // `>= 1` genuinely verifies the seeded task is counted.
       expect(result.data.stats.summary.totalOverdue).toBeGreaterThanOrEqual(1);
 
       // If there are overdue tasks, validate they have proper structure

--- a/tests/integration/validation/analytics-validation.test.ts
+++ b/tests/integration/validation/analytics-validation.test.ts
@@ -49,6 +49,14 @@ describe('Analytics Validation - Actual Calculations', () => {
       const result1 = await client.createTestTask('Completed Task for Stats', { tags: [testSessionTag] });
       const result2 = await client.createTestTask('Another Completed', { tags: [testSessionTag] });
 
+      // OMN-184: assert the creates succeeded before reading `.data.task.taskId`.
+      // createTestTask returns {success:false} (no `.data`) when OmniFocus is
+      // busy/throttling; the bare access then crashes with an anonymous
+      // "Cannot read properties of undefined (reading 'task')" that hides which
+      // create failed. expectOk surfaces result.error and names the culprit.
+      expectOk(result1, 'create Completed Task for Stats');
+      expectOk(result2, 'create Another Completed');
+
       // Complete 3 out of 5 tasks
       await client.callTool('omnifocus_write', {
         mutation: {
@@ -135,7 +143,7 @@ describe('Analytics Validation - Actual Calculations', () => {
       pastDate.setDate(pastDate.getDate() - 7); // 7 days ago
       const pastDateStr = pastDate.toISOString().split('T')[0];
 
-      await client.createTestTask('Overdue Task Test', {
+      const overdueCreate = await client.createTestTask('Overdue Task Test', {
         tags: [testSessionTag],
         dueDate: pastDateStr,
       });
@@ -145,10 +153,19 @@ describe('Analytics Validation - Actual Calculations', () => {
       futureDate.setDate(futureDate.getDate() + 7); // 7 days from now
       const futureDateStr = futureDate.toISOString().split('T')[0];
 
-      await client.createTestTask('Future Task Test', {
+      const futureCreate = await client.createTestTask('Future Task Test', {
         tags: [testSessionTag],
         dueDate: futureDateStr,
       });
+
+      // OMN-184: assert both seed creates succeeded. These were fire-and-forget,
+      // which let a silent create failure pass the test VACUOUSLY: with no
+      // overdue task seeded, overdue_analysis finds 0 and the old
+      // `toBeGreaterThanOrEqual(0)` below still passed — green CI asserting
+      // nothing. Confirming the seed exists is what makes the `>= 1` demand
+      // below safe.
+      expectOk(overdueCreate, 'create Overdue Task Test');
+      expectOk(futureCreate, 'create Future Task Test');
 
       // Run overdue analysis
       const result = await client.callTool('omnifocus_analyze', {
@@ -166,7 +183,12 @@ describe('Analytics Validation - Actual Calculations', () => {
       // Validate summary contains required fields
       expect(typeof result.data.stats.summary.totalOverdue).toBe('number');
       expect(typeof result.data.stats.summary.overduePercentage).toBe('number');
-      expect(result.data.stats.summary.totalOverdue).toBeGreaterThanOrEqual(0);
+      // OMN-184: we seeded a 7-days-overdue task (expectOk above proves it
+      // exists), so the analysis MUST count at least one. `>= 0` accepted the
+      // empty world a silent seed failure would have produced — the vacuous
+      // pass. `>= 1` is safe here: the sibling ProductivityStats block confirms
+      // freshly-created tasks reach analytics in this suite.
+      expect(result.data.stats.summary.totalOverdue).toBeGreaterThanOrEqual(1);
 
       // If there are overdue tasks, validate they have proper structure
       if (result.data.stats.overdueTasks && result.data.stats.overdueTasks.length > 0) {
@@ -184,6 +206,10 @@ describe('Analytics Validation - Actual Calculations', () => {
       const result = await client.createTestTask('Velocity Test Task', {
         tags: [testSessionTag],
       });
+
+      // OMN-184: guard `.data.task.taskId` (same class as the ProductivityStats
+      // block) so a throttled create fails by name, not as a bare TypeError.
+      expectOk(result, 'create Velocity Test Task');
 
       await client.callTool('omnifocus_write', {
         mutation: {
@@ -243,6 +269,14 @@ describe('Analytics Validation - Actual Calculations', () => {
       // crashing with "Cannot read properties of undefined (reading 'stats')".
       expectOk(productivityResult, 'cross-tool productivity_stats');
       expectOk(velocityResult, 'cross-tool task_velocity');
+
+      // OMN-184: mirror the `.data` guard the other three blocks already have,
+      // so a success-but-empty envelope fails here rather than at the nested
+      // `.data.stats` / `.data.velocity` access. Normalizes the pattern by
+      // adding the assertion, not by dropping it elsewhere — diagnostic-rich
+      // failures are the cluster's intent (OMN-56/140).
+      expect(productivityResult.data).toBeDefined();
+      expect(velocityResult.data).toBeDefined();
 
       // ✅ Both should report > 0 tasks (our test tasks + possibly others)
       expect(productivityResult.data.stats.overview.totalTasks).toBeGreaterThan(0);

--- a/tests/integration/validation/analytics-validation.test.ts
+++ b/tests/integration/validation/analytics-validation.test.ts
@@ -167,7 +167,24 @@ describe('Analytics Validation - Actual Calculations', () => {
       expectOk(overdueCreate, 'create Overdue Task Test');
       expectOk(futureCreate, 'create Future Task Test');
 
-      // Run overdue analysis
+      // OMN-184: force a cache-COLD overdue_analysis. The analytics cache has a
+      // 1h TTL and is NOT invalidated by task creates, and the shared server is
+      // a single module-level instance reused across the whole integration run.
+      // overdue_analysis caches under a FIXED key (params are hardcoded:
+      // includeRecentlyCompleted/groupBy/limit), so a sibling test that calls
+      // overdue_analysis first (e.g. the LLM-simulation suites) would leave a
+      // pre-seed snapshot that this test would otherwise read — making `>= 1`
+      // pass on stale data (or fail on a clean DB) instead of verifying OUR
+      // seed. Clearing the cache here guarantees the next call does a live
+      // OmniJS query that sees the task we just created. (Costs a re-warm of
+      // the shared caches — accepted: valid testing over speed.)
+      const cacheClear = await client.callTool('system', {
+        operation: 'cache',
+        cacheAction: 'clear',
+      });
+      expectOk(cacheClear, 'cache clear before overdue_analysis');
+
+      // Run overdue analysis (cache-cold → live query → reflects the seed)
       const result = await client.callTool('omnifocus_analyze', {
         analysis: {
           type: 'overdue_analysis',
@@ -184,10 +201,10 @@ describe('Analytics Validation - Actual Calculations', () => {
       expect(typeof result.data.stats.summary.totalOverdue).toBe('number');
       expect(typeof result.data.stats.summary.overduePercentage).toBe('number');
       // OMN-184: we seeded a 7-days-overdue task (expectOk above proves it
-      // exists), so the analysis MUST count at least one. `>= 0` accepted the
-      // empty world a silent seed failure would have produced — the vacuous
-      // pass. `>= 1` is safe here: the sibling ProductivityStats block confirms
-      // freshly-created tasks reach analytics in this suite.
+      // exists) and the cache clear above guarantees this analysis is a live
+      // query against that world, so it MUST count at least one. `>= 0`
+      // accepted the empty world a silent seed failure would have produced —
+      // the vacuous pass; `>= 1` now genuinely verifies the seed is seen.
       expect(result.data.stats.summary.totalOverdue).toBeGreaterThanOrEqual(1);
 
       // If there are overdue tasks, validate they have proper structure


### PR DESCRIPTION
## OMN-184 — test-suite hygiene (OMN-140 follow-up)

Surfaced by the `/code-review high` gate on PR #112; deferred out of OMN-140's documented `.length`-chain scope. Same crash class, different access patterns in `tests/integration/validation/analytics-validation.test.ts`.

### Three issues fixed

1. **Unguarded `.data.task.taskId`** (ProductivityStats + TaskVelocity blocks). `createTestTask` returns `{success:false}` (no `.data`) when OmniFocus throttles → bare `TypeError: Cannot read properties of undefined (reading 'task')` that hides *which* create failed. Now `expectOk` first → named failure carrying `result.error`.

2. **Vacuous pass** (the dangerous one). OverdueAnalysis seeded its overdue task **fire-and-forget**, then asserted `totalOverdue >= 0`. A silent seed failure left no overdue task → analysis returns 0 → test passed asserting *nothing* (a count is always ≥ 0). Now the seed creates are `expectOk`'d and the assertion is `>= 1` — safe because the sibling ProductivityStats block already proves freshly-created tasks reach analytics in this suite.

3. **Normalized `expect(result.data).toBeDefined()`** — present in 3 of 4 blocks; *added* it to the Cross-Tool block (rather than dropping it elsewhere). Diagnostic-rich failures are the cluster's intent (OMN-56/140).

### Verification

- `npm run typecheck:test` clean (after build).
- **Live-verified against OmniFocus**: all 4 tests pass, OverdueAnalysis green under the new `>= 1` (7.1s) — confirms the strengthened assertion is non-flaky.

Test-only; no user-facing behavior. P-low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)