### PR TITLE
feat(OMN-145): expose parentId in basic-mode tags query

### DIFF
--- a/src/contracts/ast/tag-script-builder.ts
+++ b/src/contracts/ast/tag-script-builder.ts
@@ -7,7 +7,7 @@
  *
  * Modes:
  * - 'names': Just string array (fastest)
- * - 'basic': id + name objects (for most UI)
+ * - 'basic': id + name + parentId objects (for most UI)
  * - 'full': All properties + optional usage stats
  *
  * @see docs/plans/2025-11-25-phase3-ast-extension-design.md
@@ -155,7 +155,8 @@ function buildTagNamesScript(options: TagScriptOptions = {}): GeneratedScript {
 }
 
 /**
- * Build script for 'basic' mode - returns {id, name} objects
+ * Build script for 'basic' mode - returns {id, name, parentId} objects
+ * (OMN-145: parentId is null for top-level tags, a string ID for nested tags)
  * Note: sortBy is ignored in basic mode (always sorted by name)
  */
 function buildBasicTagsScript(options: TagScriptOptions = {}): GeneratedScript {
@@ -257,7 +258,7 @@ function buildBasicTagsScript(options: TagScriptOptions = {}): GeneratedScript {
     script: script.trim(),
     filterDescription: hasFilter
       ? `name ${nameOperator === 'MATCHES' ? 'matches' : 'contains'} "${name}"`
-      : 'all tags (basic: id + name)',
+      : 'all tags (basic: id + name + parentId)',
     isEmptyFilter: !hasFilter,
   };
 }

--- a/src/contracts/ast/tag-script-builder.ts
+++ b/src/contracts/ast/tag-script-builder.ts
@@ -186,9 +186,16 @@ function buildBasicTagsScript(options: TagScriptOptions = {}): GeneratedScript {
           if (!matchesName(tag)) return;
           totalMatched++;
           ${limitCheck}
+          // OMN-145: parentId is always emitted in basic mode (null for top-level tags).
+          // Option A (unconditional field) was chosen over an opt-in mode/fields param:
+          // an opt-in flag an LLM client won't know to set defeats "make hierarchy
+          // reachable"; additive parentId is lower-friction and lower-API-surface.
+          // Cost: one O(n) property access on an already-O(n) scan — negligible.
+          const parent = tag.parent;
           tags.push({
             id: tag.id.primaryKey,
-            name: tag.name
+            name: tag.name,
+            parentId: parent ? parent.id.primaryKey : null
           });
           count++;
         });

--- a/src/contracts/tag-options.ts
+++ b/src/contracts/tag-options.ts
@@ -7,7 +7,7 @@
  *
  * Modes:
  * - 'names': Just string array of tag names (fastest)
- * - 'basic': id + name objects (for most UI use cases)
+ * - 'basic': id + name + parentId objects (for most UI use cases; parentId null for top-level tags)
  * - 'full': All properties including usage stats (for admin/analysis)
  *
  * @see docs/plans/2025-11-25-phase3-ast-extension-design.md
@@ -43,7 +43,7 @@ export interface TagQueryOptions {
   /**
    * Mode determines field projection level
    * - 'names': string[] (fastest, minimal data)
-   * - 'basic': { id, name }[] (default, for UI)
+   * - 'basic': { id, name, parentId }[] (default, for UI; parentId null for top-level)
    * - 'full': All properties including usage stats
    */
   mode: TagQueryMode;
@@ -90,7 +90,7 @@ export interface TagQueryOptions {
  */
 export const TAG_MODE_FIELDS = {
   names: [] as const, // Just string array, no object fields
-  basic: ['id', 'name'] as const,
+  basic: ['id', 'name', 'parentId'] as const,
   full: [
     'id',
     'name',

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -227,10 +227,12 @@ export const ProjectListMetadataSchema = z
 const TagNameItem = z.string();
 
 /**
- * Tag item for 'basic' mode — {id, name}.
- * Source: tag-script-builder.ts buildBasicTagsScript: {id, name}.
+ * Tag item for 'basic' mode — {id, name, parentId}.
+ * Source: tag-script-builder.ts buildBasicTagsScript: {id, name, parentId}.
+ * OMN-145: parentId is always emitted (null for top-level tags) so hierarchy
+ * is reachable through the read seam without a mode/fields opt-in param.
  */
-const TagBasicItem = z.object({ id: z.string(), name: z.string() }).strict();
+const TagBasicItem = z.object({ id: z.string(), name: z.string(), parentId: z.string().nullable() }).strict();
 
 /**
  * Tag usage stats sub-object (includeUsageStats=true only).

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -313,7 +313,8 @@ const RECURRING_TASKS_SCHEMA = astEnvelopeSchema('tasks', {
 
 /**
  * AST tag items envelope: {ok:true, v:'ast', items, summary?}.
- * Analyze tool receives 'basic' mode items ({id, name} objects).
+ * Analyze tool receives 'basic' mode items ({id, name, parentId} objects).
+ * OMN-145: parentId is null for top-level tags, string ID for nested tags.
  * Source: tag-script-builder.ts buildBasicTagsScript.
  */
 const TAG_ITEMS_SCHEMA = astEnvelopeSchema('items', {

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -96,7 +96,8 @@ const PROJECT_LIST_SCHEMA = listResultSchema(['projects', 'items'], {
 /**
  * Tag list result — emitted by buildTagsScript (basic mode in the read tool).
  * Wire shape: {ok: true, v: 'ast', items, summary}
- * Read tool uses basic mode: items are {id, name} objects.
+ * Read tool uses basic mode: items are {id, name, parentId} objects.
+ * OMN-145: parentId is null for top-level tags; non-null string ID for nested tags.
  *
  * Source: src/contracts/ast/tag-script-builder.ts — return JSON.stringify({ok:true, v:'ast', items, summary}).
  */
@@ -286,7 +287,7 @@ FOLDERS (type: "folders"):
 - Filtering (OMN-170): filters: { name: { contains: "..." } } or { name: { matches: "regex" } } to filter folders by name; filters: { folder: "<name>" } matches folders whose PARENT folder name contains <name>; filters: { folder: null } returns top-level folders only. Other filter keys (status, flagged, logical operators, etc.) reject with a steering error.
 
 TAGS (type: "tags"):
-- Returns a flat {id, name} list. Filtering (OMN-170): filters: { name: { contains: "..." } } or { name: { matches: "regex" } } to filter tags by name. Other filter keys reject with a steering error.
+- Returns a flat {id, name, parentId} list; parentId is null for top-level tags, a string ID for nested tags. Filtering (OMN-170): filters: { name: { contains: "..." } } or { name: { matches: "regex" } } to filter tags by name. Other filter keys reject with a steering error.
 
 EXPORT TO DISK:
 - outputDirectory: when set with exportType: "tasks", writes tasks.<format> to disk (raises the implicit cap to 5000); required for exportType: "all"

--- a/tests/integration/tools/unified/tag-paths.test.ts
+++ b/tests/integration/tools/unified/tag-paths.test.ts
@@ -12,14 +12,16 @@
  * Two read-back channels are used:
  *
  *   - Tool seam (omnifocus_read { type: 'tags' }): tag existence + id. The
- *     tags query runs in basic mode and returns ONLY {id, name} — it does not
- *     expose parent linkage, so it cannot verify hierarchy.
+ *     tags query runs in basic mode and returns {id, name, parentId} (OMN-145),
+ *     so it CAN verify direct parent linkage via parentId. It does not expose
+ *     parentName, so full hierarchy cross-checks (name of the parent) still
+ *     require the osascript probe.
  *   - osascript hierarchy probe (probeTagByName): an independent OmniJS read
  *     of {id, name, parentId, parentName} straight off the live DB
- *     (tag.parent is OmniJS-only). Used wherever parent linkage is the thing
- *     under test (create-under-parent, path chain, nest/unnest/reparent).
- *     Same pattern as sandbox-manager's executeJXA — fully independent of the
- *     server code under test.
+ *     (tag.parent is OmniJS-only). Used wherever parentName or multi-hop
+ *     hierarchy is the thing under test (create-under-parent, path chain,
+ *     nest/unnest/reparent). Same pattern as sandbox-manager's executeJXA —
+ *     fully independent of the server code under test.
  *
  * Envelope values (tagId, createdSegments, tasksMerged) are operation OUTPUTS,
  * not persisted-state echoes — they are asserted as such AND cross-checked
@@ -190,8 +192,8 @@ describe('OMN-128 slice 6: live tag mutation paths (AST lowerings, persisted rea
     return scriptEnvelopeOf(res);
   }
 
-  /** Tool-seam read-back: full tags list ({id, name} per tag, basic mode). */
-  async function readTags(): Promise<Array<{ id: string; name: string }>> {
+  /** Tool-seam read-back: full tags list ({id, name, parentId} per tag, basic mode). */
+  async function readTags(): Promise<Array<{ id: string; name: string; parentId: string | null }>> {
     const res = await client.callTool('omnifocus_read', { query: { type: 'tags' } });
     expectOk(res, 'tags list read-back');
     return tagsOf(res);

--- a/tests/unit/contracts/ast/tag-basic-parentid.test.ts
+++ b/tests/unit/contracts/ast/tag-basic-parentid.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildTagsScript } from '../../../../src/contracts/ast/tag-script-builder.js';
+import { recoverInnerProgram } from '../../../utils/recover-bridge-program.js';
+
+/**
+ * OMN-145: basic mode tags must expose parentId so tag hierarchy is readable
+ * through the MCP read seam.
+ *
+ * Design note (see also: tag-script-builder.ts buildBasicTagsScript):
+ * Option A — add parentId unconditionally to basic mode — was chosen over an
+ * opt-in mode/fields param. An opt-in flag hidden behind a param an LLM client
+ * won't know to set defeats "make hierarchy reachable"; an additive parentId is
+ * lower-friction and lower-API-surface.
+ */
+describe('buildTagsScript basic mode — parentId field (OMN-145)', () => {
+  it('emits tag.parent lookup in the OmniJS program (inner script)', () => {
+    const { script } = buildTagsScript({ mode: 'basic' });
+    const inner = recoverInnerProgram(script);
+    // Must read tag.parent to obtain the parent reference
+    expect(inner).toContain('tag.parent');
+  });
+
+  it('emits parentId field in the pushed tag object', () => {
+    const { script } = buildTagsScript({ mode: 'basic' });
+    const inner = recoverInnerProgram(script);
+    // Must push parentId key into each tag object
+    expect(inner).toContain('parentId');
+  });
+
+  it('emits null for top-level tags (no parent)', () => {
+    const { script } = buildTagsScript({ mode: 'basic' });
+    const inner = recoverInnerProgram(script);
+    // The null fallback for tags with no parent must be present
+    expect(inner).toContain('null');
+    // The ternary pattern: parent ? parent.id.primaryKey : null
+    expect(inner).toContain('parent ? ');
+  });
+
+  it('parentId field is present whether or not a name filter is applied', () => {
+    const filtered = buildTagsScript({ mode: 'basic', name: 'Home', nameOperator: 'CONTAINS' });
+    const inner = recoverInnerProgram(filtered.script);
+    expect(inner).toContain('parentId');
+    expect(inner).toContain('tag.parent');
+  });
+});


### PR DESCRIPTION
## Ticket

https://linear.app/omnifocus-mcp/issue/OMN-145

## What changed

The tags read query (`type: "tags"`) previously returned only `{id, name}` rows in basic mode, making tag hierarchy invisible through the MCP seam — the write side supports hierarchy mutations, but clients could never read it back.

**Option A (unconditional field)** was chosen over an opt-in `mode`/`fields` param. Decision note at the change site explains why: an opt-in flag an LLM client won't know to set defeats "make hierarchy reachable"; additive `parentId` is lower-friction and lower-API-surface.

### Files changed

| File | Symbol | Change |
|------|--------|--------|
| `src/contracts/ast/tag-script-builder.ts` | `buildBasicTagsScript` | Capture `tag.parent`; push `parentId: parent ? parent.id.primaryKey : null` into each item; decision comment at change site |
| `src/omnifocus/script-response-schemas.ts` | `TagBasicItem` | Add `parentId: z.string().nullable()` to the `.strict()` Zod schema |
| `src/tools/unified/OmniFocusReadTool.ts` | description + `TAG_LIST_SCHEMA` comment | Document that tags rows now carry `parentId` (null for top-level) |
| `tests/unit/contracts/ast/tag-basic-parentid.test.ts` | new test file | 4 TDD-first tests asserting `tag.parent` read and `parentId` emission in basic mode (written failing before any production code) |

### Acceptance criteria

- [x] `buildTagsScript({ mode: 'basic' })` emits `tag.parent` lookup in the OmniJS inner program
- [x] Each pushed tag object carries `parentId`
- [x] Top-level tags (no parent) emit `parentId: null`
- [x] Field is present with and without a name filter
- [x] `TagBasicItem` Zod schema accepts `parentId: string | null` without `.strict()` rejection
- [x] Tool description updated to document `{id, name, parentId}` shape
- [x] `npm run build` clean
- [x] `npm run test:unit` — 141 files, 3323 tests, all passing

## Perf note

`buildBasicTagsScript` performs one `tag.parent` property access per tag inside an already-O(n) `flattenedTags.forEach` scan. This adds zero additional iteration — it's O(n) total property reads on the existing loop. No new query, no second pass.

## VERIFICATION OWED

Integration test suite (`npm run test:integration`) and a live `/verify` against the OmniFocus MCP seam must be run by Kip before merge. The live seam check should confirm `parentId` appears in tags responses and is `null` for top-level tags and a non-null string for nested ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)