### PR TITLE
feat(OMN-153): exclude project-root rows from tasks queries by default

### DIFF
--- a/src/contracts/ast/builder.ts
+++ b/src/contracts/ast/builder.ts
@@ -185,6 +185,20 @@ export const FILTER_DEFS: readonly FilterDef[] = [
     }),
   ),
 
+  // --- Project-root exclusion (OMN-153) ---
+  // In OmniFocus a project IS a task (its root task). The root appears in
+  // flattenedTasks and is indistinguishable without extra inspection.
+  // Detection: task.project !== null (OmniJS Task.project returns the Project
+  // only for the project's root task; null for all other tasks).
+  // Default: exclude roots. The script-builder injects includeProjectRoot: false
+  // into effectiveFilter; this FilterDef emits ONLY when explicitly false.
+  // Opt-in (includeProjectRoot: true): the script-builder leaves the filter
+  // unset → null → FilterDef returns null → no exclusion emitted.
+  {
+    fields: ['task.project'],
+    build: (f) => (f.includeProjectRoot === false ? comparison('task.project', '==', null) : null),
+  },
+
   // --- Project filter ---
   // Support both filter.projectId (from advanced filters) and filter.project (from simple project param)
   {

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -484,6 +484,37 @@ function buildUnsortedScript(ctx: ScriptBuildContext): string {
 `;
 }
 
+// =============================================================================
+// PROJECT-ROOT EXCLUSION DEFAULT (OMN-153)
+// =============================================================================
+
+/**
+ * Inject `includeProjectRoot: false` when the caller has not set it.
+ *
+ * In OmniFocus a project IS a task (its root task). That root row appears in
+ * `flattenedTasks` and is indistinguishable from regular tasks without extra
+ * inspection. Completing or deleting it completes/deletes the PROJECT — a P5
+ * safety hazard. All task-script builders must default-exclude root rows so the
+ * hazard cannot arise from a bare query.
+ *
+ * Detection: `task.project !== null` (OmniJS Task.project returns the Project
+ * object only for the root task; null for all other tasks).
+ *
+ * Called by: buildFilteredTasksScript, buildInboxScript, buildTaskCountScript,
+ * buildExportTasksScript. Adding a new task-script builder? Route it through
+ * this helper — never inline the check.
+ *
+ * SCOPE: injects includeProjectRoot only.
+ * The existing dropped/completed defaults differ per builder (export defaults
+ * includeCompleted=true; inbox always excludes completed) and must stay inline
+ * in each builder until that interaction is audited. They are candidates for
+ * the same consolidation in a follow-up pass.
+ */
+function applyProjectRootDefault<F extends { includeProjectRoot?: boolean }>(filter: F): F {
+  if (filter.includeProjectRoot !== undefined) return filter;
+  return { ...filter, includeProjectRoot: false };
+}
+
 export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: ScriptOptions = {}): GeneratedScript {
   const { limit = 50, offset = 0, fields = [], includeCompleted = false, sort, noteTruncateLength } = options;
 
@@ -497,13 +528,8 @@ export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: 
   // count-path OMN-52 shim).
   let effectiveFilter: typeof filter =
     !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
-  // OMN-153: exclude project-root rows by default. A project's root task appears
-  // in flattenedTasks and completing/deleting it completes/deletes the PROJECT —
-  // a P5 safety hazard. Default: inject includeProjectRoot: false (emit
-  // task.project === null predicate via FILTER_DEFS). Explicit true lifts it.
-  if (filter.includeProjectRoot === undefined) {
-    effectiveFilter = { ...effectiveFilter, includeProjectRoot: false };
-  }
+  // OMN-153: exclude project-root rows by default via the consolidated helper.
+  effectiveFilter = applyProjectRootDefault(effectiveFilter);
 
   // Build the AST to check if empty (user's filter, not the effective one)
   const ast = buildAST(filter);
@@ -632,10 +658,8 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
   // routed through the AST because task.dropped is synthetic (emitter-only)
   let effectiveFilter: NormalizedTaskFilter =
     !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
-  // OMN-153: same default project-root exclusion as buildFilteredTasksScript.
-  if (filter.includeProjectRoot === undefined) {
-    effectiveFilter = { ...effectiveFilter, includeProjectRoot: false };
-  }
+  // OMN-153: same default project-root exclusion via consolidated helper.
+  effectiveFilter = applyProjectRootDefault(effectiveFilter);
 
   const filterCode = generateFilterCode(effectiveFilter);
   const filterDescription = describeFilterForScript(filter);
@@ -1630,7 +1654,14 @@ export function buildExportTasksScript(filter: ExportFilter = {}, options: Expor
   const { limit = 1000, fields = DEFAULT_EXPORT_FIELDS, format = 'json' } = options;
 
   // Normalize filter for AST generation
-  const taskFilter = normalizeExportFilter(filter);
+  const rawTaskFilter = normalizeExportFilter(filter);
+  // OMN-153: default-exclude project-root rows on the export path too.
+  // ExportFilter has no opt-in param today (follow-up: add includeProjectRoot
+  // to ExportFilter when there's a use case for exporting root rows).
+  // Preserves existing export completed/dropped behavior — export defaults
+  // includeCompleted=true (script-level completion check, not AST), so the
+  // dropped/completed interaction stays in the script body below, untouched.
+  const taskFilter = applyProjectRootDefault(rawTaskFilter);
 
   // Build AST and generate filter code
   const ast = buildAST(taskFilter);
@@ -2092,10 +2123,7 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
     if (f.completed === undefined) f.completed = false;
     // OMN-157: dropped gets the same default for the same parity reason
     if (f.dropped === undefined) f.dropped = false;
-    // OMN-153: same-predicate rule — countOnly must exclude project-root rows
-    // by default, agreeing with the buildFilteredTasksScript row path.
-    if (f.includeProjectRoot === undefined) f.includeProjectRoot = false;
-    return f;
+    return applyProjectRootDefault(f);
   })();
 
   // Build AST and generate OmniJS filter code

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -122,6 +122,9 @@ export const DETAIL_FIELDS = [
   'dropDate',
   'completionDate',
   'repetitionRule',
+  // OMN-153: boolean marker for project-root rows (useful in detail views and
+  // for agents that need to distinguish roots from regular tasks).
+  'isProjectRoot',
 ];
 
 /**
@@ -312,6 +315,11 @@ function generateFieldProjection(
       case 'dropDate':
         projections.push('dropDate: task.dropDate ? task.dropDate.toISOString() : null');
         break;
+      // OMN-153: marker so a project-root row is never again indistinguishable.
+      // task.project !== null is the OmniJS definition of "this task IS a project root".
+      case 'isProjectRoot':
+        projections.push('isProjectRoot: task.project !== null');
+        break;
     }
   }
 
@@ -487,7 +495,15 @@ export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: 
   // compiles onto it) or includeCompleted lifts it. isEmptyFilter and the
   // description stay keyed to the user's filter (same convention as the
   // count-path OMN-52 shim).
-  const effectiveFilter = !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
+  let effectiveFilter: typeof filter =
+    !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
+  // OMN-153: exclude project-root rows by default. A project's root task appears
+  // in flattenedTasks and completing/deleting it completes/deletes the PROJECT —
+  // a P5 safety hazard. Default: inject includeProjectRoot: false (emit
+  // task.project === null predicate via FILTER_DEFS). Explicit true lifts it.
+  if (filter.includeProjectRoot === undefined) {
+    effectiveFilter = { ...effectiveFilter, includeProjectRoot: false };
+  }
 
   // Build the AST to check if empty (user's filter, not the effective one)
   const ast = buildAST(filter);
@@ -614,7 +630,12 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
 
   // OMN-157: same default dropped-exclusion as buildFilteredTasksScript —
   // routed through the AST because task.dropped is synthetic (emitter-only)
-  const effectiveFilter = !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
+  let effectiveFilter: NormalizedTaskFilter =
+    !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
+  // OMN-153: same default project-root exclusion as buildFilteredTasksScript.
+  if (filter.includeProjectRoot === undefined) {
+    effectiveFilter = { ...effectiveFilter, includeProjectRoot: false };
+  }
 
   const filterCode = generateFilterCode(effectiveFilter);
   const filterDescription = describeFilterForScript(filter);
@@ -1031,6 +1052,9 @@ const BOOLEAN_FILTER_DESCRIPTORS: Array<{ key: keyof TaskFilter; trueLabel: stri
   { key: 'blocked', trueLabel: 'blocked', falseLabel: 'not blocked' },
   { key: 'available', trueLabel: 'available', falseLabel: 'not available' },
   { key: 'inInbox', trueLabel: 'inbox', falseLabel: 'not inbox' },
+  // OMN-153: includeProjectRoot appears in filters_applied; describe it so
+  // filter_description never contradicts filters_applied ("all tasks" + key present).
+  { key: 'includeProjectRoot', trueLabel: 'include project roots', falseLabel: 'exclude project roots' },
 ];
 
 /**
@@ -2068,6 +2092,9 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
     if (f.completed === undefined) f.completed = false;
     // OMN-157: dropped gets the same default for the same parity reason
     if (f.dropped === undefined) f.dropped = false;
+    // OMN-153: same-predicate rule — countOnly must exclude project-root rows
+    // by default, agreeing with the buildFilteredTasksScript row path.
+    if (f.includeProjectRoot === undefined) f.includeProjectRoot = false;
     return f;
   })();
 

--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -236,6 +236,7 @@ export const KNOWN_FIELDS = [
 
   // Relationship properties
   'task.containingProject',
+  'task.project', // OMN-153: Task.project (OmniJS) — non-null ONLY for the project's root task
   'task.repetitionRule', // RepetitionRule object or null
   'taskTags', // Special: array of tag names
 

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -178,6 +178,19 @@ export interface TaskFilter {
    */
   fastSearch?: boolean;
 
+  /**
+   * OMN-153: opt into receiving project-root rows (the task that IS the project).
+   *
+   * By default ALL tasks queries exclude project-root rows (task.project !== null
+   * in OmniJS) because a project's root task is indistinguishable from a real
+   * task in flattenedTasks and its completion/deletion deletes the PROJECT — a
+   * P5 safety hazard. Set true only when intentionally inspecting project roots.
+   *
+   * This is a QUERY-LEVEL param (like countOnly/fastSearch), NOT a filters:{} key.
+   * It threads from the compiled query onto the filter in OmniFocusReadTool.
+   */
+  includeProjectRoot?: boolean;
+
   // --- Project Status (preserved for project queries) ---
   projectStatus?: ProjectStatus[];
 
@@ -448,6 +461,7 @@ export const FILTER_PROPERTY_NAMES = [
   'parentTaskId', // OMN-114: direct children of a task
   'search',
   'fastSearch', // OMN-115: name-only fast search
+  'includeProjectRoot', // OMN-153: opt into project-root rows (query-level param, not a filters:{} key)
   'projectStatus',
   'folder',
   'folderTopLevel', // OMN-96

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -72,6 +72,9 @@ export const TaskRowSchema = z
     parentTaskName: z.string().nullable().optional(),
     reason: z.enum(['overdue', 'due_soon', 'flagged']).nullable().optional(),
     daysOverdue: z.number().optional(),
+    // OMN-153: marker emitted when 'isProjectRoot' is in the requested fields.
+    // true when task.project !== null (i.e. this task IS a project root).
+    isProjectRoot: z.boolean().optional(),
   })
   .strict();
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -203,6 +203,17 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
   // Resolve effective fields: explicit > details=true > MINIMAL_FIELDS
   let scriptFields = resolveEffectiveTaskFields(userExplicitFields, compiled.details);
 
+  // OMN-153: when the caller opts in to project-root rows, auto-inject isProjectRoot
+  // into the projection so every root row is ALWAYS marked — regardless of whether the
+  // client asked for the field. Without this, a root row returned via includeProjectRoot:true
+  // on the DEFAULT projection carries NO marker and is indistinguishable from a regular task,
+  // which is the exact P5 safety hazard the ticket exists to prevent.
+  // details:true / explicit fields:[...'isProjectRoot'...] already get it through the normal
+  // resolveEffectiveTaskFields path; this guard covers the remaining default-field case.
+  if (compiled.includeProjectRoot === true && !scriptFields.includes('isProjectRoot')) {
+    scriptFields = [...scriptFields, 'isProjectRoot'];
+  }
+
   // Today mode needs extra fields for category counting
   if (mode === 'today') {
     scriptFields = [...new Set([...scriptFields, 'reason', 'daysOverdue', 'modified'])];
@@ -283,8 +294,8 @@ RESPONSE CONTROL:
 - sort: [{ field: "dueDate", direction: "asc" }]
 - limit/offset: Pagination (default limit: 25, max: 500)
 - countOnly: true returns only count (33x faster for "how many" questions) — tasks only
-- includeProjectRoot: false (default) — project-root rows are excluded from all tasks queries. In OmniFocus a project IS a task (its root task); completing or deleting that root row completes/deletes the PROJECT. Default exclusion prevents accidental project destruction. Set true only when intentionally inspecting project roots. Root rows carry isProjectRoot: true when the isProjectRoot field is requested.
-- fields: isProjectRoot — boolean, true when the task is a project's root task (task.project !== null in OmniJS). Only present when explicitly requested or when includeProjectRoot: true.
+- includeProjectRoot: false (default) — project-root rows are excluded from all tasks queries. In OmniFocus a project IS a task (its root task); completing or deleting that root row completes/deletes the PROJECT. Default exclusion prevents accidental project destruction. Set true only when intentionally inspecting project roots. Root rows always carry isProjectRoot: true when opted in (auto-injected regardless of fields selection).
+- fields: isProjectRoot — boolean, true when the task is a project's root task (task.project !== null in OmniJS). Auto-included when includeProjectRoot: true; also requestable explicitly or via details: true.
 
 COMPLETED TASKS:
 - Use filters: { completed: true } or filters: { status: "completed" } to query completed tasks
@@ -365,7 +376,7 @@ PERFORMANCE:
             includeProjectRoot: {
               type: 'boolean',
               description:
-                'Tasks only: include project-root rows (default false). Project roots are excluded by default — completing/deleting a root row completes/deletes the PROJECT. Root rows carry isProjectRoot: true when the isProjectRoot field is requested.',
+                'Tasks only: include project-root rows (default false). Project roots are excluded by default — completing/deleting a root row completes/deletes the PROJECT. When true, isProjectRoot: true is auto-injected into every root row.',
             },
             details: { type: 'boolean' },
             includeStats: { type: 'boolean' },

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -186,7 +186,14 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
   const limit = compiled.limit || 25;
   const mode = (compiled.filters.inInbox ? 'inbox' : compiled.mode) as TaskQueryMode | undefined;
 
-  const filter = augmentFilterForMode(mode, compiled.filters, {
+  // OMN-153: thread includeProjectRoot onto the filter BEFORE augmentFilterForMode
+  // so the project-root exclusion survives mode augmentation.
+  const baseFilters: typeof compiled.filters =
+    compiled.includeProjectRoot !== undefined
+      ? { ...compiled.filters, includeProjectRoot: compiled.includeProjectRoot }
+      : compiled.filters;
+
+  const filter = augmentFilterForMode(mode, baseFilters, {
     daysAhead: compiled.daysAhead,
   });
 
@@ -276,6 +283,8 @@ RESPONSE CONTROL:
 - sort: [{ field: "dueDate", direction: "asc" }]
 - limit/offset: Pagination (default limit: 25, max: 500)
 - countOnly: true returns only count (33x faster for "how many" questions) — tasks only
+- includeProjectRoot: false (default) — project-root rows are excluded from all tasks queries. In OmniFocus a project IS a task (its root task); completing or deleting that root row completes/deletes the PROJECT. Default exclusion prevents accidental project destruction. Set true only when intentionally inspecting project roots. Root rows carry isProjectRoot: true when the isProjectRoot field is requested.
+- fields: isProjectRoot — boolean, true when the task is a project's root task (task.project !== null in OmniJS). Only present when explicitly requested or when includeProjectRoot: true.
 
 COMPLETED TASKS:
 - Use filters: { completed: true } or filters: { status: "completed" } to query completed tasks
@@ -353,6 +362,11 @@ PERFORMANCE:
             countOnly: { type: 'boolean' },
             fastSearch: { type: 'boolean' },
             daysAhead: { type: 'number' },
+            includeProjectRoot: {
+              type: 'boolean',
+              description:
+                'Tasks only: include project-root rows (default false). Project roots are excluded by default — completing/deleting a root row completes/deletes the PROJECT. Root rows carry isProjectRoot: true when the isProjectRoot field is requested.',
+            },
             details: { type: 'boolean' },
             includeStats: { type: 'boolean' },
             exportType: { type: 'string', enum: ['tasks', 'projects', 'all'] },
@@ -431,7 +445,7 @@ PERFORMANCE:
 
     // --- Count-only fast path ---
     if (compiled.countOnly) {
-      return this.executeCountOnly(filter, mode, timer);
+      return this.executeCountOnly(filter, mode, timer, compiled.includeProjectRoot);
     }
 
     // --- ID lookup fast path (always full detail) ---
@@ -507,12 +521,17 @@ PERFORMANCE:
     filter: TaskFilter,
     mode: TaskQueryMode | undefined,
     timer: OperationTimerV2,
+    includeProjectRoot?: boolean,
   ): Promise<unknown> {
     // Ensure inbox mode sets the inInbox filter (mode: "inbox" is not in
     // MODE_DEFINITIONS, so augmentFilterForMode passes through unchanged)
     const countFilter = { ...filter };
     if (mode === 'inbox' && !countFilter.inInbox) {
       countFilter.inInbox = true;
+    }
+    // OMN-153: thread includeProjectRoot so countOnly agrees with the row path.
+    if (includeProjectRoot !== undefined) {
+      countFilter.includeProjectRoot = includeProjectRoot;
     }
 
     const { script } = buildTaskCountScript(countFilter, { maxScan: 10000 });

--- a/src/tools/unified/compilers/QueryCompiler.ts
+++ b/src/tools/unified/compilers/QueryCompiler.ts
@@ -69,6 +69,7 @@ export type CompiledQuery =
       fastSearch?: boolean;
       daysAhead?: number;
       countOnly?: boolean;
+      includeProjectRoot?: boolean; // OMN-153: query-level param, threaded onto filter
     })
   | (CompiledQueryBase & { type: 'projects'; filters: ProjectFilter; includeStats?: boolean })
   | (CompiledQueryBase & { type: 'tags'; filters: TagFilter })
@@ -136,6 +137,12 @@ export class QueryCompiler {
         if ('fastSearch' in query && query.fastSearch !== undefined) {
           raw.fastSearch = query.fastSearch;
         }
+        // OMN-153: includeProjectRoot is a query-level param. Thread it onto the filter
+        // so the script builders can apply the default exclusion or opt-in projection.
+        // NOT processed through transformFilters (not a filters:{} input key).
+        if ('includeProjectRoot' in query && query.includeProjectRoot !== undefined) {
+          raw.includeProjectRoot = query.includeProjectRoot;
+        }
         const filters = normalizeFilter(raw);
         if (query.type === 'tasks') {
           this.assertSatisfiableTerminalBranches(filters); // OMN-172 S4
@@ -147,6 +154,7 @@ export class QueryCompiler {
             fastSearch: 'fastSearch' in query ? query.fastSearch : undefined,
             daysAhead: 'daysAhead' in query ? query.daysAhead : undefined,
             countOnly: 'countOnly' in query ? query.countOnly : undefined,
+            includeProjectRoot: 'includeProjectRoot' in query ? query.includeProjectRoot : undefined,
           };
         }
         return {

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -169,6 +169,7 @@ const TASK_FIELDS = [
   'parentTaskId',
   'parentTaskName',
   'inInbox',
+  'isProjectRoot', // OMN-153: true when the task IS a project root (task.project !== null in OmniJS)
 ] as const;
 
 const PROJECT_FIELDS = [
@@ -294,6 +295,9 @@ const TaskQuerySchema = BaseQuerySchema.merge(
     fastSearch: z.boolean().optional(),
     daysAhead: coerceNumber().min(1).max(30).optional(),
     countOnly: z.boolean().optional(),
+    // OMN-153: query-level param (like countOnly/fastSearch) — NOT a filters:{} key.
+    // Default false (exclude project-root rows). Set true only when inspecting project roots.
+    includeProjectRoot: z.boolean().optional(),
   }),
 ).strict();
 

--- a/tests/unit/contracts/ast/describe-filter-coverage.test.ts
+++ b/tests/unit/contracts/ast/describe-filter-coverage.test.ts
@@ -56,6 +56,7 @@ const KEY_COVERAGE = {
   todayMode: 'exempt',
   dueSoonDays: 'exempt',
   fastSearch: 'exempt',
+  includeProjectRoot: 'described', // OMN-153: appears in filters_applied; must be describable
   projectStatus: 'exempt',
   folder: 'exempt',
   folderTopLevel: 'exempt',
@@ -97,6 +98,7 @@ const SAMPLE: Partial<Record<keyof NormalizedTaskFilter, NormalizedTaskFilter>> 
   tagStatusValid: { tagStatusValid: true } as NormalizedTaskFilter,
   projectId: { projectId: 'p1' } as NormalizedTaskFilter,
   parentTaskId: { parentTaskId: 't1' } as NormalizedTaskFilter,
+  includeProjectRoot: { includeProjectRoot: true } as NormalizedTaskFilter,
 };
 
 describe('OMN-172 F10: describeFilterForScript key coverage', () => {

--- a/tests/unit/contracts/ast/project-root-exclusion.test.ts
+++ b/tests/unit/contracts/ast/project-root-exclusion.test.ts
@@ -16,13 +16,20 @@
  * 7. TaskFilter interface accepts includeProjectRoot
  * 8. TaskRowSchema accepts isProjectRoot
  * 9. describeFilterForScript handles includeProjectRoot
+ * 10. VM behavioral: root row is EXCLUDED by default; INCLUDED + marked with includeProjectRoot:true
+ * 11. Export path applies the same default exclusion
+ * 12. ID-lookup (buildTaskByIdScript / details=true) always carries isProjectRoot in its projection
  */
 
+import * as vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import {
   buildFilteredTasksScript,
   buildInboxScript,
   buildTaskCountScript,
+  buildExportTasksScript,
+  buildTaskByIdScript,
+  resolveEffectiveTaskFields,
 } from '../../../../src/contracts/ast/script-builder.js';
 import type { TaskFilter } from '../../../../src/contracts/filters.js';
 import { FILTER_PROPERTY_NAMES } from '../../../../src/contracts/filters.js';
@@ -173,5 +180,121 @@ describe('OMN-153: TaskRowSchema', () => {
   it('rejects isProjectRoot with non-boolean (strict schema)', () => {
     const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task', isProjectRoot: 'yes' });
     expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// VM behavioral test (#2): predicate execution, not just string presence
+// =============================================================================
+
+describe('OMN-153: VM behavioral — project-root exclusion and isProjectRoot marker', () => {
+  // Minimal sandbox matching what the generated script touches.
+  // Task.Status is needed for the OMN-157 dropped-exclusion predicate.
+  const Task = { Status: { Dropped: 'Dropped', Active: 'Active' } };
+
+  const regularTask = (name: string) => ({
+    id: { primaryKey: `id-${name}` },
+    name,
+    flagged: false,
+    completed: false,
+    taskStatus: Task.Status.Active,
+    inInbox: false,
+    tags: [],
+    dueDate: null,
+    deferDate: null,
+    containingProject: null,
+    // project: null → NOT a project root (normal task)
+    project: null,
+  });
+
+  const rootTask = (name: string) => ({
+    ...regularTask(name),
+    // project: non-null → IS a project root (task.project !== null in OmniJS)
+    project: { name: 'MyProject' },
+  });
+
+  function runScript(script: string, tasks: unknown[]): { tasks: unknown[]; count: number; total_matched: number } {
+    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string);
+  }
+
+  it('default script: excludes the root row, returns only regular tasks', () => {
+    const tasks = [regularTask('alpha'), regularTask('beta'), rootTask('ProjectRoot')];
+    const { script } = buildFilteredTasksScript({}, { fields: ['id', 'name'] });
+    const result = runScript(script, tasks);
+    // 3 tasks total; 1 root → 2 returned
+    expect(result.tasks).toHaveLength(2);
+    expect(result.total_matched).toBe(2);
+    const names = (result.tasks as Array<{ name: string }>).map((t) => t.name);
+    expect(names).toContain('alpha');
+    expect(names).toContain('beta');
+    expect(names).not.toContain('ProjectRoot');
+  });
+
+  it('includeProjectRoot:true: includes root row AND carries isProjectRoot:true', () => {
+    const tasks = [regularTask('alpha'), rootTask('ProjectRoot')];
+    const filter: TaskFilter = { includeProjectRoot: true };
+    const { script } = buildFilteredTasksScript(filter, { fields: ['id', 'name', 'isProjectRoot'] });
+    const result = runScript(script, tasks);
+    // Both tasks returned
+    expect(result.tasks).toHaveLength(2);
+    const root = (result.tasks as Array<{ name: string; isProjectRoot?: boolean }>).find(
+      (t) => t.name === 'ProjectRoot',
+    );
+    expect(root).toBeDefined();
+    expect(root!.isProjectRoot).toBe(true);
+    // Regular task: isProjectRoot false
+    const regular = (result.tasks as Array<{ name: string; isProjectRoot?: boolean }>).find((t) => t.name === 'alpha');
+    expect(regular!.isProjectRoot).toBe(false);
+  });
+
+  it('default script: root in a mixed set is excluded even with other filters active', () => {
+    const tasks = [regularTask('flagged'), rootTask('ProjectRoot'), regularTask('other')];
+    // flagged filter: only root is "flagged" here — but root should still be excluded
+    const flaggedRoot = { ...rootTask('FlaggedRoot'), flagged: true };
+    const flaggedRegular = { ...regularTask('FlaggedRegular'), flagged: true };
+    const mixed = [...tasks, flaggedRoot, flaggedRegular];
+    const { script } = buildFilteredTasksScript({ flagged: true }, { fields: ['id', 'name'] });
+    const result = runScript(script, mixed);
+    // Only FlaggedRegular qualifies (flagged=true AND project===null)
+    expect(result.tasks).toHaveLength(1);
+    expect((result.tasks[0] as { name: string }).name).toBe('FlaggedRegular');
+  });
+});
+
+// =============================================================================
+// Export path test (#1): buildExportTasksScript must exclude project roots
+// =============================================================================
+
+describe('OMN-153: buildExportTasksScript — project-root exclusion', () => {
+  it('default export script contains task.project === null predicate', () => {
+    const result = buildExportTasksScript({});
+    expect(result.script).toContain('task.project === null');
+  });
+
+  it('export uses applyProjectRootDefault — no opt-in param today (follow-up deferred)', () => {
+    // The export path has no includeProjectRoot opt-in in ExportFilter yet.
+    // Default exclusion is the safe baseline. This test documents the current state.
+    const result = buildExportTasksScript({});
+    expect(result.script).toContain('task.project === null');
+  });
+});
+
+// =============================================================================
+// ID-lookup test (#3): buildTaskByIdScript (via details=true) carries isProjectRoot
+// =============================================================================
+
+describe('OMN-153: buildTaskByIdScript — isProjectRoot in details=true projection', () => {
+  it('resolveEffectiveTaskFields(undefined, true) includes isProjectRoot', () => {
+    // ID lookup always calls resolveEffectiveTaskFields(fields, true) — details=true.
+    // isProjectRoot is in DETAIL_FIELDS, so it must be present.
+    const fields = resolveEffectiveTaskFields(undefined, true);
+    expect(fields).toContain('isProjectRoot');
+  });
+
+  it('buildTaskByIdScript with details=true fields emits isProjectRoot projection', () => {
+    const fields = resolveEffectiveTaskFields(undefined, true);
+    const result = buildTaskByIdScript('test-id-123', fields);
+    expect(result.script).toContain('isProjectRoot: task.project !== null');
   });
 });

--- a/tests/unit/contracts/ast/project-root-exclusion.test.ts
+++ b/tests/unit/contracts/ast/project-root-exclusion.test.ts
@@ -1,0 +1,177 @@
+/**
+ * OMN-153: Project-root exclusion tests
+ *
+ * In OmniFocus, a project IS a task (its root task). The root appears in
+ * flattenedTasks and is indistinguishable from regular tasks without extra inspection.
+ * Detection: task.project !== null (OmniJS Task.project returns the Project only for
+ * that project's root task, else null).
+ *
+ * These tests assert:
+ * 1. buildFilteredTasksScript excludes project-root rows by default (task.project === null)
+ * 2. includeProjectRoot: true opts back in
+ * 3. isProjectRoot marker is projected when the field is requested
+ * 4. buildTaskCountScript applies the same exclusion
+ * 5. buildInboxScript applies the same exclusion
+ * 6. FILTER_PROPERTY_NAMES includes includeProjectRoot
+ * 7. TaskFilter interface accepts includeProjectRoot
+ * 8. TaskRowSchema accepts isProjectRoot
+ * 9. describeFilterForScript handles includeProjectRoot
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildFilteredTasksScript,
+  buildInboxScript,
+  buildTaskCountScript,
+} from '../../../../src/contracts/ast/script-builder.js';
+import type { TaskFilter } from '../../../../src/contracts/filters.js';
+import { FILTER_PROPERTY_NAMES } from '../../../../src/contracts/filters.js';
+import { TaskFieldEnum } from '../../../../src/tools/unified/schemas/read-schema.js';
+import { TaskRowSchema } from '../../../../src/omnifocus/script-response-schemas.js';
+
+// =============================================================================
+// buildFilteredTasksScript: default exclusion
+// =============================================================================
+
+describe('OMN-153: buildFilteredTasksScript — project-root exclusion', () => {
+  it('excludes project-root rows by default via task.project === null predicate', () => {
+    const result = buildFilteredTasksScript({});
+    expect(result.script).toContain('task.project === null');
+  });
+
+  it('does NOT include task.project === null when includeProjectRoot: true', () => {
+    const filter: TaskFilter = { includeProjectRoot: true };
+    const result = buildFilteredTasksScript(filter);
+    expect(result.script).not.toContain('task.project === null');
+  });
+
+  it('includes project-root rows when includeProjectRoot: true', () => {
+    const filter: TaskFilter = { includeProjectRoot: true };
+    const result = buildFilteredTasksScript(filter);
+    // Should still filter by other things like dropped, but not exclude project roots
+    expect(result.script).not.toContain('task.project === null');
+  });
+
+  it('applies project-root exclusion alongside other filters', () => {
+    const filter: TaskFilter = { flagged: true };
+    const result = buildFilteredTasksScript(filter);
+    expect(result.script).toContain('task.project === null');
+    expect(result.script).toContain('task.flagged === true');
+  });
+
+  it('combines project-root exclusion with projectId filter', () => {
+    const filter: TaskFilter = { projectId: 'abc123' };
+    const result = buildFilteredTasksScript(filter);
+    // Even projectId-scoped queries exclude the root by default
+    expect(result.script).toContain('task.project === null');
+  });
+
+  it('excludes project-root by default — not just projectId queries (text queries too)', () => {
+    const filter: TaskFilter = { text: 'buy milk', textOperator: 'CONTAINS' };
+    const result = buildFilteredTasksScript(filter);
+    expect(result.script).toContain('task.project === null');
+  });
+});
+
+// =============================================================================
+// buildFilteredTasksScript: isProjectRoot projection
+// =============================================================================
+
+describe('OMN-153: buildFilteredTasksScript — isProjectRoot field projection', () => {
+  it('emits isProjectRoot: task.project !== null when field is requested', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name', 'isProjectRoot'] });
+    expect(result.script).toContain('isProjectRoot: task.project !== null');
+  });
+
+  it('does NOT emit isProjectRoot when field is not requested', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name'] });
+    expect(result.script).not.toContain('isProjectRoot');
+  });
+});
+
+// =============================================================================
+// buildTaskCountScript: applies same exclusion
+// =============================================================================
+
+describe('OMN-153: buildTaskCountScript — project-root exclusion', () => {
+  it('excludes project-root rows by default', () => {
+    const result = buildTaskCountScript({});
+    expect(result.script).toContain('task.project === null');
+  });
+
+  it('does NOT exclude project-root when includeProjectRoot: true', () => {
+    const result = buildTaskCountScript({ includeProjectRoot: true });
+    expect(result.script).not.toContain('task.project === null');
+  });
+
+  it('agrees with buildFilteredTasksScript: same predicate', () => {
+    const filter: TaskFilter = { flagged: true };
+    const listResult = buildFilteredTasksScript(filter);
+    const countResult = buildTaskCountScript(filter);
+    // Both should have the exclusion predicate
+    expect(listResult.script).toContain('task.project === null');
+    expect(countResult.script).toContain('task.project === null');
+  });
+});
+
+// =============================================================================
+// buildInboxScript: applies same exclusion
+// =============================================================================
+
+describe('OMN-153: buildInboxScript — project-root exclusion', () => {
+  it('excludes project-root rows by default', () => {
+    const result = buildInboxScript({});
+    expect(result.script).toContain('task.project === null');
+  });
+
+  it('does NOT exclude project-root when includeProjectRoot: true', () => {
+    const result = buildInboxScript({ includeProjectRoot: true });
+    expect(result.script).not.toContain('task.project === null');
+  });
+});
+
+// =============================================================================
+// FILTER_PROPERTY_NAMES includes includeProjectRoot
+// =============================================================================
+
+describe('OMN-153: FILTER_PROPERTY_NAMES', () => {
+  it('includes includeProjectRoot', () => {
+    expect(FILTER_PROPERTY_NAMES).toContain('includeProjectRoot');
+  });
+});
+
+// =============================================================================
+// TaskFieldEnum includes isProjectRoot
+// =============================================================================
+
+describe('OMN-153: TaskFieldEnum (read-schema.ts)', () => {
+  it('includes isProjectRoot', () => {
+    expect(TaskFieldEnum.options).toContain('isProjectRoot');
+  });
+});
+
+// =============================================================================
+// TaskRowSchema accepts isProjectRoot
+// =============================================================================
+
+describe('OMN-153: TaskRowSchema', () => {
+  it('accepts isProjectRoot: true', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'My Project', isProjectRoot: true });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts isProjectRoot: false', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Regular Task', isProjectRoot: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts isProjectRoot: undefined (optional)', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Regular Task' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects isProjectRoot with non-boolean (strict schema)', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task', isProjectRoot: 'yes' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -933,6 +933,10 @@ describe('OMN-154: generated scripts count the full population (vm-executed)', (
     effectiveDueDate: null,
     effectiveDeferDate: null,
     containingProject: null,
+    // OMN-153: task.project is null for regular tasks in OmniJS (non-null only for
+    // a project's root task). Include it so the default project-root exclusion predicate
+    // (task.project === null) works correctly in these vm-executed tests.
+    project: null,
     available: true,
     blocked: false,
   });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1865,4 +1865,62 @@ describe('OmniFocusReadTool', () => {
       expect(execJsonSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  // ─── OMN-153: isProjectRoot auto-inject ──────────────────────────────────────
+
+  describe('OMN-153: isProjectRoot auto-injected into projection when includeProjectRoot: true', () => {
+    const taskPayload = {
+      success: true as const,
+      data: {
+        tasks: [{ id: 'p1', name: 'Project Root', completed: false, isProjectRoot: true }],
+        metadata: { total_matched: 1, sorted_in_script: false },
+      },
+    };
+
+    it('auto-injects isProjectRoot into the generated script when includeProjectRoot: true and no explicit fields', async () => {
+      execJsonSpy.mockResolvedValueOnce(taskPayload satisfies ScriptResult);
+
+      await tool.execute({
+        query: { type: 'tasks', includeProjectRoot: true },
+      });
+
+      // The script sent to execJson must include the isProjectRoot projection
+      // because buildTaskQuery auto-injects it whenever includeProjectRoot:true
+      // is set — regardless of whether the client asked for the field.
+      const scriptText: string = execJsonSpy.mock.calls[0][0];
+      expect(scriptText).toContain('isProjectRoot: task.project !== null');
+    });
+
+    it('does NOT auto-inject isProjectRoot when includeProjectRoot is omitted (default false)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true as const,
+        data: {
+          tasks: [{ id: 't1', name: 'Regular Task', completed: false }],
+          metadata: { total_matched: 1, sorted_in_script: false },
+        },
+      } satisfies ScriptResult);
+
+      await tool.execute({
+        query: { type: 'tasks' },
+      });
+
+      // No includeProjectRoot → default minimal fields → isProjectRoot NOT in projection
+      // (it IS in DETAIL_FIELDS, but default queries use MINIMAL_FIELDS)
+      const scriptText: string = execJsonSpy.mock.calls[0][0];
+      expect(scriptText).not.toContain('isProjectRoot: task.project !== null');
+    });
+
+    it('does NOT duplicate isProjectRoot when caller already requests it explicitly', async () => {
+      execJsonSpy.mockResolvedValueOnce(taskPayload satisfies ScriptResult);
+
+      await tool.execute({
+        query: { type: 'tasks', includeProjectRoot: true, fields: ['id', 'name', 'isProjectRoot'] },
+      });
+
+      const scriptText: string = execJsonSpy.mock.calls[0][0];
+      // Should appear exactly once (Set dedup in buildTaskQuery)
+      const occurrences = (scriptText.match(/isProjectRoot: task\.project !== null/g) || []).length;
+      expect(occurrences).toBe(1);
+    });
+  });
 });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1033,12 +1033,16 @@ describe('OmniFocusReadTool', () => {
         })) as any;
 
         expect(result.success).toBe(true);
-        // No completed predicate emitted into the filter
+        // No completed predicate emitted into the AST filter.
+        // OMN-153: export now defaults-exclude project roots (task.project === null),
+        // so the matchesFilter predicate is task.project === null (not `return true;`).
+        // The predicate must still NOT constrain task.completed when includeCompleted:true.
         const scriptArg = execJsonSpy.mock.calls[0][0] as string;
-        // Filter description is emitted as a comment; check the predicate body
-        // does not constrain task.completed. The AST emits `true` for an empty
-        // filter.
-        expect(scriptArg).toContain('return true;');
+        // Extract the matchesFilter body to test only the predicate
+        const matchesFn = scriptArg.match(/function matchesFilter\(task\)\s*\{[^}]+\}/)?.[0] ?? '';
+        expect(matchesFn).not.toContain('completed');
+        // The project-root exclusion predicate IS present (OMN-153 export fix)
+        expect(matchesFn).toContain('task.project === null');
       });
 
       it('flags truncation in summary when the script reports limited=true', async () => {


### PR DESCRIPTION
## Summary

Fixes [OMN-153](https://linear.app/omnifocus-mcp/issue/OMN-153): In OmniFocus a project IS a task (its root task). The root appears in `flattenedTasks` and is indistinguishable from a real task, creating a **P5 safety hazard**: an agent doing "complete/delete all tasks in project X" would include the root row, and completing/deleting a project's root completes/deletes the **PROJECT**. Per-project task counts were also off by +1 vs the OmniFocus UI.

**What changed:**
- All tasks queries (list, count, inbox) now exclude project-root rows by default via `task.project === null` predicate in OmniJS (Task.project is non-null only for a project's root task)
- `includeProjectRoot: true` query-level param opts back in (like `countOnly`/`fastSearch` — NOT a `filters:{}` key)
- `isProjectRoot: boolean` field added to projection (available via `fields: ['isProjectRoot']` or `details: true`)
- `countOnly` path applies the same exclusion — row count and count-only agree under both settings
- `TaskRowSchema` (`.strict()`) extended with `isProjectRoot: z.boolean().optional()`
- Dual-schema rule followed: both Zod `TaskQuerySchema` and hand-crafted `inputSchema` updated
- `describeFilterForScript` covers `includeProjectRoot` (OMN-172 F10 coverage gate updated)

**BEHAVIOR CHANGE for existing consumers:** Per-project task counts drop by 1 (the project root row is now excluded). Kip's manual +1 reconciliation habit retires on deploy.

## Acceptance criteria checklist

- [x] `projectId` query on an N-task project returns exactly N rows by default; root absent
- [x] Same query with `includeProjectRoot: true` returns N+1; root row carries `isProjectRoot: true`
- [x] `countOnly` agrees with row count under both settings
- [x] Roots excluded from mode queries by default (overdue project root no longer appears as an overdue "task" unless opted in)
- [x] Unit coverage — 20 new tests in `tests/unit/contracts/ast/project-root-exclusion.test.ts`
- [ ] **VERIFICATION OWED (integration + live /verify):** Run against a real OmniFocus project: N-task project should return exactly N rows; N+1 with `includeProjectRoot: true`; root row should carry `isProjectRoot: true`. Kip runs this manually post-deploy.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` passes — 3341 tests, 141 test files, all green
- [ ] `npm run test:integration` — OWED (live OmniFocus required; run by Kip)
- [ ] Live `/verify` — OWED: verify a real project query returns exactly N rows (not N+1)

## Design notes

- OmniJS detection: `task.project !== null` — `Task.project` (not `Task.containingProject`) returns the `Project` object only for the project's root task; `null` for all other tasks
- FilterDef in `FILTER_DEFS` emits `task.project === null` only when `includeProjectRoot === false` (explicitly injected as default by `effectiveFilter` blocks — mirrors the `dropped:false` default pattern)
- `task.project` added to `KNOWN_FIELDS` in `types.ts` (required by the AST validator)
- VM-executed OMN-154 test stubs updated to include `project: null` to match OmniJS behavior (non-root tasks have `task.project === null`, not `undefined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)