### PR TITLE
feat(OMN-130): make task read surface honest for priority reasoning

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -26,6 +26,7 @@ import {
 } from './filter-generator.js';
 import { buildAST } from './builder.js';
 import { sanitizeForScriptComment } from './bridge-escape.js';
+import { ACTIONABLE_STATUSES } from './types.js';
 
 // =============================================================================
 // TYPES
@@ -231,22 +232,20 @@ function generateFieldProjection(
         projections.push('blocked: task.taskStatus === Task.Status.Blocked');
         break;
       case 'available':
-        // OMN-130: "actionable now" — true for any status that is not a blocker or
-        // terminal state. OmniFocus Task.Status has 7 members; the actionable set is
-        // {Available, DueSoon, Next, Overdue}. Blocked (defer date not elapsed,
-        // sequential predecessor incomplete, or on-hold project), Completed, and
-        // Dropped are non-actionable. Using indexOf (compatible with OmniJS) rather
-        // than Array.includes (not available in all OmniJS runtimes).
-        // Alternative considered: bare `=== Task.Status.Available` (old form) —
-        // rejected because it returned available:false for Overdue/DueSoon/Next tasks,
-        // making "can I act on this?" unanswerable for those common states (OMN-130).
-        projections.push(
-          'available: [Task.Status.Available, Task.Status.DueSoon, Task.Status.Next, Task.Status.Overdue].indexOf(task.taskStatus) !== -1',
-        );
+        // OMN-130: "actionable now" — uses the shared ACTIONABLE_STATUSES constant from
+        // types.ts so WHERE (filter-side emitter) and SELECT (projection) always agree.
+        // {Available, DueSoon, Next, Overdue} are actionable; Blocked (deferred / sequential
+        // predecessor / on-hold project), Completed, and Dropped are not.
+        // indexOf used over Array.includes for OmniJS runtime compatibility.
+        projections.push(`available: [${ACTIONABLE_STATUSES.join(', ')}].indexOf(task.taskStatus) !== -1`);
         break;
       case 'hasNote':
-        // OMN-130: cheap boolean — true when the task has any non-empty note text.
-        // Coalesce null/undefined to '' before checking length so it never throws.
+        // OMN-130: boolean presence marker — true when the task has any non-empty note text.
+        // Trade-off: OmniJS has no note-presence-only API, so (task.note || '') materializes
+        // the full note string per task. The boolean avoids sending multi-KB note bodies in
+        // minimal responses, but the per-task string read still happens in the OmniJS runtime.
+        // A client that needs the note body should request the 'note' field explicitly.
+        // Coalesce null/undefined to '' before .length so it never throws on a null note.
         projections.push("hasNote: (task.note || '').length > 0");
         break;
       case 'dueDate':

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -81,6 +81,13 @@ export interface GeneratedScript {
 /**
  * Thin-default fields returned when no explicit fields or details flag is set.
  * Optimized for low token usage — covers the most common query needs.
+ *
+ * OMN-130: `hasNote` added — lets a client cheaply tell if a task has context
+ * worth reading without paying the token cost of the full `note` field.
+ * Decision record: `notePreview` (~120-char snippet) was considered as an
+ * alternative but rejected — it is redundant with the full `note` field in
+ * DETAIL_FIELDS and contradicts the token-cost goal of the lean default.
+ * `hasNote` answers "is there context?"; the client requests `note` if yes.
  */
 export const MINIMAL_FIELDS = [
   'id',
@@ -92,6 +99,7 @@ export const MINIMAL_FIELDS = [
   'tags',
   'project',
   'available',
+  'hasNote',
 ];
 
 /**
@@ -223,7 +231,23 @@ function generateFieldProjection(
         projections.push('blocked: task.taskStatus === Task.Status.Blocked');
         break;
       case 'available':
-        projections.push('available: task.taskStatus === Task.Status.Available');
+        // OMN-130: "actionable now" — true for any status that is not a blocker or
+        // terminal state. OmniFocus Task.Status has 7 members; the actionable set is
+        // {Available, DueSoon, Next, Overdue}. Blocked (defer date not elapsed,
+        // sequential predecessor incomplete, or on-hold project), Completed, and
+        // Dropped are non-actionable. Using indexOf (compatible with OmniJS) rather
+        // than Array.includes (not available in all OmniJS runtimes).
+        // Alternative considered: bare `=== Task.Status.Available` (old form) —
+        // rejected because it returned available:false for Overdue/DueSoon/Next tasks,
+        // making "can I act on this?" unanswerable for those common states (OMN-130).
+        projections.push(
+          'available: [Task.Status.Available, Task.Status.DueSoon, Task.Status.Next, Task.Status.Overdue].indexOf(task.taskStatus) !== -1',
+        );
+        break;
+      case 'hasNote':
+        // OMN-130: cheap boolean — true when the task has any non-empty note text.
+        // Coalesce null/undefined to '' before checking length so it never throws.
+        projections.push("hasNote: (task.note || '').length > 0");
         break;
       case 'dueDate':
         projections.push('dueDate: task.dueDate ? task.dueDate.toISOString() : null');

--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -150,6 +150,53 @@ function emitOmniJSStatusComparison(operator: ComparisonOperator, value: unknown
   return `task.taskStatus ${shouldEqual ? '===' : '!=='} ${statusEnum}`;
 }
 
+/**
+ * OMN-130: The set of OmniFocus Task.Status values that mean "actionable now".
+ *
+ * Shared between the projection side (generateFieldProjection 'available' case in
+ * script-builder.ts) and the filter side (SYNTHETIC_FIELD_DEFS 'task.available'
+ * emitter below) so WHERE and SELECT always agree on what "available" means.
+ *
+ * Statuses and their semantics (from OmniFocus.d.ts + jxa-omnifocus-expert):
+ *   Available — standard ready task
+ *   DueSoon   — ready task approaching its due date
+ *   Next      — next action in a sequential project (sequentially unlocked)
+ *   Overdue   — ready task past its due date
+ *
+ * NOT in this set (not actionable):
+ *   Blocked   — defer date not elapsed, sequential predecessor incomplete, or on-hold project
+ *   Completed — terminal state
+ *   Dropped   — terminal state
+ *
+ * Consequence: available:true and blocked:true form a coherent XOR partition over
+ * non-terminal tasks. An overdue task → available:true, blocked:false.
+ */
+export const ACTIONABLE_STATUSES = [
+  'Task.Status.Available',
+  'Task.Status.DueSoon',
+  'Task.Status.Next',
+  'Task.Status.Overdue',
+] as const;
+
+/**
+ * Emit the OmniJS predicate for the `task.available` filter field.
+ *
+ * Uses a membership check across ACTIONABLE_STATUSES — NOT a single === comparison
+ * (the old single-status form silently excluded Overdue/DueSoon/Next tasks).
+ *
+ * available:true  → [...statuses].indexOf(task.taskStatus) !== -1
+ * available:false → [...statuses].indexOf(task.taskStatus) === -1
+ *
+ * Separate from emitOmniJSStatusComparison because `dropped` and `blocked` remain
+ * single-status comparisons; only `available` uses the multi-member set.
+ */
+function emitOmniJSAvailable(operator: ComparisonOperator, value: unknown): string {
+  const matches = value as boolean;
+  const wantMember = (operator === '==') === matches;
+  const statusArray = `[${ACTIONABLE_STATUSES.join(', ')}]`;
+  return `${statusArray}.indexOf(task.taskStatus) ${wantMember ? '!==' : '==='} -1`;
+}
+
 function emitOmniJSTagStatusValid(operator: ComparisonOperator, value: unknown): string {
   const isValid = value as boolean;
   if (operator !== '==' && operator !== '!=') {
@@ -184,10 +231,9 @@ function emitOmniJSParentTaskId(operator: ComparisonOperator, value: unknown): s
 export const SYNTHETIC_FIELD_DEFS: readonly SyntheticFieldDef[] = [
   { field: 'task.parentTaskId', omnijs: emitOmniJSParentTaskId },
   { field: 'task.dropped', omnijs: (op, val) => emitOmniJSStatusComparison(op, val, 'Task.Status.Dropped') },
-  {
-    field: 'task.available',
-    omnijs: (op, val) => emitOmniJSStatusComparison(op, val, 'Task.Status.Available'),
-  },
+  // OMN-130: task.available uses emitOmniJSAvailable (4-status membership check),
+  // NOT emitOmniJSStatusComparison — that helper is single-status only.
+  { field: 'task.available', omnijs: emitOmniJSAvailable },
   { field: 'task.blocked', omnijs: (op, val) => emitOmniJSStatusComparison(op, val, 'Task.Status.Blocked') },
   { field: 'task.tagStatusValid', omnijs: emitOmniJSTagStatusValid },
 ];

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -75,6 +75,8 @@ export const TaskRowSchema = z
     // OMN-153: marker emitted when 'isProjectRoot' is in the requested fields.
     // true when task.project !== null (i.e. this task IS a project root).
     isProjectRoot: z.boolean().optional(),
+    // OMN-130: cheap boolean — true when the task has any non-empty note text.
+    hasNote: z.boolean().optional(),
   })
   .strict();
 

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -104,6 +104,12 @@ const MODE_DEFINITIONS: Partial<Record<TaskQueryMode, ModeDefinition>> = {
       flagged: true,
     }),
   },
+  // OMN-130: smart_suggest surfaces available next actions, NOT urgency-ranked tasks.
+  // The name/description was previously overstated (implied priority ranking).
+  // Behavior: filters to active (not completed/dropped) tasks, then scoreForSmartSuggest
+  // re-ranks by deadline proximity, flagged status, and quick-win estimate — but the
+  // result is a convenience shortlist for review, not a definitive priority order.
+  // Do NOT change this to a higher-fidelity ranking without a separate ticket.
   smart_suggest: {
     augment: () => ({
       completed: false,

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -85,6 +85,10 @@ const MODE_DEFINITIONS: Partial<Record<TaskQueryMode, ModeDefinition>> = {
     },
     defaultSort: [{ field: 'dueDate', direction: 'asc' }],
   },
+  // OMN-130: available:true now emits a 4-status membership check (Available, DueSoon,
+  // Next, Overdue) — so mode:'available' returns all actionable-now tasks, including
+  // overdue and due-soon tasks. Previously only Task.Status.Available tasks were returned.
+  // BEHAVIOR CHANGE: overdue/due-soon/next tasks now appear in mode:'available' results.
   available: {
     augment: () => ({
       completed: false,

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -271,7 +271,8 @@ MODES (tasks queries ONLY — not valid on type:"projects"):
 - overdue: Tasks past their due date
 - flagged: Flagged tasks
 - upcoming: Tasks due in next N days (set daysAhead, default 7)
-- inbox, available, blocked, search, smart_suggest, all
+- inbox, available, blocked, search, all
+- smart_suggest: surfaces available next actions (NOT urgency-ranked — scored by deadline proximity/flagged/quick-win, but this is a convenience filter, not a priority ranking)
 - To SEARCH projects (or tasks) use filters, not mode: filters: { name: { contains: "..." } } or filters: { text: { matches: "regex" } }
 
 FILTER OPERATORS:
@@ -285,12 +286,13 @@ FILTER OPERATORS:
 - Projects filters: status, completed, flagged, name, text, folder, id. AND merges; OR: [...] returns the union of its branches; NOT: { status: "active"|"on_hold"|"completed"|"dropped" } matches the complement of that status over the four project states (broader than the tasks NOT, which is completed/active only).
 
 RESPONSE CONTROL:
-- Default returns minimal fields (id, name, flagged, completed, dueDate, deferDate, tags, project, available)
+- Default returns minimal fields (id, name, flagged, completed, dueDate, deferDate, tags, project, available, hasNote)
 - details: true returns all fields with full notes
 - fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true)
 - ID lookup always returns all fields with full notes
 - fields are type-specific; requesting a field of the other type (e.g. reviewInterval on tasks) returns a guided error
-- fields (tasks): id, name, completed, flagged, blocked, available, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox
+- fields (tasks): id, name, completed, flagged, blocked, available, hasNote, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox
+- available: true when actionable now (OmniFocus status Available, Next, DueSoon, or Overdue); blocked: true when waiting on a predecessor, a future defer date, or an on-hold project (status Blocked). Completed/dropped tasks are neither.
 - fields (projects): id, name, status, flagged, note, dueDate, deferDate, completionDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder, tags, plannedDate
 - sort: [{ field: "dueDate", direction: "asc" }]
 - limit/offset: Pagination (default limit: 25, max: 500)

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -220,6 +220,15 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
     scriptFields = [...new Set([...scriptFields, 'reason', 'daysOverdue', 'modified'])];
   }
 
+  // OMN-130 #3: smart_suggest scoring uses task.available (+30 pts). Force-inject
+  // 'available' so the score is reliable even when the caller passes explicit fields
+  // that omit it. MINIMAL_FIELDS already includes 'available' on the default path;
+  // this guards the explicit-fields case (mirror of the today-mode reason/daysOverdue
+  // injection above).
+  if (mode === 'smart_suggest' && !scriptFields.includes('available')) {
+    scriptFields = [...scriptFields, 'available'];
+  }
+
   // Note truncation: apply when not in detail mode
   // Truncate when using minimal fields OR when user explicitly requests note without details=true
   const shouldTruncateNotes = !compiled.details;
@@ -272,7 +281,7 @@ MODES (tasks queries ONLY — not valid on type:"projects"):
 - flagged: Flagged tasks
 - upcoming: Tasks due in next N days (set daysAhead, default 7)
 - inbox, available, blocked, search, all
-- smart_suggest: surfaces available next actions (NOT urgency-ranked — scored by deadline proximity/flagged/quick-win, but this is a convenience filter, not a priority ranking)
+- smart_suggest: surfaces available next actions (NOT urgency-ranked — scored by deadline proximity/flagged/quick-win, but this is a convenience shortlist, not a definitive priority ranking). Includes overdue, due-soon, and next tasks (all actionable statuses).
 - To SEARCH projects (or tasks) use filters, not mode: filters: { name: { contains: "..." } } or filters: { text: { matches: "regex" } }
 
 FILTER OPERATORS:

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -170,6 +170,7 @@ const TASK_FIELDS = [
   'parentTaskName',
   'inInbox',
   'isProjectRoot', // OMN-153: true when the task IS a project root (task.project !== null in OmniJS)
+  'hasNote', // OMN-130: cheap boolean — true when the task has any non-empty note text
 ] as const;
 
 const PROJECT_FIELDS = [

--- a/tests/unit/contracts/ast/emitters/omnijs.test.ts
+++ b/tests/unit/contracts/ast/emitters/omnijs.test.ts
@@ -160,8 +160,13 @@ describe('emitOmniJS', () => {
     });
   });
 
-  describe('available status comparisons', () => {
-    it('emits Task.Status.Available check for available: true', () => {
+  describe('available status comparisons (OMN-130: actionable-now 4-status set)', () => {
+    // OMN-130: available filter now emits a membership check across the full
+    // actionable-now set {Available, DueSoon, Next, Overdue}, not a single === check.
+    // available:true  → indexOf !== -1 (task IS in the actionable set)
+    // available:false → indexOf === -1 (task is NOT in the actionable set)
+
+    it('emits 4-status membership check for available: true', () => {
       const ast: FilterNode = {
         type: 'comparison',
         field: 'task.available',
@@ -169,10 +174,17 @@ describe('emitOmniJS', () => {
         value: true,
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, 'task.taskStatus === Task.Status.Available');
+      // Must reference all four actionable statuses
+      expect(code.predicate).toContain('Task.Status.Available');
+      expect(code.predicate).toContain('Task.Status.DueSoon');
+      expect(code.predicate).toContain('Task.Status.Next');
+      expect(code.predicate).toContain('Task.Status.Overdue');
+      // Must be a membership check (indexOf or includes), not a single ===
+      expect(code.predicate).toContain('indexOf');
+      expect(code.predicate).toContain('!== -1');
     });
 
-    it('emits not available check for available: false', () => {
+    it('emits inverted 4-status membership check for available: false', () => {
       const ast: FilterNode = {
         type: 'comparison',
         field: 'task.available',
@@ -180,10 +192,15 @@ describe('emitOmniJS', () => {
         value: false,
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, 'task.taskStatus !== Task.Status.Available');
+      expect(code.predicate).toContain('Task.Status.Available');
+      expect(code.predicate).toContain('Task.Status.DueSoon');
+      expect(code.predicate).toContain('Task.Status.Next');
+      expect(code.predicate).toContain('Task.Status.Overdue');
+      expect(code.predicate).toContain('indexOf');
+      expect(code.predicate).toContain('=== -1');
     });
 
-    it('emits not available for available != true', () => {
+    it('emits inverted membership check for available != true', () => {
       const ast: FilterNode = {
         type: 'comparison',
         field: 'task.available',
@@ -191,10 +208,10 @@ describe('emitOmniJS', () => {
         value: true,
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, 'task.taskStatus !== Task.Status.Available');
+      expect(code.predicate).toContain('=== -1');
     });
 
-    it('emits available for available != false', () => {
+    it('emits membership check for available != false', () => {
       const ast: FilterNode = {
         type: 'comparison',
         field: 'task.available',
@@ -202,7 +219,7 @@ describe('emitOmniJS', () => {
         value: false,
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, 'task.taskStatus === Task.Status.Available');
+      expect(code.predicate).toContain('!== -1');
     });
   });
 

--- a/tests/unit/contracts/ast/filter-generator.test.ts
+++ b/tests/unit/contracts/ast/filter-generator.test.ts
@@ -196,11 +196,18 @@ describe('generateFilterCode', () => {
       expect(result.predicate).toBe('task.taskStatus !== Task.Status.Dropped');
     });
 
-    it('generates OmniJS code for available: true using Task.Status enum', () => {
+    it('generates OmniJS code for available: true — 4-status membership check (OMN-130)', () => {
+      // OMN-130: available:true now emits a membership check across all actionable
+      // statuses {Available, DueSoon, Next, Overdue}, not a single === check.
       const filter: TaskFilter = { available: true };
       const result = generateFilterCode(filter);
 
-      expect(result.predicate).toBe('task.taskStatus === Task.Status.Available');
+      expect(result.predicate).toContain('Task.Status.Available');
+      expect(result.predicate).toContain('Task.Status.DueSoon');
+      expect(result.predicate).toContain('Task.Status.Next');
+      expect(result.predicate).toContain('Task.Status.Overdue');
+      expect(result.predicate).toContain('indexOf');
+      expect(result.predicate).toContain('!== -1');
     });
 
     it('generates OmniJS code for blocked: true using Task.Status enum', () => {

--- a/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
+++ b/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
@@ -1,0 +1,321 @@
+/**
+ * OMN-130: Read surface honesty tests
+ *
+ * Three changes tested here:
+ *  1. hasNote in MINIMAL_FIELDS + generateFieldProjection
+ *  2. available redefined as "actionable now" (Available | DueSoon | Next | Overdue)
+ *  3. (Change 2 is description-only — no code assertions needed)
+ *
+ * VM behavioral tests use node:vm to confirm the generated OmniJS code behaves
+ * correctly when evaluated with stub task objects, confirming the generated
+ * artifact — not just the script text.
+ */
+
+import * as vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import { buildFilteredTasksScript, MINIMAL_FIELDS } from '../../../../src/contracts/ast/script-builder.js';
+import { TaskFieldEnum } from '../../../../src/tools/unified/schemas/read-schema.js';
+import { TaskRowSchema } from '../../../../src/omnifocus/script-response-schemas.js';
+
+// =============================================================================
+// Change 1 — hasNote in MINIMAL_FIELDS and generateFieldProjection
+// =============================================================================
+
+describe('OMN-130 Change 1: hasNote in MINIMAL_FIELDS', () => {
+  it('MINIMAL_FIELDS includes hasNote', () => {
+    expect(MINIMAL_FIELDS).toContain('hasNote');
+  });
+});
+
+describe('OMN-130 Change 1: generateFieldProjection emits hasNote', () => {
+  it('emits hasNote projection when hasNote is in fields', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name', 'hasNote'] });
+    // hasNote: (task.note || '').length > 0
+    expect(result.script).toMatch(/hasNote\s*:/);
+    expect(result.script).toContain('task.note');
+    expect(result.script).toContain('.length > 0');
+  });
+
+  it('MINIMAL_FIELDS projection includes hasNote in default script (no explicit fields)', () => {
+    // buildFilteredTasksScript with no fields uses MINIMAL_FIELDS
+    const result = buildFilteredTasksScript({});
+    expect(result.script).toMatch(/hasNote\s*:/);
+  });
+
+  it('hasNote projection coalesces null note to empty string (no .length on null)', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['hasNote'] });
+    // Must coalesce: (task.note || '')
+    expect(result.script).toContain("task.note || ''");
+  });
+});
+
+describe('OMN-130 Change 1: TaskFieldEnum includes hasNote', () => {
+  it('TaskFieldEnum includes hasNote', () => {
+    expect(TaskFieldEnum.options).toContain('hasNote');
+  });
+});
+
+describe('OMN-130 Change 1: TaskRowSchema accepts hasNote', () => {
+  it('accepts hasNote: true', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task', hasNote: true });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts hasNote: false', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task', hasNote: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts hasNote: undefined (optional)', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects hasNote with non-boolean (strict schema)', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task', hasNote: 'yes' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown extra fields (schema stays strict)', () => {
+    const result = TaskRowSchema.safeParse({ id: 'abc', name: 'Task', unknownField: true });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// Change 1: VM behavioral — hasNote emits boolean, not string
+// =============================================================================
+
+describe('OMN-130 Change 1: VM behavioral — hasNote projection', () => {
+  // Stub Task.Status for the OMN-157 dropped-exclusion predicate
+  const Task = {
+    Status: {
+      Dropped: 'Dropped',
+      Available: 'Available',
+      Blocked: 'Blocked',
+      DueSoon: 'DueSoon',
+      Next: 'Next',
+      Overdue: 'Overdue',
+    },
+  };
+
+  function makeTask(name: string, note: string | null, taskStatus = Task.Status.Available) {
+    return {
+      id: { primaryKey: `id-${name}` },
+      name,
+      flagged: false,
+      completed: false,
+      taskStatus,
+      inInbox: false,
+      tags: [],
+      dueDate: null,
+      deferDate: null,
+      containingProject: null,
+      project: null,
+      note,
+    };
+  }
+
+  function runScript(script: string, tasks: unknown[]): { tasks: Array<Record<string, unknown>> } {
+    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string) as {
+      tasks: Array<Record<string, unknown>>;
+    };
+  }
+
+  it('hasNote is true when task has a non-empty note', () => {
+    const tasks = [makeTask('alpha', 'some context here')];
+    const { script } = buildFilteredTasksScript({}, { fields: ['id', 'name', 'hasNote'] });
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.hasNote).toBe(true);
+  });
+
+  it('hasNote is false when task has an empty string note', () => {
+    const tasks = [makeTask('beta', '')];
+    const { script } = buildFilteredTasksScript({}, { fields: ['id', 'name', 'hasNote'] });
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.hasNote).toBe(false);
+  });
+
+  it('hasNote is false when task has null note', () => {
+    const tasks = [makeTask('gamma', null)];
+    const { script } = buildFilteredTasksScript({}, { fields: ['id', 'name', 'hasNote'] });
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.hasNote).toBe(false);
+  });
+
+  it('hasNote is in default output (MINIMAL_FIELDS)', () => {
+    const tasks = [makeTask('delta', 'context'), makeTask('epsilon', null)];
+    // No explicit fields → uses MINIMAL_FIELDS which now includes hasNote
+    const { script } = buildFilteredTasksScript({});
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(2);
+    // All tasks in default output should have hasNote field
+    for (const task of result.tasks) {
+      expect(typeof task.hasNote).toBe('boolean');
+    }
+    const taskWithNote = result.tasks.find((t) => t.name === 'delta');
+    const taskWithoutNote = result.tasks.find((t) => t.name === 'epsilon');
+    expect(taskWithNote?.hasNote).toBe(true);
+    expect(taskWithoutNote?.hasNote).toBe(false);
+  });
+});
+
+// =============================================================================
+// Change 3 — available redefined as "actionable now"
+// {Available, DueSoon, Next, Overdue} → true; Blocked → false
+// =============================================================================
+
+describe('OMN-130 Change 3: available projection emits 4-status membership check', () => {
+  it('generated script references Task.Status.Available in the available projection', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name', 'available'] });
+    expect(result.script).toContain('Task.Status.Available');
+  });
+
+  it('generated script references Task.Status.DueSoon in the available projection', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name', 'available'] });
+    expect(result.script).toContain('Task.Status.DueSoon');
+  });
+
+  it('generated script references Task.Status.Next in the available projection', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name', 'available'] });
+    expect(result.script).toContain('Task.Status.Next');
+  });
+
+  it('generated script references Task.Status.Overdue in the available projection', () => {
+    const result = buildFilteredTasksScript({}, { fields: ['id', 'name', 'available'] });
+    expect(result.script).toContain('Task.Status.Overdue');
+  });
+
+  it('available projection does NOT use bare task.taskStatus === Task.Status.Available (single-status form)', () => {
+    // The old single-status form must be gone from the available projection.
+    // The new form is a multi-member check (indexOf or || chain).
+    const result = buildFilteredTasksScript({}, { fields: ['available'] });
+    // Old exact form: available: task.taskStatus === Task.Status.Available
+    // We check that it's NOT just the single equality (which would mean DueSoon/Next/Overdue are missed)
+    // by requiring that at least DueSoon also appears alongside Available in the available: line.
+    const availableLine = result.script.match(/available\s*:.*?(?=,\s*\n|\n\s*[a-z]|$)/s)?.[0] ?? '';
+    expect(availableLine).toContain('Task.Status.DueSoon');
+  });
+});
+
+// =============================================================================
+// Change 3: VM behavioral — available/blocked semantics
+// =============================================================================
+
+describe('OMN-130 Change 3: VM behavioral — available reflects 4-status set', () => {
+  const Task = {
+    Status: {
+      Dropped: 'Dropped',
+      Available: 'Available',
+      Blocked: 'Blocked',
+      DueSoon: 'DueSoon',
+      Next: 'Next',
+      Overdue: 'Overdue',
+    },
+  };
+
+  function makeTask(name: string, taskStatus: string) {
+    return {
+      id: { primaryKey: `id-${name}` },
+      name,
+      flagged: false,
+      completed: false,
+      taskStatus,
+      inInbox: false,
+      tags: [],
+      dueDate: null,
+      deferDate: null,
+      containingProject: null,
+      project: null,
+      note: null,
+    };
+  }
+
+  function runScript(script: string, tasks: unknown[]): { tasks: Array<Record<string, unknown>> } {
+    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
+    return JSON.parse(vm.runInNewContext(script, sandbox) as string) as {
+      tasks: Array<Record<string, unknown>>;
+    };
+  }
+
+  it('Overdue task: available=true, blocked=false', () => {
+    const tasks = [makeTask('overdue', Task.Status.Overdue)];
+    const { script } = buildFilteredTasksScript(
+      { dropped: false },
+      { fields: ['id', 'name', 'available', 'blocked'], includeCompleted: false },
+    );
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.available).toBe(true);
+    expect(result.tasks[0]?.blocked).toBe(false);
+  });
+
+  it('DueSoon task: available=true, blocked=false', () => {
+    const tasks = [makeTask('due-soon', Task.Status.DueSoon)];
+    const { script } = buildFilteredTasksScript(
+      { dropped: false },
+      { fields: ['id', 'name', 'available', 'blocked'], includeCompleted: false },
+    );
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.available).toBe(true);
+    expect(result.tasks[0]?.blocked).toBe(false);
+  });
+
+  it('Next task: available=true, blocked=false', () => {
+    const tasks = [makeTask('next', Task.Status.Next)];
+    const { script } = buildFilteredTasksScript(
+      { dropped: false },
+      { fields: ['id', 'name', 'available', 'blocked'], includeCompleted: false },
+    );
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.available).toBe(true);
+    expect(result.tasks[0]?.blocked).toBe(false);
+  });
+
+  it('Available task: available=true, blocked=false', () => {
+    const tasks = [makeTask('avail', Task.Status.Available)];
+    const { script } = buildFilteredTasksScript(
+      { dropped: false },
+      { fields: ['id', 'name', 'available', 'blocked'], includeCompleted: false },
+    );
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.available).toBe(true);
+    expect(result.tasks[0]?.blocked).toBe(false);
+  });
+
+  it('Blocked task (deferred or sequential): available=false, blocked=true', () => {
+    const tasks = [makeTask('deferred', Task.Status.Blocked)];
+    const { script } = buildFilteredTasksScript(
+      { dropped: false },
+      { fields: ['id', 'name', 'available', 'blocked'], includeCompleted: false },
+    );
+    const result = runScript(script, tasks);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.available).toBe(false);
+    expect(result.tasks[0]?.blocked).toBe(true);
+  });
+
+  it('available XOR blocked: Overdue is available NOT blocked', () => {
+    const overdueTask = makeTask('overdue', Task.Status.Overdue);
+    const blockedTask = makeTask('blocked', Task.Status.Blocked);
+    const { script } = buildFilteredTasksScript(
+      { dropped: false },
+      { fields: ['id', 'name', 'available', 'blocked'], includeCompleted: false },
+    );
+    const result = runScript(script, [overdueTask, blockedTask]);
+    expect(result.tasks).toHaveLength(2);
+    const overdue = result.tasks.find((t) => t.name === 'overdue');
+    const blocked = result.tasks.find((t) => t.name === 'blocked');
+    expect(overdue?.available).toBe(true);
+    expect(overdue?.blocked).toBe(false);
+    expect(blocked?.available).toBe(false);
+    expect(blocked?.blocked).toBe(true);
+  });
+});

--- a/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
+++ b/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
@@ -371,8 +371,8 @@ describe('OMN-130 #3: smart_suggest scoring uses available field (injected into 
     const yesterday = new Date(now);
     yesterday.setDate(yesterday.getDate() - 1);
 
-    const overdueAvailable = makeTask({ name: 'avail', dueDate: yesterday, available: true });
-    const overdueNotAvailable = makeTask({ name: 'blocked', dueDate: yesterday, available: false });
+    const overdueAvailable = makeTask({ name: 'avail', dueDate: yesterday.toISOString(), available: true });
+    const overdueNotAvailable = makeTask({ name: 'blocked', dueDate: yesterday.toISOString(), available: false });
 
     // scoreForSmartSuggest returns top-N tasks sorted by score
     const result = scoreForSmartSuggest([overdueAvailable, overdueNotAvailable], 10);

--- a/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
+++ b/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
@@ -3,8 +3,13 @@
  *
  * Three changes tested here:
  *  1. hasNote in MINIMAL_FIELDS + generateFieldProjection
- *  2. available redefined as "actionable now" (Available | DueSoon | Next | Overdue)
- *  3. (Change 2 is description-only — no code assertions needed)
+ *  2. smart_suggest description only (no logic assertions — tested in task-query-pipeline)
+ *  3. available redefined as "actionable now" (Available | DueSoon | Next | Overdue)
+ *     — projection AND filter-side emitter use the same shared ACTIONABLE_STATUSES constant
+ *
+ * Plus code-review follow-ups (#3, #4):
+ *  #3: smart_suggest auto-injects 'available' into scriptFields (reliable scoring)
+ *  #4: hasNote comment corrected (materializes full note string, not a lazy API)
  *
  * VM behavioral tests use node:vm to confirm the generated OmniJS code behaves
  * correctly when evaluated with stub task objects, confirming the generated
@@ -16,6 +21,8 @@ import { describe, it, expect } from 'vitest';
 import { buildFilteredTasksScript, MINIMAL_FIELDS } from '../../../../src/contracts/ast/script-builder.js';
 import { TaskFieldEnum } from '../../../../src/tools/unified/schemas/read-schema.js';
 import { TaskRowSchema } from '../../../../src/omnifocus/script-response-schemas.js';
+import { scoreForSmartSuggest } from '../../../../src/tools/tasks/task-query-pipeline.js';
+import type { OmniFocusTask } from '../../../../src/omnifocus/types.js';
 
 // =============================================================================
 // Change 1 — hasNote in MINIMAL_FIELDS and generateFieldProjection
@@ -317,5 +324,68 @@ describe('OMN-130 Change 3: VM behavioral — available reflects 4-status set', 
     expect(overdue?.blocked).toBe(false);
     expect(blocked?.available).toBe(false);
     expect(blocked?.blocked).toBe(true);
+  });
+});
+
+// =============================================================================
+// #1 (review follow-up) — ACTIONABLE_STATUSES shared constant used in projection
+// =============================================================================
+
+describe('OMN-130 #1: ACTIONABLE_STATUSES shared constant used in projection', () => {
+  it('available projection references all 4 actionable statuses (same set as filter-side)', () => {
+    // Verify the projection uses the shared set — if ACTIONABLE_STATUSES is updated,
+    // both the WHERE and SELECT sides must change together.
+    const result = buildFilteredTasksScript({}, { fields: ['available'] });
+    expect(result.script).toContain('Task.Status.Available');
+    expect(result.script).toContain('Task.Status.DueSoon');
+    expect(result.script).toContain('Task.Status.Next');
+    expect(result.script).toContain('Task.Status.Overdue');
+  });
+});
+
+// =============================================================================
+// #3 (review follow-up) — smart_suggest auto-injects 'available' into scriptFields
+// =============================================================================
+
+describe('OMN-130 #3: smart_suggest scoring uses available field (injected into scriptFields)', () => {
+  // scoreForSmartSuggest uses task.available to award +30 pts.
+  // With the broadened projection, Overdue/DueSoon/Next tasks now get available:true
+  // from the script. This test confirms the scoring logic responds to the available field.
+
+  function makeTask(overrides: Partial<OmniFocusTask>): OmniFocusTask {
+    return {
+      id: 'test-id',
+      name: 'Test task',
+      completed: false,
+      flagged: false,
+      available: false,
+      dueDate: undefined,
+      deferDate: undefined,
+      tags: [],
+      ...overrides,
+    } as OmniFocusTask;
+  }
+
+  it('overdue task with available:true scores higher than one with available:false', () => {
+    const now = new Date();
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const overdueAvailable = makeTask({ name: 'avail', dueDate: yesterday, available: true });
+    const overdueNotAvailable = makeTask({ name: 'blocked', dueDate: yesterday, available: false });
+
+    // scoreForSmartSuggest returns top-N tasks sorted by score
+    const result = scoreForSmartSuggest([overdueAvailable, overdueNotAvailable], 10);
+    // Both should appear (both have score > 0 from overdue bonus)
+    expect(result.length).toBe(2);
+    // The available one should rank first (100 + days_overdue*10 + 30 > 100 + days_overdue*10)
+    expect(result[0]?.name).toBe('avail');
+  });
+
+  it('smart_suggest scriptFields include available — default MINIMAL_FIELDS already contains it', () => {
+    // MINIMAL_FIELDS now contains 'available', so even without explicit fields injection,
+    // a default smart_suggest script will carry the available projection.
+    // This is the belt: the suspenders is the explicit injection in buildTaskQuery.
+    expect(MINIMAL_FIELDS).toContain('available');
   });
 });

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -1007,7 +1007,7 @@ describe('OMN-154: generated scripts count the full population (vm-executed)', (
 // =============================================================================
 
 describe('field set constants', () => {
-  it('MINIMAL_FIELDS contains exactly the 9 thin-default fields', () => {
+  it('MINIMAL_FIELDS contains exactly the 10 thin-default fields (OMN-130: hasNote added)', () => {
     expect(MINIMAL_FIELDS).toEqual([
       'id',
       'name',
@@ -1018,6 +1018,7 @@ describe('field set constants', () => {
       'tags',
       'project',
       'available',
+      'hasNote',
     ]);
   });
 


### PR DESCRIPTION
## Summary

Linear: https://linear.app/omnifocus-mcp/issue/OMN-130

Three changes to the tasks read path — no urgency scoring added, surface honesty only. A second commit addresses code-review follow-ups (#1–#4 from review).

---

## Commit 1: feat(OMN-130) — initial implementation

**Change 1 — \`hasNote\` added to MINIMAL_FIELDS (default task fields)**
- \`src/contracts/ast/script-builder.ts\`: \`hasNote\` in \`MINIMAL_FIELDS\`; projection emits \`hasNote: (task.note || '').length > 0\`
- \`src/tools/unified/schemas/read-schema.ts\`: \`hasNote\` in \`TASK_FIELDS\`
- \`src/omnifocus/script-response-schemas.ts\`: \`hasNote: z.boolean().optional()\` in \`TaskRowSchema\`
- Decision: \`notePreview\` was considered and rejected — redundant with full \`note\` in \`DETAIL_FIELDS\`; contradicts the token-cost goal of the lean default

**Change 2 — \`smart_suggest\` redescribed (description only, no logic change)**
- Tool description updated: plainly states "available next actions, NOT urgency-ranked"
- \`MODE_DEFINITIONS['smart_suggest']\` doc comment in \`task-query-pipeline.ts\` clarified

**Change 3 — \`available\` projection changed from single-status to 4-status**
- Old: \`task.taskStatus === Task.Status.Available\` (silently excluded Overdue/DueSoon/Next)
- New: \`[...ACTIONABLE_STATUSES].indexOf(task.taskStatus) !== -1\`

---

## Commit 2: fix(OMN-130) — code-review follow-ups #1–#4

**#1 (CRITICAL) — single source of truth: ACTIONABLE_STATUSES constant**
- Added \`ACTIONABLE_STATUSES\` and \`emitOmniJSAvailable()\` to \`src/contracts/ast/types.ts\`
- \`SYNTHETIC_FIELD_DEFS\` for \`task.available\` now uses \`emitOmniJSAvailable\` — the 4-status membership predicate (\`indexOf !== -1\`) so WHERE (\`filters:{available:true}\`, \`mode:'available'\`) and SELECT (projection) always agree
- \`generateFieldProjection\` 'available' case in \`script-builder.ts\` imports and uses the same constant
- \`dropped\` and \`blocked\` remain single-status comparisons via \`emitOmniJSStatusComparison\`

**#2 — emitter tests updated**
- \`tests/unit/contracts/ast/emitters/omnijs.test.ts\`: 'available status comparisons' block updated to assert 4-status membership check for all true/false/!= variants
- \`tests/unit/contracts/ast/filter-generator.test.ts\`: \`available: true\` assertion updated

**#3 — smart_suggest auto-injects 'available' into scriptFields**
- \`OmniFocusReadTool.ts\` buildTaskQuery: injects 'available' when \`mode='smart_suggest'\` and field is absent (mirrors today-mode pattern for reason/daysOverdue). Ensures \`scoreForSmartSuggest\`'s +30 bonus is reliable even with explicit \`fields:[...]\` that omit 'available'

**#4 — hasNote comment corrected**
- Removed "cheap boolean" label; comment now states \`(task.note || '')\` materializes the full note string in the OmniJS runtime per task — the boolean saves MCP response token cost, not per-task OmniJS work

---

## jxa-omnifocus-expert confirmation

- **{Available, DueSoon, Next, Overdue} is the correct "actionable now" set** — all four are actionable
- **A future-deferred task reports \`taskStatus === Task.Status.Blocked\`** — deferred tasks correctly excluded

## BEHAVIOR CHANGES

- \`available\` projection: now true for Overdue/DueSoon/Next tasks (previously false)
- \`filters:{available:true}\` and \`mode:'available'\`: now return Overdue/DueSoon/Next tasks (previously excluded)
- \`mode:'smart_suggest'\`: the +30 "is actionable" bonus now applies to Overdue/DueSoon/Next tasks (intended — stacks with overdue urgency points)

## Acceptance criteria

- [x] \`hasNote\` in \`MINIMAL_FIELDS\`, \`TASK_FIELDS\`, \`TaskRowSchema\`, \`generateFieldProjection\`
- [x] \`hasNote\` projection coalesces null note
- [x] \`smart_suggest\` description updated
- [x] \`ACTIONABLE_STATUSES\` constant defined once in \`types.ts\`, consumed by both WHERE and SELECT
- [x] \`available\` projection uses shared constant
- [x] \`available\` filter emitter uses shared constant (membership predicate)
- [x] \`blocked\` filter emitter unchanged (single-status)
- [x] Emitter tests updated for 4-status predicate
- [x] smart_suggest injects 'available' into scriptFields
- [x] All 3385 unit tests pass
- [x] \`inputSchema\` size: 1607 chars (well within ~3000 cap)
- [ ] OWED: live \`/verify\` at real-OmniFocus seam — an overdue task must appear in \`mode:'available'\` results; a future-deferred task must not. Cannot validate without running OmniFocus.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm run test:unit\` — 3385 tests passed (143 files)
- [ ] Integration tests: OWED (~17 min)
- [ ] Live verify: OWED (overdue + deferred task at real seam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)