### PR TITLE
OMN-190/191/192: project-root follow-up cluster (honesty surface + threading + dedup test)

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -527,11 +527,13 @@ function buildUnsortedScript(ctx: ScriptBuildContext): string {
  * buildExportTasksScript. Adding a new task-script builder? Route it through
  * this helper — never inline the check.
  *
- * SCOPE: injects includeProjectRoot only.
- * The existing dropped/completed defaults differ per builder (export defaults
- * includeCompleted=true; inbox always excludes completed) and must stay inline
- * in each builder until that interaction is audited. They are candidates for
- * the same consolidation in a follow-up pass.
+ * SCOPE: injects includeProjectRoot only (into the PREDICATE filter).
+ * The dropped/completed predicate defaults differ per builder (export defaults
+ * includeCompleted=true; inbox always excludes completed) and stay inline in each
+ * builder by design. For the HONESTY SURFACE (filter_description / filters_applied),
+ * OMN-190 consolidated all three defaults into applyHonestyDefaults — adding a new
+ * builder? Route the predicate through this helper AND the description through
+ * applyHonestyDefaults, or the new builder silently under-reports its exclusions.
  */
 function applyProjectRootDefault<F extends { includeProjectRoot?: boolean }>(filter: F): F {
   if (filter.includeProjectRoot !== undefined) return filter;

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -538,6 +538,33 @@ function applyProjectRootDefault<F extends { includeProjectRoot?: boolean }>(fil
   return { ...filter, includeProjectRoot: false };
 }
 
+/**
+ * OMN-190: the filter actually applied to the query — the user filter plus the
+ * auto-injected safety defaults (completed/dropped/project-root exclusions).
+ *
+ * Used ONLY for the honesty surface (filter_description + filters_applied) so
+ * those report what was really counted, not the user's (often empty) filter.
+ * This is DISTINCT from the predicate's effectiveFilter: the list/inbox builders
+ * enforce the completed exclusion out-of-band via completionCheck, so `completed`
+ * must NOT be fed to generateFilterCode (it would double the check) — but it MUST
+ * be described. Reverses the OMN-52 "description keyed to the user filter"
+ * convention (that keying was the bug OMN-190 fixes).
+ *
+ * Gating mirrors each builder exactly so the description never claims an
+ * exclusion that wasn't applied: completed/dropped default in only when unset and
+ * includeCompleted is false (count has no includeCompleted, so it passes false);
+ * project-root routes through the shared applyProjectRootDefault helper.
+ */
+function applyHonestyDefaults<F extends { completed?: boolean; dropped?: boolean; includeProjectRoot?: boolean }>(
+  filter: F,
+  includeCompleted: boolean,
+): F {
+  const f = { ...filter };
+  if (!includeCompleted && f.completed === undefined) f.completed = false;
+  if (!includeCompleted && f.dropped === undefined) f.dropped = false;
+  return applyProjectRootDefault(f);
+}
+
 export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: ScriptOptions = {}): GeneratedScript {
   const { limit = 50, offset = 0, fields = [], includeCompleted = false, sort, noteTruncateLength } = options;
 
@@ -546,9 +573,9 @@ export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: 
   // through the AST emitter (taskStatus !== Task.Status.Dropped) — a raw
   // script-level check is a silent no-op. Gating mirrors the completed
   // default: an explicit filter.dropped (incl. status:'dropped', which
-  // compiles onto it) or includeCompleted lifts it. isEmptyFilter and the
-  // description stay keyed to the user's filter (same convention as the
-  // count-path OMN-52 shim).
+  // compiles onto it) or includeCompleted lifts it. isEmptyFilter stays keyed
+  // to the user's filter (it gates an optimization, not the surface); the
+  // description now reflects the effective filter (OMN-190).
   let effectiveFilter: typeof filter =
     !includeCompleted && filter.dropped === undefined ? { ...filter, dropped: false } : filter;
   // OMN-153: exclude project-root rows by default via the consolidated helper.
@@ -561,8 +588,10 @@ export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: 
   // Generate the filter predicate code
   const filterCode = generateFilterCode(effectiveFilter);
 
-  // Build description
-  const filterDescription = describeFilterForScript(filter);
+  // OMN-190: describe the effective filter (auto-injected completed/dropped/
+  // project-root exclusions included) so filter_description never claims "all
+  // tasks" for a query that silently excludes three populations.
+  const filterDescription = describeFilterForScript(applyHonestyDefaults(filter, includeCompleted));
 
   // Generate field projection (thread dueSoonDays from filter for reason field)
   const fieldProjection = generateFieldProjection(fields, {
@@ -685,7 +714,9 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
   effectiveFilter = applyProjectRootDefault(effectiveFilter);
 
   const filterCode = generateFilterCode(effectiveFilter);
-  const filterDescription = describeFilterForScript(filter);
+  // OMN-190: describe the effective filter (inbox + auto-injected exclusions),
+  // not the user's filter — see buildFilteredTasksScript.
+  const filterDescription = describeFilterForScript(applyHonestyDefaults(filter, includeCompleted));
   const fieldProjection = generateFieldProjection(fields, { noteTruncateLength });
 
   // Determine completion filter - exclude completed by default for inbox
@@ -2140,20 +2171,27 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
   //
   // For inbox queries, also strip inInbox from the predicate since the
   // pre-filtered inbox collection (`doc.inboxTasks()`) already handles it.
+  //
+  // OMN-190: effectiveFilter is what we describe + echo (the honesty surface).
+  // It carries the auto-injected completed/dropped/project-root defaults AND
+  // keeps inInbox (so inbox counts are described as inbox). The predicate's
+  // filterForCode is the same set minus inInbox for the pre-filtered collection.
+  // Count has no includeCompleted option, so the defaults always apply (pass false).
+  const effectiveFilter = applyHonestyDefaults(normalizedFilter, false);
   const filterForCode = (() => {
-    const f = { ...normalizedFilter };
-    if (checkInbox) delete f.inInbox;
-    if (f.completed === undefined) f.completed = false;
-    // OMN-157: dropped gets the same default for the same parity reason
-    if (f.dropped === undefined) f.dropped = false;
-    return applyProjectRootDefault(f);
+    if (!checkInbox) return effectiveFilter;
+    const f = { ...effectiveFilter };
+    delete f.inInbox;
+    return f;
   })();
 
   // Build AST and generate OmniJS filter code
   const ast = buildAST(filterForCode);
   const isEmptyFilterValue = ast.type === 'literal' && ast.value === true;
   const filterCode = generateFilterCode(filterForCode);
-  const filterDescription = describeFilterForScript(normalizedFilter);
+  // OMN-190: describe the effective filter so the count never claims "all tasks"
+  // while silently excluding completed/dropped/project-root rows.
+  const filterDescription = describeFilterForScript(effectiveFilter);
 
   // Check if the filter needs tags - only fetch tags if the filter uses them
   const needsTags = filterCode.predicate.includes('taskTags');
@@ -2194,7 +2232,7 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
     const endTime = Date.now();
     return JSON.stringify({
       count: count,
-      filters_applied: ${JSON.stringify(stripNormalizedBrand(filter))},
+      filters_applied: ${JSON.stringify(stripNormalizedBrand(effectiveFilter))},
       query_time_ms: endTime - startTime,
       optimization: 'omnijs_count${needsTags ? '_with_tags' : '_no_tags'}',
       filter_description: ${JSON.stringify(filterDescription)},

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -780,7 +780,7 @@ export function listResultSchema<TRow extends z.ZodTypeAny, TMeta extends z.ZodT
 export const CountResultSchema = z
   .object({
     count: z.number(),
-    filters_applied: z.unknown(), // passthrough echo of caller's filter object
+    filters_applied: z.unknown(), // passthrough echo of the effective filter (OMN-190); z.unknown() is optional-by-default
     query_time_ms: z.number(),
     optimization: z.string(),
     filter_description: z.string(),

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -773,7 +773,9 @@ export function listResultSchema<TRow extends z.ZodTypeAny, TMeta extends z.ZodT
  *
  * limited is emitted on BOTH branches (true or false) — REQUIRED.
  * warning is emitted only on the scan-limit branch — OPTIONAL.
- * filters_applied echoes the raw filter object passed in — stays z.unknown() (passthrough echo).
+ * filters_applied echoes the EFFECTIVE filter — the user filter plus the auto-injected
+ * completed/dropped/project-root defaults the count actually applied (OMN-190) — stays
+ * z.unknown() (passthrough echo). The host surfaces this verbatim as metadata.filters_applied.
  */
 export const CountResultSchema = z
   .object({

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2693,6 +2693,11 @@ SCOPE FILTERING:
     // buildFilteredProjectsScript/buildTagsScript, which self-wrap). Passing the
     // bare body to execJson throws "Can't find variable: flattenedTasks", and the
     // swallowed failure silently disabled dedupe. Output shape is { tasks, metadata }.
+    //
+    // OMN-191: this inherits OMN-153's default project-root exclusion by design.
+    // A project root is named identically to its project but is NOT an actionable
+    // task, so it must not make "create a task named like the project" look like a
+    // duplicate. (To include roots in dedup, pass includeProjectRoot: true here.)
     const script = buildListTasksScriptV4({
       filter: { completed: false, dropped: false },
       fields: ['name', 'project'],

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -586,8 +586,10 @@ PERFORMANCE:
       // script computes alongside filter_description. Rebuilding from countFilter
       // here would re-introduce the very contradiction OMN-190 fixed — countFilter
       // lacks the defaults, so filters_applied:{} would disagree with a
-      // filter_description that names three exclusions. Fall back to countFilter
-      // only if the script omitted the echo (defensive; CountResultSchema requires it).
+      // filter_description that names three exclusions. The real count script
+      // always emits the echo; the countFilter fallback only fires for partial
+      // test mocks (CountResultSchema's z.unknown() field is optional-by-default,
+      // so a missing key parses as undefined rather than failing validation).
       filters_applied: data.filters_applied ?? stripNormalizedBrand(countFilter),
       optimization: data.optimization || 'ast_omnijs_bridge',
       filter_description: data.filter_description,

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -187,14 +187,12 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
   const limit = compiled.limit || 25;
   const mode = (compiled.filters.inInbox ? 'inbox' : compiled.mode) as TaskQueryMode | undefined;
 
-  // OMN-153: thread includeProjectRoot onto the filter BEFORE augmentFilterForMode
-  // so the project-root exclusion survives mode augmentation.
-  const baseFilters: typeof compiled.filters =
-    compiled.includeProjectRoot !== undefined
-      ? { ...compiled.filters, includeProjectRoot: compiled.includeProjectRoot }
-      : compiled.filters;
-
-  const filter = augmentFilterForMode(mode, baseFilters, {
+  // OMN-153/192: includeProjectRoot is a query-level param threaded onto the
+  // compiled filter at compile time (QueryCompiler, same path as fastSearch), so
+  // compiled.filters is the single source of truth — no re-merge here. It rides
+  // through augmentFilterForMode (which spreads ...filter, preserving it) into
+  // both the row script and the count filter.
+  const filter = augmentFilterForMode(mode, compiled.filters, {
     daysAhead: compiled.daysAhead,
   });
 
@@ -468,7 +466,7 @@ PERFORMANCE:
 
     // --- Count-only fast path ---
     if (compiled.countOnly) {
-      return this.executeCountOnly(filter, mode, timer, compiled.includeProjectRoot);
+      return this.executeCountOnly(filter, mode, timer);
     }
 
     // --- ID lookup fast path (always full detail) ---
@@ -544,7 +542,6 @@ PERFORMANCE:
     filter: TaskFilter,
     mode: TaskQueryMode | undefined,
     timer: OperationTimerV2,
-    includeProjectRoot?: boolean,
   ): Promise<unknown> {
     // Ensure inbox mode sets the inInbox filter (mode: "inbox" is not in
     // MODE_DEFINITIONS, so augmentFilterForMode passes through unchanged)
@@ -552,10 +549,9 @@ PERFORMANCE:
     if (mode === 'inbox' && !countFilter.inInbox) {
       countFilter.inInbox = true;
     }
-    // OMN-153: thread includeProjectRoot so countOnly agrees with the row path.
-    if (includeProjectRoot !== undefined) {
-      countFilter.includeProjectRoot = includeProjectRoot;
-    }
+    // OMN-192: includeProjectRoot already rides on `filter` (compiled.filters →
+    // augmentFilterForMode preserves it), so countFilter carries it without a
+    // separate thread — countOnly agrees with the row path by construction.
 
     const { script } = buildTaskCountScript(countFilter, { maxScan: 10000 });
     const result = await this.execJson(script, CountResultSchema);

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -572,6 +572,7 @@ PERFORMANCE:
       warning?: string;
       optimization?: string;
       filter_description?: string;
+      filters_applied?: Record<string, unknown>;
     };
     const count = data.count ?? 0;
     const response = createTaskResponseV2('tasks', [], {
@@ -580,7 +581,14 @@ PERFORMANCE:
       mode: mode || 'count_only',
       count_only: true,
       total_count: count,
-      filters_applied: stripNormalizedBrand(countFilter),
+      // OMN-190: surface the script's honest echo (the EFFECTIVE filter incl.
+      // auto-injected completed/dropped/project-root defaults), which the count
+      // script computes alongside filter_description. Rebuilding from countFilter
+      // here would re-introduce the very contradiction OMN-190 fixed — countFilter
+      // lacks the defaults, so filters_applied:{} would disagree with a
+      // filter_description that names three exclusions. Fall back to countFilter
+      // only if the script omitted the echo (defensive; CountResultSchema requires it).
+      filters_applied: data.filters_applied ?? stripNormalizedBrand(countFilter),
       optimization: data.optimization || 'ast_omnijs_bridge',
       filter_description: data.filter_description,
       warning: data.warning,

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -21,6 +21,48 @@ import type { TaskFilter } from '../../../../src/contracts/filters.js';
 import { normalizeFilter } from '../../../../src/contracts/filters.js';
 import { recoverInnerProgram } from '../../../utils/recover-bridge-program.js';
 
+describe('OMN-190: honesty surface reflects the effective filter', () => {
+  // For an empty/default query the generated script silently excludes completed,
+  // dropped, and project-root rows. filter_description (all builders) and
+  // filters_applied (count path) must reflect those auto-injected defaults, or
+  // an LLM consumer reasoning "this is the full population" is wrong by 3 silent
+  // exclusions. See the describe<->filters_applied invariant (OMN-172/177).
+
+  it('list path describes the effective defaults for an empty filter', () => {
+    expect(buildFilteredTasksScript({}).filterDescription).toBe('active AND not dropped AND exclude project roots');
+  });
+
+  it('inbox path describes inbox plus the effective defaults', () => {
+    // BOOLEAN_FILTER_DESCRIPTORS order: completed, dropped, ..., inInbox, includeProjectRoot
+    expect(buildInboxScript({}).filterDescription).toBe('active AND not dropped AND inbox AND exclude project roots');
+  });
+
+  it('count path describes AND echoes the effective defaults', () => {
+    const inner = recoverInnerProgram(buildTaskCountScript({}).script);
+    expect(inner).toContain('filter_description: "active AND not dropped AND exclude project roots"');
+    // filters_applied echoes the effective filter, not the raw (empty) user filter
+    expect(inner).toContain('"completed":false');
+    expect(inner).toContain('"dropped":false');
+    expect(inner).toContain('"includeProjectRoot":false');
+    // and never leaks the normalized brand key (OMN-177)
+    expect(inner).not.toContain('__normalized__');
+  });
+
+  it('includeCompleted lifts the completed/dropped defaults from the description', () => {
+    // root exclusion still applies (only includeProjectRoot controls it)
+    expect(buildFilteredTasksScript({}, { includeCompleted: true }).filterDescription).toBe('exclude project roots');
+  });
+
+  it('an explicit includeProjectRoot:true is reflected honestly', () => {
+    expect(buildFilteredTasksScript(normalizeFilter({ includeProjectRoot: true })).filterDescription).toBe(
+      'active AND not dropped AND include project roots',
+    );
+    const inner = recoverInnerProgram(buildTaskCountScript({ includeProjectRoot: true }).script);
+    expect(inner).toContain('"includeProjectRoot":true');
+    expect(inner).toContain('include project roots');
+  });
+});
+
 describe('buildFilteredTasksScript', () => {
   describe('basic script generation', () => {
     it('generates valid OmniJS script for empty filter', () => {
@@ -32,7 +74,11 @@ describe('buildFilteredTasksScript', () => {
       // exclusion into the predicate (dropped is synthetic — AST-only)
       expect(result.script).toContain('task.taskStatus !== Task.Status.Dropped');
       expect(result.isEmptyFilter).toBe(true);
-      expect(result.filterDescription).toBe('all tasks');
+      // OMN-190: filter_description now reflects the EFFECTIVE filter (the
+      // auto-injected completed/dropped/project-root exclusions actually
+      // applied), not the user's empty filter. "all tasks" was a lie — the
+      // query silently excludes three populations.
+      expect(result.filterDescription).toBe('active AND not dropped AND exclude project roots');
     });
 
     it('generates script with AST filter predicate', () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -288,27 +288,29 @@ describe('OmniFocusAnalyzeTool', () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       // OMN-139: executeJson now returns ScriptResult (schema validated); mock must match
-      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({
-        ok: true,
-        v: '3',
-        data: {
-          velocity: {
-            period: '7 days',
-            averageCompleted: '6.5',
-            averageCreated: '7.2',
-            dailyVelocity: '6.5',
-            backlogGrowthRate: '+0.7',
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: {
+            velocity: {
+              period: '7 days',
+              averageCompleted: '6.5',
+              averageCreated: '7.2',
+              dailyVelocity: '6.5',
+              backlogGrowthRate: '+0.7',
+            },
+            throughput: {
+              intervals: [],
+              totalCompleted: 45,
+              totalCreated: 50,
+            },
+            breakdown: { medianCompletionHours: '3.5', tasksAnalyzed: 150 },
+            projections: { tasksPerDay: '6.5', tasksPerWeek: '45.5', tasksPerMonth: '195' },
+            optimization: 'Current velocity is sustainable',
           },
-          throughput: {
-            intervals: [],
-            totalCompleted: 45,
-            totalCreated: 50,
-          },
-          breakdown: { medianCompletionHours: '3.5', tasksAnalyzed: 150 },
-          projections: { tasksPerDay: '6.5', tasksPerWeek: '45.5', tasksPerMonth: '195' },
-          optimization: 'Current velocity is sustainable',
-        },
-      }));
+        }),
+      );
 
       const res: any = await tool.execute({
         analysis: { type: 'task_velocity', params: { groupBy: 'day' } },
@@ -429,19 +431,21 @@ describe('OmniFocusAnalyzeTool', () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       // OMN-139: executeJson returns ScriptResult; wrap V3 envelope
-      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({
-        ok: true,
-        v: '3',
-        data: {
-          insights: [{ insight: 'Focus on review cadence' }, { message: 'Reduce WIP' }],
-          patterns: { bottlenecks: 3, projects: 2 },
-          recommendations: [{ recommendation: 'Batch similar tasks' }],
-          totalTasks: 123,
-          totalProjects: 12,
-          analysisTime: 250,
-          dataPoints: 4000,
-        },
-      }));
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: {
+            insights: [{ insight: 'Focus on review cadence' }, { message: 'Reduce WIP' }],
+            patterns: { bottlenecks: 3, projects: 2 },
+            recommendations: [{ recommendation: 'Batch similar tasks' }],
+            totalTasks: 123,
+            totalProjects: 12,
+            analysisTime: 250,
+            dataPoints: 4000,
+          },
+        }),
+      );
 
       const res: any = await tool.execute({
         analysis: { type: 'workflow_analysis' },
@@ -455,11 +459,13 @@ describe('OmniFocusAnalyzeTool', () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       // OMN-139: executeJson returns ScriptResult; wrap V3 envelope
-      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({
-        ok: true,
-        v: '3',
-        data: { insights: [], patterns: {}, recommendations: [] },
-      }));
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: { insights: [], patterns: {}, recommendations: [] },
+        }),
+      );
 
       const res: any = await tool.execute({
         analysis: { type: 'workflow_analysis' },
@@ -525,13 +531,15 @@ describe('OmniFocusAnalyzeTool', () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       // OMN-139: executeJson returns ScriptResult; mock must match RecurringPatternsSchema
-      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({
-        totalRecurring: 5,
-        patterns: [{ pattern: 'weekly', count: 3 }],
-        byProject: [{ project: 'Work', count: 2 }],
-        mostCommon: { pattern: 'weekly', count: 3 },
-        duration: 250,
-      }));
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          totalRecurring: 5,
+          patterns: [{ pattern: 'weekly', count: 3 }],
+          byProject: [{ project: 'Work', count: 2 }],
+          mostCommon: { pattern: 'weekly', count: 3 },
+          duration: 250,
+        }),
+      );
 
       const res: any = await tool.execute({
         analysis: { type: 'recurring_tasks', params: { operation: 'patterns' } },
@@ -880,6 +888,29 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(tasksScript).toContain('evaluateJavascript');
       });
 
+      it('OMN-191: the dedup tasks read excludes project-root rows by default (inherits OMN-153)', async () => {
+        // A project root is named identically to its project but is NOT an
+        // actionable task — it must not make "create a task named like the
+        // project" look like a duplicate. fetchExistingIncompleteTasks routes
+        // through buildListTasksScriptV4 -> buildFilteredTasksScript, which applies
+        // OMN-153's default project-root exclusion, so root rows never reach dedup.
+        const scripts: string[] = [];
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          scripts.push(script);
+          return Promise.resolve({ tasks: [] });
+        });
+
+        await tool.execute({
+          analysis: { type: 'parse_meeting_notes', params: { items: [{ name: 'X', project: 'Y' }] } },
+        });
+
+        const tasksScript = scripts.find((s) => s.includes('flattenedTasks'));
+        expect(tasksScript).toBeDefined();
+        // OMN-153 predicate: a project root is the only task with task.project !== null,
+        // so excluding `task.project === null` rows keeps roots out of the dedup set.
+        expect(tasksScript).toContain('task.project === null');
+      });
+
       it('emits a batchPayload that round-trips unchanged through WriteSchema { batch }', async () => {
         const res: any = await tool.execute({
           analysis: {
@@ -924,15 +955,17 @@ describe('OmniFocusAnalyzeTool', () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       // OMN-139: executeJson returns ScriptResult; mock must match REVIEWS_LIST_SCHEMA
-      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({
-        success: true,
-        projects: [
-          { id: 'p1', name: 'Overdue', nextReviewDate: yesterday },
-          { id: 'p2', name: 'Due Today', nextReviewDate: today },
-          { id: 'p3', name: 'Due Soon', nextReviewDate: soon },
-          { id: 'p4', name: 'No Schedule' },
-        ],
-      }));
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          success: true,
+          projects: [
+            { id: 'p1', name: 'Overdue', nextReviewDate: yesterday },
+            { id: 'p2', name: 'Due Today', nextReviewDate: today },
+            { id: 'p3', name: 'Due Soon', nextReviewDate: soon },
+            { id: 'p4', name: 'No Schedule' },
+          ],
+        }),
+      );
 
       const res: any = await tool.execute({
         analysis: { type: 'manage_reviews', params: { operation: 'list_for_review' } },

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1557,7 +1557,7 @@ describe('OmniFocusReadTool', () => {
           filters_applied: { completed: false, dropped: false, includeProjectRoot: false },
           filter_description: 'active AND not dropped AND exclude project roots',
         },
-      } as unknown as ScriptResult);
+      } satisfies ScriptResult);
 
       const result = (await tool.execute({
         query: { type: 'tasks', countOnly: true },

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1544,6 +1544,35 @@ describe('OmniFocusReadTool', () => {
       expect(result.metadata.filters_applied).toMatchObject({ flagged: true, includeProjectRoot: true });
     });
 
+    it('OMN-190: count metadata.filters_applied surfaces the script honest echo (no contradiction with filter_description)', async () => {
+      // Regression guard for the review finding: the host must NOT rebuild
+      // filters_applied from the pre-honesty countFilter — for a default query that
+      // would yield filters_applied:{} while filter_description names three
+      // exclusions (the exact OMN-172/177 contradiction OMN-190 fixes). The count
+      // script emits the honest echo in data.filters_applied; the host surfaces it.
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          count: 5,
+          filters_applied: { completed: false, dropped: false, includeProjectRoot: false },
+          filter_description: 'active AND not dropped AND exclude project roots',
+        },
+      } as unknown as ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', countOnly: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.filters_applied).toEqual({
+        completed: false,
+        dropped: false,
+        includeProjectRoot: false,
+      });
+      // filter_description and filters_applied must agree (the invariant)
+      expect(result.metadata.filter_description).toBe('active AND not dropped AND exclude project roots');
+    });
+
     it('script error during count: returns SCRIPT_ERROR', async () => {
       execJsonSpy.mockResolvedValueOnce({
         success: false,

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1528,6 +1528,22 @@ describe('OmniFocusReadTool', () => {
       expect(result.metadata.filters_applied).toMatchObject({ inInbox: true });
     });
 
+    it('OMN-192: countOnly threads includeProjectRoot into the count filter via the compiled filter', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: { count: 3 },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { flagged: true }, countOnly: true, includeProjectRoot: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      // filters_applied echoes the countFilter; includeProjectRoot must reach it
+      // through the compiled filter alone (no redundant executeCountOnly merge).
+      expect(result.metadata.filters_applied).toMatchObject({ flagged: true, includeProjectRoot: true });
+    });
+
     it('script error during count: returns SCRIPT_ERROR', async () => {
       execJsonSpy.mockResolvedValueOnce({
         success: false,

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -67,6 +67,26 @@ describe('QueryCompiler', () => {
       expect(compiled.filters.fastSearch).toBeUndefined();
     });
 
+    it('OMN-192: includeProjectRoot is single-sourced onto the compiled filter (like fastSearch)', () => {
+      const compiled = compiler.compile({
+        query: { type: 'tasks', filters: {}, includeProjectRoot: true },
+      } as ReadInput) as CompiledTasks;
+
+      // The compiled filter is the SINGLE source of truth — buildTaskQuery must
+      // NOT re-merge includeProjectRoot (the OMN-192 double-write). The top-level
+      // query-level field is retained for query-level reads (mirrors fastSearch).
+      expect(compiled.filters.includeProjectRoot).toBe(true);
+      expect(compiled.includeProjectRoot).toBe(true);
+    });
+
+    it('OMN-192: omits includeProjectRoot from the filter when not requested', () => {
+      const compiled = compiler.compile({
+        query: { type: 'tasks', filters: {} },
+      } as ReadInput) as CompiledTasks;
+
+      expect(compiled.filters.includeProjectRoot).toBeUndefined();
+    });
+
     it('OMN-114: passes parentTaskId filter through to the compiled filter', () => {
       const input: ReadInput = {
         query: {
@@ -1188,17 +1208,23 @@ describe('QueryCompiler', () => {
     });
 
     it('control: status "active" compiles without throwing (completed:false)', () => {
-      const compiled = compiler.compile({ query: { type: 'tasks', filters: { status: 'active' } } } as never) as CompiledTasks;
+      const compiled = compiler.compile({
+        query: { type: 'tasks', filters: { status: 'active' } },
+      } as never) as CompiledTasks;
       expect(compiled.filters.completed).toBe(false);
     });
 
     it('control: status "completed" compiles without throwing (completed:true)', () => {
-      const compiled = compiler.compile({ query: { type: 'tasks', filters: { status: 'completed' } } } as never) as CompiledTasks;
+      const compiled = compiler.compile({
+        query: { type: 'tasks', filters: { status: 'completed' } },
+      } as never) as CompiledTasks;
       expect(compiled.filters.completed).toBe(true);
     });
 
     it('control: status "dropped" compiles without throwing (dropped:true)', () => {
-      const compiled = compiler.compile({ query: { type: 'tasks', filters: { status: 'dropped' } } } as never) as CompiledTasks;
+      const compiled = compiler.compile({
+        query: { type: 'tasks', filters: { status: 'dropped' } },
+      } as never) as CompiledTasks;
       expect(compiled.filters.dropped).toBe(true);
     });
 


### PR DESCRIPTION
Closes the three deferred follow-ups from the OMN-153 PR #122 `/code-review high` (findings #5/#6/#7). All three were symbol-disjoint (parallel-safe) but tiny and share two files, so landed serially as one cohesive cluster.

## OMN-190 — honesty surface reflects the effective filter (finding #5, P-medium)
A default/empty tasks query reported `filter_description: "all tasks"` and `filters_applied: {}` while the generated script silently excluded **three** populations (`completed:false`, `dropped:false`, and the safety-critical `includeProjectRoot:false`). An LLM consumer reasoning "this is the full population" was wrong by 3 silent exclusions.

**Approach (Option A, Kip's call):** describe & echo the *effective* filter in `filter_description` + `filters_applied` (count path), keeping the documented `filter_description must not contradict filters_applied` invariant (OMN-172/177). Reverses the OMN-52 "description keyed to the user filter" convention — that keying was the bug.

- new `applyHonestyDefaults()` helper — distinct from the predicate's `effectiveFilter` (the list/inbox builders enforce `completed` out-of-band via `completionCheck`, so it must be *described* but not fed to `generateFilterCode`, which would double the check).
- empty query now: `filter_description: "active AND not dropped AND exclude project roots"`, `filters_applied: {completed:false,dropped:false,includeProjectRoot:false}` (no `__normalized__` leak).
- `isEmptyFilter` stays keyed to the user filter (gates an optimization, not the surface).

⚠️ Changes real prod output for default queries → live /verify owed after deploy.

## OMN-192 — single-source `includeProjectRoot` threading (finding #7, P-low)
`includeProjectRoot` (a query-level param, declared on `TaskFilter` like `fastSearch`) was written onto the filter three times: QueryCompiler `raw` thread → `compiled.filters` (the correct single source), then re-merged in `buildTaskQuery`, then again in `executeCountOnly`. Both re-merges are redundant — `augmentFilterForMode` spreads `...filter` (no mode strips the field), so the value rides on `filter` into both the row script and the count filter. Collapsed to the single `compiled.filters` source (matches the `fastSearch` precedent). No behavior change.

## OMN-191 — lock in project-root exclusion in parse_meeting_notes dedup (finding #6, P-low)
`fetchExistingIncompleteTasks` inherits OMN-153's project-root exclusion (via `buildListTasksScriptV4` → `buildFilteredTasksScript`), so a task named identically to a project is no longer flagged as a duplicate of that project. Intended behavior, but silent. Documented at the call site (+ `includeProjectRoot:true` opt-out) and added a test asserting the dedup read carries the `task.project === null` exclusion predicate.

## Verification
- `npm run test:unit`: 3394 passed (+5 OMN-190, +3 OMN-192, +1 OMN-191).
- `tsc -p tsconfig.test.json --noEmit`: clean.
- `npm run build`: clean.
- No integration test asserts on `filter_description` (checked) — OMN-190's output change is safe there.
- Per project norm: **not merging** — awaiting Kip-run `/code-review` (SAFE-gated `--squash --auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)