### PR TITLE
docs(OMN-179): document ResponseBuilder.entity() list-envelope shape

### DIFF
--- a/tests/utils/mock-factories.ts
+++ b/tests/utils/mock-factories.ts
@@ -1,7 +1,5 @@
 import { vi } from 'vitest';
-import {
-  createListResponseV2,
-} from '../../src/utils/response-format.js';
+import { createListResponseV2 } from '../../src/utils/response-format.js';
 import { SchemaTestHelper } from './schema-helpers.js';
 
 /**
@@ -324,6 +322,23 @@ export class ResponseBuilder {
     };
   }
 
+  /**
+   * Wraps a single entity in a **list-response envelope** (`data.items: [entity]`).
+   *
+   * Despite its name, this method does NOT return a singular-entity shape. It delegates to
+   * `createListResponseV2` with `itemType: 'other'`, which produces:
+   *
+   * ```json
+   * { "success": true, "data": { "items": [entity] }, "metadata": { ... } }
+   * ```
+   *
+   * This was intentionally rewritten during OMN-176 cleanup to use the v2 list envelope.
+   * If you need a true single-entity response shape, build it directly — do not add a new
+   * helper here (risk of divergence with the list path).
+   *
+   * Zero callers in the test tree as of OMN-179 (confirmed via grep). This method is latent
+   * infrastructure; this doc comment exists so the first caller understands the actual shape.
+   */
   static entity(operation: string, entity: any, metadata: any = {}) {
     return createListResponseV2(operation, [entity], 'other', metadata);
   }


### PR DESCRIPTION
## Summary

- `ResponseBuilder.entity()` in `tests/utils/mock-factories.ts` was rewritten during OMN-176 cleanup to delegate to `createListResponseV2(operation, [entity], 'other', metadata)`, which returns a **list-response envelope** (`data.items: [entity]`) — not a singular-entity shape.
- The method name implies singular; the implementation is plural. This is latent (zero callers, confirmed via grep on `ResponseBuilder.entity` and `.entity(` across `tests/`), but the mismatch is a trap for the first caller.
- Fix chosen: **doc comment only** (lowest churn, honest). Explains the actual shape, points future callers to build directly if they need a true singular response, and documents the zero-caller status as of OMN-179.
- No production code touched. No runtime change. No new helpers.

## Test plan

- [x] `npm run build` — passes clean
- [x] `npm run test:unit` — 143 files, 3417 tests, all pass
- [x] Pre-push hooks: typecheck + lint (warnings only, pre-existing) + unit suite — all pass

Parked for Kip's `/code-review` gate (CLAUDE.md workflow norms) — do not merge until reviewed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)