### PR TITLE
feat(OMN-150): schema-level regex validation for { matches } patterns

### DIFF
--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -16,10 +16,25 @@ const DateFilterSchema = z.union([
   z.object({ between: z.tuple([z.string(), z.string()]) }).strict(),
 ]);
 
+// Validates that a string is a syntactically valid regex pattern (OMN-150).
+// Catches input errors at the schema boundary before a round-trip to OmniFocus.
+// Cross-engine note: Node validates here, JavaScriptCore executes later —
+// grammar divergence is negligible for the patterns the MCP surface receives.
+const regexPatternString = z.string().superRefine((pattern, ctx) => {
+  try {
+    new RegExp(pattern);
+  } catch (e) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid regex pattern "${pattern}": ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+});
+
 // Text filter as discriminated union - only ONE operator allowed
 const TextFilterSchema = z.union([
   z.object({ contains: z.string() }).strict(),
-  z.object({ matches: z.string() }).strict(),
+  z.object({ matches: regexPatternString }).strict(),
 ]);
 
 // Number filter as discriminated union - only ONE operator allowed

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -658,4 +658,66 @@ describe('ReadSchema', () => {
       expect(ReadSchema.safeParse({ query: { type: 'projects', mode: 'forecast_past' } }).success).toBe(false);
     });
   });
+
+  // OMN-150: schema-level regex validation for { matches } patterns.
+  // An invalid regex is an input-validation problem, not a runtime OF error.
+  // TextFilterSchema.matches should reject at the schema boundary with a message
+  // naming the pattern and the regex error — before the script reaches OmniFocus.
+  describe('regex validation for { matches } (OMN-150)', () => {
+    it('rejects an invalid regex on filters.text with a message naming the pattern', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { text: { matches: '(unclosed' } } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const msg = JSON.stringify(result.error.issues);
+        expect(msg).toContain('(unclosed');
+      }
+    });
+
+    it('rejects an invalid regex on filters.name with a message naming the pattern', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { name: { matches: '[bad' } } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const msg = JSON.stringify(result.error.issues);
+        expect(msg).toContain('[bad');
+      }
+    });
+
+    it('accepts a valid regex pattern on filters.text', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { text: { matches: '\\d{4}-\\d{2}-\\d{2}' } } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a plain string (valid as a regex literal) on filters.text', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { text: { matches: 'quarterly review' } } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a valid regex on filters.name', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'projects', filters: { name: { matches: '^Weekly' } } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('error message for invalid regex names the pattern and indicates a regex error', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { text: { matches: '(unclosed' } } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const msg = JSON.stringify(result.error.issues);
+        // Message must name the bad pattern AND include some indication of the error
+        expect(msg).toContain('(unclosed');
+        expect(msg.toLowerCase()).toMatch(/invalid|regex|pattern/);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a `superRefine` guard on the `matches` branch of `TextFilterSchema` in `src/tools/unified/schemas/read-schema.ts`
- An invalid regex pattern (e.g. `(unclosed`) now fails at the Zod schema boundary with a message naming the pattern and the JS `RegExp` constructor error, rather than surviving to the OmniFocus script and costing a full automation round trip
- `TextFilterSchema` is shared by both `filters.text` and `filters.name`, so both task and project queries are covered by this single change

## Dual-schema audit

**No `inputSchema` change needed.** `OmniFocusReadTool.get inputSchema()` advertises `filters` as `{ type: 'object' }` — an opaque object. The Zod refinement is purely server-side validation, invisible to MCP clients. Dual-schema rule satisfied; explicitly verified.

## Test plan

- [x] 6 new unit tests in `tests/unit/tools/unified/schemas/read-schema.test.ts` under `describe('regex validation for { matches } (OMN-150)')`
  - Invalid regex on `filters.text` rejects with message naming the pattern
  - Invalid regex on `filters.name` rejects with message naming the pattern
  - Error message includes "invalid"/"regex"/"pattern" wording
  - Valid regex pattern passes
  - Plain string (valid regex literal) passes
  - Valid regex on `filters.name` passes
- [x] All 3423 unit tests pass (`npm run test:unit`)
- [x] Build clean (`npm run build`)
- [x] Pre-push hooks pass (typecheck + lint)

---

Parked for Kip's `/code-review` gate (CLAUDE.md workflow norms) — do not merge until reviewed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)