### PR TITLE
fix(OMN-195): drop misleading all-zero summary from tasks countOnly responses

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -679,11 +679,12 @@ PERFORMANCE:
       warning: data.warning,
     });
 
-    // Override summary total_count with actual count from JXA
-    // (generateTaskSummary receives [] for countOnly, producing total_count: 0)
-    if (response.summary && 'total_count' in response.summary) {
-      (response.summary as { total_count: number }).total_count = count;
-    }
+    // OMN-195: drop summary entirely (matching the OMN-174 convention for
+    // projects/tags/folders). generateTaskSummary([]) produces a breakdown
+    // where every field is 0, which contradicts total_count and actively
+    // misleads LLMs ("breakdown.overdue:0" alongside "total_count:67").
+    // metadata.total_count is the single authoritative answer.
+    delete response.summary;
 
     return response;
   }

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1493,7 +1493,12 @@ describe('OmniFocusReadTool', () => {
   });
 
   describe('countOnly through execute() (OMN-35 gap 2)', () => {
-    it('returns count + metadata flags + overrides summary.total_count from JXA', async () => {
+    // OMN-195: tasks countOnly must drop the summary block entirely (matching the
+    // OMN-174 convention for projects/tags/folders). The breakdown fields are all
+    // 0 (derived from the empty tasks[] passed to generateTaskSummary), which
+    // contradicts total_count — an LLM reading breakdown.overdue:0 next to
+    // total_count:67 is actively misled. metadata.total_count is the answer.
+    it('drops summary entirely; metadata.total_count carries the count (OMN-195)', async () => {
       execJsonSpy.mockResolvedValueOnce({
         success: true,
         data: { count: 42, optimization: 'omnijs_count_no_tags', filter_description: 'flagged' },
@@ -1506,9 +1511,26 @@ describe('OmniFocusReadTool', () => {
       expect(result.success).toBe(true);
       expect(result.metadata.count_only).toBe(true);
       expect(result.metadata.total_count).toBe(42);
-      // Summary total_count must reflect the JXA count, not the 0 from the empty tasks[] array
-      expect(result.summary.total_count).toBe(42);
+      // OMN-195: summary must be absent — all-0 breakdown contradicts total_count
+      expect(result.summary).toBeUndefined();
       expect(result.metadata.optimization).toBe('omnijs_count_no_tags');
+    });
+
+    it('mode:"forecast_past" + countOnly: summary absent, metadata.total_count authoritative (OMN-195)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: { count: 67 },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', mode: 'forecast_past', countOnly: true },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.count_only).toBe(true);
+      expect(result.metadata.total_count).toBe(67);
+      // forecast_past routes through executeCountOnly — same fix applies
+      expect(result.summary).toBeUndefined();
     });
 
     it('mode:"inbox" + countOnly auto-injects inInbox into the count filter', async () => {


### PR DESCRIPTION
## Problem

`countOnly` tasks queries (and `mode:'forecast_past' + countOnly`, which shares the same path) return a `summary` block whose breakdown fields are all `0` while `metadata.total_count` reports the real population — a self-contradiction. An LLM reading `breakdown.overdue:0` alongside `total_count:67` is actively misled.

**Root cause:** `executeCountOnly` calls `createTaskResponseV2('tasks', [], …)` → `generateTaskSummary([])` → all-zero breakdown. The previous workaround only patched `summary.total_count` but left every breakdown field wrong.

## Fix

Drop `summary` entirely from count-only tasks responses, matching the OMN-174 convention already in place for projects/tags/folders. `metadata.total_count` + `metadata.count_only: true` are the authoritative answer — no dashboard summary is needed for a count query.

## Changes

| File | Change |
|------|--------|
| `src/tools/unified/OmniFocusReadTool.ts` | `executeCountOnly`: replace `summary.total_count` override with `delete response.summary` |
| `tests/unit/tools/unified/OmniFocusReadTool.test.ts` | Renamed existing test to assert `summary` is absent; added `forecast_past + countOnly` coverage |

## Verification

- Pure host-side response shaping — no OmniFocus script change, no new seam
- `npm run build`: clean
- `npm run test:unit`: 3418/3418 passing (143 files)
- TDD: wrote failing tests first (2 red), then implemented fix (all green)

## Notes for reviewer

- No Zod schema changes → no `inputSchema` override update needed (dual-schema rule doesn't apply here)
- Both `{type:'tasks', countOnly:true}` and `mode:'forecast_past' + countOnly` route through the same `executeCountOnly` method; one fix covers both
- The pre-existing `summary.total_count` override comment is removed with the dead code

---

Parked for Kip's `/code-review` gate (CLAUDE.md workflow norms) — do not merge until reviewed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)