### PR TITLE
test(OMN-188): add expectOkData<T> helper; adopt at 4 analytics-validation sites

### DIFF
--- a/tests/integration/helpers/expect-ok.ts
+++ b/tests/integration/helpers/expect-ok.ts
@@ -17,7 +17,24 @@
  *   // After this call, TypeScript narrows updateResult.success to true.
  *
  * Do NOT use for negative-path assertions — those should keep using
- * `expect(result.success).toBe(false)`.
+ *   `expect(result.success).toBe(false)`.
+ *
+ * expectOkData — opt-in companion that asserts success AND returns the narrowed
+ * payload, collapsing the common three-step pattern:
+ *
+ *   expectOk(result, ctx);
+ *   expect(result.data).toBeDefined();   // no TS narrowing
+ *   result.data.task.taskId              // .data still possibly-undefined
+ *
+ * into a single call:
+ *
+ *   const data = expectOkData(result, ctx);
+ *   data.task.taskId                     // fully narrowed
+ *
+ * Use only when you immediately access the payload. Keep expectOk for cases
+ * where data access comes later or the test logic branches on shape.
+ *
+ * See OMN-188.
  */
 
 export interface ResultLike {
@@ -38,6 +55,36 @@ export function expectOk<T extends ResultLike>(result: T, context?: string): ass
 
   const errText = formatError((result as ResultLike).error);
   throw new Error(`${label}: expected success=true, got success=${String(result.success)} — error: ${errText}`);
+}
+
+/**
+ * Asserts success=true and returns the narrowed, non-null data payload.
+ *
+ * Reuses expectOk's diagnostic-rich success assertion, then verifies data is
+ * present. Throws with a clear message if success=true but data is null/undefined
+ * (an unexpected server contract violation).
+ *
+ * Generic design: `TResult` captures the whole result object so that
+ * `TResult['data']` extracts the data type. When `TResult` is `any` (the common
+ * case — `callTool` returns `any`), `any['data'] = any`, so
+ * `Exclude<any, null | undefined> = any` and the return type is transparent.
+ * When `TResult` is a concrete type the return is narrowed to the non-nullable
+ * data shape.
+ *
+ * @example
+ *   const data = expectOkData(result, 'productivity_stats');
+ *   expect(data.stats.overview.totalTasks).toBeGreaterThan(0);
+ */
+export function expectOkData<TResult extends { success: boolean; data?: unknown; error?: unknown }>(
+  result: TResult,
+  context?: string,
+): Exclude<TResult['data'], null | undefined> {
+  expectOk(result, context);
+  if (result.data == null) {
+    const label = context ? `expectOkData(${context})` : 'expectOkData';
+    throw new Error(`${label}: success=true but data is ${String(result.data)}`);
+  }
+  return result.data as Exclude<TResult['data'], null | undefined>;
 }
 
 function formatError(err: unknown): string {

--- a/tests/integration/validation/analytics-validation.test.ts
+++ b/tests/integration/validation/analytics-validation.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { getSharedClient } from '../helpers/shared-server.js';
 import { MCPTestClient } from '../helpers/mcp-test-client.js';
 import { runScopedTag } from '../helpers/run-id.js';
-import { expectOk } from '../helpers/expect-ok.js';
+import { expectOk, expectOkData } from '../helpers/expect-ok.js';
 
 describe('Analytics Validation - Actual Calculations', () => {
   let client: MCPTestClient;
@@ -111,28 +111,29 @@ describe('Analytics Validation - Actual Calculations', () => {
         },
       });
 
-      // ✅ Validate calculation is reasonable
-      expectOk(result, 'productivity_stats');
-      expect(result.data).toBeDefined();
+      // ✅ Validate calculation is reasonable — expectOkData asserts success AND
+      // returns the narrowed payload, replacing the two-step expectOk+toBeDefined
+      // that gave no TS narrowing on .data (OMN-188).
+      const statsData = expectOkData(result, 'productivity_stats');
 
       // Can't validate exact counts (other tasks may exist) but validate structure
-      expect(result.data.stats).toBeDefined();
-      expect(result.data.stats.overview).toBeDefined();
-      expect(typeof result.data.stats.overview.totalTasks).toBe('number');
-      expect(typeof result.data.stats.overview.completedTasks).toBe('number');
-      expect(typeof result.data.stats.overview.completionRate).toBe('number');
+      expect(statsData.stats).toBeDefined();
+      expect(statsData.stats.overview).toBeDefined();
+      expect(typeof statsData.stats.overview.totalTasks).toBe('number');
+      expect(typeof statsData.stats.overview.completedTasks).toBe('number');
+      expect(typeof statsData.stats.overview.completionRate).toBe('number');
 
       // Validate completionRate is a valid percentage (0-100 format)
-      expect(result.data.stats.overview.completionRate).toBeGreaterThanOrEqual(0);
-      expect(result.data.stats.overview.completionRate).toBeLessThanOrEqual(100);
+      expect(statsData.stats.overview.completionRate).toBeGreaterThanOrEqual(0);
+      expect(statsData.stats.overview.completionRate).toBeLessThanOrEqual(100);
 
       // Validate healthScore is calculated
-      expect(typeof result.data.healthScore).toBe('number');
-      expect(result.data.healthScore).toBeGreaterThanOrEqual(0);
-      expect(result.data.healthScore).toBeLessThanOrEqual(100);
+      expect(typeof statsData.healthScore).toBe('number');
+      expect(statsData.healthScore).toBeGreaterThanOrEqual(0);
+      expect(statsData.healthScore).toBeLessThanOrEqual(100);
 
       // Also validate non-zero stats (regression test for bug where all stats were 0)
-      expect(result.data.stats.overview.totalTasks).toBeGreaterThan(0);
+      expect(statsData.stats.overview.totalTasks).toBeGreaterThan(0);
     }, 150000); // 150s timeout: 5 creates + 3 completes + 1 query + 1 analytics = 10+ operations
   });
 
@@ -174,15 +175,15 @@ describe('Analytics Validation - Actual Calculations', () => {
         },
       });
 
-      // ✅ Validate analysis structure
-      expectOk(result, 'overdue_analysis');
-      expect(result.data).toBeDefined();
-      expect(result.data.stats).toBeDefined();
-      expect(result.data.stats.summary).toBeDefined();
+      // ✅ Validate analysis structure — expectOkData asserts success AND returns
+      // the narrowed payload (OMN-188).
+      const overdueData = expectOkData(result, 'overdue_analysis');
+      expect(overdueData.stats).toBeDefined();
+      expect(overdueData.stats.summary).toBeDefined();
 
       // Validate summary contains required fields
-      expect(typeof result.data.stats.summary.totalOverdue).toBe('number');
-      expect(typeof result.data.stats.summary.overduePercentage).toBe('number');
+      expect(typeof overdueData.stats.summary.totalOverdue).toBe('number');
+      expect(typeof overdueData.stats.summary.overduePercentage).toBe('number');
       // OMN-184: we seeded a 7-days-overdue task and expectOk above proves the
       // create succeeded. A successful create invalidates the analytics cache
       // (omnifocus_write create → CacheManager.invalidateForTaskChange, which
@@ -191,7 +192,7 @@ describe('Analytics Validation - Actual Calculations', () => {
       // the world that now contains our seed. The old `>= 0` accepted the empty
       // world a silent seed failure would have produced — the vacuous pass;
       // `>= 1` genuinely verifies the seeded task is counted.
-      expect(result.data.stats.summary.totalOverdue).toBeGreaterThanOrEqual(1);
+      expect(overdueData.stats.summary.totalOverdue).toBeGreaterThanOrEqual(1);
 
       // OMN-187: these were always-0/empty before the read-path fix — the tool
       // read v3 field names the script never emitted. With ≥1 real overdue task
@@ -199,10 +200,10 @@ describe('Analytics Validation - Actual Calculations', () => {
       // `if (overdueTasks.length > 0)` guard was dead code (the list was always
       // empty), so the per-task structure assertions never ran — the exact
       // "passes but validates nothing" class this file exists to catch.
-      expect(result.data.stats.summary.overduePercentage).toBeGreaterThan(0);
-      expect(result.data.stats.summary.averageDaysOverdue).toBeGreaterThan(0);
+      expect(overdueData.stats.summary.overduePercentage).toBeGreaterThan(0);
+      expect(overdueData.stats.summary.averageDaysOverdue).toBeGreaterThan(0);
 
-      const overdueTasks = result.data.stats.overdueTasks;
+      const overdueTasks = overdueData.stats.overdueTasks;
       expect(Array.isArray(overdueTasks)).toBe(true);
       expect(overdueTasks.length).toBeGreaterThanOrEqual(1);
 
@@ -245,16 +246,16 @@ describe('Analytics Validation - Actual Calculations', () => {
         },
       });
 
-      // ✅ Validate velocity structure
-      expectOk(velocityResult, 'task_velocity');
-      expect(velocityResult.data).toBeDefined();
-      expect(velocityResult.data.velocity).toBeDefined();
+      // ✅ Validate velocity structure — expectOkData asserts success AND returns
+      // the narrowed payload (OMN-188).
+      const velData = expectOkData(velocityResult, 'task_velocity');
+      expect(velData.velocity).toBeDefined();
 
       // Validate velocity contains required metrics
-      expect(typeof velocityResult.data.velocity.tasksCompleted).toBe('number');
-      expect(typeof velocityResult.data.velocity.averagePerDay).toBe('number');
-      expect(velocityResult.data.velocity.tasksCompleted).toBeGreaterThanOrEqual(0);
-      expect(velocityResult.data.velocity.averagePerDay).toBeGreaterThanOrEqual(0);
+      expect(typeof velData.velocity.tasksCompleted).toBe('number');
+      expect(typeof velData.velocity.averagePerDay).toBe('number');
+      expect(velData.velocity.tasksCompleted).toBeGreaterThanOrEqual(0);
+      expect(velData.velocity.averagePerDay).toBeGreaterThanOrEqual(0);
     }, 120000);
   });
 
@@ -280,23 +281,15 @@ describe('Analytics Validation - Actual Calculations', () => {
         },
       });
 
-      // OMN-140: assert tool success BEFORE touching nested data so a failed
-      // call surfaces its real error (expectOk reports result.error) instead of
-      // crashing with "Cannot read properties of undefined (reading 'stats')".
-      expectOk(productivityResult, 'cross-tool productivity_stats');
-      expectOk(velocityResult, 'cross-tool task_velocity');
-
-      // OMN-184: mirror the `.data` guard the other three blocks already have,
-      // so a success-but-empty envelope fails here rather than at the nested
-      // `.data.stats` / `.data.velocity` access. Normalizes the pattern by
-      // adding the assertion, not by dropping it elsewhere — diagnostic-rich
-      // failures are the cluster's intent (OMN-56/140).
-      expect(productivityResult.data).toBeDefined();
-      expect(velocityResult.data).toBeDefined();
+      // OMN-140/188: expectOkData is diagnostic-rich (OMN-56/140 intent) AND
+      // returns the narrowed payload, replacing the two-step expectOk+toBeDefined
+      // that gave no TS narrowing on .data.
+      const prodData = expectOkData(productivityResult, 'cross-tool productivity_stats');
+      const crossVelData = expectOkData(velocityResult, 'cross-tool task_velocity');
 
       // ✅ Both should report > 0 tasks (our test tasks + possibly others)
-      expect(productivityResult.data.stats.overview.totalTasks).toBeGreaterThan(0);
-      expect(velocityResult.data.velocity.tasksCompleted).toBeGreaterThanOrEqual(0);
+      expect(prodData.stats.overview.totalTasks).toBeGreaterThan(0);
+      expect(crossVelData.velocity.tasksCompleted).toBeGreaterThanOrEqual(0);
     }, 90000);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `expectOkData<TResult>` to `tests/integration/helpers/expect-ok.ts`: asserts `success=true` (via existing `expectOk`, diagnostic-rich per OMN-56) and returns the narrowed, non-null data payload in one call.
- Adopted at **4 sites** in `tests/integration/validation/analytics-validation.test.ts` (productivity_stats, overdue_analysis, task_velocity, cross-tool consistency) — the opt-in targets from OMN-188. No other `expectOk` call sites changed.
- No production source changes; test helpers only.

**Generic design rationale:** `TResult` captures the whole result object so `TResult['data']` extracts the payload type. When `TResult=any` (the common case — `callTool` returns `any`), `Exclude<any, null|undefined>=any` and the return is transparent. When `TResult` is a concrete type, the return is narrowed to the non-nullable data shape. This sidesteps TypeScript's inference-from-`any` edge case where `T` would otherwise collapse to `{}`.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run typecheck:test` (test tree: `tsc -p tsconfig.test.json --noEmit`) — clean
- [x] `npm run test:unit` — 143 files, 3417 tests, all pass

**Runtime not verified** — the natural verification is the live integration suite (`npm run test:integration`), which is Kip's gate per CLAUDE.md workflow norms. Integration tests require a live OmniFocus session and were not run.

---

Parked for Kip's `/code-review` gate (CLAUDE.md workflow norms) — do not merge until reviewed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)