### PR TITLE
feat(OMN-204): surface parse_meeting_notes pre-flight read failures in warnings[]

### DIFF
--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -284,7 +284,9 @@ ANALYSIS TYPES:
   The tool does a read-only pre-flight (resolves project names, dedupes against
   existing tasks, classifies tags existing-vs-new) and returns a batchPayload you
   send to omnifocus_write { batch } (try dryRun:true first). Set
-  validateAgainstExisting:false to skip the DB reads.
+  validateAgainstExisting:false to skip the DB reads. If a pre-flight read fails,
+  it is reported in warnings[] (validation may be incomplete) rather than silently
+  degrading to "nothing exists".
   FALLBACK: pass params.text (raw prose) and the heuristic extractor runs;
   un-parsed lines are surfaced in unparsed[]. Provide exactly one of items|text.
 - manage_reviews: Project review operations
@@ -2387,14 +2389,18 @@ SCOPE FILTERING:
 
       this.logger.info('Parsing structured meeting items', { count: items.length, validate });
 
+      // OMN-204: collect pre-flight read failures here instead of swallowing them.
+      // A failed read silently degrades to "nothing exists" (no projects/tags/dups),
+      // which looks like correct output — the OMN-125 silent-dedupe bug. Surface it.
+      const warnings: string[] = [];
       let existingProjects: string[] = [];
       let existingTags = new Set<string>();
       let existingTasks: Array<{ name: string; project: string | null }> = [];
       if (validate) {
         [existingProjects, existingTags, existingTasks] = await Promise.all([
-          this.fetchExistingProjectNames(),
-          this.fetchExistingTagNames(),
-          this.fetchExistingIncompleteTasks(),
+          this.fetchExistingProjectNames(warnings),
+          this.fetchExistingTagNames(warnings),
+          this.fetchExistingIncompleteTasks(warnings),
         ]);
       }
 
@@ -2442,11 +2448,19 @@ SCOPE FILTERING:
       ];
       const newTags = [...new Set(previewItems.flatMap((p) => p.tags.new))];
 
+      const baseNextSteps =
+        operations.length > 0
+          ? 'Review the preview (duplicateOf, project.match==="none", tags.new), then send batchPayload to omnifocus_write { mutation: { operation: "batch", operations } } — try dryRun:true first.'
+          : 'No items ready to create (all were duplicates). Review duplicateOf entries.';
+
       const result = {
         mode: 'structured' as const,
         // Strip the internal combinedTags helper from the surfaced shape.
         items: previewItems.map(({ combinedTags: _omit, ...rest }) => rest),
         unparsed: [] as string[],
+        // OMN-204: pre-flight read failures, surfaced rather than swallowed. Empty
+        // when validation is skipped or every read succeeded.
+        warnings,
         summary: {
           total: previewItems.length,
           readyToCreate: operations.length,
@@ -2457,12 +2471,13 @@ SCOPE FILTERING:
           newProjects: validate ? newProjects.length : null,
           newTags: validate ? newTags.length : null,
           unparsedCount: 0,
+          warnings: warnings.length,
         },
         batchPayload: { operations },
         nextSteps:
-          operations.length > 0
-            ? 'Review the preview (duplicateOf, project.match==="none", tags.new), then send batchPayload to omnifocus_write { mutation: { operation: "batch", operations } } — try dryRun:true first.'
-            : 'No items ready to create (all were duplicates). Review duplicateOf entries.',
+          warnings.length > 0
+            ? `⚠️ ${warnings.length} pre-flight read(s) failed (see warnings[]) — project/tag/dedupe validation may be incomplete; treat readyToCreate with caution. ${baseNextSteps}`
+            : baseNextSteps,
       };
 
       return createSuccessResponseV2('parse_meeting_notes', result, undefined, timer.toMetadata());
@@ -2555,20 +2570,26 @@ SCOPE FILTERING:
   }
 
   /** Read existing project names (lite, no stats). Returns [] on script error. */
-  private async fetchExistingProjectNames(): Promise<string[]> {
+  private async fetchExistingProjectNames(warnings: string[]): Promise<string[]> {
     const gen = buildFilteredProjectsScript({}, { limit: 1000, includeStats: false, performanceMode: 'lite' });
     const result = await this.execJson(gen.script, PROJECTS_LIST_SCHEMA);
-    if (!isScriptSuccess(result)) return [];
+    if (!isScriptSuccess(result)) {
+      warnings.push('project resolution unavailable: existing-projects read failed');
+      return [];
+    }
     return this.unwrapList(result.data, ['projects', 'items'])
       .map((p) => (p as { name?: unknown }).name)
       .filter((n): n is string => typeof n === 'string');
   }
 
-  /** Read existing tag names (basic mode). Returns empty set on script error. */
-  private async fetchExistingTagNames(): Promise<Set<string>> {
+  /** Read existing tag names (basic mode). Warns + returns empty set on script error. */
+  private async fetchExistingTagNames(warnings: string[]): Promise<Set<string>> {
     const gen = buildTagsScript({ mode: 'basic', includeEmpty: true, sortBy: 'name' });
     const result = await this.execJson(gen.script, TAG_ITEMS_SCHEMA);
-    if (!isScriptSuccess(result)) return new Set();
+    if (!isScriptSuccess(result)) {
+      warnings.push('tag classification unavailable: existing-tags read failed');
+      return new Set();
+    }
     const names = this.unwrapList(result.data, ['tags', 'items'])
       .map((t) => (typeof t === 'string' ? t : (t as { name?: unknown }).name))
       .filter((n): n is string => typeof n === 'string');
@@ -2576,7 +2597,9 @@ SCOPE FILTERING:
   }
 
   /** Read incomplete (not completed/dropped) tasks with their project name. */
-  private async fetchExistingIncompleteTasks(): Promise<Array<{ name: string; project: string | null }>> {
+  private async fetchExistingIncompleteTasks(
+    warnings: string[],
+  ): Promise<Array<{ name: string; project: string | null }>> {
     // Both terminal states excluded: a dropped task has completed===false, so
     // without dropped:false an abandoned task would false-positive as a duplicate.
     //
@@ -2598,7 +2621,10 @@ SCOPE FILTERING:
       limit: 2000,
     });
     const result = await this.execJson(script, TASKS_LIST_SCHEMA);
-    if (!isScriptSuccess(result)) return [];
+    if (!isScriptSuccess(result)) {
+      warnings.push('dedupe unavailable: incomplete-tasks read failed');
+      return [];
+    }
     return this.unwrapList(result.data, ['tasks', 'items'])
       .map((t) => {
         const rec = t as { name?: unknown; project?: unknown };

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2569,7 +2569,7 @@ SCOPE FILTERING:
     return data;
   }
 
-  /** Read existing project names (lite, no stats). Returns [] on script error. */
+  /** Read existing project names (lite, no stats). Warns + returns [] on script error (OMN-204). */
   private async fetchExistingProjectNames(warnings: string[]): Promise<string[]> {
     const gen = buildFilteredProjectsScript({}, { limit: 1000, includeStats: false, performanceMode: 'lite' });
     const result = await this.execJson(gen.script, PROJECTS_LIST_SCHEMA);
@@ -2596,7 +2596,7 @@ SCOPE FILTERING:
     return new Set(names);
   }
 
-  /** Read incomplete (not completed/dropped) tasks with their project name. */
+  /** Read incomplete (not completed/dropped) tasks with their project name. Warns + returns [] on script error (OMN-204). */
   private async fetchExistingIncompleteTasks(
     warnings: string[],
   ): Promise<Array<{ name: string; project: string | null }>> {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -957,6 +957,8 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(Array.isArray(res.data.warnings)).toBe(true);
         // names which pre-flight read failed; dedupe degradation is no longer silent
         expect(res.data.warnings.join(' ')).toMatch(/dedup|incomplete-tasks/i);
+        // summary.warnings count stays in lockstep with the surfaced array
+        expect(res.data.summary.warnings).toBe(res.data.warnings.length);
       });
 
       it('OMN-204: warnings[] is empty when every pre-flight read succeeds', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -3,7 +3,7 @@ import { OmniFocusAnalyzeTool } from '../../../../src/tools/unified/OmniFocusAna
 import { WriteSchema } from '../../../../src/tools/unified/schemas/write-schema.js';
 import { CacheManager } from '../../../../src/cache/CacheManager.js';
 import { OmniAutomation } from '../../../../src/omnifocus/OmniAutomation.js';
-import { createScriptSuccess } from '../../../../src/omnifocus/script-result-types.js';
+import { createScriptSuccess, createScriptError } from '../../../../src/omnifocus/script-result-types.js';
 
 vi.mock('../../../../src/cache/CacheManager.js', () => ({ CacheManager: vi.fn() }));
 vi.mock('../../../../src/omnifocus/OmniAutomation.js', () => ({ OmniAutomation: vi.fn() }));
@@ -932,6 +932,51 @@ describe('OmniFocusAnalyzeTool', () => {
         // Only the non-duplicate item is in the batch payload.
         expect(res.data.batchPayload.operations).toHaveLength(1);
         expect(res.data.batchPayload.operations[0].data.name).toBe('Buy lock');
+      });
+
+      it('OMN-204: surfaces a warnings[] when a pre-flight read fails (no silent degrade)', async () => {
+        // projects + tags succeed; the incomplete-tasks read FAILS. Pre-fix, the
+        // failure was swallowed (return []) → "no existing tasks → no duplicates",
+        // a silent false-negative. Post-fix: a warning is surfaced loudly.
+        const dbResponses = [
+          createScriptSuccess({ projects: [{ name: 'Hardware' }] }),
+          createScriptSuccess({ ok: true, v: 'ast', items: [] }),
+          createScriptError("Can't find variable: flattenedTasks", 'list_tasks'),
+        ];
+        let call = 0;
+        mockOmni.executeJson.mockImplementation(() => Promise.resolve(dbResponses[call++]));
+
+        const res: any = await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: { items: [{ name: 'Order scanners', project: 'Hardware' }] },
+          },
+        });
+
+        expect(res.success).toBe(true);
+        expect(Array.isArray(res.data.warnings)).toBe(true);
+        // names which pre-flight read failed; dedupe degradation is no longer silent
+        expect(res.data.warnings.join(' ')).toMatch(/dedup|incomplete-tasks/i);
+      });
+
+      it('OMN-204: warnings[] is empty when every pre-flight read succeeds', async () => {
+        const dbResponses = [
+          createScriptSuccess({ projects: [{ name: 'Hardware' }] }),
+          createScriptSuccess({ ok: true, v: 'ast', items: [] }),
+          createScriptSuccess({ tasks: [] }),
+        ];
+        let call = 0;
+        mockOmni.executeJson.mockImplementation(() => Promise.resolve(dbResponses[call++]));
+
+        const res: any = await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: { items: [{ name: 'Buy lock', project: 'Hardware' }] },
+          },
+        });
+
+        expect(res.success).toBe(true);
+        expect(res.data.warnings).toEqual([]);
       });
 
       it('on a partial project match, dedupes against the create target (requested), not the partial match', async () => {


### PR DESCRIPTION
## What
The parse_meeting_notes structured pre-flight runs three read-only DB scans (existing projects, tags, incomplete tasks). On a script failure each one **silently degraded to empty** — which reads as "nothing exists → no duplicates / no known tags", the silent false-negative behind the OMN-125 dedupe bug. This surfaces those failures in a `warnings[]` array instead.

## Change
- The three `fetchExisting*` helpers take a `warnings: string[]` param and push a specific message on `!isScriptSuccess` (e.g. `"dedupe unavailable: incomplete-tasks read failed"`) before returning the degraded-empty value.
- The structured response gains top-level `warnings[]` (empty when validation is skipped or all reads succeed), `summary.warnings` (count), and a loud `nextSteps` caveat when any read failed.
- Tool description documents the `warnings[]` surface.

## Scope / non-scope
- Carved from **OMN-126 #1**. The 2000-task dedup-cap revisit stays with parent **OMN-126** (plan-only).
- **No dual-schema change**: parse_meeting_notes has no response Zod schema / inputSchema response advertisement (response is unstructured), so adding `warnings[]` is purely additive — confirmed during the OMN-126 premise-check.

## Verification (local)
- New unit tests (mocked failed read; no live OmniFocus seam): a failed incomplete-tasks read surfaces a `warnings[]` entry; `warnings[]` is empty when all reads succeed.
- `npm run build` clean; `npm run test:unit` **144 files / 3454 tests pass, 0 failures**.

Spec: `Technical/specs/OMN-126-parse-meeting-notes-preflight.md` §4.1

Closes OMN-204

🤖 Generated with [Claude Code](https://claude.com/claude-code)