### PR TITLE
feat(OMN-198): expose sequential on task create (was silently dropped)

### DIFF
--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -300,6 +300,7 @@ export function lowerTaskCreate(
     deferDate: true,
     plannedDate: true,
     flagged: true,
+    sequential: true,
     estimatedMinutes: true,
     repetitionRule: true,
   };
@@ -345,6 +346,13 @@ export function lowerTaskCreate(
 
   statements.push(setProp(ref(names.taskVar), 'note', json(data.note || '')));
   statements.push(setProp(ref(names.taskVar), 'flagged', json(data.flagged || false)));
+
+  // OMN-198: action-group ordering. Only emitted when provided (no-op on leaf tasks
+  // in OmniFocus, so a childless create with sequential:true is harmless). Matches
+  // the update path (lowerUpdateScalars) and project-create's sequential setter.
+  if (data.sequential !== undefined) {
+    statements.push(setProp(ref(names.taskVar), 'sequential', json(data.sequential)));
+  }
 
   for (const field of ['dueDate', 'deferDate', 'plannedDate'] as const) {
     const value = data[field];

--- a/src/contracts/mutations.ts
+++ b/src/contracts/mutations.ts
@@ -149,6 +149,7 @@ export interface TaskCreateData {
   deferDate?: string;
   plannedDate?: string;
   flagged?: boolean;
+  sequential?: boolean; // Action-group ordering: meaningful on parent tasks; no-op on leaves (OMN-198)
   estimatedMinutes?: number;
   repetitionRule?: RepetitionRule;
 }

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -226,7 +226,7 @@ SAFETY:
       estimatedMinutes: { type: 'number', description: 'minutes (not "estimate")' },
       repetitionRule: { type: 'object' },
       folder: { type: 'string', description: 'project-only: name/path/ID; bad path errors; null→root (see desc)' },
-      sequential: { type: 'boolean', description: 'project-only' },
+      sequential: { type: 'boolean', description: 'projects + task action groups' },
       status: { type: 'string', description: 'project-only: active|on_hold|completed|dropped' },
       reviewInterval: { description: 'project-only: days or {steps,unit}' },
     };

--- a/tests/unit/contracts/ast/mutation/create-task.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-task.test.ts
@@ -24,6 +24,7 @@ const FULL_FIELD_DATA: TaskCreateData = {
   deferDate: '2026-06-10 08:00',
   plannedDate: '2026-06-11 12:00',
   flagged: true,
+  sequential: true,
   estimatedMinutes: 30,
   repetitionRule: { frequency: 'weekly', interval: 1 },
 };
@@ -183,6 +184,7 @@ describe('buildCreateTaskProgram', () => {
       'constructTask', // name + container
       'setProp', // note
       'setProp', // flagged
+      'setProp', // sequential (OMN-198)
       'setProp', // dueDate
       'setProp', // deferDate
       'setProp', // plannedDate
@@ -195,12 +197,27 @@ describe('buildCreateTaskProgram', () => {
     expect(props).toEqual([
       'note',
       'flagged',
+      'sequential',
       'dueDate',
       'deferDate',
       'plannedDate',
       'estimatedMinutes',
       'repetitionRule',
     ]);
+  });
+
+  // OMN-198: sequential lowers to a setProp on CREATE (was silently dropped — the
+  // field reached the tool bridge but TaskCreateData/lowerTaskCreate never emitted it).
+  it('sequential lowers to a setProp on create', () => {
+    const p = buildCreateTaskProgram({ name: 'Group', sequential: true });
+    const seq = p.statements.find((s) => s.type === 'setProp' && (s as any).prop === 'sequential') as any;
+    expect(seq).toBeDefined();
+    expect(emitProgram(p)).toContain('sequential = true');
+  });
+
+  it('omits the sequential setProp when not provided', () => {
+    const p = buildCreateTaskProgram({ name: 'Leaf' });
+    expect(p.statements.some((s) => s.type === 'setProp' && (s as any).prop === 'sequential')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What
Wires `sequential` (action-group ordering) through the task **create** path. Today `sequential` is accepted by the Zod `CreateDataSchema` and copied through the tool bridge, but `TaskCreateData` lacks the field and `lowerTaskCreate` never emits a setter — so **`sequential` on a task create is silently dropped** (a no-silent-failure violation). UPDATE was already fully wired.

## Change
- `src/contracts/mutations.ts`: add `sequential?: boolean` to `TaskCreateData`.
- `src/contracts/ast/mutation/defs.ts`: emit a conditional `setProp(sequential)` in `lowerTaskCreate` (after `flagged`) + add `sequential` to the compile-time exhaustiveness guard.
- `src/tools/unified/OmniFocusWriteTool.ts`: relabel the inputSchema `sequential` description from `'project-only'` → `'projects + task action groups'` (kept terse — the **4KB inputSchema budget** is enforced by a unit test, which caught a verbose first draft).

## Semantics (per OMN-198 decision)
Accept `sequential` always; it's a no-op on leaf tasks (OmniFocus ignores it on childless tasks), so no validation/rejection. Conditional emit keeps every existing minimal-create test unaffected.

## Verification (local)
- New unit tests: `sequential` lowers to a setProp on create; omitted when not provided; full-field order assertion updated to include it.
- `npm run build` clean; `npm run test:unit` **144 files / 3454 tests pass, 0 failures**.
- **Live `/verify` deferred to Kip** (spec §5): create a parent task with `sequential:true`, read-back-assert the action group respects ordering — this is the write seam the loop can't exercise.

Spec: `Technical/specs/OMN-198-sequential-task-ordering.md`

Closes OMN-198

🤖 Generated with [Claude Code](https://claude.com/claude-code)