### PR TITLE
feat(OMN-206): wire `sequential` through batch task create (parity with OMN-198)

### DIFF
--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -507,6 +507,7 @@ export interface BatchTaskSpec {
   deferDate?: string;
   plannedDate?: string;
   estimatedMinutes?: number;
+  sequential?: boolean; // Action-group ordering: meaningful on parent tasks; no-op on leaves (OMN-206, parity with OMN-198)
   parentTempId?: string;
   parentTaskId?: string;
   projectId?: string;

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -469,6 +469,7 @@ function toTaskCreateData(spec: BatchTaskSpec): TaskCreateData {
     deferDate: true,
     plannedDate: true,
     estimatedMinutes: true,
+    sequential: true,
     parentTempId: true,
     parentTaskId: true,
     projectId: true,
@@ -483,6 +484,9 @@ function toTaskCreateData(spec: BatchTaskSpec): TaskCreateData {
   if (spec.deferDate !== undefined) data.deferDate = spec.deferDate;
   if (spec.plannedDate !== undefined) data.plannedDate = spec.plannedDate;
   if (spec.estimatedMinutes !== undefined) data.estimatedMinutes = spec.estimatedMinutes;
+  // OMN-206: parity with the OMN-198 single-create fix — preserve an explicit
+  // false (!== undefined), so lowerTaskCreate emits the setProp.
+  if (spec.sequential !== undefined) data.sequential = spec.sequential;
   if (spec.parentTaskId !== undefined) data.parentTaskId = spec.parentTaskId;
   if (spec.projectId !== undefined) data.project = spec.projectId;
   return data;

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1868,6 +1868,9 @@ SAFETY:
       if (item.deferDate) spec.deferDate = localToUTC(item.deferDate, 'defer');
       if (item.plannedDate) spec.plannedDate = localToUTC(item.plannedDate, 'planned');
       if (item.estimatedMinutes !== undefined) spec.estimatedMinutes = item.estimatedMinutes;
+      // OMN-206: action-group ordering — parity with single-create. !== undefined
+      // preserves an explicit false (lowerTaskCreate emits the setProp only then).
+      if (item.sequential !== undefined) spec.sequential = item.sequential;
       // Container priority mirrors resolveBatchTaskParent, but parentTempId is
       // passed through verbatim — it is resolved inside the script, not here
       // (the parent has no real id yet at build time).
@@ -2088,6 +2091,10 @@ SAFETY:
       deferDate: item.deferDate ? localToUTC(item.deferDate, 'defer') : undefined,
       plannedDate: item.plannedDate ? localToUTC(item.plannedDate, 'planned') : undefined,
       estimatedMinutes: item.estimatedMinutes,
+      // OMN-206: action-group ordering. Direct passthrough (undefined when
+      // absent) — lowerTaskCreate emits the setProp only when !== undefined, so
+      // a leaf task stays a no-op. Parity with single-create + the fast path.
+      sequential: item.sequential,
       // OMN-128: lowered in-program by the AST builder (no post-create second
       // script); a repetition failure surfaces as an OMN-137 warning instead of
       // a silent log line. No date conversion — endDate stays YYYY-MM-DD.

--- a/tests/unit/contracts/ast/mutation/create-task-batch.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-task-batch.test.ts
@@ -157,6 +157,18 @@ describe('buildBatchCreateTasksProgram', () => {
     expect(item.statements.some((s) => s.type === 'setProp' && s.prop === 'sequential')).toBe(false);
   });
 
+  // OMN-206: an EXPLICIT false must still emit the setProp (sequential = false),
+  // NOT be coerced to "absent". This is the load-bearing reason toTaskCreateData
+  // uses `!== undefined` rather than a truthy check — making an action group
+  // parallel is a real user intent, distinct from "didn't say".
+  it('emits sequential = false on a batch spec when explicitly false', () => {
+    const p = build([{ tempId: 'g', name: 'Group', sequential: false }]);
+    const item = p.statements[1] as { type: string; statements: Array<{ type: string; prop?: string }> };
+    const seq = item.statements.find((s) => s.type === 'setProp' && s.prop === 'sequential');
+    expect(seq).toBeDefined();
+    expect(emitProgram(p)).toContain('sequential = false');
+  });
+
   it('duplicate tempId throws at build time', () => {
     expect(() =>
       build([

--- a/tests/unit/contracts/ast/mutation/create-task-batch.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-task-batch.test.ts
@@ -138,6 +138,25 @@ describe('buildBatchCreateTasksProgram', () => {
     expect(out).not.toContain('byTempId');
   });
 
+  // OMN-206: sequential (action-group ordering) carries through the batch fast
+  // path (buildBatchCreateTasksProgram → toTaskCreateData → lowerTaskCreate),
+  // parity with the OMN-198 single-create fix. Was silently dropped because
+  // BatchTaskSpec had no sequential field and toTaskCreateData never mapped it.
+  it('sequential:true on a batch spec lowers to a setProp inside the item', () => {
+    const p = build([{ tempId: 'g', name: 'Group', sequential: true }]);
+    const item = p.statements[1] as { type: string; statements: Array<{ type: string; prop?: string }> };
+    expect(item.type).toBe('batchItem');
+    const seq = item.statements.find((s) => s.type === 'setProp' && s.prop === 'sequential');
+    expect(seq).toBeDefined();
+    expect(emitProgram(p)).toContain('sequential = true');
+  });
+
+  it('omits the sequential setProp on a batch spec when not provided', () => {
+    const p = build([{ tempId: 'leaf', name: 'Leaf' }]);
+    const item = p.statements[1] as { type: string; statements: Array<{ type: string; prop?: string }> };
+    expect(item.statements.some((s) => s.type === 'setProp' && s.prop === 'sequential')).toBe(false);
+  });
+
   it('duplicate tempId throws at build time', () => {
     expect(() =>
       build([

--- a/tests/unit/tools/batch/batch-create-project-field.test.ts
+++ b/tests/unit/tools/batch/batch-create-project-field.test.ts
@@ -69,6 +69,91 @@ describe('Batch create project field', () => {
     spy.mockRestore();
   });
 
+  // OMN-206: sequential (action-group ordering) must reach the fast-path spec,
+  // parity with the OMN-198 single-create fix. Was silently dropped — the
+  // fast-path item→spec map omitted it and BatchTaskSpec had no field for it.
+  it('should pass sequential to the batch-create fast path when provided (OMN-206)', async () => {
+    const cache = new StubCache();
+    const tool = new OmniFocusWriteTool(cache as any);
+
+    const spy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+      script: 'mock script',
+      operation: 'create',
+      target: 'task',
+      description: 'mock',
+    });
+
+    vi.spyOn(tool as any, 'execJson').mockResolvedValue({
+      success: true,
+      data: { results: [{ tempId: 'grp', taskId: 'new-group-id', success: true }] },
+    });
+
+    await tool.execute({
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'grp', name: 'Sequential group', sequential: true },
+          },
+        ],
+      },
+    });
+
+    expect(spy).toHaveBeenCalledOnce();
+    const specs = spy.mock.calls[0][0];
+    expect(specs[0]).toHaveProperty('sequential', true);
+
+    spy.mockRestore();
+  });
+
+  // OMN-206: a repetitionRule makes the batch fast-path-ineligible, so the item
+  // takes the per-item path (createBatchTask → buildCreateTaskScript). sequential
+  // must survive that route too.
+  it('should pass sequential to the per-item path (repetitionRule forces it) (OMN-206)', async () => {
+    const cache = new StubCache();
+    const tool = new OmniFocusWriteTool(cache as any);
+
+    const taskSpy = vi.spyOn(scriptBuilder, 'buildCreateTaskScript').mockResolvedValue({
+      script: 'mock script',
+      operation: 'create',
+      target: 'task',
+      description: 'mock',
+    });
+
+    vi.spyOn(tool as any, 'execJson').mockResolvedValue({
+      success: true,
+      data: { results: [{ tempId: 'grp', taskId: 'new-group-id', success: true }] },
+    });
+
+    await tool.execute({
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'grp',
+              name: 'Sequential repeating group',
+              sequential: true,
+              repetitionRule: { frequency: 'weekly', interval: 1 },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(taskSpy).toHaveBeenCalledOnce();
+    const taskData = taskSpy.mock.calls[0][0];
+    expect(taskData).toHaveProperty('sequential', true);
+
+    taskSpy.mockRestore();
+  });
+
   it('should prefer parentTempId over project field when both present', async () => {
     const cache = new StubCache();
     const tool = new OmniFocusWriteTool(cache as any);

--- a/tests/unit/tools/batch/batch-create-project-field.test.ts
+++ b/tests/unit/tools/batch/batch-create-project-field.test.ts
@@ -109,6 +109,47 @@ describe('Batch create project field', () => {
     spy.mockRestore();
   });
 
+  // OMN-206: an EXPLICIT false must survive to the fast-path spec (parallel
+  // action group is a real intent), NOT be coerced away. Guards the fast path's
+  // `!== undefined` check against a regression to a truthy `if (item.sequential)`,
+  // which would silently drop false and make toHaveProperty fail.
+  it('should pass sequential:false (not drop it) to the batch-create fast path (OMN-206)', async () => {
+    const cache = new StubCache();
+    const tool = new OmniFocusWriteTool(cache as any);
+
+    const spy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+      script: 'mock script',
+      operation: 'create',
+      target: 'task',
+      description: 'mock',
+    });
+
+    vi.spyOn(tool as any, 'execJson').mockResolvedValue({
+      success: true,
+      data: { results: [{ tempId: 'grp', taskId: 'new-group-id', success: true }] },
+    });
+
+    await tool.execute({
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'grp', name: 'Parallel group', sequential: false },
+          },
+        ],
+      },
+    });
+
+    expect(spy).toHaveBeenCalledOnce();
+    const specs = spy.mock.calls[0][0];
+    expect(specs[0]).toHaveProperty('sequential', false);
+
+    spy.mockRestore();
+  });
+
   // OMN-206: a repetitionRule makes the batch fast-path-ineligible, so the item
   // takes the per-item path (createBatchTask → buildCreateTaskScript). sequential
   // must survive that route too.


### PR DESCRIPTION
## What

Closes the sibling silent-drop found while reviewing #141 (OMN-198). OMN-198 wired `sequential` through **single** task create and widened the shared inputSchema description from `'project-only'` → `'projects + task action groups'`. The **batch** task-create path still silently dropped `sequential`, so that widened description over-claimed for batch creates.

## The drop

`BatchItemDataSchema` extends `CreateDataSchema`, so it **accepts** `sequential` on every batch item. For **task** items it was then discarded in both live routes:
- **fast path** (`executeBatchCreatesFastPath`) — the `item`→`BatchTaskSpec` map omitted it, and `BatchTaskSpec` had no field for it;
- **per-item path** (`createBatchTask`, taken when a `repetitionRule` or mixed project+task makes the batch fast-path-ineligible) — the inline `taskData` omitted it.

`createBatchProject` already read `item.sequential`, which is why projects worked and tasks didn't. Net: a batch-created sequential parent became a flat/parallel group with **no error and no warning** — the same no-silent-failure violation OMN-198 exists to kill.

## Change (parity-driven, +116 lines, additive)

- `BatchTaskSpec`: add `sequential?: boolean`.
- `toTaskCreateData`: add `sequential` to the `_exhaustive` compile guard (the compiler forces it) and map it.
- `executeBatchCreatesFastPath` + `createBatchTask`: carry `item.sequential`.

`!== undefined` gating throughout preserves an explicit `sequential:false` (parity with single-create `handleTaskCreate` and the update path `lowerUpdateScalars`). `lowerTaskCreate` still emits the setProp only when provided, so leaf tasks stay a no-op.

## Tests (TDD — watched each fail first)

- **AST** (`create-task-batch.test.ts`): a batch spec with `sequential:true` lowers to a setProp inside the item; omitted → no setProp.
- **Tool** (`batch-create-project-field.test.ts`): `sequential` reaches the fast-path spec; and the per-item path (forced via a `repetitionRule`) too.

Full unit suite green (3458), build clean (validates the new `_exhaustive` key), lint 0 errors.

## Stacking & verification

- **Stacks on #141** (OMN-198) — it depends on `TaskCreateData.sequential` + the `lowerTaskCreate` emit. Base is `main`, so until #141 squash-merges this PR's diff also shows #141's changes; I'll rebase onto main after #141 lands to isolate the delta.
- **Live verify owed post-merge**: confirm a batch create with `sequential:true` persists action-group ordering on the parent against prod MCP (the OMN-206 acceptance criterion). Unit coverage proves the field reaches the builder on both routes; the OmniFocus-persistence check is the post-deploy step.

Found by: `/code-review high 141` (2026-06-19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)