### PR TITLE
refactor(OMN-205): dedup task/project mutation result schemas via entityResult helper

### DIFF
--- a/src/omnifocus/response-schemas/write.ts
+++ b/src/omnifocus/response-schemas/write.ts
@@ -166,6 +166,22 @@ const TaskUpdateResult = z
 export const TaskWriteResultSchema = z.union([TaskCreateResult, TaskUpdateResult]);
 
 /**
+ * Task-or-project entity result (OMN-205): a strict union where exactly one of
+ * taskId/projectId identifies the entity, alongside a shared `name` and the
+ * caller-supplied per-operation fields. Backs CompleteResultSchema and
+ * DeleteResultSchema, which previously hand-rolled the same two-variant shape.
+ *
+ * Note: there is NO error branch — these are success-only payloads (the error
+ * dialect lives in the tool layer, see BulkDeleteResultSchema), so this is a
+ * task/project identity union, not a success+error envelope.
+ */
+const entityResult = <T extends z.ZodRawShape>(extra: T) =>
+  z.union([
+    z.object({ taskId: z.string(), name: z.string(), ...extra }).strict(),
+    z.object({ projectId: z.string(), name: z.string(), ...extra }).strict(),
+  ]);
+
+/**
  * Complete result — task or project variant.
  *
  * Source-verified against src/contracts/ast/mutation/defs.ts (lowerComplete):
@@ -174,24 +190,10 @@ export const TaskWriteResultSchema = z.union([TaskCreateResult, TaskUpdateResult
  *
  * Union: one of taskId OR projectId required (each variant strict).
  */
-export const CompleteResultSchema = z.union([
-  z
-    .object({
-      taskId: z.string(),
-      name: z.string(),
-      completed: z.literal(true),
-      completionDate: isoDateOrNull,
-    })
-    .strict(),
-  z
-    .object({
-      projectId: z.string(),
-      name: z.string(),
-      completed: z.literal(true),
-      completionDate: isoDateOrNull,
-    })
-    .strict(),
-]);
+export const CompleteResultSchema = entityResult({
+  completed: z.literal(true),
+  completionDate: isoDateOrNull,
+});
 
 /**
  * Delete result — task or project variant.
@@ -200,22 +202,9 @@ export const CompleteResultSchema = z.union([
  *  - task variant:    {taskId,    name, deleted: true}
  *  - project variant: {projectId, name, deleted: true}
  */
-export const DeleteResultSchema = z.union([
-  z
-    .object({
-      taskId: z.string(),
-      name: z.string(),
-      deleted: z.literal(true),
-    })
-    .strict(),
-  z
-    .object({
-      projectId: z.string(),
-      name: z.string(),
-      deleted: z.literal(true),
-    })
-    .strict(),
-]);
+export const DeleteResultSchema = entityResult({
+  deleted: z.literal(true),
+});
 
 /**
  * Bulk task delete result.

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -3,10 +3,13 @@
  * All definitions live in src/omnifocus/response-schemas/{common,read,analyze,write}.ts.
  * Import sites continue to import from this file — the public surface is unchanged.
  *
- * Rule: re-export ONLY the original 47 public names (44 value schemas + 3 inferred
- * types). The 3 newly-exported helpers
- * in common.ts (isoDate, isoDateOrNull, warningsArray) are NOT re-exported here;
- * they were private before and are consumed only by the domain modules.
+ * Rule: re-export ONLY names that were public before the OMN-169 split. The
+ * three helpers added to common.ts during that split (isoDate, isoDateOrNull,
+ * warningsArray) are NOT re-exported here — they were private before and are
+ * consumed only by the domain modules. (No hardcoded export count: it rotted
+ * silently once already — read "43" while the true total was 47 — because
+ * nothing guards the number. The boundary rule above is the invariant; the
+ * count is not.)
  */
 
 // ---------------------------------------------------------------------------

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -3,7 +3,8 @@
  * All definitions live in src/omnifocus/response-schemas/{common,read,analyze,write}.ts.
  * Import sites continue to import from this file — the public surface is unchanged.
  *
- * Rule: re-export ONLY the original 43 public names. The 3 newly-exported helpers
+ * Rule: re-export ONLY the original 47 public names (44 value schemas + 3 inferred
+ * types). The 3 newly-exported helpers
  * in common.ts (isoDate, isoDateOrNull, warningsArray) are NOT re-exported here;
  * they were private before and are consumed only by the domain modules.
  */


### PR DESCRIPTION
## Summary

Dedup the two hand-rolled task-or-project mutation result schemas in
`src/omnifocus/response-schemas/write.ts` behind a small `entityResult(extra)`
helper, and correct a stale count in the barrel comment.

`CompleteResultSchema` and `DeleteResultSchema` both encoded the same shape: a
strict union where exactly one of `taskId`/`projectId` identifies the entity,
plus a shared `name` and per-operation fields. `entityResult` factors that
repeated union; each call supplies only its operation-specific fields
(`completed`/`completionDate` vs `deleted`). The result is **behavior- and
type-identical** — same strict per-variant validation, same inferred types —
at net **-10 lines**.

## Scope note — the original ticket premise was wrong

OMN-205 was filed as a "shared success+error envelope" factoring / "export
reduction." That premise does **not** hold: these are **success-only payloads**
— the error dialect lives in the tool layer (see `BulkDeleteResultSchema`), so
there is no shared success+error envelope to extract. The real, useful change is
just the task/project identity-union dedup. The public export count is
**unchanged at 47** (44 value schemas + 3 inferred types); this is not an export
reduction. The helper's doc comment records this explicitly to prevent the wrong
mental model from recurring.

The 10-variant `TagMutationResultSchema` was **deliberately left alone** — its
per-variant comments are source-verified and worth more than the compression.

## Barrel comment fix

`script-response-schemas.ts` claimed "43 public names." The true count is **47**
(44 value schemas via `export {…}` + 3 inferred types via `export type {…}`).
Corrected, with the breakdown spelled out.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (17 pre-existing warnings, none in touched files)
- `npm run test:unit` — **3452/3452 passed**, including `complete.test.ts` and
  `delete.test.ts` which validate the exact schemas refactored here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
