### PR TITLE
fix(OMN-200): workflow_analysis scans the full task DB (uncap) — fixes understated percentages

### DIFF
--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -39,7 +39,7 @@ export const WORKFLOW_ANALYSIS_V3 = `
       const nowTime = now.getTime();
 
       // Extract options in JXA context to pass to OmniJS
-      const analysisDepth = options.analysisDepth || 'standard';
+      const analysisDepth = options.analysisDepth || 'full'; // OMN-200: full-DB is the only mode now
       const focusAreas = options.focusAreas || ['productivity', 'workload', 'bottlenecks'];
       const maxInsights = options.maxInsights || 15;
       const includeRawData = options.includeRawData || false;
@@ -135,7 +135,14 @@ export const WORKFLOW_ANALYSIS_V3 = `
           const totalTasks = allTasks.length;
           const totalProjects = allProjects.length;
 
-          const maxTasksToProcess = analysisDepth === 'deep' ? totalTasks : Math.min(1000, totalTasks);
+          // OMN-200: always iterate the full task DB. The old cap processed only
+          // the first 1000 tasks (a biased DB-order prefix) while totalTasks stayed
+          // full, so every workflowMetrics.*Percentage divided a capped numerator by
+          // the full denominator — a systematic ~2.5x understatement. With the loop
+          // full-population, numerator and denominator agree and the percentages are
+          // correct with no separate math change. The 'deep' escape hatch was dead
+          // code (analysisDepth was hardcoded 'standard', never 'deep').
+          const maxTasksToProcess = totalTasks;
 
           for (let i = 0; i < maxTasksToProcess; i++) {
             const task = allTasks[i];

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -1906,7 +1906,10 @@ SCOPE FILTERING:
     const wfLogger = createLogger('workflow_analysis');
 
     try {
-      const analysisDepth = 'standard';
+      // OMN-200: 'full' — workflow_analysis always scans the entire task DB (the
+      // 1000-task cap and its unreachable 'deep' branch were removed). The label is
+      // informational only; it no longer gates any behavior.
+      const analysisDepth = 'full';
       const focusAreas = ['productivity', 'workload', 'bottlenecks'];
       const maxInsights = 15;
       const includeRawData = false;

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -295,7 +295,7 @@ ANALYSIS TYPES:
 
 PERFORMANCE WARNINGS:
 - pattern_analysis on 1000+ items: ~5-10 seconds
-- workflow_analysis: ~3-5 seconds for comprehensive
+- workflow_analysis: ~20-45s — scans the ENTIRE task database (no cap); scales with DB size
 - Most others: <1 second with caching
 
 SCOPE FILTERING:
@@ -2005,12 +2005,16 @@ SCOPE FILTERING:
       wfLogger.error('Workflow analysis failed', error);
       const errorMessage = error instanceof Error ? error.message : String(error);
 
-      let suggestion = 'Try reducing analysis depth or focus areas';
+      // OMN-200: suggestions are actionable. analysisDepth and focusAreas are not
+      // user-configurable (both hardcoded; the old 'quick'/'standard'/'deep' knob
+      // never existed on this tool), so don't tell users to tune them.
+      let suggestion = 'Retry; if it persists, your task database may be very large or OmniFocus may be busy';
       let errorCode = 'EXECUTION_ERROR';
 
       if (errorMessage.includes('timeout') || errorMessage.includes('timed out')) {
         errorCode = 'SCRIPT_TIMEOUT';
-        suggestion = 'Try using "quick" analysis depth or reduce the focus areas for faster results';
+        suggestion =
+          'workflow_analysis scans the entire task database and exceeded the 120s script timeout — your DB may be unusually large. Retry, and report it if it recurs so the per-task loop can be profiled';
       } else if (errorMessage.includes('not running') || errorMessage.includes("can't find process")) {
         errorCode = 'OMNIFOCUS_NOT_RUNNING';
         suggestion = 'Start OmniFocus and ensure it is running';

--- a/tests/unit/omnifocus/script-response-schemas.test.ts
+++ b/tests/unit/omnifocus/script-response-schemas.test.ts
@@ -2581,7 +2581,7 @@ describe('WORKFLOW_ANALYSIS_V3_SCHEMA', () => {
       analysisTime: 1200,
       dataPoints: 200,
       metadata: {
-        analysisDepth: 'standard',
+        analysisDepth: 'full', // OMN-200: full-DB scan is the only mode now
         focusAreas: ['productivity', 'workload'],
         maxInsights: 15,
         method: 'omnijs_v3_single_bridge',

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -550,7 +550,9 @@ describe('OmniFocusAnalyzeTool', () => {
         analysis: { type: 'workflow_analysis' },
       });
       expect(res.success).toBe(true);
-      expect(res.data.analysis.depth).toBe('standard');
+      // OMN-200: depth is now reported as 'full' — the analysis always scans the
+      // entire task DB (the 1000-cap + its dead 'deep' escape hatch were removed).
+      expect(res.data.analysis.depth).toBe('full');
       expect(Array.isArray(res.summary.key_findings)).toBe(true);
     });
 
@@ -593,6 +595,17 @@ describe('OmniFocusAnalyzeTool', () => {
       // Completed inbox tasks (2-minute rule) should not inflate inboxPercentage
       expect(source).toMatch(/if \(inInbox && !completed\) totalInboxTasks/);
       expect(source).not.toMatch(/if \(inInbox\) totalInboxTasks/);
+    });
+
+    it('OMN-200: processes the full task DB — no 1000-cap, no dead deep ternary', async () => {
+      const fs = await import('fs');
+      const source = fs.readFileSync('src/omnifocus/scripts/analytics/workflow-analysis-v3.ts', 'utf-8');
+      // The per-task loop must iterate every task: a capped numerator over a full
+      // `totalTasks` denominator was a ~2.5x understatement of every *Percentage.
+      expect(source).toMatch(/const maxTasksToProcess = totalTasks;/);
+      // The cap and its unreachable 'deep' escape hatch are gone.
+      expect(source).not.toMatch(/Math\.min\(1000/);
+      expect(source).not.toMatch(/analysisDepth === 'deep'/);
     });
   });
 


### PR DESCRIPTION
## Summary

`workflow_analysis` was **understating every percentage metric ~2.5×** and undercounting. Its per-task loop was capped at the first 1000 tasks (`Math.min(1000, totalTasks)`), but `totalTasks` stayed the full DB — so each `workflowMetrics.*Percentage` divided a **capped numerator** by the **full denominator**.

Live evidence (prod `255ed36e`, same DB/moment): `workflow_analysis` reported **24 overdue / overduePercentage 0.9%**; the authoritative `analyze_overdue` reported **56 overdue** (true rate 56/2572 ≈ **2.2%**).

The `analysisDepth === 'deep'` escape hatch that would have scanned the full DB was **dead code** — `analysisDepth` is hardcoded `'standard'`, never `'deep'`, so there was no way to get an accurate workflow analysis.

## Fix (option A from the ticket — recommended)

One-line core change in `workflow-analysis-v3.ts`:
```diff
- const maxTasksToProcess = analysisDepth === 'deep' ? totalTasks : Math.min(1000, totalTasks);
+ const maxTasksToProcess = totalTasks;
```
With the loop full-population, numerator and denominator agree, so **all `*Percentage` fields become correct with no separate math change**. `dataPoints` now honestly equals `totalTasks`.

`analysisDepth` is **relabeled `'full'`** (Kip's call) — it now gates nothing, so the metadata honestly reports a full-DB scan. Kept in the response object, so the validated `WorkflowAnalysisDataSchema` is **unchanged** (no contract change).

## Latency

Default script timeout is **120s** (`OmniAutomation.ts`); the ticket's full-DB estimate is **~40s** (standard/1000-task run measured 16.2s) — comfortably within budget, **no timeout risk**. Per the ticket, real full-DB time is measured in the live probe; if it lands near/over ~40s I'll file a perf follow-up (out of scope here — correctness-first).

## Tests

The runtime logic is generated OmniJS (CI-blind). Added a **CI-guardable source assertion** that the cap and the dead `'deep'` ternary are gone and the loop is full-population; flipped the depth assertion to `'full'`; refreshed one schema fixture. `typecheck` clean · `build` clean · `lint` 0 errors · `test:unit` **3463/3463**.

## ⚠️ Mandatory live verify (post-merge + redeploy — CI cannot exercise this)

1. `workflow_analysis` runs clean (no script error from the uncapped loop) and **measure real full-DB time**.
2. `workflowMetrics.overduePercentage` ≈ `analyze_overdue`'s true rate (the 0.9%→~2.2%, 24→56 correction).
3. Spot-check a `workloadDistribution.byProject` count against a direct `omnifocus_read` of that project.

Percentages will shift **upward** once the denominators agree — expected, not a regression.

## Spotted follow-up (not in this PR)

`tests/integration/test-workflow-analysis-performance.ts` is stale dead code — it calls the defunct `life_analysis` tool (pre-unified-API) and its summary asserts the now-false "Processes 1000+ tasks in under 2 seconds… No optimization needed." Worth deleting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
