### PR TITLE
fix(OMN-209): rank workflow_analysis deferralDetails by deferral magnitude

### DIFF
--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -812,7 +812,8 @@ export const WORKFLOW_ANALYSIS_V3 = `
             problematicDeferrals: problematicDeferrals,
             strategicRate: totalTasks > 0 ? round1(strategicDeferrals / totalTasks * 100) : 0,
             problematicRate: totalTasks > 0 ? round1(problematicDeferrals / totalTasks * 100) : 0,
-            deferralDetails: deferredTaskDetails.slice(0, 10) // Top 10 for analysis
+            // True "Top 10": rank by deferral magnitude (longest defer first), not DB iteration order
+            deferralDetails: deferredTaskDetails.slice().sort(function(a, b) { return b.deferDays - a.deferDays; }).slice(0, 10)
           };
 
           return JSON.stringify({


### PR DESCRIPTION
Follow-up from OMN-200 (#145) code review. Fixes [OMN-209](https://linear.app/omnifocus-mcp/issue/OMN-209/workflow-analysis-deferraldetails-top-10-is-db-order-not-ranked-by).

## Problem

In `workflow-analysis-v3.ts`, `deferredTaskDetails` is `push`ed in `flattenedTasks` iteration order, so `deferredTaskDetails.slice(0, 10) // Top 10` returned the **first 10 deferred tasks encountered** — an arbitrary DB-order prefix, not a ranking. The field name and comment ("Top 10") asserted a contract the code never enforced.

OMN-200 removed the 1000-task cap, so the loop now iterates the full DB, changing *which* 10 surface and making the mislabel more visible.

## Fix

Picked the "rank it" option over "relabel it" — it makes the field both honest *and* more useful (longest-deferred tasks are the ones worth flagging for problematic-deferral analysis).

```js
// before
deferralDetails: deferredTaskDetails.slice(0, 10) // Top 10 for analysis
// after
deferralDetails: deferredTaskDetails.slice().sort(function(a, b) { return b.deferDays - a.deferDays; }).slice(0, 10)
```

- `.slice()` before `.sort()` — `sort` mutates in place; copy-then-sort avoids reordering the source array for any later reader.
- ES5 `function` syntax matches the surrounding JXA/OmniJS script-body style (this code ships as a string and runs in OmniFocus's automation runtime).

## Verification

- `npm run build` — clean
- 282 tests pass across `script-response-schemas.test.ts` + `OmniFocusAnalyzeTool.test.ts` (no test asserted deferral ordering; behavior-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)