### PR TITLE
docs(OMN-39): spell out HTTP transport's cleartext/no-TLS security gap

### DIFF
--- a/docs/user/HTTP-TRANSPORT.md
+++ b/docs/user/HTTP-TRANSPORT.md
@@ -261,7 +261,7 @@ server provides only the former:
   Wi-Fi, a compromised router — can read the token and your task data off the wire, and replay the token to impersonate
   you.
 
-**A token alone is not transport security.** Treat it as a lock on the door, not as walls around the room.
+**A token alone is not transport security.**
 
 ### Safe deployment: wrap HTTP in an encrypted tunnel
 
@@ -276,6 +276,12 @@ this server does not:
 
 **Do not** expose the HTTP port directly to the public internet or to an untrusted LAN, even with `MCP_AUTH_TOKEN` set.
 Without a VPN there is no transport encryption, so the token and your data are exposed regardless.
+
+**Mind the defaults — they are not safe out of the box.** `--host` defaults to `0.0.0.0` (every network interface, not
+just localhost), and authentication is **off unless you set `MCP_AUTH_TOKEN`**. So a bare `node dist/index.js --http`
+already listens on your LAN with no token required. A safe setup is an active choice: bind `--host 127.0.0.1` for
+same-machine use, or keep the port reachable only inside your tailnet/firewall, and always set a token for remote
+access.
 
 ### Checklist
 

--- a/docs/user/HTTP-TRANSPORT.md
+++ b/docs/user/HTTP-TRANSPORT.md
@@ -252,10 +252,37 @@ Normal. HTTP creates sessions per connection; they auto-cleanup after 30 minutes
 
 ## Security
 
-1. **Use authentication** (`MCP_AUTH_TOKEN`) for remote access
-2. **Use Tailscale/VPN** instead of public internet exposure
-3. **Bind to localhost** for same-machine only: `--host 127.0.0.1`
-4. **Strong tokens:** `openssl rand -hex 32`
+HTTP transport sends requests over **plain HTTP — there is no built-in TLS/encryption.** Both the bearer token and your
+OmniFocus data travel across the network in cleartext. Authentication and encryption are separate concerns, and this
+server provides only the former:
+
+- The `MCP_AUTH_TOKEN` bearer token **authenticates** requests (proves the caller knows the secret).
+- It does **not encrypt** them. Anyone who can observe the network path — another host on an untrusted LAN, public
+  Wi-Fi, a compromised router — can read the token and your task data off the wire, and replay the token to impersonate
+  you.
+
+**A token alone is not transport security.** Treat it as a lock on the door, not as walls around the room.
+
+### Safe deployment: wrap HTTP in an encrypted tunnel
+
+Run the HTTP transport only over a network you fully trust, or wrap it in a VPN that supplies the transport encryption
+this server does not:
+
+- **Recommended — Tailscale (WireGuard):** the [Tailscale setup above](#secure-setup-with-tailscale) encrypts the entire
+  tunnel end-to-end, so the cleartext HTTP inside it is protected. Bearer token + plain HTTP **inside** a Tailscale
+  tunnel is the supported secure configuration.
+- **Local-only:** bind to localhost (`--host 127.0.0.1`) when the client runs on the same machine — nothing leaves the
+  host.
+
+**Do not** expose the HTTP port directly to the public internet or to an untrusted LAN, even with `MCP_AUTH_TOKEN` set.
+Without a VPN there is no transport encryption, so the token and your data are exposed regardless.
+
+### Checklist
+
+1. **Use a VPN/Tailscale** (or a fully trusted LAN) — never raw HTTP over an untrusted network.
+2. **Always set `MCP_AUTH_TOKEN`** for any remote access.
+3. **Bind to localhost** (`--host 127.0.0.1`) for same-machine-only use.
+4. **Use strong tokens:** `openssl rand -hex 32`.
 
 ## stdio vs HTTP
 


### PR DESCRIPTION
## Summary

Implements **OMN-39 Option 3**: makes the HTTP transport's security gap explicit in the user docs instead of adding TLS.

The HTTP transport speaks plain `node:http` (no TLS), so the `MCP_AUTH_TOKEN` bearer token and all task data travel in cleartext. The old Security section recommended Tailscale but never explained *why* it's load-bearing. This expands `docs/user/HTTP-TRANSPORT.md` to:

- State plainly there is no transport encryption; **auth ≠ encryption** (the token is sniffable and replayable on an untrusted network).
- Document **Tailscale (WireGuard) as the supported secure config** — the tunnel supplies the encryption the server doesn't, so bearer-token + plain HTTP *inside* the tunnel is fine.
- Warn against exposing the port to the public internet / an untrusted LAN even with a token set.
- Fold the existing 4 tips into a checklist.

## Why docs-only (not TLS)

OMN-39 was deprioritized because the intended deployment is Windows-client → Mac-server over Tailscale, where WireGuard already encrypts the tunnel. Option 1 (built-in TLS) and Option 2 (refuse auth over plain HTTP) were deferred; Option 3 (document the gap) is this PR.

## Scope / safety

- Docs-only, **+32/−4** in `docs/user/HTTP-TRANSPORT.md`. No code paths touched.
- Uses only stable anchors (commands, an in-doc link) per the version-pin rule; the `claude-md-paths` guard only covers `CLAUDE.md`, so it's unaffected.

Closes **OMN-39** (disposition: documented, not TLS) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)