### PR TITLE
refactor(OMN-215): extract emitTextCondition; unify the task-side emitter

### DIFF
--- a/src/contracts/ast/emitters/omnijs.ts
+++ b/src/contracts/ast/emitters/omnijs.ts
@@ -9,6 +9,7 @@
 
 import type { FilterNode, ComparisonNode, ExistsNode, ComparisonOperator } from '../types.js';
 import { SYNTHETIC_FIELD_MAP } from '../types.js';
+import { emitTextCondition } from '../text-condition.js';
 
 /**
  * Result of emitting a filter node to OmniJS code.
@@ -122,18 +123,19 @@ export function emitOmniJS(ast: FilterNode): EmitResult {
         break;
 
       case 'includes':
-        predicate = `${accessor}.toLowerCase().includes(${emitValue(value)}.toLowerCase())`;
+        // OMN-215: delegate to the shared emitter (single source of truth across
+        // the string-codegen and AST-emit layers). The term is lowercased at
+        // codegen time — `includes("home")`, not the older runtime-lowercase
+        // `includes("Home".toLowerCase())` form. Behaviourally identical.
+        predicate = emitTextCondition(accessor, String(value));
         break;
 
       case 'matches':
-        // OMN-149: the pattern crosses into generated code ONLY as a JSON
-        // string literal. A regex literal (`/${pattern}/i`) raw-interpolates
-        // user data — a pattern containing `/` breaks the script, and a
-        // crafted pattern can inject code into the predicate. This is the same
-        // injection-safe form as the canonical folderTextCondition() in
-        // filter-generator.ts, but an INDEPENDENT copy (this emitter does not
-        // delegate) — keep the two in sync by hand until unified (OMN-215).
-        predicate = `new RegExp(${JSON.stringify(String(value))}, 'i').test(${accessor})`;
+        // OMN-149: the pattern crosses into generated code ONLY as a JSON string
+        // literal (the shared emitter enforces this) — never a raw regex literal,
+        // which would let a `/` break the script or inject code. OMN-215: same
+        // canonical emitter as project/folder/tag filters.
+        predicate = emitTextCondition(accessor, String(value), 'MATCHES');
         break;
 
       case 'some':

--- a/src/contracts/ast/filter-generator.ts
+++ b/src/contracts/ast/filter-generator.ts
@@ -27,6 +27,7 @@ import { buildAST } from './builder.js';
 import { validateFilterAST, type ValidationResult } from './validator.js';
 import { emitOmniJS, type EmitResult } from './emitters/omnijs.js';
 import { emitFolderPathMatch } from './folder-path-match.js';
+import { emitTextCondition } from './text-condition.js';
 
 // =============================================================================
 // TYPES
@@ -264,12 +265,12 @@ const PROJECT_STATUS_MAP: Record<ProjectStatus, string> = {
 
 /**
  * Emit one case-insensitive match condition against a project string field.
- * Thin wrapper over the shared {@link folderTextCondition} emitter (single
- * source of truth for the CONTAINS-lowercase / MATCHES-regexp strategy) — it
- * only supplies the null-guarded `project.<field>` accessor (OMN-213).
+ * Thin wrapper over the shared {@link emitTextCondition} emitter (single source
+ * of truth for the CONTAINS-lowercase / MATCHES-regexp strategy) — it only
+ * supplies the null-guarded `project.<field>` accessor (OMN-213).
  */
 function projectTextCondition(field: 'name' | 'note', term: string, operator?: TextOperator): string {
-  return folderTextCondition(`(project.${field} || '')`, term, operator);
+  return emitTextCondition(`(project.${field} || '')`, term, operator);
 }
 
 /**
@@ -421,22 +422,6 @@ export function describeProjectFilter(filter: ProjectFilter): string {
 // =============================================================================
 
 /**
- * Emit one case-insensitive match condition against an arbitrary OmniJS string
- * accessor. CONTAINS lowercases both sides; MATCHES compiles to a RegExp test.
- * The term is injected via JSON.stringify only — never raw interpolation
- * (OMN-149-safe). Single source of truth for project-, folder-, and tag-name
- * text filters: callers supply the accessor and delegate here —
- * {@link projectTextCondition} in this file, and the tags-side tag builder via
- * this exported symbol (OMN-213/214).
- */
-export function folderTextCondition(accessor: string, term: string, operator?: TextOperator): string {
-  if (operator === 'MATCHES') {
-    return `new RegExp(${JSON.stringify(term)}, 'i').test(${accessor})`;
-  }
-  return `${accessor}.toLowerCase().includes(${JSON.stringify(term.toLowerCase())})`;
-}
-
-/**
  * Generate OmniJS filter code for a FolderFilter (OMN-170 S2). Operates on the
  * OmniJS `folder` object inside buildFilteredFoldersScript. Direct code
  * generation (no AST), mirroring generateProjectFilterCode.
@@ -448,13 +433,13 @@ export function generateFolderFilterCode(filter: FolderFilter): string {
 
   // Name search — name ONLY (folders have no note).
   if (filter.name) {
-    conditions.push(`(${folderTextCondition("(folder.name || '')", filter.name, filter.nameOperator)})`);
+    conditions.push(`(${emitTextCondition("(folder.name || '')", filter.name, filter.nameOperator)})`);
   }
 
   // Parent folder name (case-insensitive substring), null-guarded. CONTAINS-only
   // (no parentName operator), so the shared emitter's default branch applies (OMN-213).
   if (filter.parentName) {
-    conditions.push(`(folder.parent && ${folderTextCondition("(folder.parent.name || '')", filter.parentName)})`);
+    conditions.push(`(folder.parent && ${emitTextCondition("(folder.parent.name || '')", filter.parentName)})`);
   }
 
   // Top-level only — no containing parent folder.

--- a/src/contracts/ast/tag-script-builder.ts
+++ b/src/contracts/ast/tag-script-builder.ts
@@ -15,7 +15,7 @@
 
 import type { TagQueryOptions, TagSortBy } from '../tag-options.js';
 import type { TextOperator } from '../filters.js';
-import { folderTextCondition } from './filter-generator.js';
+import { emitTextCondition } from './text-condition.js';
 import type { GeneratedScript } from './script-builder.js';
 
 // =============================================================================
@@ -88,12 +88,12 @@ const TAG_PARENT_ID_EXPR = 'parent ? parent.id.primaryKey : null';
  * OMN-170 S2: emit a safe case-insensitive tag-name match predicate (OMN-149
  * pattern — term injected via JSON.stringify only). Returns 'true' (match all)
  * when no name filter is present. Delegates the CONTAINS/MATCHES strategy to the
- * canonical folderTextCondition emitter — single source of truth shared with
- * project- and folder-name filters (OMN-214).
+ * shared {@link emitTextCondition} emitter — single source of truth shared with
+ * project-, folder-, and task-name filters (OMN-214/215).
  */
 function tagNamePredicate(name?: string, operator?: TextOperator): string {
   if (!name) return 'true';
-  return folderTextCondition("(tag.name || '')", name, operator);
+  return emitTextCondition("(tag.name || '')", name, operator);
 }
 
 /**

--- a/src/contracts/ast/text-condition.ts
+++ b/src/contracts/ast/text-condition.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared OmniJS text-condition emitter (OMN-213/214/215).
+ *
+ * Single source of truth for the case-insensitive CONTAINS / safe-RegExp MATCHES
+ * strategy, shared across BOTH codegen layers so they can never silently diverge:
+ *   - the direct string codegen in `filter-generator.ts` (project/folder/tag name filters)
+ *   - the AST emitter in `emitters/omnijs.ts` (task name/note filters)
+ *
+ * This is a leaf module (it imports only the TextOperator type) so both of those
+ * modules can import it without forming the `filter-generator` ↔ `emitters/omnijs`
+ * import cycle that previously blocked the task emitter from delegating.
+ */
+
+import type { TextOperator } from '../filters.js';
+
+/**
+ * Emit one case-insensitive match condition against an arbitrary OmniJS string
+ * accessor. CONTAINS lowercases the accessor at runtime and the term at codegen
+ * time (so the term crosses as a plain lowercased literal); MATCHES compiles to a
+ * case-insensitive RegExp test. The term is injected via JSON.stringify only —
+ * never raw interpolation (OMN-149-safe: a `/` or backtick in the term stays inert).
+ */
+export function emitTextCondition(accessor: string, term: string, operator?: TextOperator): string {
+  if (operator === 'MATCHES') {
+    return `new RegExp(${JSON.stringify(term)}, 'i').test(${accessor})`;
+  }
+  return `${accessor}.toLowerCase().includes(${JSON.stringify(term.toLowerCase())})`;
+}

--- a/tests/unit/contracts/ast/emitters/omnijs.test.ts
+++ b/tests/unit/contracts/ast/emitters/omnijs.test.ts
@@ -76,7 +76,9 @@ describe('emitOmniJS', () => {
         value: 'review',
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, 'task.name.toLowerCase().includes("review".toLowerCase())');
+      // OMN-215: term lowercased at codegen time (shared emitTextCondition form),
+      // not the older runtime `"review".toLowerCase()`. Behaviourally identical.
+      expectPredicate(code, 'task.name.toLowerCase().includes("review")');
     });
 
     it('emits regex match via RegExp constructor (OMN-149: pattern is JSON-escaped, never a raw literal)', () => {
@@ -424,7 +426,8 @@ describe('emitOmniJS', () => {
         value: 'important',
       };
       const code = emitOmniJS(ast);
-      expectPredicate(code, 'task.note.toLowerCase().includes("important".toLowerCase())');
+      // OMN-215: codegen-time lowercasing (shared emitTextCondition form).
+      expectPredicate(code, 'task.note.toLowerCase().includes("important")');
     });
 
     it('emits regex match for note field via RegExp constructor (OMN-149)', () => {

--- a/tests/unit/contracts/ast/text-condition.test.ts
+++ b/tests/unit/contracts/ast/text-condition.test.ts
@@ -1,0 +1,66 @@
+/**
+ * OMN-215 — shared text-condition emitter (`src/contracts/ast/text-condition.ts`).
+ *
+ * Single source of truth for the case-insensitive CONTAINS / safe-RegExp MATCHES
+ * strategy across BOTH codegen layers: the direct string codegen in
+ * filter-generator.ts (project/folder/tag name filters) AND the AST emitter in
+ * emitters/omnijs.ts (task name/note filters). This module is the leaf both sides
+ * import — extracting it broke the filter-generator ↔ omnijs import cycle that
+ * blocked delegating the task emitter (OMN-213/214 unified the string-codegen
+ * surfaces; OMN-215 brings the AST emitter in).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { emitTextCondition } from '../../../../src/contracts/ast/text-condition.js';
+
+describe('emitTextCondition — CONTAINS (default operator)', () => {
+  it('lowercases the accessor at runtime and the term at codegen', () => {
+    expect(emitTextCondition("(x.name || '')", 'Home')).toBe('(x.name || \'\').toLowerCase().includes("home")');
+  });
+
+  it('treats an explicit CONTAINS operator the same as the default', () => {
+    expect(emitTextCondition('acc', 'Work', 'CONTAINS')).toBe(emitTextCondition('acc', 'Work'));
+  });
+
+  it('lowercases a mixed-case term to a single codegen-time literal', () => {
+    expect(emitTextCondition('acc', 'HeLLo')).toContain('includes("hello")');
+  });
+
+  it('injects the term as a JSON string literal, never raw (injection-safe)', () => {
+    // A term with a quote/backslash must round-trip through JSON.stringify.
+    const code = emitTextCondition('acc', 'a"b\\c');
+    expect(code).toContain(JSON.stringify('a"b\\c'.toLowerCase()));
+    expect(() => new Function(`return ${code};`)).not.toThrow();
+  });
+});
+
+describe('emitTextCondition — MATCHES', () => {
+  it('compiles to a case-insensitive RegExp test against the accessor', () => {
+    expect(emitTextCondition("(x.name || '')", '^Home$', 'MATCHES')).toBe(
+      'new RegExp("^Home$", \'i\').test((x.name || \'\'))',
+    );
+  });
+
+  it('injects the pattern as a JSON string literal, never a raw regex literal (OMN-149)', () => {
+    // A pattern containing `/` must not break out into a regex literal.
+    const code = emitTextCondition('acc', 'a/b', 'MATCHES');
+    expect(code).toContain(JSON.stringify('a/b'));
+    expect(code).not.toContain('/a/b/');
+    expect(() => new Function(`return ${code};`)).not.toThrow();
+  });
+
+  it('introduces no backtick of its own (no template literals in the generated code)', () => {
+    // A backtick-free term must yield backtick-free output — the emitter never
+    // wraps anything in a template literal (would break JXA → OmniJS interpolation).
+    expect(emitTextCondition('acc', 'Development : Web', 'MATCHES').includes('`')).toBe(false);
+    expect(emitTextCondition('acc', 'Development : Web').includes('`')).toBe(false);
+  });
+
+  it('keeps a backtick IN THE TERM inert — it rides inside the JSON string literal (OMN-129)', () => {
+    // The backtick is present but harmless: it lives inside a double-quoted JSON
+    // string, not a template literal, so the generated code still parses.
+    const code = emitTextCondition('acc', 'a`b');
+    expect(code).toContain('includes("a`b")');
+    expect(() => new Function(`return ${code};`)).not.toThrow();
+  });
+});

--- a/tests/unit/contracts/ast/text-condition.test.ts
+++ b/tests/unit/contracts/ast/text-condition.test.ts
@@ -19,7 +19,11 @@ describe('emitTextCondition — CONTAINS (default operator)', () => {
   });
 
   it('treats an explicit CONTAINS operator the same as the default', () => {
-    expect(emitTextCondition('acc', 'Work', 'CONTAINS')).toBe(emitTextCondition('acc', 'Work'));
+    const explicit = emitTextCondition('acc', 'Work', 'CONTAINS');
+    // Pin the concrete output (not just symmetry with the default — a bug that made
+    // both return the same wrong string would otherwise pass).
+    expect(explicit).toBe('acc.toLowerCase().includes("work")');
+    expect(explicit).toBe(emitTextCondition('acc', 'Work'));
   });
 
   it('lowercases a mixed-case term to a single codegen-time literal', () => {
@@ -37,7 +41,7 @@ describe('emitTextCondition — CONTAINS (default operator)', () => {
 describe('emitTextCondition — MATCHES', () => {
   it('compiles to a case-insensitive RegExp test against the accessor', () => {
     expect(emitTextCondition("(x.name || '')", '^Home$', 'MATCHES')).toBe(
-      'new RegExp("^Home$", \'i\').test((x.name || \'\'))',
+      "new RegExp(\"^Home$\", 'i').test((x.name || ''))",
     );
   });
 


### PR DESCRIPTION
## Summary

Closes the DRY thread (OMN-213 → 214 → 215): **project, folder, tag, AND task** text filters now share ONE canonical CONTAINS/MATCHES emitter.

The task-side AST emitter (`emitters/omnijs.ts`) was the 4th independent copy. It could **not** simply delegate to `folderTextCondition` — `filter-generator.ts` imports `emitOmniJS` from `emitters/omnijs.ts`, so the reverse import would close a cycle. **The layering forces extraction:** the canonical emitter moves to a new leaf module `src/contracts/ast/text-condition.ts` (`emitTextCondition`), imported by `filter-generator`, `tag-script-builder`, AND `omnijs`. This also drops the folder-scoped name — the "misleading name" finding the OMN-213/214 reviews deferred here.

## ⚠️ Not byte-identical — this one needs a redeploy + live-verify

Unlike OMN-213/214 (byte-identical, no redeploy), this **changes the generated task-query predicate**:

| | before | after |
|---|---|---|
| task CONTAINS | `task.name.toLowerCase().includes("Review".toLowerCase())` | `task.name.toLowerCase().includes("review")` |

The term is now lowercased at **codegen** time instead of **runtime**. **Behaviourally identical** (same case-insensitive match), but it's a generated-output change on the hot task-query seam → **redeploy + live-verify task name/note search before closing.** MATCHES is byte-identical. The two omnijs CONTAINS test pins were updated accordingly.

## Test

New `text-condition.test.ts` directly exercises `emitTextCondition` (CONTAINS, MATCHES, codegen-lowercasing, injection-safety) — mirrors `folder-path-match.test.ts`. This is genuinely new coverage of the shared primitive.

**No cross-layer parity test** (the ticket suggested one): post-extraction both layers delegate to `emitTextCondition`, so a cross-layer comparison would be tautological (the OMN-214 lesson). The primitive's direct test + each layer's own output pins are the honest coverage.

## Verification

- `npm run build` clean
- `tsc -p tsconfig.test.json --noEmit` clean (OMN-176 gate)
- **3482 unit tests pass** (+8 from the new module test); no golden/snapshot ripple
- Zero remaining `folderTextCondition` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)