### PR TITLE
refactor(OMN-199): add { summary: false } opt-out to V2 response builders

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -660,7 +660,6 @@ PERFORMANCE:
         filter_description: data.filter_description,
         warning: data.warning,
       },
-      undefined,
       { summary: false },
     );
   }
@@ -781,7 +780,6 @@ PERFORMANCE:
         operation: 'list',
         mode: 'id_lookup',
       },
-      undefined,
       { summary: false },
     ) as unknown as Record<string, unknown>;
 
@@ -820,7 +818,7 @@ PERFORMANCE:
     // folders carry total_folders as their headline metric (mirrors the row path).
     if (entityType === 'folders') metadata.total_folders = population;
 
-    return createListResponseV2(entityType, [], entityType, metadata, undefined, { summary: false });
+    return createListResponseV2(entityType, [], entityType, metadata, { summary: false });
   }
 
   /**
@@ -920,8 +918,7 @@ PERFORMANCE:
           from_cache: true,
           operation: 'list',
         },
-        { population: cached.totalMatched },
-        { summary: !isNarrowLookup },
+        { population: cached.totalMatched, summary: !isNarrowLookup },
       ) as unknown as Record<string, unknown>;
 
       // Post-hoc field projection (always applied for thin-by-default)
@@ -967,8 +964,7 @@ PERFORMANCE:
         from_cache: false,
         operation: 'list',
       },
-      { population: totalMatched },
-      { summary: !isNarrowLookup },
+      { population: totalMatched, summary: !isNarrowLookup },
     ) as unknown as Record<string, unknown>;
 
     // Post-hoc field projection (always applied for thin-by-default)

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -633,35 +633,36 @@ PERFORMANCE:
       filters_applied?: Record<string, unknown>;
     };
     const count = data.count ?? 0;
-    const response = createTaskResponseV2('tasks', [], {
-      ...timer.toMetadata(),
-      from_cache: false,
-      mode: mode || 'count_only',
-      count_only: true,
-      total_count: count,
-      // OMN-190: surface the script's honest echo (the EFFECTIVE filter incl.
-      // auto-injected completed/dropped/project-root defaults), which the count
-      // script computes alongside filter_description. Rebuilding from countFilter
-      // here would re-introduce the very contradiction OMN-190 fixed — countFilter
-      // lacks the defaults, so filters_applied:{} would disagree with a
-      // filter_description that names three exclusions. The real count script
-      // always emits the echo; the countFilter fallback only fires for partial
-      // test mocks (CountResultSchema's z.unknown() field is optional-by-default,
-      // so a missing key parses as undefined rather than failing validation).
-      filters_applied: data.filters_applied ?? stripNormalizedBrand(countFilter),
-      optimization: data.optimization || 'ast_omnijs_bridge',
-      filter_description: data.filter_description,
-      warning: data.warning,
-    });
-
-    // OMN-195: drop summary entirely (matching the OMN-174 convention for
-    // projects/tags/folders). generateTaskSummary([]) produces a breakdown
-    // where every field is 0, which contradicts total_count and actively
-    // misleads LLMs ("breakdown.overdue:0" alongside "total_count:67").
-    // metadata.total_count is the single authoritative answer.
-    delete response.summary;
-
-    return response;
+    // OMN-195/OMN-199: suppress the summary (matching the OMN-174 convention for
+    // projects/tags/folders). generateTaskSummary([]) would produce an all-zero
+    // breakdown contradicting total_count; metadata.total_count is the single
+    // authoritative answer for a count-only result.
+    return createTaskResponseV2(
+      'tasks',
+      [],
+      {
+        ...timer.toMetadata(),
+        from_cache: false,
+        mode: mode || 'count_only',
+        count_only: true,
+        total_count: count,
+        // OMN-190: surface the script's honest echo (the EFFECTIVE filter incl.
+        // auto-injected completed/dropped/project-root defaults), which the count
+        // script computes alongside filter_description. Rebuilding from countFilter
+        // here would re-introduce the very contradiction OMN-190 fixed — countFilter
+        // lacks the defaults, so filters_applied:{} would disagree with a
+        // filter_description that names three exclusions. The real count script
+        // always emits the echo; the countFilter fallback only fires for partial
+        // test mocks (CountResultSchema's z.unknown() field is optional-by-default,
+        // so a missing key parses as undefined rather than failing validation).
+        filters_applied: data.filters_applied ?? stripNormalizedBrand(countFilter),
+        optimization: data.optimization || 'ast_omnijs_bridge',
+        filter_description: data.filter_description,
+        warning: data.warning,
+      },
+      undefined,
+      { summary: false },
+    );
   }
 
   private async executeIdLookup(
@@ -769,15 +770,20 @@ PERFORMANCE:
       );
     }
 
-    const listResult = createListResponseV2('projects', projects, 'projects', {
-      ...timer.toMetadata(),
-      from_cache: false,
-      operation: 'list',
-      mode: 'id_lookup',
-    }) as unknown as Record<string, unknown>;
-
-    // Narrow lookup — strip the dashboard-style summary (matches OMN-19 rule).
-    delete listResult.summary;
+    // Narrow lookup — suppress the dashboard-style summary (OMN-19 rule, OMN-199).
+    const listResult = createListResponseV2(
+      'projects',
+      projects,
+      'projects',
+      {
+        ...timer.toMetadata(),
+        from_cache: false,
+        operation: 'list',
+        mode: 'id_lookup',
+      },
+      undefined,
+      { summary: false },
+    ) as unknown as Record<string, unknown>;
 
     return projectFieldsOnResult(listResult, fields);
   }
@@ -792,10 +798,10 @@ PERFORMANCE:
    * `0 < population → truncated` and emit a false "Showing 0 of N (truncated)"
    * notice. A count-only result is row-less by design, not a truncated row set.
    *
-   * The summary block is dropped: createListResponseV2 builds a projects summary
-   * from the (empty) rows, so its breakdown (active/on_hold/completed/…) would all
-   * be 0 and contradict total_count (e.g. active:0 alongside total_count:183). A
-   * count is a single number, not a dashboard — metadata.total_count is the answer.
+   * The summary block is suppressed (OMN-199 `{ summary: false }`): an all-zero
+   * breakdown built from the empty rows (active/on_hold/completed/…) would
+   * contradict total_count (e.g. active:0 alongside total_count:183). A count is a
+   * single number, not a dashboard — metadata.total_count is the answer.
    * Mirrors the narrow-lookup summary suppression in handleProjectQuery.
    */
   private buildCountOnlyResponse(
@@ -814,9 +820,7 @@ PERFORMANCE:
     // folders carry total_folders as their headline metric (mirrors the row path).
     if (entityType === 'folders') metadata.total_folders = population;
 
-    const response = createListResponseV2(entityType, [], entityType, metadata) as unknown as Record<string, unknown>;
-    delete response.summary;
-    return response;
+    return createListResponseV2(entityType, [], entityType, metadata, undefined, { summary: false });
   }
 
   /**
@@ -917,9 +921,8 @@ PERFORMANCE:
           operation: 'list',
         },
         { population: cached.totalMatched },
+        { summary: !isNarrowLookup },
       ) as unknown as Record<string, unknown>;
-
-      if (isNarrowLookup) delete cacheResult.summary;
 
       // Post-hoc field projection (always applied for thin-by-default)
       return projectFieldsOnResult(cacheResult, effectiveFields);
@@ -965,9 +968,8 @@ PERFORMANCE:
         operation: 'list',
       },
       { population: totalMatched },
+      { summary: !isNarrowLookup },
     ) as unknown as Record<string, unknown>;
-
-    if (isNarrowLookup) delete listResult.summary;
 
     // Post-hoc field projection (always applied for thin-by-default)
     return projectFieldsOnResult(listResult, effectiveFields);

--- a/src/utils/response-format.ts
+++ b/src/utils/response-format.ts
@@ -102,6 +102,17 @@ export interface CountHonestyInput {
 }
 
 /**
+ * OMN-199: options for the V2 list/task response builders. Combines the
+ * count-honesty inputs (population/offset) with `summary` control in a single
+ * trailing bag, so a caller wanting only summary suppression never has to pass an
+ * `undefined` tombstone for counts just to reach a separate opts parameter.
+ */
+export interface ResponseListOptions extends CountHonestyInput {
+  /** Default true. When false, suppress dashboard-summary generation at the source. */
+  summary?: boolean;
+}
+
+/**
  * OMN-154 R1/R2/R3: make headline counts report the population and truncation
  * unmistakable. Mutates the already-built response IN PLACE, after the
  * metadata spread — population is authoritative over caller metadata.
@@ -577,11 +588,13 @@ export function createListResponseV2<T>(
   items: T[],
   itemType: 'tasks' | 'projects' | 'tags' | 'folders' | 'other',
   metadata: Partial<StandardMetadataV2> = {},
-  counts?: CountHonestyInput,
-  // OMN-199: `summary: false` suppresses summary generation at the source so
-  // count-only / narrow-lookup callers no longer build-then-delete it (which
-  // risked leaking the misleading all-zero summary from an empty row set).
-  opts?: { summary?: boolean },
+  // OMN-199: count-honesty inputs (population/offset) and summary suppression
+  // share ONE options bag so callers never thread an `undefined` tombstone past
+  // counts to reach summary control. `summary: false` suppresses summary
+  // generation at the source so count-only / narrow-lookup callers no longer
+  // build-then-delete it (which risked leaking the misleading all-zero summary
+  // from an empty row set).
+  opts?: ResponseListOptions,
 ): StandardResponseV2<Record<string, T[]>> {
   // Generate summary based on item type
   const includeSummary = opts?.summary !== false;
@@ -599,6 +612,9 @@ export function createListResponseV2<T>(
 
   const response: StandardResponseV2<Record<string, T[]>> = {
     success: true,
+    // OMN-199: omit the `summary` key entirely (vs `summary: undefined`) when no
+    // summary was generated — this includes the tags/folders/'other' item types,
+    // which never produce one, so `'summary' in response` is false for them.
     ...(summary && { summary }),
     data: {
       [dataKey]: items,
@@ -619,7 +635,7 @@ export function createListResponseV2<T>(
   if (itemType === 'projects' || itemType === 'folders') {
     noun = itemType;
   }
-  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, noun);
+  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, opts, noun);
   return response;
 }
 
@@ -680,9 +696,9 @@ export function createTaskResponseV2<T>(
   operation: string,
   tasks: T[],
   metadata: Partial<StandardMetadataV2> = {},
-  counts?: CountHonestyInput,
-  // OMN-199: see createListResponseV2 — `summary: false` omits the summary.
-  opts?: { summary?: boolean },
+  // OMN-199: see createListResponseV2 — one options bag carries count-honesty
+  // (population/offset) and summary suppression. `summary: false` omits the summary.
+  opts?: ResponseListOptions,
 ): StandardResponseV2<{ tasks: T[] }> {
   const includeSummary = opts?.summary !== false;
   const summary = includeSummary ? generateTaskSummary(tasks as unknown[]) : undefined;
@@ -717,7 +733,7 @@ export function createTaskResponseV2<T>(
     },
   };
 
-  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, counts, 'tasks');
+  applyCountHonesty(response as { summary?: Record<string, unknown>; metadata: StandardMetadataV2 }, opts, 'tasks');
   return response;
 }
 

--- a/src/utils/response-format.ts
+++ b/src/utils/response-format.ts
@@ -576,13 +576,19 @@ export function createListResponseV2<T>(
   itemType: 'tasks' | 'projects' | 'tags' | 'folders' | 'other',
   metadata: Partial<StandardMetadataV2> = {},
   counts?: CountHonestyInput,
+  // OMN-199: `summary: false` suppresses summary generation at the source so
+  // count-only / narrow-lookup callers no longer build-then-delete it (which
+  // risked leaking the misleading all-zero summary from an empty row set).
+  opts?: { summary?: boolean },
 ): StandardResponseV2<Record<string, T[]>> {
   // Generate summary based on item type
   let summary: TaskSummary | ProjectSummary | undefined;
-  if (itemType === 'tasks') {
-    summary = generateTaskSummary(items as unknown[]);
-  } else if (itemType === 'projects') {
-    summary = generateProjectSummary(items as unknown[]);
+  if (opts?.summary !== false) {
+    if (itemType === 'tasks') {
+      summary = generateTaskSummary(items as unknown[]);
+    } else if (itemType === 'projects') {
+      summary = generateProjectSummary(items as unknown[]);
+    }
   }
 
   // Use entity-specific key, fallback to 'items' for 'other'
@@ -590,7 +596,7 @@ export function createListResponseV2<T>(
 
   const response: StandardResponseV2<Record<string, T[]>> = {
     success: true,
-    summary,
+    ...(summary && { summary }),
     data: {
       [dataKey]: items,
     },
@@ -672,8 +678,10 @@ export function createTaskResponseV2<T>(
   tasks: T[],
   metadata: Partial<StandardMetadataV2> = {},
   counts?: CountHonestyInput,
+  // OMN-199: see createListResponseV2 — `summary: false` omits the summary.
+  opts?: { summary?: boolean },
 ): StandardResponseV2<{ tasks: T[] }> {
-  const summary = generateTaskSummary(tasks as unknown[]);
+  const summary = opts?.summary === false ? undefined : generateTaskSummary(tasks as unknown[]);
 
   // Apply truncation
   const { data: truncatedTasks, truncation } = truncateResponse(tasks);
@@ -681,13 +689,13 @@ export function createTaskResponseV2<T>(
   // Invariant (OMN-42): summary.returned_count must equal data.tasks.length.
   // Truncation reduces the returned set, so the summary count must follow.
   // total_count stays at the pre-truncation length to communicate the full dataset.
-  if (truncation?.truncated) {
+  if (summary && truncation?.truncated) {
     summary.returned_count = truncatedTasks.length;
   }
 
   const response: StandardResponseV2<{ tasks: T[] }> = {
     success: true,
-    summary,
+    ...(summary && { summary }),
     data: {
       tasks: truncatedTasks,
     },

--- a/src/utils/response-format.ts
+++ b/src/utils/response-format.ts
@@ -479,7 +479,9 @@ export function createSuccessResponseV2<T>(
 ): StandardResponseV2<T> {
   return {
     success: true,
-    summary,
+    // OMN-199: omit the key when no summary (matches createTaskResponseV2 /
+    // createListResponseV2) rather than emitting `summary: undefined`.
+    ...(summary && { summary }),
     data,
     metadata: {
       operation,
@@ -582,8 +584,9 @@ export function createListResponseV2<T>(
   opts?: { summary?: boolean },
 ): StandardResponseV2<Record<string, T[]>> {
   // Generate summary based on item type
+  const includeSummary = opts?.summary !== false;
   let summary: TaskSummary | ProjectSummary | undefined;
-  if (opts?.summary !== false) {
+  if (includeSummary) {
     if (itemType === 'tasks') {
       summary = generateTaskSummary(items as unknown[]);
     } else if (itemType === 'projects') {
@@ -681,7 +684,8 @@ export function createTaskResponseV2<T>(
   // OMN-199: see createListResponseV2 — `summary: false` omits the summary.
   opts?: { summary?: boolean },
 ): StandardResponseV2<{ tasks: T[] }> {
-  const summary = opts?.summary === false ? undefined : generateTaskSummary(tasks as unknown[]);
+  const includeSummary = opts?.summary !== false;
+  const summary = includeSummary ? generateTaskSummary(tasks as unknown[]) : undefined;
 
   // Apply truncation
   const { data: truncatedTasks, truncation } = truncateResponse(tasks);

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -104,3 +104,34 @@ describe('OMN-154 applyCountHonesty via createListResponseV2 (projects)', () => 
     expect('truncated' in r.metadata).toBe(false);
   });
 });
+
+// OMN-199: applyCountHonesty must update metadata even when the summary is
+// suppressed ({ summary: false }) — the metadata-honesty half (R1/R2) runs,
+// while the summary-insight half no-ops safely on the absent summary.
+describe('OMN-199 applyCountHonesty with summary omitted', () => {
+  const task = (name: string) => ({ id: `id-${name}`, name, flagged: false, completed: false });
+  const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
+
+  it('tasks: metadata still gets population + truncated, no summary field', () => {
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 }, { summary: false });
+    expect(r.metadata.total_count).toBe(48);
+    expect(r.metadata.truncated).toBe(true);
+    expect(r.summary).toBeUndefined();
+    expect('summary' in r).toBe(false);
+  });
+
+  it('projects: metadata still gets population + truncated, no summary field', () => {
+    const r = createListResponseV2(
+      'projects',
+      [project('p1')],
+      'projects',
+      {},
+      { population: 160 },
+      { summary: false },
+    );
+    expect(r.metadata.total_count).toBe(160);
+    expect(r.metadata.truncated).toBe(true);
+    expect(r.summary).toBeUndefined();
+    expect('summary' in r).toBe(false);
+  });
+});

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -113,7 +113,7 @@ describe('OMN-199 applyCountHonesty with summary omitted', () => {
   const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
 
   it('tasks: metadata still gets population + truncated, no summary field', () => {
-    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48 }, { summary: false });
+    const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48, summary: false });
     expect(r.metadata.total_count).toBe(48);
     expect(r.metadata.truncated).toBe(true);
     expect(r.summary).toBeUndefined();
@@ -121,14 +121,7 @@ describe('OMN-199 applyCountHonesty with summary omitted', () => {
   });
 
   it('projects: metadata still gets population + truncated, no summary field', () => {
-    const r = createListResponseV2(
-      'projects',
-      [project('p1')],
-      'projects',
-      {},
-      { population: 160 },
-      { summary: false },
-    );
+    const r = createListResponseV2('projects', [project('p1')], 'projects', {}, { population: 160, summary: false });
     expect(r.metadata.total_count).toBe(160);
     expect(r.metadata.truncated).toBe(true);
     expect(r.summary).toBeUndefined();

--- a/tests/unit/utils/response-format-utilities.test.ts
+++ b/tests/unit/utils/response-format-utilities.test.ts
@@ -248,6 +248,33 @@ describe('Response Format Utilities', () => {
       expect(response.summary).toBeDefined();
       expect((response.summary as any).total_count).toBe(2);
     });
+
+    // OMN-199: { summary: false } suppresses summary generation at the source,
+    // replacing the build-then-delete workaround.
+    it('omits summary when { summary: false } (tasks)', () => {
+      const timer = new OperationTimerV2();
+      const tasks = [{ id: 1, name: 'Task 1', completed: false }];
+
+      const response = createListResponseV2('task-list', tasks, 'tasks', timer.toMetadata(), undefined, {
+        summary: false,
+      });
+
+      expect(response.summary).toBeUndefined();
+      expect('summary' in response).toBe(false);
+      expect(response.data.tasks).toEqual(tasks);
+    });
+
+    it('omits summary when { summary: false } (projects)', () => {
+      const timer = new OperationTimerV2();
+      const projects = [{ id: 'p1', name: 'Project 1', status: 'active' }];
+
+      const response = createListResponseV2('project-list', projects, 'projects', timer.toMetadata(), undefined, {
+        summary: false,
+      });
+
+      expect(response.summary).toBeUndefined();
+      expect('summary' in response).toBe(false);
+    });
   });
 
   describe('createTaskResponseV2', () => {
@@ -267,6 +294,22 @@ describe('Response Format Utilities', () => {
       expect((response.summary as any).total_count).toBe(2);
       expect((response.summary as any).returned_count).toBe(2);
       expect((response.summary as any).breakdown?.completed).toBe(1);
+    });
+
+    // OMN-199: { summary: false } suppresses summary generation at the source.
+    it('omits summary when { summary: false }', () => {
+      const timer = new OperationTimerV2();
+      const tasks = [
+        { id: 't1', name: 'Task 1', completed: false },
+        { id: 't2', name: 'Task 2', completed: true },
+      ];
+
+      const response = createTaskResponseV2('task-query', tasks, timer.toMetadata(), undefined, { summary: false });
+
+      expect(response.summary).toBeUndefined();
+      expect('summary' in response).toBe(false);
+      expect(response.data.tasks).toEqual(tasks);
+      expect(response.metadata.total_count).toBe(2);
     });
 
     it('should handle tasks with full details', () => {

--- a/tests/unit/utils/response-format-utilities.test.ts
+++ b/tests/unit/utils/response-format-utilities.test.ts
@@ -255,7 +255,7 @@ describe('Response Format Utilities', () => {
       const timer = new OperationTimerV2();
       const tasks = [{ id: 1, name: 'Task 1', completed: false }];
 
-      const response = createListResponseV2('task-list', tasks, 'tasks', timer.toMetadata(), undefined, {
+      const response = createListResponseV2('task-list', tasks, 'tasks', timer.toMetadata(), {
         summary: false,
       });
 
@@ -268,7 +268,7 @@ describe('Response Format Utilities', () => {
       const timer = new OperationTimerV2();
       const projects = [{ id: 'p1', name: 'Project 1', status: 'active' }];
 
-      const response = createListResponseV2('project-list', projects, 'projects', timer.toMetadata(), undefined, {
+      const response = createListResponseV2('project-list', projects, 'projects', timer.toMetadata(), {
         summary: false,
       });
 
@@ -304,7 +304,7 @@ describe('Response Format Utilities', () => {
         { id: 't2', name: 'Task 2', completed: true },
       ];
 
-      const response = createTaskResponseV2('task-query', tasks, timer.toMetadata(), undefined, { summary: false });
+      const response = createTaskResponseV2('task-query', tasks, timer.toMetadata(), { summary: false });
 
       expect(response.summary).toBeUndefined();
       expect('summary' in response).toBe(false);


### PR DESCRIPTION
## Summary

Replaces 5 build-then-`delete`-summary workarounds in `OmniFocusReadTool` with a declarative `opts?: { summary?: boolean }` (default `true`) on `createTaskResponseV2` and `createListResponseV2`. When `false`, the summary is never generated and the key is omitted entirely.

Closes OMN-199.

## Why

The delete-after-build pattern was a **silent-failure footgun**, not just a DRY smell: `generate*Summary([])` emits an all-zero breakdown that contradicts `metadata.total_count` (the exact misleading output OMN-195 just removed). Any new countOnly/narrow path that forgot the `delete` would silently re-leak it. The flag enforces suppression structurally instead of by remembered cleanup.

## Changes

**`src/utils/response-format.ts`**
- `createTaskResponseV2(op, tasks, metadata?, counts?, opts?)` — `opts.summary === false` skips `generateTaskSummary` and omits the `summary` key.
- `createListResponseV2(op, items, itemType, metadata?, counts?, opts?)` — same for tasks/projects summaries.
- `opts` is the **last** positional param → zero churn to existing callers.

**`src/tools/unified/OmniFocusReadTool.ts`** — 5 sites migrated:
| Path | Before → After |
| -- | -- |
| tasks countOnly (`executeCountOnly`) | `delete response.summary` → `{ summary: false }` |
| projects narrow id-lookup (`executeProjectIdLookup`) | `delete listResult.summary` → `{ summary: false }` |
| shared `buildCountOnlyResponse` (projects/tags/folders) | `delete response.summary` → `{ summary: false }` |
| narrow-lookup cache path | `if (isNarrowLookup) delete cacheResult.summary` → `{ summary: !isNarrowLookup }` |
| narrow-lookup list path | `if (isNarrowLookup) delete listResult.summary` → `{ summary: !isNarrowLookup }` |

## Behavior preservation

Pure refactor — no wire-shape change. The 5 paths already emitted summary-less responses via `delete`. `applyCountHonesty` still runs and writes `metadata.total_count`/`truncated` **before** its `if (!summary) return` guard, so narrow-lookup truncation metadata is unchanged. The existing OMN-195 / countOnly / narrow-lookup tests pass **unchanged** (they assert `summary` is `undefined`).

## Tests (TDD)

- Builder unit tests: summary **present by default**; **absent** with `{ summary: false }` (tasks + projects).
- `applyCountHonesty` with summary omitted: metadata still gets population + `truncated`, no spurious summary field, no throw.
- `npm run build` clean · `npm run lint` clean (`--max-warnings=0`) · `npm run test:unit` = 3487 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)