### PR TITLE
fix(OMN-219): suppress summary on task id-lookup to match project id-lookup

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -716,12 +716,20 @@ PERFORMANCE:
     }
 
     const projectedTasks = projectFields(tasks, fields);
-    return createTaskResponseV2('tasks', projectedTasks, {
-      ...timer.toMetadata(),
-      from_cache: false,
-      mode: 'id_lookup',
-      sort_applied: false,
-    });
+    // Narrow lookup — suppress the dashboard-style summary (OMN-19 rule, OMN-199
+    // `{ summary: false }` primitive). OMN-219: aligns task id-lookup with
+    // executeProjectIdLookup, which already suppresses its summary on this path.
+    return createTaskResponseV2(
+      'tasks',
+      projectedTasks,
+      {
+        ...timer.toMetadata(),
+        from_cache: false,
+        mode: 'id_lookup',
+        sort_applied: false,
+      },
+      { summary: false },
+    );
   }
 
   /**

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -55,22 +55,6 @@ describe('OmniFocusReadTool', () => {
       // Field projection: flagged should be excluded
       expect(result.data.tasks[0].flagged).toBeUndefined();
       expect(result.metadata.mode).toBe('id_lookup');
-    });
-
-    it('suppresses the dashboard summary on task id-lookup (OMN-219, mirrors project id-lookup)', async () => {
-      execJsonSpy.mockResolvedValueOnce({
-        success: true,
-        data: {
-          tasks: [{ id: 'task-abc', name: 'Test Task', completed: false, flagged: true, blocked: false }],
-        },
-      } satisfies ScriptResult);
-
-      const result = (await tool.execute({
-        query: { type: 'tasks', filters: { id: 'task-abc' } },
-      })) as any;
-
-      expect(result.success).toBe(true);
-      expect(result.metadata.mode).toBe('id_lookup');
       // Narrow lookup → no dashboard-style summary (OMN-19 rule, matches executeProjectIdLookup).
       expect(result.summary).toBeUndefined();
     });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -57,6 +57,24 @@ describe('OmniFocusReadTool', () => {
       expect(result.metadata.mode).toBe('id_lookup');
     });
 
+    it('suppresses the dashboard summary on task id-lookup (OMN-219, mirrors project id-lookup)', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          tasks: [{ id: 'task-abc', name: 'Test Task', completed: false, flagged: true, blocked: false }],
+        },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { id: 'task-abc' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.metadata.mode).toBe('id_lookup');
+      // Narrow lookup → no dashboard-style summary (OMN-19 rule, matches executeProjectIdLookup).
+      expect(result.summary).toBeUndefined();
+    });
+
     it('returns NOT_FOUND error when task does not exist', async () => {
       execJsonSpy.mockResolvedValueOnce({
         success: true,


### PR DESCRIPTION
## What

`executeIdLookup` (single task by ID, `src/tools/unified/OmniFocusReadTool.ts`) returned a dashboard-style `TaskSummary` computed over the 1-task result set. The analogous **project** id-lookup, `executeProjectIdLookup`, already **suppresses** its summary on this path (OMN-19 narrow-lookup rule). This aligns the two.

A **pre-existing inconsistency** — the task id-lookup path never had a build-then-`delete` workaround, so it was out of scope for OMN-199 (which removed the 5 `delete`-summary sites). Surfaced in the high-effort `/code-review` of PR #159.

## Change

One call site. Pass the OMN-199 `{ summary: false }` primitive (shipped to main in #159, squash `27351bcd`) as the 4th arg to `createTaskResponseV2`, exactly mirroring `executeProjectIdLookup` and `executeCountOnly`:

```ts
return createTaskResponseV2(
  'tasks',
  projectedTasks,
  { ...timer.toMetadata(), from_cache: false, mode: 'id_lookup', sort_applied: false },
  { summary: false },
);
```

Behavior change: task id-lookup wire output drops the `summary` block. Not a schema/`inputSchema`/tool-description change — purely a response-builder argument, so no dual-schema update.

## TDD

- Added a unit test (`OmniFocusReadTool.test.ts`, "ID lookup fast path") asserting `result.summary` is `undefined` on task id-lookup, mirroring the existing project id-lookup test ("strips summary when id filter is present").
- **Red before the fix** (summary present), **green after**.
- Confirmed no other test asserts summary *presence* on the task id-lookup path.

## Local validation

- `npm run build` ✅
- `npm run test:unit` ✅ (3488 passed, incl. the new test)
- `eslint` + `prettier` ✅

The `execJson` spy makes this path fully unit-testable without live OmniFocus — no integration `/verify` needed (the change is response post-processing, not an OmniFocus query).

Closes OMN-219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
