### PR TITLE
chore(OMN-220): deferred /code-review cleanup in response builders (3 fixed, #6 declined)

### DIFF
--- a/src/utils/response-format.ts
+++ b/src/utils/response-format.ts
@@ -480,6 +480,17 @@ export function generateProjectSummary(projects: unknown[]): ProjectSummary {
 }
 
 /**
+ * OMN-220: single source of the omit-summary-if-falsy rule shared by the three
+ * V2 builders (createSuccessResponseV2 / createListResponseV2 / createTaskResponseV2).
+ * Spreading the result omits the `summary` key entirely when there is no summary
+ * (vs emitting `summary: undefined`) — `'summary' in response` is then false.
+ * Centralizing it means a future change to the omit semantics touches one place.
+ */
+function summaryField<S>(summary: S | undefined): { summary: S } | Record<string, never> {
+  return summary ? { summary } : {};
+}
+
+/**
  * Create enhanced success response with summary
  */
 export function createSuccessResponseV2<T>(
@@ -492,7 +503,7 @@ export function createSuccessResponseV2<T>(
     success: true,
     // OMN-199: omit the key when no summary (matches createTaskResponseV2 /
     // createListResponseV2) rather than emitting `summary: undefined`.
-    ...(summary && { summary }),
+    ...summaryField(summary),
     data,
     metadata: {
       operation,
@@ -615,7 +626,7 @@ export function createListResponseV2<T>(
     // OMN-199: omit the `summary` key entirely (vs `summary: undefined`) when no
     // summary was generated — this includes the tags/folders/'other' item types,
     // which never produce one, so `'summary' in response` is false for them.
-    ...(summary && { summary }),
+    ...summaryField(summary),
     data: {
       [dataKey]: items,
     },
@@ -715,7 +726,7 @@ export function createTaskResponseV2<T>(
 
   const response: StandardResponseV2<{ tasks: T[] }> = {
     success: true,
-    ...(summary && { summary }),
+    ...summaryField(summary),
     data: {
       tasks: truncatedTasks,
     },

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -367,7 +367,7 @@ describe('OmniFocusReadTool', () => {
       })) as any;
 
       expect(result.success).toBe(true);
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
     });
 
     // OMN-131: an unsupported NOT payload used to compile to an EMPTY filter —
@@ -419,7 +419,7 @@ describe('OmniFocusReadTool', () => {
       })) as any;
 
       expect(result.success).toBe(true);
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
     });
 
     it('preserves summary for broad browses (no narrow filter)', async () => {
@@ -456,7 +456,7 @@ describe('OmniFocusReadTool', () => {
 
       expect(result.success).toBe(true);
       expect(result.metadata.from_cache).toBe(true);
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
     });
   });
 
@@ -1161,7 +1161,7 @@ describe('OmniFocusReadTool', () => {
       expect(result.metadata.count_only).toBe(true);
       expect(result.metadata.total_count).toBe(42);
       // OMN-195: summary must be absent — all-0 breakdown contradicts total_count
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
       expect(result.metadata.optimization).toBe('omnijs_count_no_tags');
     });
 
@@ -1179,7 +1179,7 @@ describe('OmniFocusReadTool', () => {
       expect(result.metadata.count_only).toBe(true);
       expect(result.metadata.total_count).toBe(67);
       // forecast_past routes through executeCountOnly — same fix applies
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
     });
 
     it('mode:"inbox" + countOnly auto-injects inInbox into the count filter', async () => {
@@ -1300,7 +1300,7 @@ describe('OmniFocusReadTool', () => {
       expect(result.data.projects).toEqual([]);
       // No dashboard summary on a count-only result — its breakdown would be computed
       // from the empty rows (active:0…) and contradict total_count.
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
       // count-only is row-less by design, NOT a truncated row set (no false notice)
       expect('truncated' in result.metadata).toBe(false);
     });

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -56,7 +56,7 @@ describe('OmniFocusReadTool', () => {
       expect(result.data.tasks[0].flagged).toBeUndefined();
       expect(result.metadata.mode).toBe('id_lookup');
       // Narrow lookup → no dashboard-style summary (OMN-19 rule, matches executeProjectIdLookup).
-      expect(result.summary).toBeUndefined();
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
     });
 
     it('returns NOT_FOUND error when task does not exist', async () => {

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -112,15 +112,13 @@ describe('OMN-199 applyCountHonesty with summary omitted', () => {
     const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48, summary: false });
     expect(r.metadata.total_count).toBe(48);
     expect(r.metadata.truncated).toBe(true);
-    expect(r.summary).toBeUndefined();
-    expect('summary' in r).toBe(false);
+    expect('summary' in r).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
   });
 
   it('projects: metadata still gets population + truncated, no summary field', () => {
     const r = createListResponseV2('projects', [project('p1')], 'projects', {}, { population: 160, summary: false });
     expect(r.metadata.total_count).toBe(160);
     expect(r.metadata.truncated).toBe(true);
-    expect(r.summary).toBeUndefined();
-    expect('summary' in r).toBe(false);
+    expect('summary' in r).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
   });
 });

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { createTaskResponseV2, createListResponseV2 } from '../../../src/utils/response-format.js';
 
 const task = (name: string) => ({ id: `id-${name}`, name, flagged: false, completed: false });
+const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
 
 describe('OMN-154 applyCountHonesty via createTaskResponseV2', () => {
   it('R1: total_count = population, returned_count = rows', () => {
@@ -77,8 +78,6 @@ describe('OMN-154 applyCountHonesty via createTaskResponseV2', () => {
 });
 
 describe('OMN-154 applyCountHonesty via createListResponseV2 (projects)', () => {
-  const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
-
   it('R1/R3: total_count and summary.total_projects = population', () => {
     const r = createListResponseV2('projects', [project('p1'), project('p2')], 'projects', {}, { population: 160 });
     expect(r.metadata.total_count).toBe(160);
@@ -109,9 +108,6 @@ describe('OMN-154 applyCountHonesty via createListResponseV2 (projects)', () => 
 // suppressed ({ summary: false }) — the metadata-honesty half (R1/R2) runs,
 // while the summary-insight half no-ops safely on the absent summary.
 describe('OMN-199 applyCountHonesty with summary omitted', () => {
-  // OMN-220: use the file-scope `task` factory (was a duplicate shadow here).
-  const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
-
   it('tasks: metadata still gets population + truncated, no summary field', () => {
     const r = createTaskResponseV2('tasks', [task('a'), task('b')], {}, { population: 48, summary: false });
     expect(r.metadata.total_count).toBe(48);

--- a/tests/unit/utils/count-honesty.test.ts
+++ b/tests/unit/utils/count-honesty.test.ts
@@ -109,7 +109,7 @@ describe('OMN-154 applyCountHonesty via createListResponseV2 (projects)', () => 
 // suppressed ({ summary: false }) — the metadata-honesty half (R1/R2) runs,
 // while the summary-insight half no-ops safely on the absent summary.
 describe('OMN-199 applyCountHonesty with summary omitted', () => {
-  const task = (name: string) => ({ id: `id-${name}`, name, flagged: false, completed: false });
+  // OMN-220: use the file-scope `task` factory (was a duplicate shadow here).
   const project = (name: string) => ({ id: `id-${name}`, name, status: 'active' });
 
   it('tasks: metadata still gets population + truncated, no summary field', () => {


### PR DESCRIPTION
## What

Clears the non-blocking cleanup deferred from the OMN-199 `/code-review high` (PR #159, verdict SAFE). Resolves **3 of 4** findings; **#6 declined with rationale** (it would regress OMN-19). Behavior-preserving refactor + strictly stronger tests.

## Findings resolved

**#4 — DRY the omit-summary spread.** `...(summary && { summary })` was duplicated across the three V2 builders. Extracted a `summaryField(summary)` helper (`src/utils/response-format.ts`); the omit-if-falsy rule now lives in one place. Behavior-identical (a future change to the omit semantics touches one site instead of three).

**#3 — pin the actual #159 invariant in tests.** The summary-suppression tests asserted `expect(result.summary).toBeUndefined()`, which passes whether the key is **absent** *or* **present-with-`undefined`** — so it never pinned #159's real invariant (the key is **omitted**). Tightened to `expect('summary' in result).toBe(false)`. Swept the whole class: 3 narrow-lookup (OMN-19) + 3 countOnly (OMN-195). The countOnly trio passing **confirms that path also omits the key**, not just the narrow-lookup path.

**#7 — test dedup.** Removed the shadowing `task` factory re-declared inside the OMN-199 `describe` in `count-honesty.test.ts`; it now uses the file-scope one.

## Finding #6 — DECLINED (would regress OMN-19)

The finding proposed deriving `{ summary: !isNarrowLookup }` from a `mode: 'id_lookup'` metadata flag inside the builder so callers don't thread the boolean. On inspection that mechanism is wrong:

- The two project call sites (`handleProjectQuery`) set `operation: 'list'`, **not** `mode: 'id_lookup'`. The id-lookup fast path is a *separate* function (`executeProjectIdLookup`, which already passes `{ summary: false }` directly).
- `isNarrowLookup = Boolean(name || text || id)` — it covers **name/text** narrow lookups, broader than id-lookup.

Deriving from `mode:'id_lookup'` would therefore (a) match nothing on these list paths and (b) miss the name/text narrowness — **name/text narrow lookups would regain their summary**, regressing the OMN-19 rule. Threading the boolean is the correct design. (Per receiving-code-review discipline: verified before implementing.)

## Validation

- `npm run build` ✅
- `npm run test:unit` ✅ (3487 passed; the tightened assertions are strictly stronger and all pass)
- `eslint` + `prettier` ✅

Pure refactor + test hardening, no `src` behavior change → fully unit-covered, no live `/verify` owed.

> Minor merge note: touches `OmniFocusReadTool.test.ts`, which PR #161 (OMN-219) also edits — different tests/lines, should merge cleanly; rebase if #161 lands first.

Closes OMN-220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
