### PR TITLE
feat(OMN-207): read task sequential (read-side parity with the write side)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- **Readable `sequential` field on tasks** (OMN-207) — `type:"tasks"` queries can now request `sequential` via
+  `fields:["sequential"]`, closing the settable-but-not-readable gap left by the write side (OMN-198/206). Reported as
+  the raw stored boolean on every task (not conditional on child count): OmniFocus persists `sequential` across
+  leaf↔action-group transitions, and the write side can set it on a childless task, so a leaf's value is
+  vacuous-but-real and is reported honestly. The flag governs the ordering of a task's **own** children, so it is only
+  meaningful for projects and task action groups. Live write→read round-trip covered in `field-roundtrip.test.ts`.
 - **Folder filter on `type:"tasks"` queries** (OMN-167) — `filters.folder` now works on tasks (was rejected with
   steering since OMN-162). A string is a `Parent : Child` **path** matched against the folder **subtree** of the task's
   containing project (a bare name is a single-segment path; case-insensitive substring per segment; status-agnostic — no
@@ -18,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **`details:true` task responses now include `sequential`** (OMN-207) — adding the field to the task `details` set
+  means every task row from a `details:true` (or all-fields ID-lookup) query now carries a `sequential` boolean. Pure
+  **additive** shape change — no existing field is removed or altered — but a caller validating task rows against an
+  exact-equality fixture or a strict (no-unknown-keys) schema will see the new key.
 - **Projects folder filter widened to subtree path** (OMN-167) — `type:"projects"` `filters.folder: "<name>"` changed
   from a **direct-parent** substring match to a **subtree** `Parent : Child` path match (shared with the new tasks-side
   filter). This is a pure **superset**: subtree includes the direct-parent case, so no previously-matching query loses

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -134,6 +134,10 @@ export const DETAIL_FIELDS = [
   // OMN-153: boolean marker for project-root rows (useful in detail views and
   // for agents that need to distinguish roots from regular tasks).
   'isProjectRoot',
+  // OMN-207: action-group ordering, read-side parity with the write side
+  // (OMN-198/206). Cheap boolean; reachable via details:true (DETAIL, not the
+  // thin MINIMAL default) — mirrors `sequential` in DETAIL_PROJECT_FIELDS.
+  'sequential',
 ];
 
 /**
@@ -342,6 +346,12 @@ function generateFieldProjection(
       // task.project !== null is the OmniJS definition of "this task IS a project root".
       case 'isProjectRoot':
         projections.push('isProjectRoot: task.project !== null');
+        break;
+      // OMN-207: action-group ordering, read-side parity with the write side
+      // (OMN-198/206). `|| false` returns the stored boolean — false ≠ absent.
+      // Mirrors the project projection case (`sequential: project.sequential || false`).
+      case 'sequential':
+        projections.push('sequential: task.sequential || false');
         break;
     }
   }

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -350,6 +350,21 @@ function generateFieldProjection(
       // OMN-207: action-group ordering, read-side parity with the write side
       // (OMN-198/206). `|| false` returns the stored boolean — false ≠ absent.
       // Mirrors the project projection case (`sequential: project.sequential || false`).
+      //
+      // Decision (OMN-207 /code-review): report the RAW stored property
+      // unconditionally, not conditionally on `task.children.length > 0`.
+      // `sequential` governs a task's OWN children's ordering; a leaf's value is
+      // vacuous-but-real. Conditional emission was rejected because:
+      //   (1) OmniFocus persists `sequential` across leaf↔action-group
+      //       transitions (childless tasks with a stored `true` exist), so
+      //       omitting it while childless would HIDE a real stored value;
+      //   (2) the write side (OMN-198/206) can SET `sequential` on a childless
+      //       task — omitting it on read re-opens the exact settable-but-not-
+      //       readable honesty gap this ticket closes;
+      //   (3) presence-coupled-to-child-count makes the response shape churn as
+      //       the tree mutates, breaking shape stability.
+      // (`|| false` is a defensive mirror of the project case; OmniJS currently
+      // returns a boolean for every task, so it is a no-op today.)
       case 'sequential':
         projections.push('sequential: task.sequential || false');
         break;

--- a/src/omnifocus/response-schemas/read.ts
+++ b/src/omnifocus/response-schemas/read.ts
@@ -61,6 +61,9 @@ export const TaskRowSchema = z
     isProjectRoot: z.boolean().optional(),
     // OMN-130: cheap boolean — true when the task has any non-empty note text.
     hasNote: z.boolean().optional(),
+    // OMN-207: action-group ordering, read-side parity with the write side
+    // (OMN-198/206). Emitted by the `sequential` task projection case.
+    sequential: z.boolean().optional(),
   })
   .strict();
 

--- a/src/omnifocus/types.ts
+++ b/src/omnifocus/types.ts
@@ -24,4 +24,11 @@ export interface OmniFocusTask {
   parentTaskId?: string;
   parentTaskName?: string;
   inInbox?: boolean;
+  // OMN-207: read-side parity with the write side. Reported as the raw stored
+  // property on every task (not conditional on children) — see the decision
+  // record in src/contracts/ast/script-builder.ts. Other projected fields
+  // (isProjectRoot, hasNote, plannedDate, repetitionRule) are still absent from
+  // this interface and reach projectFields() via the `as keyof` cast; closing
+  // that pre-existing gap is out of scope for OMN-207.
+  sequential?: boolean;
 }

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -289,7 +289,7 @@ RESPONSE CONTROL:
 - fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true)
 - ID lookup always returns all fields with full notes
 - fields are type-specific; requesting a field of the other type (e.g. reviewInterval on tasks) returns a guided error
-- fields (tasks): id, name, completed, flagged, blocked, available, hasNote, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox
+- fields (tasks): id, name, completed, flagged, blocked, available, hasNote, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox, sequential
 - available: true when actionable now (OmniFocus status Available, Next, DueSoon, or Overdue); blocked: true when waiting on a predecessor, a future defer date, or an on-hold project (status Blocked). Completed/dropped tasks are neither.
 - fields (projects): id, name, status, flagged, note, dueDate, deferDate, completionDate, folder, folderPath, folderId, sequential, lastReviewDate, nextReviewDate, reviewInterval, defaultSingletonActionHolder, tags, plannedDate
 - sort: [{ field: "dueDate", direction: "asc" }]

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -297,6 +297,7 @@ RESPONSE CONTROL:
 - countOnly: true returns only the matching count (metadata.total_count), no rows — for "how many" questions. Valid on tasks, projects, tags, and folders (not perspectives). Skips row materialization (and, for projects, the per-project taskCounts/nextTask enrichment); on tags/folders it mainly trims the response payload, since those scripts already enumerate every row
 - includeProjectRoot: false (default) — project-root rows are excluded from all tasks queries. In OmniFocus a project IS a task (its root task); completing or deleting that root row completes/deletes the PROJECT. Default exclusion prevents accidental project destruction. Set true only when intentionally inspecting project roots. Root rows always carry isProjectRoot: true when opted in (auto-injected regardless of fields selection).
 - fields: isProjectRoot — boolean, true when the task is a project's root task (task.project !== null in OmniJS). Auto-included when includeProjectRoot: true; also requestable explicitly or via details: true.
+- fields: sequential — boolean, governs the ordering of a task's OWN children (and so is only meaningful for projects and task action groups, matching the write side). It is the raw stored flag, reported on every task; a childless leaf returns its stored value (usually false), which says nothing about that task's position among its siblings — the PARENT's sequential governs that.
 
 COMPLETED TASKS:
 - Use filters: { completed: true } or filters: { status: "completed" } to query completed tasks

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -190,6 +190,7 @@ const TASK_FIELDS = [
   'inInbox',
   'isProjectRoot', // OMN-153: true when the task IS a project root (task.project !== null in OmniJS)
   'hasNote', // OMN-130: cheap boolean — true when the task has any non-empty note text
+  'sequential', // OMN-207: action-group ordering — settable (OMN-198/206) and now readable on the task side
 ] as const;
 
 const PROJECT_FIELDS = [

--- a/tests/integration/tools/unified/field-roundtrip.test.ts
+++ b/tests/integration/tools/unified/field-roundtrip.test.ts
@@ -300,6 +300,18 @@ describe('OMN-61 Phase 3: per-field write→read round-trip', () => {
       extract: (t) => /WEEKLY/i.test(t?.repetitionRule?.ruleString ?? ''),
       expected: true,
     },
+    {
+      // OMN-207: the task-side read parity this PR exists for. The project-side
+      // sequential round-trip lives in projectRows below; a childless task can
+      // carry `sequential: true` (OmniFocus persists the flag across leaf↔group
+      // transitions), so this exercises the live OmniJS task.sequential read.
+      field: 'sequential',
+      op: 'create',
+      setValue: true,
+      readFields: ['sequential'],
+      extract: (t) => t?.sequential,
+      expected: true,
+    },
   ];
 
   describe('task scalar fields', () => {

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -103,6 +103,14 @@ describe('buildFilteredTasksScript', () => {
       expect(result.script).toContain('flagged: task.flagged');
     });
 
+    it('OMN-207: projects task `sequential` as a real boolean (mirror of project side)', () => {
+      const result = buildFilteredTasksScript({}, { fields: ['id', 'sequential'] });
+
+      // `|| false` so the value is the stored boolean — false ≠ "field absent"
+      // (the same load-bearing distinction OMN-206 locked on the write side).
+      expect(result.script).toContain('sequential: task.sequential || false');
+    });
+
     it('excludes completed tasks by default', () => {
       const result = buildFilteredTasksScript({});
 

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -380,6 +380,20 @@ describe('ReadSchema', () => {
   });
 
   describe('type-discriminated fields', () => {
+    it('OMN-207: should accept sequential on task queries (read-side parity with the write side)', () => {
+      const input = {
+        query: {
+          type: 'tasks',
+          fields: ['id', 'name', 'sequential'],
+        },
+      };
+      const result = ReadSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success && result.data.query.type === 'tasks') {
+        expect(result.data.query.fields).toContain('sequential');
+      }
+    });
+
     it('should accept project fields on project queries', () => {
       const input = {
         query: {

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -390,7 +390,10 @@ describe('ReadSchema', () => {
       const result = ReadSchema.safeParse(input);
       expect(result.success).toBe(true);
       if (result.success && result.data.query.type === 'tasks') {
-        expect(result.data.query.fields).toContain('sequential');
+        // Pin the full round-trip array (matching the sibling project test) so a
+        // regression that drops/mutates/reorders fields is caught — toContain
+        // could not, since z.enum never silently drops an accepted value.
+        expect(result.data.query.fields).toEqual(['id', 'name', 'sequential']);
       }
     });
 


### PR DESCRIPTION
## What

Makes `sequential` (action-group ordering) **readable on tasks**. It was made *settable* on a task via OMN-198/206, but the read side rejected it:

```
omnifocus_read { type:"tasks", filters:{id}, fields:["sequential"] }
→ MCP error -32602: 'sequential' is a projects-only field
```

A settable-but-not-readable honesty gap (selection/reporting-honesty cluster). The value **is** persisted by OmniFocus; only our task field projection + read-schema allowlist still treated `sequential` as projects-only.

## Five sync points

The dual-schema rule is really *multi*-schema for a projectable field. The parity tests (`schema-impl-parity`, `projection-parity`) caught each one as I went:

| # | File | Change |
|---|------|--------|
| 1 | `schemas/read-schema.ts` | add `sequential` to `TASK_FIELDS` → `TaskFieldEnum` accepts it (clears the -32602) |
| 2 | `ast/script-builder.ts` `DETAIL_FIELDS` | add `sequential` → reachable via `details:true` (NOT the thin `MINIMAL` default). Satisfies the OMN-51 `TaskFieldEnum ↔ DEFAULT_FIELDS` parity test; mirrors `sequential` in `DETAIL_PROJECT_FIELDS`. Cheap boolean. |
| 3 | `ast/script-builder.ts` task projection switch | `case 'sequential'` → `sequential: task.sequential || false` (mirrors the project case; `|| false` returns the stored boolean — false ≠ absent) |
| 4 | `response-schemas/read.ts` `TaskRowSchema` | add `sequential` (`.strict()` closed set — the response-row parser) |
| 5 | `OmniFocusReadTool.ts` tool description | advertise `sequential` in the tasks field list |

## Design note — opt-in tier

Added to `DETAIL_FIELDS`, not `MINIMAL_FIELDS`: returned on `details:true` or an explicit `fields:["sequential"]`, but not in the thin default response. This is the ticket's "opt-in… unless cheap" intent and matches the project side exactly (`DETAIL_PROJECT_FIELDS`). The OMN-51 parity test forces enum members into `DEFAULT_FIELDS`, so `DETAIL` is the correct (and only clean) home.

## TDD

- `read-schema.test.ts`: a tasks query with `fields:["sequential"]` parses (was rejected).
- `script-builder.test.ts`: the generated script emits exactly `sequential: task.sequential || false`.
- Both **red before, green after**; the parameterized parity tests auto-cover the new enum member (projection + DEFAULT_FIELDS membership + row-schema).

## Validation

- `npm run build` ✅
- `npm run test:unit` ✅ (3491 passed)
- `eslint` + `prettier` ✅

## ⚠️ Needs a live read-back before merge

Per the ticket's acceptance: create a `sequential:true` task group and read the parent's `sequential` back as `true`. That live read-back can't run in-loop (guardrail) or in CI (no OmniFocus) — unit tests cover the -32602 fix + projection, but the round-trip against real OmniFocus is owed to you (same shape as #160).

Closes OMN-207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
