### PR TITLE
perf(OMN-126): scope parse_meeting_notes dedup read to target project(s)+inbox

### DIFF
--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2417,9 +2417,11 @@ SCOPE FILTERING:
         // The scoped read resolves the project name case-insensitively itself, so
         // `existingProjects` is needed only for the preview's project.match — a
         // failed projects read degrades that preview, never the dedup read.
-        existingProjects = await this.fetchExistingProjectNames(warnings);
+        // scopeProjects derives purely from items/defaultProject (not existingProjects),
+        // so all three pre-flight reads run concurrently — no sequential dependency.
         const scopeProjects = [...new Set(items.map((item) => this.requestedScope(item, defaultProject)))];
-        [existingTags, existingTasks] = await Promise.all([
+        [existingProjects, existingTags, existingTasks] = await Promise.all([
+          this.fetchExistingProjectNames(warnings),
           this.fetchExistingTagNames(warnings),
           this.fetchExistingIncompleteTasks(warnings, scopeProjects),
         ]);
@@ -2656,10 +2658,9 @@ SCOPE FILTERING:
     warnings: string[],
     scopeProjects: Array<string | null>,
   ): Promise<Array<{ name: string; project: string | null }>> {
-    const scopes = [...new Set(scopeProjects)];
-
+    // scopeProjects is already de-duplicated by the caller — one read per distinct scope.
     const reads = await Promise.all(
-      scopes.map(async (scope) => ({ scope, ...(await this.readScopedIncompleteTasks(scope)) })),
+      scopeProjects.map(async (scope) => ({ scope, ...(await this.readScopedIncompleteTasks(scope)) })),
     );
 
     // Review ③: name the scope(s) whose read failed instead of a single blanket
@@ -2748,10 +2749,13 @@ SCOPE FILTERING:
       'var lower = target.toLowerCase();' +
       'var named = flattenedProjects.filter(function(p){ return p.name.toLowerCase() === lower; });' +
       'var live = named.filter(function(p){ return p.status !== Project.Status.Dropped && p.status !== Project.Status.Done; });' +
-      'var p = (live.length > 0 ? live : named)[0];' +
-      'if (!p) return JSON.stringify({ tasks: [] });' +
+      // OmniFocus does not enforce unique project names: aggregate across ALL matching
+      // live projects (fall back to any match only if none are live) so a duplicate in
+      // a second same-named project is not missed — matching the old whole-DB read,
+      // which keyed candidates by project NAME, not a single project object.
+      'var matches = live.length > 0 ? live : named;' +
       'var out = [];' +
-      'p.flattenedTasks.forEach(function(t){ if (t.taskStatus !== Task.Status.Completed && t.taskStatus !== Task.Status.Dropped) { out.push({ name: t.name, project: p.name }); } });' +
+      'matches.forEach(function(p){ p.flattenedTasks.forEach(function(t){ if (t.taskStatus !== Task.Status.Completed && t.taskStatus !== Task.Status.Dropped) { out.push({ name: t.name, project: p.name }); } }); });' +
       'return JSON.stringify({ tasks: out });' +
       '})()';
     return `(() => { const app = Application('OmniFocus'); return app.evaluateJavascript(${JSON.stringify(program)}); })()`;

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2420,10 +2420,20 @@ SCOPE FILTERING:
         // null, the read returns zero tasks, and a real duplicate is missed. This
         // requires the project-names read first, so it now precedes (rather than
         // parallels) the scoped task read.
-        existingProjects = await this.fetchExistingProjectNames(warnings);
-        const scopeProjects = items.map((item) =>
-          this.canonicalProjectScope(item.project ?? defaultProject ?? null, existingProjects),
-        );
+        const proj = await this.fetchExistingProjectNames(warnings);
+        existingProjects = proj.names;
+        // Review ②: if the existing-projects read failed we cannot canonicalize a
+        // case-mismatched name, so per-project name-scoping would silently miss
+        // duplicates. Fall back to ONE whole-DB dedup read (findDuplicateTask
+        // compares project names case-insensitively) — pre-OMN-126 behavior on this
+        // error path. `undefined` signals that whole-DB read.
+        // Review ⑧: dedup the raw scopes first, then canonicalize each DISTINCT one
+        // (D canonicalizations, not one per item).
+        const scopeProjects = proj.ok
+          ? [...new Set(items.map((item) => this.requestedScope(item, defaultProject)))].map((s) =>
+              this.canonicalProjectScope(s, existingProjects),
+            )
+          : undefined;
         [existingTags, existingTasks] = await Promise.all([
           this.fetchExistingTagNames(warnings),
           this.fetchExistingIncompleteTasks(warnings, scopeProjects),
@@ -2431,7 +2441,7 @@ SCOPE FILTERING:
       }
 
       const previewItems = items.map((item) => {
-        const requestedProject = item.project ?? defaultProject ?? null;
+        const requestedProject = this.requestedScope(item, defaultProject);
         const combinedTags = [...new Set([...(item.tags ?? []), ...defaultTags])];
 
         const project = this.resolveProjectName(requestedProject, existingProjects, validate);
@@ -2521,20 +2531,33 @@ SCOPE FILTERING:
   }
 
   /**
+   * The project a structured item targets: `item.project`, else `defaultProject`,
+   * else the inbox (`null`). An empty-string project is treated as inbox (`null`),
+   * NOT a project literally named '' — otherwise the scoped dedup read would filter
+   * on `name === ''` (zero matches) and silently miss inbox duplicates (review ①).
+   * Used at both the scope-building and per-item preview sites so the two never
+   * diverge on what "the requested project" is.
+   */
+  private requestedScope(item: { project?: string | null }, defaultProject: string | null): string | null {
+    const p = item.project ?? defaultProject ?? null;
+    return p === '' ? null : p;
+  }
+
+  /**
    * OMN-126: map a requested project name to the canonical existing name (exact
    * case-insensitive match) for scoping the dedup read. The scoped read resolves
    * the name by a case-SENSITIVE exact match (post-OMN-224: a status-aware
    * `flattenedProjects` scan, `p.name === target`), so a case-mismatched name
-   * would otherwise find no project and silently miss duplicates. `null`
-   * (inbox) passes through; an unknown name passes through unchanged (no existing
-   * project to scope to, so the read correctly finds nothing). Deliberately the
-   * `exact` match only — NOT resolveProjectName's `partial`/substring fallback,
-   * which would scope a different project than findDuplicateTask compares against.
+   * would otherwise find no project and silently miss duplicates. `null` (inbox)
+   * passes through; an unknown name passes through unchanged (no existing project
+   * to scope to, so the read correctly finds nothing). Deliberately the EXACT match
+   * only — never resolveProjectName's `partial`/substring fallback, which would
+   * scope a different project than findDuplicateTask compares against. Delegates to
+   * resolveProjectName so the exact-match lookup lives in one place (review ⑥).
    */
   private canonicalProjectScope(name: string | null, existing: string[]): string | null {
-    if (name === null) return null;
-    const lower = name.toLowerCase();
-    return existing.find((p) => p.toLowerCase() === lower) ?? name;
+    const r = this.resolveProjectName(name, existing, true);
+    return r.match === 'exact' ? r.resolved : name;
   }
 
   /** Resolve a requested project name against existing projects (case-insensitive). */
@@ -2612,17 +2635,23 @@ SCOPE FILTERING:
     return data;
   }
 
-  /** Read existing project names (lite, no stats). Warns + returns [] on script error (OMN-204). */
-  private async fetchExistingProjectNames(warnings: string[]): Promise<string[]> {
+  /**
+   * Read existing project names (lite, no stats). Warns + returns `ok:false` on
+   * script error (OMN-204). The caller needs `ok` (not just an empty list) because
+   * a failed read means names can't be canonicalized, so the dedup read must fall
+   * back to a whole-DB scan rather than scope by an unresolvable name (review ②).
+   */
+  private async fetchExistingProjectNames(warnings: string[]): Promise<{ ok: boolean; names: string[] }> {
     const gen = buildFilteredProjectsScript({}, { limit: 1000, includeStats: false, performanceMode: 'lite' });
     const result = await this.execJson(gen.script, PROJECTS_LIST_SCHEMA);
     if (!isScriptSuccess(result)) {
       warnings.push('project resolution unavailable: existing-projects read failed');
-      return [];
+      return { ok: false, names: [] };
     }
-    return this.unwrapList(result.data, ['projects', 'items'])
+    const names = this.unwrapList(result.data, ['projects', 'items'])
       .map((p) => (p as { name?: unknown }).name)
       .filter((n): n is string => typeof n === 'string');
+    return { ok: true, names };
   }
 
   /** Read existing tag names (basic mode). Warns + returns empty set on script error. */
@@ -2654,22 +2683,36 @@ SCOPE FILTERING:
    * (findDuplicateTask) is already against `project.requested`, so scoping the
    * candidate set changes no match results; it only kills the ~8s whole-DB scan and
    * makes the 2000-row cap per-scope instead of a global truncation.
+   *
+   * `scopeProjects === undefined` requests a single WHOLE-DB read — the review-②
+   * fallback used when the existing-projects read failed and names can't be
+   * canonicalized. This is the only reachable whole-DB path (the call site always
+   * passes a non-empty scope list otherwise), so the ~8s scan is now a deliberate,
+   * named error fallback rather than dead defensive code.
    */
   private async fetchExistingIncompleteTasks(
     warnings: string[],
-    scopeProjects: Array<string | null> = [],
+    scopeProjects: Array<string | null> | undefined,
   ): Promise<Array<{ name: string; project: string | null }>> {
-    // `undefined` sentinel = no scope → whole-DB read (degenerate empty-items call,
-    // preserves the pre-OMN-126 behavior). Otherwise one read per distinct scope.
-    const distinct = [...new Set(scopeProjects)];
-    const scopes: Array<string | null | undefined> = distinct.length > 0 ? distinct : [undefined];
+    const scopes: Array<string | null | undefined> =
+      scopeProjects === undefined ? [undefined] : [...new Set(scopeProjects)];
 
-    const reads = await Promise.all(scopes.map((scope) => this.readScopedIncompleteTasks(scope)));
+    const reads = await Promise.all(
+      scopes.map(async (scope) => ({ scope, ...(await this.readScopedIncompleteTasks(scope)) })),
+    );
 
-    // A single failed scoped read degrades dedupe for that scope — surface it once
-    // (OMN-204 no-silent-failure), not once per failing scope.
-    if (reads.some((r) => !r.ok)) {
-      warnings.push('dedupe unavailable: incomplete-tasks read failed');
+    // Review ③: name the scope(s) whose read failed instead of a single blanket
+    // "dedupe unavailable" — dedupe still works for the scopes that succeeded, so a
+    // global warning is both over- and under-informative. (OMN-204 no-silent-failure.)
+    const failed = reads.filter((r) => !r.ok).map((r) => r.scope);
+    if (failed.length > 0) {
+      const label = (s: string | null | undefined): string => {
+        if (s === undefined) return 'whole database';
+        if (s === null) return 'inbox';
+        return s;
+      };
+      const names = failed.map(label).join(', ');
+      warnings.push(`dedupe unavailable: incomplete-tasks read failed for ${names}`);
     }
 
     // Merge + dedup by (name, project): scopes can overlap (e.g. two items request

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -57,6 +57,7 @@ import { extractDates } from '../capture/date-extraction.js';
 // OMN-124: read-only pre-flight for structured meeting-note items.
 import { buildFilteredProjectsScript } from '../../contracts/ast/script-builder.js';
 import { buildListTasksScriptV4 } from '../../omnifocus/scripts/tasks/list-tasks-ast.js';
+import type { TaskFilter } from '../../contracts/filters.js';
 import { buildTagsScript } from '../../contracts/ast/tag-script-builder.js';
 
 // Response types
@@ -2404,10 +2405,17 @@ SCOPE FILTERING:
       let existingTags = new Set<string>();
       let existingTasks: Array<{ name: string; project: string | null }> = [];
       if (validate) {
+        // OMN-126: scope the dedup read to the requested target project(s) + inbox
+        // instead of the whole DB. The duplicate comparison (findDuplicateTask) is
+        // already project-scoped against `project.requested` — which is exactly
+        // `item.project ?? defaultProject ?? null` — so scoping the candidate read
+        // changes no match results; it only kills the ~8s whole-DB scan and makes
+        // the 2000-row cap effectively per-scope instead of a global truncation.
+        const scopeProjects = items.map((item) => item.project ?? defaultProject ?? null);
         [existingProjects, existingTags, existingTasks] = await Promise.all([
           this.fetchExistingProjectNames(warnings),
           this.fetchExistingTagNames(warnings),
-          this.fetchExistingIncompleteTasks(warnings),
+          this.fetchExistingIncompleteTasks(warnings, scopeProjects),
         ]);
       }
 
@@ -2603,36 +2611,91 @@ SCOPE FILTERING:
     return new Set(names);
   }
 
-  /** Read incomplete (not completed/dropped) tasks with their project name. Warns + returns [] on script error (OMN-204). */
+  /**
+   * Read incomplete (not completed/dropped) tasks with their project name, scoped
+   * to the dedup candidates we actually need. Warns + returns [] on script error
+   * (OMN-204). OMN-126: scope to the requested target project(s) + inbox instead
+   * of scanning the whole DB.
+   *
+   * We issue ONE scoped read per distinct requested scope and merge, rather than a
+   * single `OR`-of-projects read: the AST contradiction detector rejects two
+   * `{ project }` OR branches as "contradictory conditions on task.containingProject"
+   * (project=A OR project=B is a legitimate union, but the detector flags same-field
+   * branches). Per-scope reads sidestep that and are still far cheaper than the old
+   * whole-DB scan — each is project- or inbox-scoped. The duplicate comparison
+   * (findDuplicateTask) is already against `project.requested`, so scoping the
+   * candidate set changes no match results; it only kills the ~8s whole-DB scan and
+   * makes the 2000-row cap per-scope instead of a global truncation.
+   */
   private async fetchExistingIncompleteTasks(
     warnings: string[],
+    scopeProjects: Array<string | null> = [],
   ): Promise<Array<{ name: string; project: string | null }>> {
-    // Both terminal states excluded: a dropped task has completed===false, so
-    // without dropped:false an abandoned task would false-positive as a duplicate.
-    //
-    // OMN-124 follow-up: use buildListTasksScriptV4, NOT the bare
-    // buildFilteredTasksScript — the latter returns an OmniJS body that uses
-    // `flattenedTasks`, which only exists inside the evaluateJavascript bridge.
-    // The V4 wrapper embeds that body in the JXA→bridge harness (unlike
-    // buildFilteredProjectsScript/buildTagsScript, which self-wrap). Passing the
-    // bare body to execJson throws "Can't find variable: flattenedTasks", and the
-    // swallowed failure silently disabled dedupe. Output shape is { tasks, metadata }.
-    //
-    // OMN-191: this inherits OMN-153's default project-root exclusion by design.
-    // A project root is named identically to its project but is NOT an actionable
-    // task, so it must not make "create a task named like the project" look like a
-    // duplicate. (To include roots in dedup, pass includeProjectRoot: true here.)
+    // `undefined` sentinel = no scope → whole-DB read (degenerate empty-items call,
+    // preserves the pre-OMN-126 behavior). Otherwise one read per distinct scope.
+    const distinct = [...new Set(scopeProjects)];
+    const scopes: Array<string | null | undefined> = distinct.length > 0 ? distinct : [undefined];
+
+    const reads = await Promise.all(scopes.map((scope) => this.readScopedIncompleteTasks(scope)));
+
+    // A single failed scoped read degrades dedupe for that scope — surface it once
+    // (OMN-204 no-silent-failure), not once per failing scope.
+    if (reads.some((r) => !r.ok)) {
+      warnings.push('dedupe unavailable: incomplete-tasks read failed');
+    }
+
+    // Merge + dedup by (name, project): scopes can overlap (e.g. two items request
+    // the same project, or a project named like the inbox fallback).
+    const seen = new Set<string>();
+    const merged: Array<{ name: string; project: string | null }> = [];
+    for (const r of reads) {
+      for (const t of r.tasks) {
+        const key = `${t.name.toLowerCase()} ${t.project?.toLowerCase() ?? ''}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          merged.push(t);
+        }
+      }
+    }
+    return merged;
+  }
+
+  /**
+   * One scoped incomplete-tasks read. `scope`: a project name → tasks in that
+   * project; `null` → inbox tasks; `undefined` → whole DB (no scope).
+   *
+   * Both terminal states excluded: a dropped task has completed===false, so without
+   * dropped:false an abandoned task would false-positive as a duplicate.
+   *
+   * Uses buildListTasksScriptV4, NOT the bare buildFilteredTasksScript — the latter
+   * returns an OmniJS body that uses `flattenedTasks`, which only exists inside the
+   * evaluateJavascript bridge. The V4 wrapper embeds that body in the JXA→bridge
+   * harness. (OMN-124: passing the bare body to execJson threw "Can't find variable:
+   * flattenedTasks" and silently disabled dedupe.)
+   *
+   * OMN-191: inherits OMN-153's default project-root exclusion — a project root is
+   * named identically to its project but is NOT an actionable task, so it must not
+   * make "create a task named like the project" look like a duplicate.
+   */
+  private async readScopedIncompleteTasks(
+    scope: string | null | undefined,
+  ): Promise<{ ok: boolean; tasks: Array<{ name: string; project: string | null }> }> {
+    const filter: TaskFilter = { completed: false, dropped: false };
+    if (scope === null) {
+      filter.inInbox = true; // inbox-bound items dedup against inbox tasks
+    } else if (typeof scope === 'string') {
+      filter.project = scope; // named-project items dedup against that project's tasks
+    }
     const script = buildListTasksScriptV4({
-      filter: { completed: false, dropped: false },
+      filter,
       fields: ['name', 'project'],
       limit: 2000,
     });
     const result = await this.execJson(script, TASKS_LIST_SCHEMA);
     if (!isScriptSuccess(result)) {
-      warnings.push('dedupe unavailable: incomplete-tasks read failed');
-      return [];
+      return { ok: false, tasks: [] };
     }
-    return this.unwrapList(result.data, ['tasks', 'items'])
+    const tasks = this.unwrapList(result.data, ['tasks', 'items'])
       .map((t) => {
         const rec = t as { name?: unknown; project?: unknown };
         return {
@@ -2641,6 +2704,7 @@ SCOPE FILTERING:
         };
       })
       .filter((t) => t.name.length > 0);
+    return { ok: true, tasks };
   }
 
   /**

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2411,9 +2411,19 @@ SCOPE FILTERING:
         // `item.project ?? defaultProject ?? null` — so scoping the candidate read
         // changes no match results; it only kills the ~8s whole-DB scan and makes
         // the 2000-row cap effectively per-scope instead of a global truncation.
-        const scopeProjects = items.map((item) => item.project ?? defaultProject ?? null);
-        [existingProjects, existingTags, existingTasks] = await Promise.all([
-          this.fetchExistingProjectNames(warnings),
+        //
+        // The scoped read's project filter compiles to a case-SENSITIVE
+        // `flattenedProjects.byName()`; canonicalize each scope to the exact
+        // existing name (case-insensitive) so a case-mismatched `item.project`
+        // ('hardware' vs a real 'Hardware') still finds its project — otherwise
+        // byName returns null, the read yields zero tasks, and a real duplicate
+        // is missed. This requires the project-names read first, so it now
+        // precedes (rather than parallels) the scoped task read.
+        existingProjects = await this.fetchExistingProjectNames(warnings);
+        const scopeProjects = items.map((item) =>
+          this.canonicalProjectScope(item.project ?? defaultProject ?? null, existingProjects),
+        );
+        [existingTags, existingTasks] = await Promise.all([
           this.fetchExistingTagNames(warnings),
           this.fetchExistingIncompleteTasks(warnings, scopeProjects),
         ]);
@@ -2507,6 +2517,22 @@ SCOPE FILTERING:
         timer.toMetadata(),
       );
     }
+  }
+
+  /**
+   * OMN-126: map a requested project name to the canonical existing name (exact
+   * case-insensitive match) for scoping the dedup read. The scoped read's filter
+   * compiles to a case-SENSITIVE `flattenedProjects.byName()`, so a case-mismatched
+   * name would otherwise find no project and silently miss duplicates. `null`
+   * (inbox) passes through; an unknown name passes through unchanged (no existing
+   * project to scope to, so the read correctly finds nothing). Deliberately the
+   * `exact` match only — NOT resolveProjectName's `partial`/substring fallback,
+   * which would scope a different project than findDuplicateTask compares against.
+   */
+  private canonicalProjectScope(name: string | null, existing: string[]): string | null {
+    if (name === null) return null;
+    const lower = name.toLowerCase();
+    return existing.find((p) => p.toLowerCase() === lower) ?? name;
   }
 
   /** Resolve a requested project name against existing projects (case-insensitive). */

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2412,13 +2412,14 @@ SCOPE FILTERING:
         // changes no match results; it only kills the ~8s whole-DB scan and makes
         // the 2000-row cap effectively per-scope instead of a global truncation.
         //
-        // The scoped read's project filter compiles to a case-SENSITIVE
-        // `flattenedProjects.byName()`; canonicalize each scope to the exact
-        // existing name (case-insensitive) so a case-mismatched `item.project`
-        // ('hardware' vs a real 'Hardware') still finds its project — otherwise
-        // byName returns null, the read yields zero tasks, and a real duplicate
-        // is missed. This requires the project-names read first, so it now
-        // precedes (rather than parallels) the scoped task read.
+        // The scoped read's project filter resolves the name by a case-SENSITIVE
+        // exact match (post-OMN-224: a status-aware `flattenedProjects` scan,
+        // `p.name === target`); canonicalize each scope to the exact existing name
+        // (case-insensitive) so a case-mismatched `item.project` ('hardware' vs a
+        // real 'Hardware') still finds its project — otherwise resolution yields
+        // null, the read returns zero tasks, and a real duplicate is missed. This
+        // requires the project-names read first, so it now precedes (rather than
+        // parallels) the scoped task read.
         existingProjects = await this.fetchExistingProjectNames(warnings);
         const scopeProjects = items.map((item) =>
           this.canonicalProjectScope(item.project ?? defaultProject ?? null, existingProjects),
@@ -2521,9 +2522,10 @@ SCOPE FILTERING:
 
   /**
    * OMN-126: map a requested project name to the canonical existing name (exact
-   * case-insensitive match) for scoping the dedup read. The scoped read's filter
-   * compiles to a case-SENSITIVE `flattenedProjects.byName()`, so a case-mismatched
-   * name would otherwise find no project and silently miss duplicates. `null`
+   * case-insensitive match) for scoping the dedup read. The scoped read resolves
+   * the name by a case-SENSITIVE exact match (post-OMN-224: a status-aware
+   * `flattenedProjects` scan, `p.name === target`), so a case-mismatched name
+   * would otherwise find no project and silently miss duplicates. `null`
    * (inbox) passes through; an unknown name passes through unchanged (no existing
    * project to scope to, so the read correctly finds nothing). Deliberately the
    * `exact` match only — NOT resolveProjectName's `partial`/substring fallback,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -57,7 +57,6 @@ import { extractDates } from '../capture/date-extraction.js';
 // OMN-124: read-only pre-flight for structured meeting-note items.
 import { buildFilteredProjectsScript } from '../../contracts/ast/script-builder.js';
 import { buildListTasksScriptV4 } from '../../omnifocus/scripts/tasks/list-tasks-ast.js';
-import type { TaskFilter } from '../../contracts/filters.js';
 import { buildTagsScript } from '../../contracts/ast/tag-script-builder.js';
 
 // Response types
@@ -2405,35 +2404,21 @@ SCOPE FILTERING:
       let existingTags = new Set<string>();
       let existingTasks: Array<{ name: string; project: string | null }> = [];
       if (validate) {
-        // OMN-126: scope the dedup read to the requested target project(s) + inbox
-        // instead of the whole DB. The duplicate comparison (findDuplicateTask) is
-        // already project-scoped against `project.requested` — which is exactly
-        // `item.project ?? defaultProject ?? null` — so scoping the candidate read
-        // changes no match results; it only kills the ~8s whole-DB scan and makes
-        // the 2000-row cap effectively per-scope instead of a global truncation.
+        // OMN-126: scope the dedup read to the requested target project(s) + inbox.
+        // Each named scope reads ONLY that project's own task subtree
+        // (`project.flattenedTasks`, ~0.3s — see readScopedIncompleteTasks), NOT a
+        // filter over the global `flattenedTasks`, which hits the ~10s whole-DB
+        // iteration floor PER scope and, fanned out over N distinct projects,
+        // serializes on OmniFocus's single automation channel past the osascript
+        // timeout. The duplicate comparison (findDuplicateTask) is already against
+        // `project.requested` and compares names case-insensitively, so scoping the
+        // candidate read changes no match results.
         //
-        // The scoped read's project filter resolves the name by a case-SENSITIVE
-        // exact match (post-OMN-224: a status-aware `flattenedProjects` scan,
-        // `p.name === target`); canonicalize each scope to the exact existing name
-        // (case-insensitive) so a case-mismatched `item.project` ('hardware' vs a
-        // real 'Hardware') still finds its project — otherwise resolution yields
-        // null, the read returns zero tasks, and a real duplicate is missed. This
-        // requires the project-names read first, so it now precedes (rather than
-        // parallels) the scoped task read.
-        const proj = await this.fetchExistingProjectNames(warnings);
-        existingProjects = proj.names;
-        // Review ②: if the existing-projects read failed we cannot canonicalize a
-        // case-mismatched name, so per-project name-scoping would silently miss
-        // duplicates. Fall back to ONE whole-DB dedup read (findDuplicateTask
-        // compares project names case-insensitively) — pre-OMN-126 behavior on this
-        // error path. `undefined` signals that whole-DB read.
-        // Review ⑧: dedup the raw scopes first, then canonicalize each DISTINCT one
-        // (D canonicalizations, not one per item).
-        const scopeProjects = proj.ok
-          ? [...new Set(items.map((item) => this.requestedScope(item, defaultProject)))].map((s) =>
-              this.canonicalProjectScope(s, existingProjects),
-            )
-          : undefined;
+        // The scoped read resolves the project name case-insensitively itself, so
+        // `existingProjects` is needed only for the preview's project.match — a
+        // failed projects read degrades that preview, never the dedup read.
+        existingProjects = await this.fetchExistingProjectNames(warnings);
+        const scopeProjects = [...new Set(items.map((item) => this.requestedScope(item, defaultProject)))];
         [existingTags, existingTasks] = await Promise.all([
           this.fetchExistingTagNames(warnings),
           this.fetchExistingIncompleteTasks(warnings, scopeProjects),
@@ -2543,23 +2528,6 @@ SCOPE FILTERING:
     return p === '' ? null : p;
   }
 
-  /**
-   * OMN-126: map a requested project name to the canonical existing name (exact
-   * case-insensitive match) for scoping the dedup read. The scoped read resolves
-   * the name by a case-SENSITIVE exact match (post-OMN-224: a status-aware
-   * `flattenedProjects` scan, `p.name === target`), so a case-mismatched name
-   * would otherwise find no project and silently miss duplicates. `null` (inbox)
-   * passes through; an unknown name passes through unchanged (no existing project
-   * to scope to, so the read correctly finds nothing). Deliberately the EXACT match
-   * only — never resolveProjectName's `partial`/substring fallback, which would
-   * scope a different project than findDuplicateTask compares against. Delegates to
-   * resolveProjectName so the exact-match lookup lives in one place (review ⑥).
-   */
-  private canonicalProjectScope(name: string | null, existing: string[]): string | null {
-    const r = this.resolveProjectName(name, existing, true);
-    return r.match === 'exact' ? r.resolved : name;
-  }
-
   /** Resolve a requested project name against existing projects (case-insensitive). */
   private resolveProjectName(
     requested: string | null,
@@ -2636,22 +2604,22 @@ SCOPE FILTERING:
   }
 
   /**
-   * Read existing project names (lite, no stats). Warns + returns `ok:false` on
-   * script error (OMN-204). The caller needs `ok` (not just an empty list) because
-   * a failed read means names can't be canonicalized, so the dedup read must fall
-   * back to a whole-DB scan rather than scope by an unresolvable name (review ②).
+   * Read existing project names (lite, no stats) for the preview's project.match
+   * classification. Warns + returns [] on script error (OMN-204). NOTE: the dedup
+   * read no longer depends on this — readScopedIncompleteTasks resolves each project
+   * name case-insensitively itself — so a failed projects read degrades only the
+   * preview's match labels, never duplicate detection.
    */
-  private async fetchExistingProjectNames(warnings: string[]): Promise<{ ok: boolean; names: string[] }> {
+  private async fetchExistingProjectNames(warnings: string[]): Promise<string[]> {
     const gen = buildFilteredProjectsScript({}, { limit: 1000, includeStats: false, performanceMode: 'lite' });
     const result = await this.execJson(gen.script, PROJECTS_LIST_SCHEMA);
     if (!isScriptSuccess(result)) {
       warnings.push('project resolution unavailable: existing-projects read failed');
-      return { ok: false, names: [] };
+      return [];
     }
-    const names = this.unwrapList(result.data, ['projects', 'items'])
+    return this.unwrapList(result.data, ['projects', 'items'])
       .map((p) => (p as { name?: unknown }).name)
       .filter((n): n is string => typeof n === 'string');
-    return { ok: true, names };
   }
 
   /** Read existing tag names (basic mode). Warns + returns empty set on script error. */
@@ -2683,19 +2651,12 @@ SCOPE FILTERING:
    * (findDuplicateTask) is already against `project.requested`, so scoping the
    * candidate set changes no match results; it only kills the ~8s whole-DB scan and
    * makes the 2000-row cap per-scope instead of a global truncation.
-   *
-   * `scopeProjects === undefined` requests a single WHOLE-DB read — the review-②
-   * fallback used when the existing-projects read failed and names can't be
-   * canonicalized. This is the only reachable whole-DB path (the call site always
-   * passes a non-empty scope list otherwise), so the ~8s scan is now a deliberate,
-   * named error fallback rather than dead defensive code.
    */
   private async fetchExistingIncompleteTasks(
     warnings: string[],
-    scopeProjects: Array<string | null> | undefined,
+    scopeProjects: Array<string | null>,
   ): Promise<Array<{ name: string; project: string | null }>> {
-    const scopes: Array<string | null | undefined> =
-      scopeProjects === undefined ? [undefined] : [...new Set(scopeProjects)];
+    const scopes = [...new Set(scopeProjects)];
 
     const reads = await Promise.all(
       scopes.map(async (scope) => ({ scope, ...(await this.readScopedIncompleteTasks(scope)) })),
@@ -2706,12 +2667,7 @@ SCOPE FILTERING:
     // global warning is both over- and under-informative. (OMN-204 no-silent-failure.)
     const failed = reads.filter((r) => !r.ok).map((r) => r.scope);
     if (failed.length > 0) {
-      const label = (s: string | null | undefined): string => {
-        if (s === undefined) return 'whole database';
-        if (s === null) return 'inbox';
-        return s;
-      };
-      const names = failed.map(label).join(', ');
+      const names = failed.map((s) => (s === null ? 'inbox' : s)).join(', ');
       warnings.push(`dedupe unavailable: incomplete-tasks read failed for ${names}`);
     }
 
@@ -2732,36 +2688,35 @@ SCOPE FILTERING:
   }
 
   /**
-   * One scoped incomplete-tasks read. `scope`: a project name → tasks in that
-   * project; `null` → inbox tasks; `undefined` → whole DB (no scope).
+   * One scoped incomplete-tasks read. `scope`: a project name → tasks in THAT
+   * project's own subtree; `null` → inbox tasks.
+   *
+   * Named project: read `project.flattenedTasks` (the resolved project's own
+   * descendants) instead of filtering the global `flattenedTasks`. The latter
+   * iterates the whole database (~10s floor) on EVERY scope, which serializes past
+   * the script timeout over multiple projects; `project.flattenedTasks` is ~40x
+   * faster and naturally excludes the project ROOT (OMN-191: a root is named like
+   * its project but is not actionable, so it must not look like a duplicate). The
+   * project name is resolved case-insensitively here, so the dedup read needs no
+   * separate canonicalization step.
+   *
+   * Inbox: the global `flattenedTasks` pipeline (buildListTasksScriptV4, embedded in
+   * the JXA→bridge harness) is fine — the inbox is small, so the read is sub-second.
    *
    * Both terminal states excluded: a dropped task has completed===false, so without
-   * dropped:false an abandoned task would false-positive as a duplicate.
-   *
-   * Uses buildListTasksScriptV4, NOT the bare buildFilteredTasksScript — the latter
-   * returns an OmniJS body that uses `flattenedTasks`, which only exists inside the
-   * evaluateJavascript bridge. The V4 wrapper embeds that body in the JXA→bridge
-   * harness. (OMN-124: passing the bare body to execJson threw "Can't find variable:
-   * flattenedTasks" and silently disabled dedupe.)
-   *
-   * OMN-191: inherits OMN-153's default project-root exclusion — a project root is
-   * named identically to its project but is NOT an actionable task, so it must not
-   * make "create a task named like the project" look like a duplicate.
+   * the Dropped exclusion an abandoned task would false-positive as a duplicate.
    */
   private async readScopedIncompleteTasks(
-    scope: string | null | undefined,
+    scope: string | null,
   ): Promise<{ ok: boolean; tasks: Array<{ name: string; project: string | null }> }> {
-    const filter: TaskFilter = { completed: false, dropped: false };
-    if (scope === null) {
-      filter.inInbox = true; // inbox-bound items dedup against inbox tasks
-    } else if (typeof scope === 'string') {
-      filter.project = scope; // named-project items dedup against that project's tasks
-    }
-    const script = buildListTasksScriptV4({
-      filter,
-      fields: ['name', 'project'],
-      limit: 2000,
-    });
+    const script =
+      scope === null
+        ? buildListTasksScriptV4({
+            filter: { completed: false, dropped: false, inInbox: true },
+            fields: ['name', 'project'],
+            limit: 2000,
+          })
+        : this.buildProjectScopedDedupScript(scope);
     const result = await this.execJson(script, TASKS_LIST_SCHEMA);
     if (!isScriptSuccess(result)) {
       return { ok: false, tasks: [] };
@@ -2776,6 +2731,30 @@ SCOPE FILTERING:
       })
       .filter((t) => t.name.length > 0);
     return { ok: true, tasks };
+  }
+
+  /**
+   * Build a JXA→OmniJS script that reads incomplete (not completed/dropped) tasks
+   * from ONE project's own subtree (`project.flattenedTasks`), resolving the project
+   * name case-insensitively (status-aware: prefer a non-dropped/done match). Returns
+   * raw `{ tasks: [{ name, project }] }` for execJson to wrap. The program crosses
+   * the JXA→OmniJS boundary as a single JSON.stringify'd string (no nested template /
+   * hand-rolled escaper — closes the OMN-111/113 injection class).
+   */
+  private buildProjectScopedDedupScript(projectName: string): string {
+    const program =
+      '(() => {' +
+      `var target = ${JSON.stringify(projectName)};` +
+      'var lower = target.toLowerCase();' +
+      'var named = flattenedProjects.filter(function(p){ return p.name.toLowerCase() === lower; });' +
+      'var live = named.filter(function(p){ return p.status !== Project.Status.Dropped && p.status !== Project.Status.Done; });' +
+      'var p = (live.length > 0 ? live : named)[0];' +
+      'if (!p) return JSON.stringify({ tasks: [] });' +
+      'var out = [];' +
+      'p.flattenedTasks.forEach(function(t){ if (t.taskStatus !== Task.Status.Completed && t.taskStatus !== Task.Status.Dropped) { out.push({ name: t.name, project: p.name }); } });' +
+      'return JSON.stringify({ tasks: out });' +
+      '})()';
+    return `(() => { const app = Application('OmniFocus'); return app.evaluateJavascript(${JSON.stringify(program)}); })()`;
   }
 
   /**

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -2650,7 +2650,7 @@ SCOPE FILTERING:
     const merged: Array<{ name: string; project: string | null }> = [];
     for (const r of reads) {
       for (const t of r.tasks) {
-        const key = `${t.name.toLowerCase()} ${t.project?.toLowerCase() ?? ''}`;
+        const key = `${t.name.toLowerCase()}\u0000${t.project?.toLowerCase() ?? ''}`;
         if (!seen.has(key)) {
           seen.add(key);
           merged.push(t);

--- a/tests/integration/omn-126-dedup-scope.test.ts
+++ b/tests/integration/omn-126-dedup-scope.test.ts
@@ -1,0 +1,123 @@
+/**
+ * OMN-126: parse_meeting_notes dedup, scoped to the target project, must detect a
+ * real existing task — exercised against REAL OmniFocus.
+ *
+ * OMN-126 scopes the dedup candidate read to the requested project(s) + inbox via
+ * `filter.project = <canonical name>` (instead of an ~8s whole-DB scan). That
+ * scoped read is exactly the path that OMN-224 fixed: before OMN-224 it threw
+ * (`document.projectsMatching is not a function`), the failure was swallowed, and
+ * dedup silently found nothing — every item came back `duplicateOf: null`. The
+ * 59 unit tests on this path mock `execJson`, so they validate the scoping LOGIC
+ * but never run the scoped read; this test runs it end-to-end through the server.
+ *
+ * Contract under test:
+ *  - an item whose name matches an existing task in the target project is flagged
+ *    `duplicateOf` (readyToCreate: false);
+ *  - a novel item in the same project is not flagged (readyToCreate: true);
+ *  - no `dedupe unavailable` warning (the scoped read succeeded).
+ *
+ * Uses the test sandbox for isolation (project created inside the sandbox folder).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getSharedClient } from './helpers/shared-server.js';
+import { MCPTestClient } from './helpers/mcp-test-client.js';
+import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from './helpers/sandbox-manager.js';
+import { runScopedName } from './helpers/run-id.js';
+
+const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
+const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
+
+interface BatchResponse {
+  success: boolean;
+  data: { tempIdMapping?: Record<string, string> };
+}
+interface ParsePreviewItem {
+  name: string;
+  duplicateOf: unknown;
+  readyToCreate: boolean;
+}
+interface ParseResponse {
+  success: boolean;
+  data?: {
+    items?: ParsePreviewItem[];
+    warnings?: string[];
+    summary?: { duplicates?: number; readyToCreate?: number };
+  };
+}
+
+d('OMN-126: project-scoped dedup detects a real existing task', () => {
+  let client: MCPTestClient;
+
+  const PROJECT_NAME = runScopedName('OMN126_DedupScope');
+  const DUP_TASK_NAME = runScopedName('OMN126_DupTarget');
+  const NEW_TASK_NAME = runScopedName('OMN126_UniqueNew');
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'project',
+            data: { tempId: 'proj', name: PROJECT_NAME, folder: SANDBOX_FOLDER_NAME },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'dup', name: DUP_TASK_NAME, parentTempId: 'proj' },
+          },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+
+    expect(response.success).toBe(true);
+    expect(response.data).toBeTruthy();
+    expect(response.data.tempIdMapping?.['dup']).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it('flags the scoped duplicate and passes the novel item through', async () => {
+    const result = (await client.callTool('omnifocus_analyze', {
+      analysis: {
+        type: 'parse_meeting_notes',
+        params: {
+          items: [
+            { name: DUP_TASK_NAME, project: PROJECT_NAME },
+            { name: NEW_TASK_NAME, project: PROJECT_NAME },
+          ],
+        },
+      },
+    })) as ParseResponse;
+
+    expect(result.success).toBe(true);
+    // The scoped read must have succeeded — no swallowed dedupe failure.
+    expect(result.data?.warnings ?? []).not.toContain('dedupe unavailable: incomplete-tasks read failed');
+
+    const items = result.data?.items ?? [];
+    const dup = items.find((i) => i.name === DUP_TASK_NAME);
+    const fresh = items.find((i) => i.name === NEW_TASK_NAME);
+
+    // Pre-OMN-224 the scoped read threw → existingTasks empty → duplicateOf null.
+    expect(dup?.duplicateOf).toBeTruthy();
+    expect(dup?.readyToCreate).toBe(false);
+
+    expect(fresh?.duplicateOf).toBeFalsy();
+    expect(fresh?.readyToCreate).toBe(true);
+
+    expect(result.data?.summary?.duplicates).toBe(1);
+  }, 60000);
+});

--- a/tests/integration/omn-126-dedup-scope.test.ts
+++ b/tests/integration/omn-126-dedup-scope.test.ts
@@ -2,13 +2,13 @@
  * OMN-126: parse_meeting_notes dedup, scoped to the target project, must detect a
  * real existing task — exercised against REAL OmniFocus.
  *
- * OMN-126 scopes the dedup candidate read to the requested project(s) + inbox via
- * `filter.project = <canonical name>` (instead of an ~8s whole-DB scan). That
- * scoped read is exactly the path that OMN-224 fixed: before OMN-224 it threw
- * (`document.projectsMatching is not a function`), the failure was swallowed, and
- * dedup silently found nothing — every item came back `duplicateOf: null`. The
- * unit tests on this path mock `execJson`, so they validate the scoping LOGIC but
- * never run the scoped read; this test runs it end-to-end through the server.
+ * OMN-126 scopes the dedup candidate read to the requested project(s) + inbox.
+ * Each named scope reads the resolved project's OWN subtree (project.flattenedTasks,
+ * ~0.3s, resolving the name case-insensitively) instead of filtering the global
+ * flattenedTasks (~10s floor PER scope, which serialized past the timeout over many
+ * projects). The unit tests on this path mock `execJson`, so they validate the
+ * scoping LOGIC but never run the scoped read; this test runs it end-to-end through
+ * the server.
  *
  * Contract under test:
  *  - an item whose name matches an existing task in the target project is flagged
@@ -105,7 +105,7 @@ d('OMN-126: project-scoped dedup detects a real existing task', () => {
 
     expect(result.success).toBe(true);
     // The scoped read must have succeeded — no swallowed dedupe failure.
-    expect(result.data?.warnings ?? []).not.toContain('dedupe unavailable: incomplete-tasks read failed');
+    expect((result.data?.warnings ?? []).some((w) => w.includes('dedupe unavailable'))).toBe(false);
 
     const items = result.data?.items ?? [];
     const dup = items.find((i) => i.name === DUP_TASK_NAME);
@@ -133,8 +133,8 @@ d('OMN-126: a case-mismatched project name still dedups (canonicalization)', () 
   let client: MCPTestClient;
 
   // Same full name in two cases: identical `__TEST__-<runid>-` prefix, suffix
-  // differs only in case → case-insensitively equal, so canonicalProjectScope must
-  // resolve the lowercase query to the canonical mixed-case project.
+  // differs only in case → case-insensitively equal, so the scoped read's own
+  // case-insensitive resolution must map the lowercase query to the real project.
   const SUFFIX = 'OMN126CanonHW';
   const PROJECT_NAME = runScopedName(SUFFIX); // ...-OMN126CanonHW
   const LOWER_QUERY = `${RUN_NAME_PREFIX}${SUFFIX.toLowerCase()}`; // ...-omn126canonhw
@@ -179,7 +179,7 @@ d('OMN-126: a case-mismatched project name still dedups (canonicalization)', () 
     })) as ParseResponse;
 
     expect(result.success).toBe(true);
-    expect(result.data?.warnings ?? []).not.toContain('dedupe unavailable: incomplete-tasks read failed');
+    expect((result.data?.warnings ?? []).some((w) => w.includes('dedupe unavailable'))).toBe(false);
     const item = (result.data?.items ?? []).find((i) => i.name === DUP_TASK_NAME);
     // Case-mismatched scope must still resolve → dup found.
     expect(item?.duplicateOf).toBeTruthy();

--- a/tests/integration/omn-126-dedup-scope.test.ts
+++ b/tests/integration/omn-126-dedup-scope.test.ts
@@ -7,8 +7,8 @@
  * scoped read is exactly the path that OMN-224 fixed: before OMN-224 it threw
  * (`document.projectsMatching is not a function`), the failure was swallowed, and
  * dedup silently found nothing — every item came back `duplicateOf: null`. The
- * 59 unit tests on this path mock `execJson`, so they validate the scoping LOGIC
- * but never run the scoped read; this test runs it end-to-end through the server.
+ * unit tests on this path mock `execJson`, so they validate the scoping LOGIC but
+ * never run the scoped read; this test runs it end-to-end through the server.
  *
  * Contract under test:
  *  - an item whose name matches an existing task in the target project is flagged
@@ -23,7 +23,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { getSharedClient } from './helpers/shared-server.js';
 import { MCPTestClient } from './helpers/mcp-test-client.js';
 import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from './helpers/sandbox-manager.js';
-import { runScopedName } from './helpers/run-id.js';
+import { runScopedName, RUN_NAME_PREFIX } from './helpers/run-id.js';
 
 const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
 const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
@@ -119,5 +119,108 @@ d('OMN-126: project-scoped dedup detects a real existing task', () => {
     expect(fresh?.readyToCreate).toBe(true);
 
     expect(result.data?.summary?.duplicates).toBe(1);
+  }, 60000);
+});
+
+/**
+ * OMN-126 review ④: the case-canonicalization — the headline of this PR — is
+ * actually exercised end-to-end. A lowercase `item.project` must resolve to the
+ * canonical existing project (case-insensitive) so its scoped read finds the
+ * project's tasks. The unit tests mock `execJson` so `existingProjects` is empty
+ * and canonicalization is never exercised; this runs it against real OmniFocus.
+ */
+d('OMN-126: a case-mismatched project name still dedups (canonicalization)', () => {
+  let client: MCPTestClient;
+
+  // Same full name in two cases: identical `__TEST__-<runid>-` prefix, suffix
+  // differs only in case → case-insensitively equal, so canonicalProjectScope must
+  // resolve the lowercase query to the canonical mixed-case project.
+  const SUFFIX = 'OMN126CanonHW';
+  const PROJECT_NAME = runScopedName(SUFFIX); // ...-OMN126CanonHW
+  const LOWER_QUERY = `${RUN_NAME_PREFIX}${SUFFIX.toLowerCase()}`; // ...-omn126canonhw
+  const DUP_TASK_NAME = runScopedName('OMN126CanonDup');
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'project',
+            data: { tempId: 'proj', name: PROJECT_NAME, folder: SANDBOX_FOLDER_NAME },
+          },
+          { operation: 'create', target: 'task', data: { tempId: 'dup', name: DUP_TASK_NAME, parentTempId: 'proj' } },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+    expect(response.success).toBe(true);
+    expect(response.data?.tempIdMapping?.['dup']).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it('resolves a lowercase project name to the canonical project and flags the dup', async () => {
+    const result = (await client.callTool('omnifocus_analyze', {
+      analysis: {
+        type: 'parse_meeting_notes',
+        params: { items: [{ name: DUP_TASK_NAME, project: LOWER_QUERY }] },
+      },
+    })) as ParseResponse;
+
+    expect(result.success).toBe(true);
+    expect(result.data?.warnings ?? []).not.toContain('dedupe unavailable: incomplete-tasks read failed');
+    const item = (result.data?.items ?? []).find((i) => i.name === DUP_TASK_NAME);
+    // Case-mismatched scope must still resolve → dup found.
+    expect(item?.duplicateOf).toBeTruthy();
+    expect(item?.readyToCreate).toBe(false);
+  }, 60000);
+});
+
+/**
+ * OMN-126 review ①: an empty-string `project` must be treated as the inbox
+ * (`null`), not a project literally named '' — otherwise the scoped read filters
+ * on `name === ''` (zero matches) and silently misses a real inbox duplicate.
+ */
+d('OMN-126: an empty-string project dedups against the inbox', () => {
+  let client: MCPTestClient;
+  const INBOX_DUP_NAME = runScopedName('OMN126EmptyProjInbox');
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+    // A real inbox task (no project) — createTestTask tracks it for cleanup.
+    const created = await client.createTestTask(INBOX_DUP_NAME);
+    expect(created?.success ?? created?.data?.task?.taskId).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it("treats project:'' as inbox and flags the inbox duplicate", async () => {
+    const result = (await client.callTool('omnifocus_analyze', {
+      analysis: {
+        type: 'parse_meeting_notes',
+        params: { items: [{ name: INBOX_DUP_NAME, project: '' }] },
+      },
+    })) as ParseResponse;
+
+    expect(result.success).toBe(true);
+    const item = (result.data?.items ?? []).find((i) => i.name === INBOX_DUP_NAME);
+    // Pre-fix: project:'' scoped the read to a project named '' → 0 tasks → missed.
+    expect(item?.duplicateOf).toBeTruthy();
+    expect(item?.readyToCreate).toBe(false);
   }, 60000);
 });

--- a/tests/integration/omn-126-dedup-scope.test.ts
+++ b/tests/integration/omn-126-dedup-scope.test.ts
@@ -224,3 +224,68 @@ d('OMN-126: an empty-string project dedups against the inbox', () => {
     expect(item?.readyToCreate).toBe(false);
   }, 60000);
 });
+
+/**
+ * OMN-126 review: OmniFocus does not enforce unique project names. When two
+ * projects share the requested name, the dedup read must aggregate BOTH — a
+ * duplicate in the second same-named project must still be caught. (Pre-fix the
+ * read picked matches[0] and read only one project's subtree.)
+ */
+d('OMN-126: same-named projects — dedup aggregates across all of them', () => {
+  let client: MCPTestClient;
+  const DUP_PROJECT_NAME = runScopedName('OMN126SameName');
+  const DUP_TASK_NAME = runScopedName('OMN126SameNameTask');
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+    // Two active projects with the SAME name; the EMPTY one is created first (so a
+    // matches[0] pick would land on it and miss the task), the dup task lives in the
+    // second.
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'project',
+            data: { tempId: 'p1', name: DUP_PROJECT_NAME, folder: SANDBOX_FOLDER_NAME },
+          },
+          {
+            operation: 'create',
+            target: 'project',
+            data: { tempId: 'p2', name: DUP_PROJECT_NAME, folder: SANDBOX_FOLDER_NAME },
+          },
+          { operation: 'create', target: 'task', data: { tempId: 'dup', name: DUP_TASK_NAME, parentTempId: 'p2' } },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+    expect(response.success).toBe(true);
+    expect(response.data?.tempIdMapping?.['dup']).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it('flags a duplicate that lives in the SECOND same-named project', async () => {
+    const result = (await client.callTool('omnifocus_analyze', {
+      analysis: {
+        type: 'parse_meeting_notes',
+        params: { items: [{ name: DUP_TASK_NAME, project: DUP_PROJECT_NAME }] },
+      },
+    })) as ParseResponse;
+
+    expect(result.success).toBe(true);
+    const item = (result.data?.items ?? []).find((i) => i.name === DUP_TASK_NAME);
+    // Pre-fix: matches[0] = the empty first project → task missed → readyToCreate:true.
+    expect(item?.duplicateOf).toBeTruthy();
+    expect(item?.readyToCreate).toBe(false);
+  }, 60000);
+});

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1052,16 +1052,17 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(tasksScript).toContain('evaluateJavascript');
       });
 
-      it('OMN-191: the dedup tasks read excludes project-root rows by default (inherits OMN-153)', async () => {
-        // A project root is named identically to its project but is NOT an
-        // actionable task — it must not make "create a task named like the
-        // project" look like a duplicate. fetchExistingIncompleteTasks routes
-        // through buildListTasksScriptV4 -> buildFilteredTasksScript, which applies
-        // OMN-153's default project-root exclusion, so root rows never reach dedup.
+      it('OMN-191: the project-scoped dedup read excludes the project root by construction', async () => {
+        // A project root is named identically to its project but is NOT an actionable
+        // task — it must not make "create a task named like the project" look like a
+        // duplicate. The project-scoped read uses the resolved project's own subtree
+        // (project.flattenedTasks), which does NOT include the root (the root is
+        // project.task, not a member of flattenedTasks) — root exclusion is structural,
+        // no predicate needed.
         const scripts: string[] = [];
         mockOmni.executeJson.mockImplementation((script: string) => {
           scripts.push(script);
-          return Promise.resolve({ tasks: [] });
+          return Promise.resolve(createScriptSuccess({ tasks: [] }));
         });
 
         await tool.execute({
@@ -1070,9 +1071,8 @@ describe('OmniFocusAnalyzeTool', () => {
 
         const tasksScript = scripts.find((s) => s.includes('flattenedTasks'));
         expect(tasksScript).toBeDefined();
-        // OMN-153 predicate: a project root is the only task with task.project !== null,
-        // so excluding `task.project === null` rows keeps roots out of the dedup set.
-        expect(tasksScript).toContain('task.project === null');
+        expect(tasksScript).toContain('p.flattenedTasks');
+        expect(tasksScript).not.toContain('task.project === null');
       });
 
       it('OMN-126: scopes the dedup read per requested scope — project read + inbox read, not whole-DB', async () => {
@@ -1102,8 +1102,8 @@ describe('OmniFocusAnalyzeTool', () => {
           },
         });
 
-        // Project-scoped read: flattenedTasks narrowed by the containing-project target.
-        const projectRead = scripts.find((s) => s.includes('task.containingProject ==='));
+        // Project-scoped read: the resolved project's own subtree (project.flattenedTasks).
+        const projectRead = scripts.find((s) => s.includes('p.flattenedTasks'));
         expect(projectRead).toBeDefined();
         // Inbox-scoped read: a separate inbox.forEach pass for the project-less item.
         const inboxRead = scripts.find((s) => s.includes('inbox.forEach') && s.includes('task.inInbox === true'));
@@ -1138,25 +1138,16 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(taskReads).toBe(2);
       });
 
-      it('OMN-126: scopes the project read by the CANONICAL existing name, not the raw user case', async () => {
-        // Bug: filter.project = the raw 'hardware' resolves by a case-SENSITIVE exact
-        // match (post-OMN-224: a status-aware flattenedProjects scan, p.name === target)
-        // → null → the scoped read yields zero tasks → a real duplicate is missed and a
-        // second task is created. The existing dedup test passes only because it mocks
-        // responses by CALL ORDER (returning the task regardless of the script's project
-        // case); this test asserts on the emitted SCRIPT, where the bug actually lives.
-        // Fix: resolve the scope to the canonical existing name ('Hardware') so the
-        // exact-match read succeeds.
+      it('OMN-126: the project-scoped read resolves the project name case-insensitively', async () => {
+        // A case-mismatched item.project ('hardware' vs a real 'Hardware') must still
+        // find its project. The scoped read embeds the RAW requested name and resolves
+        // it case-insensitively inside OmniJS (flattenedProjects scan, both sides
+        // lowercased) — so the read needs no separate canonicalization step against the
+        // project-names list.
         const scripts: string[] = [];
-        const dbResponses = [
-          createScriptSuccess({ projects: [{ name: 'Hardware' }] }), // project-names read
-          createScriptSuccess({ ok: true, v: 'ast', items: [] }), // tag-names read
-          createScriptSuccess({ tasks: [] }), // scoped task read
-        ];
-        let call = 0;
         mockOmni.executeJson.mockImplementation((script: string) => {
           scripts.push(script);
-          return Promise.resolve(dbResponses[call++] ?? createScriptSuccess({ tasks: [] }));
+          return Promise.resolve(createScriptSuccess({ tasks: [] }));
         });
 
         await tool.execute({
@@ -1166,14 +1157,12 @@ describe('OmniFocusAnalyzeTool', () => {
           },
         });
 
-        const projectRead = scripts.find((s) => s.includes('task.containingProject ==='));
+        const projectRead = scripts.find((s) => s.includes('p.flattenedTasks'));
         expect(projectRead).toBeDefined();
-        // The byName target embedded in the scoped read is the canonical 'Hardware', not raw
-        // 'hardware'. (The program is embedded in app.evaluateJavascript("..."), so its quotes
-        // are backslash-escaped — assert on the case-distinct token, the only source of which
-        // is the project scope.)
-        expect(projectRead).toContain('Hardware');
-        expect(projectRead).not.toContain('hardware');
+        // Raw requested name embedded + case-insensitive resolution (toLowerCase on both
+        // sides), so 'hardware' resolves to a real 'Hardware' at runtime.
+        expect(projectRead).toContain('hardware');
+        expect(projectRead).toContain('toLowerCase');
       });
 
       it("OMN-126 review ①: project:'' scopes the dedup read to the inbox, not a project named ''", async () => {
@@ -1197,10 +1186,11 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(taskScripts.some((s) => s.includes('task.containingProject ==='))).toBe(false);
       });
 
-      it('OMN-126 review ②: a failed projects read falls back to ONE whole-DB dedup read', async () => {
-        // When the existing-projects read fails, names can't be canonicalized, so
-        // per-project scoping is unreliable → fall back to a single whole-DB read
-        // (findDuplicateTask compares case-insensitively, so dedup still works).
+      it('OMN-126 review ②: a failed projects read does NOT break dedup (the scoped read self-resolves)', async () => {
+        // The scoped dedup read resolves the project name itself, so a failed
+        // existing-projects read degrades only the preview's project.match — never
+        // duplicate detection. (Contrast the pre-rework design, where the read scoped
+        // by a name it could not canonicalize and silently missed dups.)
         const scripts: string[] = [];
         let call = 0;
         mockOmni.executeJson.mockImplementation((script: string) => {
@@ -1218,15 +1208,15 @@ describe('OmniFocusAnalyzeTool', () => {
           },
         });
 
-        // Exactly one task read, and it is whole-DB (no project/inbox narrowing).
-        const taskScripts = scripts.filter((s) => s.includes('flattenedTasks'));
-        expect(taskScripts).toHaveLength(1);
-        expect(taskScripts[0]).not.toContain('task.containingProject ===');
-        expect(taskScripts[0]).not.toContain('inbox.forEach');
-        expect((res.data.warnings as string[]).some((w) => w.includes('project resolution unavailable'))).toBe(true);
-        // Dedup still works via the whole-DB fallback (case-insensitive comparison).
+        // The dedup read is still the project-scoped self-resolving read (not whole-DB).
+        const projectRead = scripts.find((s) => s.includes('p.flattenedTasks'));
+        expect(projectRead).toBeDefined();
+        // Dedup still works (the scoped read self-resolved 'hardware'; findDuplicateTask
+        // compares case-insensitively).
         expect(res.data.items[0].duplicateOf).toBeTruthy();
         expect(res.data.items[0].readyToCreate).toBe(false);
+        // The projects-read failure is still surfaced (degrades preview match only).
+        expect((res.data.warnings as string[]).some((w) => w.includes('project resolution unavailable'))).toBe(true);
       });
 
       it('OMN-126 review ③: a single failed scope read NAMES that scope in the warning', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1082,9 +1082,12 @@ describe('OmniFocusAnalyzeTool', () => {
         // narrowed by task.containingProject; an inbox-bound item → a separate
         // inbox.forEach read. The old whole-DB read had neither narrowing clause.
         const scripts: string[] = [];
+        // Wrap in a success envelope: the projects read must succeed (ok:true) for
+        // the per-scope path to run — a non-success projects read now falls back to
+        // a single whole-DB read (review ②).
         mockOmni.executeJson.mockImplementation((script: string) => {
           scripts.push(script);
-          return Promise.resolve({ tasks: [] });
+          return Promise.resolve(createScriptSuccess({ tasks: [] }));
         });
 
         await tool.execute({
@@ -1112,9 +1115,11 @@ describe('OmniFocusAnalyzeTool', () => {
         // "Contradictory conditions on field task.containingProject" in the AST. The
         // per-scope-read design avoids that — two distinct projects = two reads.
         let taskReads = 0;
+        // Success envelope so the projects read succeeds (ok:true) and the per-scope
+        // path runs; a non-success projects read falls back to one whole-DB read.
         mockOmni.executeJson.mockImplementation((script: string) => {
           if (script.includes('flattenedTasks')) taskReads++;
-          return Promise.resolve({ tasks: [] });
+          return Promise.resolve(createScriptSuccess({ tasks: [] }));
         });
 
         const res: any = await tool.execute({
@@ -1134,12 +1139,14 @@ describe('OmniFocusAnalyzeTool', () => {
       });
 
       it('OMN-126: scopes the project read by the CANONICAL existing name, not the raw user case', async () => {
-        // Bug: filter.project = the raw 'hardware' compiles to flattenedProjects.byName('hardware'),
-        // which is case-SENSITIVE in OmniFocus → null → the scoped read yields zero tasks → a real
-        // duplicate is missed and a second task is created. The existing dedup test passes only
-        // because it mocks responses by CALL ORDER (returning the task regardless of the script's
-        // project case); this test asserts on the emitted SCRIPT, where the bug actually lives.
-        // Fix: resolve the scope to the canonical existing name ('Hardware') so byName succeeds.
+        // Bug: filter.project = the raw 'hardware' resolves by a case-SENSITIVE exact
+        // match (post-OMN-224: a status-aware flattenedProjects scan, p.name === target)
+        // → null → the scoped read yields zero tasks → a real duplicate is missed and a
+        // second task is created. The existing dedup test passes only because it mocks
+        // responses by CALL ORDER (returning the task regardless of the script's project
+        // case); this test asserts on the emitted SCRIPT, where the bug actually lives.
+        // Fix: resolve the scope to the canonical existing name ('Hardware') so the
+        // exact-match read succeeds.
         const scripts: string[] = [];
         const dbResponses = [
           createScriptSuccess({ projects: [{ name: 'Hardware' }] }), // project-names read
@@ -1167,6 +1174,96 @@ describe('OmniFocusAnalyzeTool', () => {
         // is the project scope.)
         expect(projectRead).toContain('Hardware');
         expect(projectRead).not.toContain('hardware');
+      });
+
+      it("OMN-126 review ①: project:'' scopes the dedup read to the inbox, not a project named ''", async () => {
+        // An empty-string project must be treated as the inbox (null). Otherwise the
+        // scoped read filters on a project named '' (zero matches) and silently misses
+        // a real inbox duplicate.
+        const scripts: string[] = [];
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          scripts.push(script);
+          return Promise.resolve(createScriptSuccess({ tasks: [] }));
+        });
+
+        await tool.execute({
+          analysis: { type: 'parse_meeting_notes', params: { items: [{ name: 'X', project: '' }] } },
+        });
+
+        // Inbox-scoped read present; no project-name narrowing (which would scope on '').
+        const inboxRead = scripts.find((s) => s.includes('inbox.forEach') && s.includes('task.inInbox === true'));
+        expect(inboxRead).toBeDefined();
+        const taskScripts = scripts.filter((s) => s.includes('flattenedTasks'));
+        expect(taskScripts.some((s) => s.includes('task.containingProject ==='))).toBe(false);
+      });
+
+      it('OMN-126 review ②: a failed projects read falls back to ONE whole-DB dedup read', async () => {
+        // When the existing-projects read fails, names can't be canonicalized, so
+        // per-project scoping is unreliable → fall back to a single whole-DB read
+        // (findDuplicateTask compares case-insensitively, so dedup still works).
+        const scripts: string[] = [];
+        let call = 0;
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          scripts.push(script);
+          call++;
+          // Call 1 is the projects read — fail it (non-success envelope).
+          if (call === 1) return Promise.resolve({});
+          return Promise.resolve(createScriptSuccess({ tasks: [{ name: 'Order scanners', project: 'Hardware' }] }));
+        });
+
+        const res: any = await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: { items: [{ name: 'Order scanners', project: 'hardware' }] },
+          },
+        });
+
+        // Exactly one task read, and it is whole-DB (no project/inbox narrowing).
+        const taskScripts = scripts.filter((s) => s.includes('flattenedTasks'));
+        expect(taskScripts).toHaveLength(1);
+        expect(taskScripts[0]).not.toContain('task.containingProject ===');
+        expect(taskScripts[0]).not.toContain('inbox.forEach');
+        expect((res.data.warnings as string[]).some((w) => w.includes('project resolution unavailable'))).toBe(true);
+        // Dedup still works via the whole-DB fallback (case-insensitive comparison).
+        expect(res.data.items[0].duplicateOf).toBeTruthy();
+        expect(res.data.items[0].readyToCreate).toBe(false);
+      });
+
+      it('OMN-126 review ③: a single failed scope read NAMES that scope in the warning', async () => {
+        // Two named scopes; the 'Software' read fails while 'Hardware' succeeds. The
+        // warning must name the failed scope, not blanket "dedupe unavailable" — dedup
+        // still worked for Hardware.
+        let call = 0;
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          call++;
+          if (call === 1) {
+            return Promise.resolve(createScriptSuccess({ projects: [{ name: 'Hardware' }, { name: 'Software' }] }));
+          }
+          if (script.includes('flattenedTasks')) {
+            // Fail only the Software-scoped read (its scope name is embedded literally).
+            if (script.includes('Software')) return Promise.resolve({});
+            return Promise.resolve(createScriptSuccess({ tasks: [] }));
+          }
+          return Promise.resolve(createScriptSuccess({ tags: [] }));
+        });
+
+        const res: any = await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: {
+              items: [
+                { name: 'A', project: 'Hardware' },
+                { name: 'B', project: 'Software' },
+              ],
+            },
+          },
+        });
+
+        const warnings = res.data.warnings as string[];
+        const dedupeWarn = warnings.find((w) => w.startsWith('dedupe unavailable'));
+        expect(dedupeWarn).toBeDefined();
+        expect(dedupeWarn).toContain('Software');
+        expect(dedupeWarn).not.toContain('Hardware');
       });
 
       it('emits a batchPayload that round-trips unchanged through WriteSchema { batch }', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -892,15 +892,19 @@ describe('OmniFocusAnalyzeTool', () => {
       });
 
       it('validates against the live DB by default: resolves projects, dedupes, classifies tags', async () => {
-        // execJson reads run via Promise.all in array order: projects, tags, tasks.
-        // OMN-139: executeJson now returns ScriptResult; shapes must match per-site schemas:
+        // execJson reads run via Promise.all: projects, tags, then ONE incomplete-tasks
+        // read PER DISTINCT requested scope (OMN-126 scoped dedup). Two distinct
+        // projects here ('hardware', 'Nonexistent Project') → two task reads → 4 calls.
+        // Call order: projects, tags, hardware-scoped read, nonexistent-scoped read.
+        // OMN-139: executeJson returns ScriptResult; shapes must match per-site schemas:
         //   projects → PROJECTS_LIST_SCHEMA {projects:[...], metadata?}
         //   tags     → TAG_ITEMS_SCHEMA {ok:true, v:'ast', items:[...]}
         //   tasks    → TASKS_LIST_SCHEMA {tasks:[...], metadata?}
         const dbResponses = [
           createScriptSuccess({ projects: [{ name: 'Hardware' }] }),
           createScriptSuccess({ ok: true, v: 'ast', items: [{ name: '@errand' }] }),
-          createScriptSuccess({ tasks: [{ name: 'Order scanners', project: 'Hardware' }] }),
+          createScriptSuccess({ tasks: [{ name: 'Order scanners', project: 'Hardware' }] }), // 'hardware' scope
+          createScriptSuccess({ tasks: [] }), // 'Nonexistent Project' scope
         ];
         let call = 0;
         mockOmni.executeJson.mockImplementation(() => Promise.resolve(dbResponses[call++]));
@@ -919,7 +923,8 @@ describe('OmniFocusAnalyzeTool', () => {
         });
 
         expect(res.success).toBe(true);
-        expect(mockOmni.executeJson).toHaveBeenCalledTimes(3);
+        // projects + tags + 2 scoped task reads (one per distinct requested project)
+        expect(mockOmni.executeJson).toHaveBeenCalledTimes(4);
 
         const [a, b] = res.data.items;
         // Item A: exact (case-insensitive) project, tag split, flagged duplicate.
@@ -1068,6 +1073,64 @@ describe('OmniFocusAnalyzeTool', () => {
         // OMN-153 predicate: a project root is the only task with task.project !== null,
         // so excluding `task.project === null` rows keeps roots out of the dedup set.
         expect(tasksScript).toContain('task.project === null');
+      });
+
+      it('OMN-126: scopes the dedup read per requested scope — project read + inbox read, not whole-DB', async () => {
+        // The candidate read is scoped to the requested project(s) + inbox via one
+        // read per distinct scope (the AST rejects project=A OR project=B in a single
+        // query, so per-scope reads are used). A named project → a flattenedTasks read
+        // narrowed by task.containingProject; an inbox-bound item → a separate
+        // inbox.forEach read. The old whole-DB read had neither narrowing clause.
+        const scripts: string[] = [];
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          scripts.push(script);
+          return Promise.resolve({ tasks: [] });
+        });
+
+        await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: {
+              items: [
+                { name: 'A', project: 'Hardware' }, // named project → project-scoped read
+                { name: 'B' }, // no project → inbox-bound → inbox-scoped read
+              ],
+            },
+          },
+        });
+
+        // Project-scoped read: flattenedTasks narrowed by the containing-project target.
+        const projectRead = scripts.find((s) => s.includes('task.containingProject ==='));
+        expect(projectRead).toBeDefined();
+        // Inbox-scoped read: a separate inbox.forEach pass for the project-less item.
+        const inboxRead = scripts.find((s) => s.includes('inbox.forEach') && s.includes('task.inInbox === true'));
+        expect(inboxRead).toBeDefined();
+      });
+
+      it('OMN-126: two distinct projects → two project-scoped reads (no contradictory-OR throw)', async () => {
+        // Regression guard: a single OR-of-two-projects query throws
+        // "Contradictory conditions on field task.containingProject" in the AST. The
+        // per-scope-read design avoids that — two distinct projects = two reads.
+        let taskReads = 0;
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          if (script.includes('flattenedTasks')) taskReads++;
+          return Promise.resolve({ tasks: [] });
+        });
+
+        const res: any = await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: {
+              items: [
+                { name: 'A', project: 'Hardware' },
+                { name: 'B', project: 'Software' },
+              ],
+            },
+          },
+        });
+
+        expect(res.success).toBe(true);
+        expect(taskReads).toBe(2);
       });
 
       it('emits a batchPayload that round-trips unchanged through WriteSchema { batch }', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1082,9 +1082,11 @@ describe('OmniFocusAnalyzeTool', () => {
         // narrowed by task.containingProject; an inbox-bound item → a separate
         // inbox.forEach read. The old whole-DB read had neither narrowing clause.
         const scripts: string[] = [];
-        // Wrap in a success envelope: the projects read must succeed (ok:true) for
-        // the per-scope path to run — a non-success projects read now falls back to
-        // a single whole-DB read (review ②).
+        // Every mocked read returns a success envelope so the scripts yield
+        // well-formed data. The per-scope dedup path runs independently of the
+        // projects read — scopeProjects derives from items/defaultProject, not
+        // existingProjects — so there is no whole-DB fallback (review ②: a failed
+        // projects read degrades only the preview's match labels, never dedup).
         mockOmni.executeJson.mockImplementation((script: string) => {
           scripts.push(script);
           return Promise.resolve(createScriptSuccess({ tasks: [] }));
@@ -1115,8 +1117,9 @@ describe('OmniFocusAnalyzeTool', () => {
         // "Contradictory conditions on field task.containingProject" in the AST. The
         // per-scope-read design avoids that — two distinct projects = two reads.
         let taskReads = 0;
-        // Success envelope so the projects read succeeds (ok:true) and the per-scope
-        // path runs; a non-success projects read falls back to one whole-DB read.
+        // Every mocked read returns a success envelope. The per-scope path runs
+        // independently of the projects read (scopeProjects derives from
+        // items/defaultProject), so there is no whole-DB fallback — see review ②.
         mockOmni.executeJson.mockImplementation((script: string) => {
           if (script.includes('flattenedTasks')) taskReads++;
           return Promise.resolve(createScriptSuccess({ tasks: [] }));

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1133,6 +1133,42 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(taskReads).toBe(2);
       });
 
+      it('OMN-126: scopes the project read by the CANONICAL existing name, not the raw user case', async () => {
+        // Bug: filter.project = the raw 'hardware' compiles to flattenedProjects.byName('hardware'),
+        // which is case-SENSITIVE in OmniFocus → null → the scoped read yields zero tasks → a real
+        // duplicate is missed and a second task is created. The existing dedup test passes only
+        // because it mocks responses by CALL ORDER (returning the task regardless of the script's
+        // project case); this test asserts on the emitted SCRIPT, where the bug actually lives.
+        // Fix: resolve the scope to the canonical existing name ('Hardware') so byName succeeds.
+        const scripts: string[] = [];
+        const dbResponses = [
+          createScriptSuccess({ projects: [{ name: 'Hardware' }] }), // project-names read
+          createScriptSuccess({ ok: true, v: 'ast', items: [] }), // tag-names read
+          createScriptSuccess({ tasks: [] }), // scoped task read
+        ];
+        let call = 0;
+        mockOmni.executeJson.mockImplementation((script: string) => {
+          scripts.push(script);
+          return Promise.resolve(dbResponses[call++] ?? createScriptSuccess({ tasks: [] }));
+        });
+
+        await tool.execute({
+          analysis: {
+            type: 'parse_meeting_notes',
+            params: { items: [{ name: 'Order scanners', project: 'hardware' }] }, // lowercase mismatch
+          },
+        });
+
+        const projectRead = scripts.find((s) => s.includes('task.containingProject ==='));
+        expect(projectRead).toBeDefined();
+        // The byName target embedded in the scoped read is the canonical 'Hardware', not raw
+        // 'hardware'. (The program is embedded in app.evaluateJavascript("..."), so its quotes
+        // are backslash-escaped — assert on the case-distinct token, the only source of which
+        // is the project scope.)
+        expect(projectRead).toContain('Hardware');
+        expect(projectRead).not.toContain('hardware');
+      });
+
       it('emits a batchPayload that round-trips unchanged through WriteSchema { batch }', async () => {
         const res: any = await tool.execute({
           analysis: {


### PR DESCRIPTION
## What

Scopes the `parse_meeting_notes` dedup candidate read to the **requested project(s) + inbox** instead of scanning the whole DB. The old read was `buildListTasksScriptV4({ filter:{completed:false,dropped:false}, limit:2000 })` — a ~8s whole-DB scan on every `validateAgainstExisting:true`, and the 2000-row cap could **globally truncate** a target project's tasks (unrelated projects fill the cap → silently-missed duplicates).

This is the remaining piece of OMN-126; the `warnings[]` half shipped as OMN-204.

## Why it's a pure perf/completeness win (no match-result change)

`findDuplicateTask` already compares on `(name, project.requested)`, where `project.requested = item.project ?? defaultProject ?? null`. The whole-DB read only supplied candidates; the comparison was already project-scoped. So scoping the *read* to those same projects changes no results — it just kills the scan and makes the 2000 cap per-scope. (The spec's "accept a semantic shift" framing was a self-correction in the spec itself — there is no shift.)

## Implementation — per-scope reads + merge (not OR-of-projects)

The spec's preferred single scoped read via `orBranches` works for *one* project + inbox, but the AST contradiction detector **rejects two `{project}` OR branches**:

```
Filter validation failed: Contradictory conditions on field 'task.containingProject': A AND B
```

`project=A OR project=B` is a legitimate union the detector mis-flags. Rather than touch the AST pipeline (out of scope / RISKY), `fetchExistingIncompleteTasks` now issues **one scoped read per distinct requested scope** (named project → project-filtered read; inbox-bound item → inbox read; no items → whole-DB, unchanged) and merges + dedups by `(name, project)`. Each read is project/inbox-scoped — far cheaper than whole-DB, and the 2000 cap is now per-scope.

## TDD

- **Scoped, not whole-DB:** asserts a project-scoped `flattenedTasks` read (narrowed by `task.containingProject`) **and** a separate `inbox.forEach` read for the project-less item.
- **Multi-project regression guard:** two distinct projects → two reads, `res.success === true` (the exact case that threw with `orBranches`).
- Updated the existing live-DB test for the new read count (2 distinct projects → 4 `execJson` calls).
- Existing single-project tests (bridge, OMN-191 root exclusion, partial-match, OMN-204 warnings) unchanged and green.

## Validation

- `npm run build` ✅
- `npm run test:unit` ✅ (3489)
- `eslint` + `prettier` ✅

## Edge note (safe direction)

Duplicate project **names**: a scoped `{project:"Foo"}` read resolves to the first "Foo", so a dup in a *second* same-named project could be missed. Rare, discouraged, surfaced via the script's duplicate-project warning, and a *missed dup* (never a false positive) — the same safety direction the old 2000-cap already had.

## ⚠️ Verify-debt owed (CI has no OmniFocus)

Live: confirm the ~8s whole-DB scan is gone on `validateAgainstExisting:true`, and that a duplicate **beyond the old 2000-cap** in a target project is now found (the completeness win). Unit tests prove the read is scoped; the timing + cap-beating behavior need a live run.

Closes OMN-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
