### PR TITLE
fix(OMN-224): resolve tasks project-by-name filter (document.projectsMatching threw in OmniJS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,11 +83,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   populated projects; only the `projectId` filter worked. The OmniJS emitter (`emitProjectComparison`) built its
   name-resolution preamble with `document.projectsMatching(target)` — but in OmniJS `projectsMatching` is a bare global
   (a `Database` method exposed on the global scope), not a method on `document` (which is undefined there), so every
-  name-scoped tasks read threw `TypeError: document.projectsMatching is not a function`. Exact-name duplicate detection
-  now scans `flattenedProjects` directly (`flattenedProjects.filter(p => p.name === target)`), which is OmniJS-native
-  and never throws. Covered by a new integration test that exercises the **real** query path against a sandbox project
-  (the unit tests asserted on emitted script text and the parse integration test mocks `executeJson`, so the live path
-  was never run — which is why this stayed hidden). Unblocks OMN-126's name-scoped dedup read.
+  name-scoped tasks read threw `TypeError: document.projectsMatching is not a function`. Name resolution now uses a
+  **status-aware** scan of `flattenedProjects` (OmniJS-native, never throws): it prefers non-dropped, non-completed
+  projects, falling back to dead matches only when no live project carries the name. This also fixes a latent shadowing
+  bug — `flattenedProjects.byName` is status-blind and ordered by creation, so a dropped same-named project created
+  before the active one would resolve first and silently return zero tasks; and dead projects no longer inflate the
+  duplicate-project count. Covered by new integration tests that exercise the **real** query path against sandbox
+  projects, including a dropped-project shadowing case (the unit tests asserted on emitted script text and the parse
+  integration test mocks `executeJson`, so the live path was never run — which is why this stayed hidden). Unblocks
+  OMN-126's name-scoped dedup read.
 - **Filter keys beside AND/OR/NOT and all logical-operator edge-cases now compose correctly** (OMN-151) — Filter keys at
   the same level as `AND`, `OR`, or `NOT` (e.g. `{ flagged: true, OR: [...] }`) were silently dropped instead of
   AND-composing with the operator group. `AND` merged via `Object.assign` (last-wins), so two AND items setting the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Tasks `project`-by-name filter now resolves real projects** (OMN-224) —
+  `read { type:"tasks", filters:{ project: "<exact existing name>" } }` returned **0 tasks** (a `SCRIPT_ERROR`) for real
+  populated projects; only the `projectId` filter worked. The OmniJS emitter (`emitProjectComparison`) built its
+  name-resolution preamble with `document.projectsMatching(target)` — but in OmniJS `projectsMatching` is a bare global
+  (a `Database` method exposed on the global scope), not a method on `document` (which is undefined there), so every
+  name-scoped tasks read threw `TypeError: document.projectsMatching is not a function`. Exact-name duplicate detection
+  now scans `flattenedProjects` directly (`flattenedProjects.filter(p => p.name === target)`), which is OmniJS-native
+  and never throws. Covered by a new integration test that exercises the **real** query path against a sandbox project
+  (the unit tests asserted on emitted script text and the parse integration test mocks `executeJson`, so the live path
+  was never run — which is why this stayed hidden). Unblocks OMN-126's name-scoped dedup read.
 - **Filter keys beside AND/OR/NOT and all logical-operator edge-cases now compose correctly** (OMN-151) — Filter keys at
   the same level as `AND`, `OR`, or `NOT` (e.g. `{ flagged: true, OR: [...] }`) were silently dropped instead of
   AND-composing with the operator group. `AND` merged via `Object.assign` (last-wins), so two AND items setting the same

--- a/src/contracts/ast/emitters/omnijs.ts
+++ b/src/contracts/ast/emitters/omnijs.ts
@@ -155,14 +155,20 @@ export function emitOmniJS(ast: FilterNode): EmitResult {
     const varName = nextProjectVar();
     const val = JSON.stringify(projectValue);
 
+    // OMN-224: exact-name duplicate detection scans `flattenedProjects` directly.
+    // The previous `document.projectsMatching(target)` threw at runtime — in OmniJS
+    // `projectsMatching` is a bare global (a Database method exposed on the global
+    // scope), NOT a method on `document` (which is undefined there). That TypeError
+    // made EVERY name-scoped tasks read fail with a SCRIPT_ERROR (returning zero
+    // tasks). `flattenedProjects.filter` is OmniJS-native and gives precise
+    // exact-name dup detection without depending on projectsMatching's fuzzy match.
     const preamble = `var ${varName} = (function() {
   var target = ${val};
   var byId = Project.byIdentifier(target);
   if (byId) return { project: byId, method: "id", duplicates: 0, allMatches: [{ id: byId.id.primaryKey, name: byId.name }] };
   var byName = flattenedProjects.byName(target);
   if (!byName) return null;
-  var matches = document.projectsMatching(target);
-  var exact = matches.filter(function(p) { return p.name === target; });
+  var exact = flattenedProjects.filter(function(p) { return p.name === target; });
   return {
     project: byName,
     method: "name",

--- a/src/contracts/ast/emitters/omnijs.ts
+++ b/src/contracts/ast/emitters/omnijs.ts
@@ -155,25 +155,33 @@ export function emitOmniJS(ast: FilterNode): EmitResult {
     const varName = nextProjectVar();
     const val = JSON.stringify(projectValue);
 
-    // OMN-224: exact-name duplicate detection scans `flattenedProjects` directly.
-    // The previous `document.projectsMatching(target)` threw at runtime — in OmniJS
-    // `projectsMatching` is a bare global (a Database method exposed on the global
-    // scope), NOT a method on `document` (which is undefined there). That TypeError
-    // made EVERY name-scoped tasks read fail with a SCRIPT_ERROR (returning zero
-    // tasks). `flattenedProjects.filter` is OmniJS-native and gives precise
-    // exact-name dup detection without depending on projectsMatching's fuzzy match.
+    // OMN-224: resolve a project name to a LIVE project via a status-aware scan of
+    // `flattenedProjects`. Two reasons it is written this way:
+    //   1. The previous `document.projectsMatching(target)` threw at runtime — in
+    //      OmniJS `projectsMatching` is a bare global (a Database method on the
+    //      global scope), NOT a method on `document` (undefined there). That
+    //      TypeError made EVERY name-scoped tasks read fail with a SCRIPT_ERROR.
+    //   2. `flattenedProjects.byName()` is status-blind and ordered by creation, so
+    //      a dropped/completed same-named project that precedes the active one would
+    //      resolve first — the predicate then targets the dead project and the
+    //      active project's tasks go silently invisible (success, 0 tasks). We
+    //      therefore prefer non-dropped, non-completed matches, falling back to dead
+    //      matches only when no live project carries the name (so a deliberately
+    //      dropped-project query does not newly return nothing). Duplicate detection
+    //      counts the same live pool, so dead projects never inflate the warning.
     const preamble = `var ${varName} = (function() {
   var target = ${val};
   var byId = Project.byIdentifier(target);
   if (byId) return { project: byId, method: "id", duplicates: 0, allMatches: [{ id: byId.id.primaryKey, name: byId.name }] };
-  var byName = flattenedProjects.byName(target);
-  if (!byName) return null;
-  var exact = flattenedProjects.filter(function(p) { return p.name === target; });
+  var named = flattenedProjects.filter(function(p) { return p.name === target; });
+  if (named.length === 0) return null;
+  var live = named.filter(function(p) { return p.status !== Project.Status.Dropped && p.status !== Project.Status.Done; });
+  var pool = live.length > 0 ? live : named;
   return {
-    project: byName,
+    project: pool[0],
     method: "name",
-    duplicates: exact.length - 1,
-    allMatches: exact.map(function(p) { return { id: p.id.primaryKey, name: p.name }; })
+    duplicates: pool.length - 1,
+    allMatches: pool.map(function(p) { return { id: p.id.primaryKey, name: p.name }; })
   };
 })();`;
 

--- a/tests/integration/project-name-filter.test.ts
+++ b/tests/integration/project-name-filter.test.ts
@@ -104,6 +104,7 @@ d('OMN-224: tasks project-by-name filter resolves real projects', () => {
     })) as BatchResponse;
 
     expect(response.success).toBe(true);
+    expect(response.data).toBeTruthy();
     const mapping = response.data.tempIdMapping ?? {};
     projectId = mapping['proj'];
     task1Id = mapping['task1'];
@@ -160,5 +161,86 @@ d('OMN-224: tasks project-by-name filter resolves real projects', () => {
     const nameIds = (byName.data?.tasks ?? []).map((t) => t.id).sort((a, b) => a.localeCompare(b));
     const idIds = (byId.data?.tasks ?? []).map((t) => t.id).sort((a, b) => a.localeCompare(b));
     expect(nameIds).toEqual(idIds);
+  }, 60000);
+});
+
+/**
+ * OMN-224 (review follow-up): a DROPPED project must not shadow an active project
+ * of the same name.
+ *
+ * `flattenedProjects` / `byName` are status-blind and ordered by creation, so a
+ * dropped same-named project created *before* the active one resolves first —
+ * the predicate then targets the dead project and the active project's tasks go
+ * silently invisible (success:true, 0 tasks). The emitter now resolves among
+ * "live" (non-dropped, non-completed) projects, falling back to dead matches only
+ * if no live project carries the name.
+ */
+d('OMN-224: a dropped same-named project does not shadow the active one', () => {
+  let client: MCPTestClient;
+
+  const DUP_NAME = runScopedName('OMN224_DroppedShadow');
+  let activeTaskId: string;
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+
+    // DROPPED project created FIRST (so it precedes the active one in
+    // flattenedProjects order — the worst case for status-blind byName), then the
+    // ACTIVE project holding the probe task.
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'project',
+            data: { tempId: 'dropped', name: DUP_NAME, folder: SANDBOX_FOLDER_NAME, status: 'dropped' },
+          },
+          {
+            operation: 'create',
+            target: 'project',
+            data: { tempId: 'active', name: DUP_NAME, folder: SANDBOX_FOLDER_NAME, status: 'active' },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: { tempId: 'activeTask', name: runScopedName('OMN224_ActiveDupTask'), parentTempId: 'active' },
+          },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+
+    expect(response.success).toBe(true);
+    expect(response.data).toBeTruthy();
+    const mapping = response.data.tempIdMapping ?? {};
+    activeTaskId = mapping['activeTask'];
+    expect(activeTaskId).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it('resolves the active project, not the dropped one created first', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: {
+        type: 'tasks',
+        filters: { project: DUP_NAME, completed: false },
+        fields: ['id', 'name'],
+        limit: 50,
+      },
+    })) as TasksReadResponse;
+
+    expect(result.success).toBe(true);
+    const ids = (result.data?.tasks ?? []).map((t) => t.id);
+    // Pre-fix: byName resolved the dropped project (created first) → 0 tasks.
+    expect(ids).toContain(activeTaskId);
   }, 60000);
 });

--- a/tests/integration/project-name-filter.test.ts
+++ b/tests/integration/project-name-filter.test.ts
@@ -1,0 +1,164 @@
+/**
+ * OMN-224 regression: tasks `project`-by-name filter must return the project's
+ * tasks against REAL OmniFocus.
+ *
+ * The bug: `emitProjectComparison` (src/contracts/ast/emitters/omnijs.ts) built
+ * its name-resolution preamble with `document.projectsMatching(target)` — but in
+ * OmniJS `projectsMatching` is a bare global (a Database method exposed on the
+ * global scope), NOT a method on `document` (which is undefined there). So EVERY
+ * name-scoped tasks read threw `TypeError: document.projectsMatching is not a
+ * function`, surfacing as a SCRIPT_ERROR / `success: false`, returning zero tasks.
+ *
+ * Why it stayed hidden: the unit tests assert on the *emitted script text*
+ * (`expect(preamble).toContain('document.projectsMatching')` literally codified
+ * the bug), and the parse integration test mocks `executeJson`. Nothing fed the
+ * emitted script to real OmniFocus. This test does — it exercises the real query
+ * path end-to-end through the MCP server.
+ *
+ * Contract under test:
+ *  - `read { type: 'tasks', filters: { project: <exact existing name> } }`
+ *    succeeds (does not throw) and returns the project's tasks.
+ *  - That name-scoped result equals the trusted `projectId`-scoped result
+ *    (the A-vs-B oracle from the ticket: name path == id path).
+ *
+ * Uses the test sandbox for isolation (project created inside the sandbox folder,
+ * so cleanup stays folder-scoped).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getSharedClient } from './helpers/shared-server.js';
+import { MCPTestClient } from './helpers/mcp-test-client.js';
+import { ensureSandboxFolder, fullCleanup, SANDBOX_FOLDER_NAME } from './helpers/sandbox-manager.js';
+import { runScopedName } from './helpers/run-id.js';
+
+const RUN_INTEGRATION_TESTS = process.env.DISABLE_INTEGRATION_TESTS !== 'true' && process.platform === 'darwin';
+const d = RUN_INTEGRATION_TESTS ? describe : describe.skip;
+
+interface TaskRow {
+  id: string;
+  name: string;
+}
+interface TasksReadResponse {
+  success: boolean;
+  data?: { tasks?: TaskRow[] };
+}
+interface BatchResponse {
+  success: boolean;
+  data: { tempIdMapping?: Record<string, string> };
+}
+
+d('OMN-224: tasks project-by-name filter resolves real projects', () => {
+  let client: MCPTestClient;
+
+  // Run-unique project name → byName resolves it unambiguously and the task set
+  // is exactly our probe tasks. Deterministic per suffix, so the SAME string is
+  // used to create the project and as the filter value.
+  const PROJECT_NAME = runScopedName('OMN224_NameFilter');
+
+  let projectId: string;
+  let task1Id: string;
+  let task2Id: string;
+
+  beforeAll(async () => {
+    client = await getSharedClient();
+    await ensureSandboxFolder();
+
+    const response = (await client.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'batch',
+        target: 'task',
+        operations: [
+          {
+            operation: 'create',
+            target: 'project',
+            data: {
+              tempId: 'proj',
+              name: PROJECT_NAME,
+              folder: SANDBOX_FOLDER_NAME,
+            },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'task1',
+              name: runScopedName('OMN224_Task_A'),
+              parentTempId: 'proj',
+            },
+          },
+          {
+            operation: 'create',
+            target: 'task',
+            data: {
+              tempId: 'task2',
+              name: runScopedName('OMN224_Task_B'),
+              parentTempId: 'proj',
+            },
+          },
+        ],
+        createSequentially: true,
+        atomicOperation: false,
+        returnMapping: true,
+        stopOnError: true,
+      },
+    })) as BatchResponse;
+
+    expect(response.success).toBe(true);
+    const mapping = response.data.tempIdMapping ?? {};
+    projectId = mapping['proj'];
+    task1Id = mapping['task1'];
+    task2Id = mapping['task2'];
+    expect(projectId).toBeTruthy();
+    expect(task1Id).toBeTruthy();
+    expect(task2Id).toBeTruthy();
+  }, 120000);
+
+  afterAll(async () => {
+    await fullCleanup();
+    await client.thoroughCleanup();
+  });
+
+  it('returns the project tasks when filtered by exact project NAME (not just ID)', async () => {
+    const result = (await client.callTool('omnifocus_read', {
+      query: {
+        type: 'tasks',
+        filters: { project: PROJECT_NAME, completed: false },
+        fields: ['id', 'name'],
+        limit: 50,
+      },
+    })) as TasksReadResponse;
+
+    // Pre-fix this threw (success:false, SCRIPT_ERROR) — the regression assertion.
+    expect(result.success).toBe(true);
+    const ids = (result.data?.tasks ?? []).map((t) => t.id);
+    expect(ids).toContain(task1Id);
+    expect(ids).toContain(task2Id);
+  }, 60000);
+
+  it('name-scoped result equals the trusted projectId-scoped result (A-vs-B oracle)', async () => {
+    const byName = (await client.callTool('omnifocus_read', {
+      query: {
+        type: 'tasks',
+        filters: { project: PROJECT_NAME, completed: false },
+        fields: ['id', 'name'],
+        limit: 50,
+      },
+    })) as TasksReadResponse;
+
+    const byId = (await client.callTool('omnifocus_read', {
+      query: {
+        type: 'tasks',
+        filters: { projectId, completed: false },
+        fields: ['id', 'name'],
+        limit: 50,
+      },
+    })) as TasksReadResponse;
+
+    expect(byName.success).toBe(true);
+    expect(byId.success).toBe(true);
+
+    const nameIds = (byName.data?.tasks ?? []).map((t) => t.id).sort((a, b) => a.localeCompare(b));
+    const idIds = (byId.data?.tasks ?? []).map((t) => t.id).sort((a, b) => a.localeCompare(b));
+    expect(nameIds).toEqual(idIds);
+  }, 60000);
+});

--- a/tests/unit/contracts/ast/emitters/omnijs.test.ts
+++ b/tests/unit/contracts/ast/emitters/omnijs.test.ts
@@ -659,7 +659,12 @@ describe('emitOmniJS', () => {
       const result = emitOmniJS(ast);
       expect(result.preamble).toContain('Project.byIdentifier');
       expect(result.preamble).toContain('flattenedProjects.byName');
-      expect(result.preamble).toContain('document.projectsMatching');
+      // OMN-224: exact-name dup detection scans flattenedProjects directly. The
+      // old `document.projectsMatching(target)` threw at runtime (`document` has
+      // no such method in OmniJS), failing every name-scoped tasks read. Guard
+      // against the broken receiver ever returning.
+      expect(result.preamble).toContain('flattenedProjects.filter(function(p) { return p.name === target; })');
+      expect(result.preamble).not.toContain('document.projectsMatching');
       expect(result.preamble).toContain('__projectTarget_0');
       expect(result.predicate).toBe('(__projectTarget_0 && task.containingProject === __projectTarget_0.project)');
     });

--- a/tests/unit/contracts/ast/emitters/omnijs.test.ts
+++ b/tests/unit/contracts/ast/emitters/omnijs.test.ts
@@ -658,13 +658,17 @@ describe('emitOmniJS', () => {
       };
       const result = emitOmniJS(ast);
       expect(result.preamble).toContain('Project.byIdentifier');
-      expect(result.preamble).toContain('flattenedProjects.byName');
-      // OMN-224: exact-name dup detection scans flattenedProjects directly. The
-      // old `document.projectsMatching(target)` threw at runtime (`document` has
-      // no such method in OmniJS), failing every name-scoped tasks read. Guard
-      // against the broken receiver ever returning.
+      // OMN-224: name resolution scans flattenedProjects directly. Two guards:
+      // (1) the old `document.projectsMatching(target)` threw at runtime
+      // (`document` has no such method in OmniJS), failing every name-scoped read;
+      // (2) resolution must be status-aware — a dropped/completed same-named
+      // project must not shadow the active one (status-blind byName picked the
+      // first by creation order), so dead projects are filtered out of the pool.
       expect(result.preamble).toContain('flattenedProjects.filter(function(p) { return p.name === target; })');
+      expect(result.preamble).toContain('Project.Status.Dropped');
+      expect(result.preamble).toContain('Project.Status.Done');
       expect(result.preamble).not.toContain('document.projectsMatching');
+      expect(result.preamble).not.toContain('flattenedProjects.byName');
       expect(result.preamble).toContain('__projectTarget_0');
       expect(result.predicate).toBe('(__projectTarget_0 && task.containingProject === __projectTarget_0.project)');
     });

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -1281,7 +1281,8 @@ describe('buildFilteredTasksScript preamble and warning injection', () => {
     const filter = { projectId: 'Work' };
     const result = buildFilteredTasksScript(filter, { limit: 10 });
     expect(result.script).toContain('Project.byIdentifier');
-    expect(result.script).toContain('flattenedProjects.byName');
+    // OMN-224: status-aware name resolution scans flattenedProjects (byName removed).
+    expect(result.script).toContain('flattenedProjects.filter(function(p) { return p.name === target; })');
     expect(result.script).toContain('__projectTarget_0');
     const preambleIndex = result.script.indexOf('__projectTarget_0 = (function');
     const matchesFilterIndex = result.script.indexOf('function matchesFilter');


### PR DESCRIPTION
## Summary

`omnifocus_read { type:"tasks", filters:{ project:"<exact existing name>" } }` returned **0 tasks** (a `SCRIPT_ERROR`) for real, populated projects — only the `projectId` filter worked. Fixes OMN-224 and unblocks OMN-126 / #164.

## Root cause (live-reproduced, NOT the ticket's hypothesis)

The OmniJS emitter (`emitProjectComparison`, `src/contracts/ast/emitters/omnijs.ts`) built its name-resolution preamble with `document.projectsMatching(target)`. In OmniJS, `projectsMatching` is a **bare global** (a `Database` method exposed on the global scope) — there is no `document` object hosting it (`document.projectsMatching` is `undefined`). So every name-scoped tasks read threw `TypeError: document.projectsMatching is not a function`, failing the whole query.

The ticket guessed `flattenedProjects.byName(target)` returned null. Live probing disproved that: `byName` resolves fine (and is even fresh for just-created projects). The throw is one line *below* the `byName` short-circuit. The "byName freshness" caveat in the ticket was a misattribution of the same root cause — the `projectId` filter compiles to a different predicate that never touches the broken line.

## Fix

Drop the broken `document.projectsMatching(target)` line; compute exact-name duplicates directly via `flattenedProjects.filter(p => p.name === target)` — OmniJS-native, never throws, precise exact-name semantics, and keeps the `byName` resolution intact. Minimal scope: case-insensitive resolution stays OMN-126's domain (its canonicalization workaround remains meaningful).

## Why it stayed hidden

- The emitter unit test asserted on emitted **script text** — `expect(preamble).toContain('document.projectsMatching')` literally codified the bug.
- The parse integration test mocks `executeJson`.

Nothing fed the emitted script to real OmniFocus.

## Tests

- **New:** `tests/integration/project-name-filter.test.ts` — spawns the compiled server and reads a real sandbox project **by name** against live OmniFocus. RED pre-fix (`success:false`), GREEN post-fix. Includes a name-path == id-path A/B-oracle parity assertion.
- **Updated:** the emitter unit test now asserts the corrected preamble and guards `not.toContain('document.projectsMatching')`.
- Full unit suite green (3491 tests); typecheck + lint clean.

## Live verification

`/verify`'d against the real `"Work next actions"` project: name filter now resolves it (`method:"name"`, `duplicates:0`) and returns its 6 incomplete tasks — identical to the `projectId` oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)