### PR TITLE
fix(OMN-225): id-lookup no longer throws ID_MISMATCH when fields omit id

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -813,20 +813,27 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
 }
 
 /**
+ * OMN-225: id-lookup builders must always project `id` so the read tool's
+ * id-match guard (OmniFocusReadTool.executeIdLookup / executeProjectIdLookup)
+ * can verify `row.id === requested id` BEFORE projectFields() re-adds id
+ * downstream. Without id in the row the guard reads undefined and mis-fires
+ * ID_MISMATCH for ANY id — the bug was misattributed to freshly-created ids
+ * because the failing repro also dropped id from `fields`. Empty `fields`
+ * already falls back to the DEFAULT_*_FIELDS set (which includes id) inside the
+ * *FieldProjection helpers, so only force id when an explicit list omits it.
+ * Single-sourced across both id-lookup builders so a future tweak can't silently
+ * re-open the bug on one path. Chosen over relaxing the guard, which would skip
+ * the right-task verification when id isn't requested.
+ */
+function ensureIdField(fields: string[]): string[] {
+  return fields.length === 0 || fields.includes('id') ? fields : ['id', ...fields];
+}
+
+/**
  * Build an OmniJS script for a specific task by ID
  */
 export function buildTaskByIdScript(taskId: string, fields: string[] = []): GeneratedScript {
-  // OMN-225: the id-lookup guard (OmniFocusReadTool.executeIdLookup) verifies
-  // `row.id === requested id` BEFORE projectFields() re-adds id downstream, so the
-  // row MUST carry id even when the caller's `fields` omit it — otherwise the guard
-  // reads undefined and mis-fires ID_MISMATCH for ANY id (the bug was misattributed
-  // to freshly-created ids because the failing repro also dropped id from `fields`).
-  // Empty `fields` already falls back to DEFAULT_FIELDS (which includes id) inside
-  // generateFieldProjection, so only force id when an explicit list omits it.
-  // Decision: force id in the script projection rather than relaxing the guard —
-  // relaxing would silently skip the right-task verification when id isn't requested.
-  const idFields = fields.length === 0 || fields.includes('id') ? fields : ['id', ...fields];
-  const fieldProjection = generateFieldProjection(idFields);
+  const fieldProjection = generateFieldProjection(ensureIdField(fields)); // OMN-225: see ensureIdField
 
   // OMN-185: resolve the task directly via Task.byIdentifier (O(1)) instead of
   // iterating flattenedTasks (O(n), pays the ~7-10s materialization floor for a
@@ -1577,11 +1584,7 @@ export function buildFilteredProjectsScript(
  * Build an OmniJS script for a specific project by ID
  */
 export function buildProjectByIdScript(projectId: string, fields: string[] = []): GeneratedScript {
-  // OMN-225: same id-lookup guard contract as buildTaskByIdScript — the project
-  // id-match guard (executeProjectIdLookup) inspects row.id before projectFields()
-  // re-adds it, so the row must carry id even when the caller's `fields` omit it.
-  const idFields = fields.length === 0 || fields.includes('id') ? fields : ['id', ...fields];
-  const fieldProjection = generateProjectFieldProjection(idFields);
+  const fieldProjection = generateProjectFieldProjection(ensureIdField(fields)); // OMN-225: see ensureIdField
 
   const omniJsSource = `
       (() => {

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -816,7 +816,17 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
  * Build an OmniJS script for a specific task by ID
  */
 export function buildTaskByIdScript(taskId: string, fields: string[] = []): GeneratedScript {
-  const fieldProjection = generateFieldProjection(fields);
+  // OMN-225: the id-lookup guard (OmniFocusReadTool.executeIdLookup) verifies
+  // `row.id === requested id` BEFORE projectFields() re-adds id downstream, so the
+  // row MUST carry id even when the caller's `fields` omit it — otherwise the guard
+  // reads undefined and mis-fires ID_MISMATCH for ANY id (the bug was misattributed
+  // to freshly-created ids because the failing repro also dropped id from `fields`).
+  // Empty `fields` already falls back to DEFAULT_FIELDS (which includes id) inside
+  // generateFieldProjection, so only force id when an explicit list omits it.
+  // Decision: force id in the script projection rather than relaxing the guard —
+  // relaxing would silently skip the right-task verification when id isn't requested.
+  const idFields = fields.length === 0 || fields.includes('id') ? fields : ['id', ...fields];
+  const fieldProjection = generateFieldProjection(idFields);
 
   // OMN-185: resolve the task directly via Task.byIdentifier (O(1)) instead of
   // iterating flattenedTasks (O(n), pays the ~7-10s materialization floor for a
@@ -1567,7 +1577,11 @@ export function buildFilteredProjectsScript(
  * Build an OmniJS script for a specific project by ID
  */
 export function buildProjectByIdScript(projectId: string, fields: string[] = []): GeneratedScript {
-  const fieldProjection = generateProjectFieldProjection(fields);
+  // OMN-225: same id-lookup guard contract as buildTaskByIdScript — the project
+  // id-match guard (executeProjectIdLookup) inspects row.id before projectFields()
+  // re-adds it, so the row must carry id even when the caller's `fields` omit it.
+  const idFields = fields.length === 0 || fields.includes('id') ? fields : ['id', ...fields];
+  const fieldProjection = generateProjectFieldProjection(idFields);
 
   const omniJsSource = `
       (() => {

--- a/tests/integration/tools/unified/field-roundtrip.test.ts
+++ b/tests/integration/tools/unified/field-roundtrip.test.ts
@@ -455,6 +455,41 @@ describe('OMN-61 Phase 3: per-field write→read round-trip', () => {
     );
   });
 
+  // ── OMN-225: id-lookup read-back must not require `id` in `fields` ──────
+  // The canonical "read back exactly this one task" path is filters:{id}. Its
+  // guard (executeIdLookup/executeProjectIdLookup) verifies the returned row's
+  // id BEFORE the final projection re-adds id, so when the caller's `fields`
+  // omit "id" the script projected no id and the guard mis-fired ID_MISMATCH —
+  // for ANY id, fresh or long-existing. (The bug was misattributed to
+  // freshly-created ids only because the failing repro also dropped id from
+  // `fields`.) NOTE: this block reads back with fields that OMIT id on purpose —
+  // it must NOT use taskQuery()/projectQuery(), which prepend 'id' and thereby
+  // hide exactly this defect.
+  describe('OMN-225: id-lookup read-back with id-omitting fields', () => {
+    it('task id-lookup succeeds (no ID_MISMATCH) when fields omit id, right after create', async () => {
+      const taskId = await createTask({ sequential: true });
+      const res = await client.callTool('omnifocus_read', {
+        query: { type: 'tasks', filters: { id: taskId }, fields: ['name', 'sequential'] },
+      });
+      expectOk(res, 'task id-lookup with fields omitting id');
+      const row = (res.data?.tasks ?? res.data?.items ?? [])[0];
+      // Even though the caller asked only for name+sequential, the row carries id
+      // (projectFields always re-adds it) and it matches the created id.
+      expect(row?.id, `id-lookup row id (response: ${JSON.stringify(res).slice(0, 300)})`).toBe(taskId);
+      expect(row?.sequential).toBe(true);
+    }, 120000);
+
+    it('project id-lookup succeeds (no ID_MISMATCH) when fields omit id', async () => {
+      const projId = await createProject({});
+      const res = await client.callTool('omnifocus_read', {
+        query: { type: 'projects', filters: { id: projId }, fields: ['name', 'status'] },
+      });
+      expectOk(res, 'project id-lookup with fields omitting id');
+      const row = (res.data?.projects ?? res.data?.items ?? [])[0];
+      expect(row?.id, `id-lookup row id (response: ${JSON.stringify(res).slice(0, 300)})`).toBe(projId);
+    }, 120000);
+  });
+
   // ── Relational fields (need extra sandbox entities) ───────────────────
   describe('relational fields', () => {
     it('task.project move persists (projectId reads back the new project)', async () => {

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -4,6 +4,7 @@ import {
   buildFilteredTasksScript,
   buildInboxScript,
   buildTaskByIdScript,
+  buildProjectByIdScript,
   buildRecurringTasksScript,
   buildTaskCountScript,
   buildFilteredProjectsScript,
@@ -459,6 +460,50 @@ describe('buildTaskByIdScript (vm-executed, OMN-185)', () => {
     expect(result.count).toBe(0);
     expect(result.mode).toBe('id_lookup');
     expect(result.targetId).toBe('missing');
+  });
+});
+
+describe('OMN-225: id-lookup always projects id so the id-match guard can verify it', () => {
+  // The read tool's id-lookup guard (executeIdLookup / executeProjectIdLookup)
+  // checks `row.id === requestedId` BEFORE projectFields() re-adds id. The script
+  // projects only the caller's requested fields, so a `fields` list that omits
+  // "id" left the row without an id → the guard read undefined and mis-fired
+  // ID_MISMATCH for ANY id (fresh or long-existing), not just freshly-created ones.
+
+  it('buildTaskByIdScript projects id even when the caller omits it from fields', () => {
+    const { script } = buildTaskByIdScript('abc123', ['name', 'sequential']);
+    expect(script).toContain('id: task.id.primaryKey');
+  });
+
+  it('buildTaskByIdScript: vm-executed row carries id when fields omit it', () => {
+    const Task = {
+      byIdentifier: (id: string) =>
+        id === 'abc123' ? { id: { primaryKey: 'abc123' }, name: 'X', sequential: true } : null,
+    };
+    const { script } = buildTaskByIdScript('abc123', ['name', 'sequential']);
+    const result = JSON.parse(vm.runInNewContext(script, { Task, JSON }) as string);
+
+    expect(result.tasks).toHaveLength(1);
+    // The row the guard inspects MUST carry id even though the caller asked only
+    // for name + sequential.
+    expect(result.tasks[0].id).toBe('abc123');
+  });
+
+  it('buildTaskByIdScript does not duplicate the id projection when fields include it', () => {
+    const { script } = buildTaskByIdScript('abc123', ['id', 'name']);
+    const matches = script.match(/id: task\.id\.primaryKey/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('buildProjectByIdScript projects id even when the caller omits it from fields', () => {
+    const { script } = buildProjectByIdScript('proj123', ['name', 'status']);
+    expect(script).toContain('id: project.id.primaryKey');
+  });
+
+  it('buildProjectByIdScript does not duplicate the id projection when fields include it', () => {
+    const { script } = buildProjectByIdScript('proj123', ['id', 'name']);
+    const matches = script.match(/id: project\.id\.primaryKey/g) ?? [];
+    expect(matches).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

`omnifocus_read` id-lookup (`filters:{id}`) threw `ID_MISMATCH "received undefined/unknown"` whenever the caller's `fields` list omitted `"id"` — for **any** id, not just freshly-created ones. This broke the canonical create→read-back round-trip whenever the verify call didn't happen to request `id`.

## Root cause (the ticket's hypothesis was wrong)

OMN-225 hypothesized the OMN-28 JXA↔OmniJS id-split / `Task.byIdentifier` indexing lag, "localized to freshly-created ids." That was a **confounded comparison**: the failing repro used `fields:["name","sequential"]` (no `id`) while *every* succeeding control — search and the long-existing-id checks — used `fields:["id",...]`. Two variables changed at once.

The real cause is deterministic and id-agnostic: the id-lookup builders (`buildTaskByIdScript`, `buildProjectByIdScript`) project **only the caller's requested fields**, so a `fields` list without `"id"` produces a row with no `id`. The post-execution guard (`executeIdLookup` / `executeProjectIdLookup`) checks `row.id === requestedId` **before** `projectFields()` re-adds id — so it reads `undefined` and mis-fires.

**Falsification (live, prod `8bd27bb4`):** a *long-existing* task id (`pjrw9SzOxLz`) and project id (`owIWaZnn26a`) both throw the identical `ID_MISMATCH` when `fields` omit `id`, and both succeed when `id` is included. Fresh-vs-existing was never the variable; presence of `id` in `fields` was.

## Fix

Force `"id"` into the script-side projection in both id-lookup builders (only when an explicit `fields` list omits it; empty `fields` already falls back to `DEFAULT_FIELDS`, which includes id). Chosen over relaxing the guard — relaxing would silently skip the right-task verification when `id` isn't requested.

## Tests / verification

- **Unit:** 5 new tests (string-contains + vm-execution oracle), covering both builders, including the no-duplicate-when-id-present case. Full unit suite green (3496).
- **Integration:** added a create→read-back-by-id round-trip with **id-omitting fields** to `field-roundtrip.test.ts` — the existing `['id', ...fields]` read-back helper masked exactly this gap.
- **Live:** ran the freshly-built server against the real OmniFocus DB — **10/10**, including the exact prod failures (`pjrw9SzOxLz`, `owIWaZnn26a`) now resolving, fresh create→read-back, and the id-inclusive control unregressed.

No dual-schema impact (no tool params, enums, or descriptions changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)