### PR TITLE
fix(OMN-218): read folder filter accepts ':' and '/'; unresolvable folder errors loudly

### DIFF
--- a/src/contracts/ast/folder-path-match.ts
+++ b/src/contracts/ast/folder-path-match.ts
@@ -14,23 +14,28 @@
  * is required, which both codegen paths already satisfy.
  */
 
-const FOLDER_PATH_SEPARATOR = ':';
+// OMN-218: accept BOTH `:` and `/` as segment separators. The `folders` query
+// EMITS `/`-joined paths and the WRITE path (`resolveFolderFlexible`) accepts `/`,
+// so the read filter must round-trip its own output. `:` stays first-party too
+// (OmniFocus Shortcuts/URL convention — see reference_of_folder_path_separator_conventions).
+const FOLDER_PATH_SEPARATOR = /[:/]/;
 
 /**
  * Parse a user folder path into lowercased, trimmed segments (leaf last).
  *
- * `"Development"`          → `['development']`        (bare name = single-segment path)
- * `"Personal : Bills"`     → `['personal', 'bills']`  (leaf segment last)
+ * `"Development"`             → `['development']`        (bare name = single-segment path)
+ * `"Personal : Bills"`        → `['personal', 'bills']`  (leaf segment last)
+ * `"Personal/Bills"`          → `['personal', 'bills']`  (OMN-218: `/` is a separator too)
  *
- * Throws on an empty segment (`" : B"`, `"A : "`, `"A : : B"`) so the compiler can
- * surface a steering VALIDATION_ERROR rather than silently matching nothing.
+ * Throws on an empty segment (`" : B"`, `"A : "`, `"A : : B"`, `"/B"`, `"A//B"`) so the
+ * compiler can surface a steering VALIDATION_ERROR rather than silently matching nothing.
  *
- * Limitation: a literal `:` in a folder name is not escapable — a folder named
- * `"A:B"` parses as two segments. Documented, acceptable (no existing escape
- * mechanism; rare).
+ * Limitation: a literal `:` OR `/` in a folder name is not escapable — a folder named
+ * `"A/B"` or `"A:B"` parses as two segments. Documented, acceptable (no existing escape
+ * mechanism; rare) — and symmetric with the write-side `parseFolderPath`.
  *
  * NOTE: distinct from the WRITE-side `parseFolderPath` in `mutation/snippets.ts` —
- * that is an OmniJS-string snippet with a different contract (accepts `/` separators,
+ * that is an OmniJS-string snippet with a different contract (spaced `' : '` OR `/`,
  * returns null for a bare name). The names were deliberately disambiguated (OMN-167
  * review) so a future "align these" refactor doesn't merge two divergent contracts.
  */
@@ -38,7 +43,7 @@ export function parseFolderFilterPath(path: string): string[] {
   const segments = path.split(FOLDER_PATH_SEPARATOR).map((s) => s.trim().toLowerCase());
   if (segments.some((s) => s.length === 0)) {
     throw new Error(
-      `Invalid folder path "${path}": segments cannot be empty. Use "Parent : Child" with non-empty names.`,
+      `Invalid folder path "${path}": segments cannot be empty. Use "Parent : Child" or "Parent/Child" with non-empty names.`,
     );
   }
   return segments;
@@ -59,10 +64,106 @@ export function parseFolderFilterPath(path: string): string[] {
  * full path.
  */
 export function emitFolderPathMatch(leafFolderExpr: string, path: string): string {
-  const segs = parseFolderFilterPath(path);
-  const segsLiteral = JSON.stringify(segs);
-  // One template literal (not concatenated parts) so the embedded OmniJS `''`
-  // empty-string literals don't fight the lint quote rule. Whitespace in the
-  // generated source is irrelevant.
-  return `(() => { const segs = ${segsLiteral}; let a = (${leafFolderExpr}); while (a) { let f = a, ok = true; for (let i = segs.length - 1; i >= 0; i--) { if (!f || !((f.name || '').toLowerCase().includes(segs[i]))) { ok = false; break; } f = f.parent; } if (ok) return true; a = a.parent; } return false; })()`;
+  const segsLiteral = JSON.stringify(parseFolderFilterPath(path));
+  return emitFolderChainPredicate(leafFolderExpr, segsLiteral);
+}
+
+/**
+ * Shared per-folder chain predicate (OMN-218): an OmniJS boolean expression that is
+ * `true` iff the ancestor chain starting at `startFolderExpr` passes THROUGH a folder
+ * matching the baked-in `segsLiteral` (a JSON literal array of lowercased segments).
+ *
+ * Single source of truth for BOTH the row matcher (`emitFolderPathMatch`) and the
+ * existence guard (`emitFolderExistsGuard`) so the two can never diverge — a folder
+ * "resolves" iff a row under it could match. Kept as one template literal so the
+ * embedded `''` OmniJS empty-string literals don't fight the lint quote rule;
+ * whitespace in the generated source is irrelevant.
+ */
+function emitFolderChainPredicate(startFolderExpr: string, segsLiteral: string): string {
+  return `(() => { const segs = ${segsLiteral}; let a = (${startFolderExpr}); while (a) { let f = a, ok = true; for (let i = segs.length - 1; i >= 0; i--) { if (!f || !((f.name || '').toLowerCase().includes(segs[i]))) { ok = false; break; } f = f.parent; } if (ok) return true; a = a.parent; } return false; })()`;
+}
+
+/**
+ * Emit an OmniJS boolean expression that is `true` iff `flattenedFolders` contains at
+ * least one folder whose ancestry matches `path` — i.e. the folder reference RESOLVES.
+ *
+ * OMN-218 fix (b): the read `folder` filter is a per-row predicate that silently returns
+ * `false` when nothing matches, so an unresolvable folder reference is indistinguishable
+ * from a genuinely empty folder. Callers use this guard to fail LOUDLY (FOLDER_NOT_FOUND)
+ * before the row loop, mirroring the write path's `"Folder not found"` guard.
+ *
+ * Uses the SAME per-folder chain predicate as `emitFolderPathMatch`, so:
+ *   - the path resolves iff at least one row could match it (no semantic drift), and
+ *   - an existing-but-empty folder still RESOLVES (it is itself in `flattenedFolders`),
+ *     keeping "empty ≠ unresolvable".
+ */
+export function emitFolderExistsGuard(path: string): string {
+  const segsLiteral = JSON.stringify(parseFolderFilterPath(path));
+  return `flattenedFolders.some((__omn218f) => ${emitFolderChainPredicate('__omn218f', segsLiteral)})`;
+}
+
+/**
+ * Emit a complete OmniJS guard STATEMENT for the top of a read script's row loop:
+ * if `path` resolves to no folder, `return` a `{ error:true, ... }` envelope carrying
+ * `details.code === 'FOLDER_NOT_FOUND'` — instead of iterating and returning an empty set.
+ *
+ * OMN-218 fix (b). The `code` rides in `details` (not top-level) because the wire error
+ * dialect (`detectKnownErrorShape`, `{error:true}` branch) preserves only `message` +
+ * `details`; the tool layer maps `details.code === 'FOLDER_NOT_FOUND'` → a NOT_FOUND error.
+ * Shared by both read builders (tasks + projects) so the envelope shape can't drift.
+ *
+ * Callers must emit this ONLY for a non-empty string folder PATH — never for `folder:null`
+ * (top-level), which is a different flag and must keep returning empty-set success.
+ */
+export function emitFolderNotFoundGuard(path: string): string {
+  const message = `Folder not found: ${path}. Verify the folder exists; both ':' and '/' separators are accepted.`;
+  return `if (!(${emitFolderExistsGuard(path)})) { return JSON.stringify({ error: true, message: ${JSON.stringify(
+    message,
+  )}, details: { code: 'FOLDER_NOT_FOUND', folder: ${JSON.stringify(path)} } }); }`;
+}
+
+/** A filter shape carrying a string-keyed folder-path field plus optional OR branches of itself. */
+type FilterWithFolderAndOr<K extends string> = { orBranches?: FilterWithFolderAndOr<K>[] } & {
+  [P in K]?: string | boolean | null;
+};
+
+/**
+ * Recursively collect every distinct non-empty string folder-PATH value referenced
+ * anywhere in `filter` — the top-level `key` plus `key` on every (possibly nested)
+ * `orBranches` entry. Boolean/null values (e.g. `folderTopLevel`, `folder: null`) are
+ * ignored — only string paths need an existence check.
+ */
+function collectFolderPaths<K extends string>(filter: FilterWithFolderAndOr<K> | undefined, key: K): string[] {
+  if (!filter) return [];
+  const paths: string[] = [];
+  const top = filter[key];
+  if (typeof top === 'string' && top.length > 0) paths.push(top);
+  if (Array.isArray(filter.orBranches)) {
+    for (const branch of filter.orBranches) {
+      paths.push(...collectFolderPaths(branch, key));
+    }
+  }
+  return paths;
+}
+
+/**
+ * Emit the FOLDER_NOT_FOUND guard for every distinct folder path referenced ANYWHERE in
+ * `filter` — the top-level filter and any (possibly nested) `orBranches` entries.
+ *
+ * OMN-218 (review round 2): a folder value nested in an OR branch — e.g.
+ * `{ OR: [{ folder: "Typo" }, { flagged: true }] }` — used to be invisible to the guard
+ * (only the top-level key was checked), so an unresolvable folder inside an OR branch
+ * silently contributed zero matches instead of failing loudly. Single source of truth
+ * for the "does this filter reference a folder path?" question, so tasks-list,
+ * projects-list, tasks-count, and inbox all derive the guard identically — no triplicated
+ * ternaries to drift out of sync.
+ *
+ * `key` is `'folder'` for task filters, `'folderName'` for project filters.
+ */
+export function emitFolderNotFoundGuardsForFilter<K extends string>(
+  filter: FilterWithFolderAndOr<K> | undefined,
+  key: K,
+): string {
+  const uniquePaths = [...new Set(collectFolderPaths(filter, key))];
+  return uniquePaths.map((path) => emitFolderNotFoundGuard(path)).join('\n');
 }

--- a/src/contracts/ast/folder-path-match.ts
+++ b/src/contracts/ast/folder-path-match.ts
@@ -164,6 +164,19 @@ export function emitFolderNotFoundGuardsForFilter<K extends string>(
   filter: FilterWithFolderAndOr<K> | undefined,
   key: K,
 ): string {
-  const uniquePaths = [...new Set(collectFolderPaths(filter, key))];
+  // OMN-218 (review round 3, PR #168): dedup on the NORMALIZED path (the same
+  // lowercased, segment-parsed form parseFolderFilterPath produces), not the raw
+  // string — otherwise "Personal/Bills" and "Personal : Bills" (same real folder,
+  // different separator/casing) each emit their own redundant guard closure. Keep
+  // one representative raw path per unique normalized form (first-seen wins) so
+  // emitFolderNotFoundGuard's error message still echoes something the caller wrote.
+  const seenNormalized = new Set<string>();
+  const uniquePaths: string[] = [];
+  for (const path of collectFolderPaths(filter, key)) {
+    const normalized = JSON.stringify(parseFolderFilterPath(path));
+    if (seenNormalized.has(normalized)) continue;
+    seenNormalized.add(normalized);
+    uniquePaths.push(path);
+  }
   return uniquePaths.map((path) => emitFolderNotFoundGuard(path)).join('\n');
 }

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -1448,7 +1448,13 @@ export function buildFilteredProjectsScript(
 
   // OMN-218: fail loudly on any unresolvable folder PATH — top-level + OR branches
   // (review round 2). Not folder:null / topLevelOnly (boolean, ignored by the collector).
-  const folderGuard = emitFolderNotFoundGuardsForFilter(filter, 'folderName');
+  // Skipped when `id` is set (review round 3, PR #168): `id` is documented elsewhere
+  // (buildProjectByIdScript / buildTaskByIdScript) as the sole selector — sibling keys
+  // are ignored. countOnly routes id+folder queries THROUGH this builder instead of the
+  // dedicated id-lookup path (compiled.countOnly is checked before projectFilter.id in
+  // OmniFocusReadTool), so without this guard an id-scoped countOnly query could newly
+  // hard-error on a typo'd folder where the equivalent non-countOnly query ignores it.
+  const folderGuard = filter.id ? '' : emitFolderNotFoundGuardsForFilter(filter, 'folderName');
 
   const omniJsSource = `
       (() => {
@@ -1976,7 +1982,13 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
   // OMN-218: countOnly parity with the list path — any unresolvable folder PATH (top-level
   // or OR-branch, review round 2) fails loudly instead of silently counting 0.
   // folder:null / folderTopLevel is a different (boolean) flag and stays a valid 0-count.
-  const folderGuard = emitFolderNotFoundGuardsForFilter(normalizedFilter, 'folder');
+  // Skipped when `id` is set (review round 3, PR #168): `id` is documented elsewhere
+  // (buildTaskByIdScript) as the sole selector — sibling keys are ignored. countOnly
+  // routes id+folder queries THROUGH this builder instead of the dedicated id-lookup
+  // path (compiled.countOnly is checked before filter.id in OmniFocusReadTool), so
+  // without this guard an id-scoped countOnly query could newly hard-error on a typo'd
+  // folder where the equivalent non-countOnly query ignores it entirely.
+  const folderGuard = normalizedFilter.id ? '' : emitFolderNotFoundGuardsForFilter(normalizedFilter, 'folder');
 
   // Count runs in OmniJS (see JSDoc): one bridge round-trip, no per-task IPC.
   const omniJsSource = `

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -26,6 +26,7 @@ import {
 } from './filter-generator.js';
 import { buildAST } from './builder.js';
 import { sanitizeForScriptComment } from './bridge-escape.js';
+import { emitFolderNotFoundGuardsForFilter } from './folder-path-match.js';
 import { ACTIONABLE_STATUSES } from './types.js';
 
 // =============================================================================
@@ -400,6 +401,12 @@ interface ScriptBuildContext {
   projectValue: string | undefined | null;
   limit: number;
   offset: number;
+  /**
+   * OMN-218: an OmniJS guard statement emitted at the top of the row loop that returns a
+   * FOLDER_NOT_FOUND envelope when a string folder PATH filter resolves to no folder.
+   * Empty string when there is no folder-path filter (or `folder:null` top-level).
+   */
+  folderExistsGuard: string;
 }
 
 /** Generate the duplicate-project warnings block (shared by sort and no-sort paths) */
@@ -442,6 +449,7 @@ function buildSortedScript(ctx: ScriptBuildContext, sort: SortSpec[]): string {
 
   return `
 (() => {
+  ${ctx.folderExistsGuard}
   const allResults = [];
 
   ${matchesFilterBlock}
@@ -491,6 +499,7 @@ function buildUnsortedScript(ctx: ScriptBuildContext): string {
 
   return `
 (() => {
+  ${ctx.folderExistsGuard}
   const results = [];
   let count = 0;
   let totalMatched = 0;
@@ -633,6 +642,11 @@ export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: 
   const defaultCompletionCheck = includeCompleted ? '' : 'if (task.completed) return;';
   const completionCheck = filter.completed !== undefined ? '' : defaultCompletionCheck;
 
+  // OMN-218: fail loudly on any unresolvable folder PATH — the top-level `filter.folder`
+  // AND any OR-branch's `folder` (review round 2). `folder:null` arrives as folderTopLevel,
+  // a boolean the collector ignores, so it keeps returning empty-set success (guard stays '').
+  const folderExistsGuard = emitFolderNotFoundGuardsForFilter(filter, 'folder');
+
   const ctx: ScriptBuildContext = {
     filterCode,
     filterDescription,
@@ -642,6 +656,7 @@ export function buildFilteredTasksScript(filter: NormalizedTaskFilter, options: 
     projectValue: filter.projectId ?? filter.project,
     limit,
     offset,
+    folderExistsGuard,
   };
 
   // When sort is specified, collect ALL matching tasks, sort in-script, then slice.
@@ -760,8 +775,15 @@ export function buildInboxScript(additionalFilter: TaskFilter = {}, options: Scr
   const offsetCheck = useOffset ? 'if (skipped < offset) { skipped++; return; }' : '';
   const offsetMetadata = useOffset ? `offset_applied: ${offset},` : '';
 
+  // OMN-218 (review round 2): inbox mode was missing the guard entirely — a folder
+  // filter combined with mode:'inbox' bypassed the loud-error path. Inbox tasks
+  // structurally have no containing folder (the filter always matches nothing), but
+  // an UNRESOLVABLE folder reference must still error, independent of match count.
+  const folderExistsGuard = emitFolderNotFoundGuardsForFilter(filter, 'folder');
+
   const script = `
 (() => {
+  ${folderExistsGuard}
   const results = [];
   let count = 0;
   let totalMatched = 0;
@@ -1424,8 +1446,13 @@ export function buildFilteredProjectsScript(
   // Include task counts only in normal mode
   const includeTaskCounts = performanceMode !== 'lite';
 
+  // OMN-218: fail loudly on any unresolvable folder PATH — top-level + OR branches
+  // (review round 2). Not folder:null / topLevelOnly (boolean, ignored by the collector).
+  const folderGuard = emitFolderNotFoundGuardsForFilter(filter, 'folderName');
+
   const omniJsSource = `
       (() => {
+        ${folderGuard}
         const results = [];
         let count = 0;
         let totalMatched = 0;
@@ -1548,6 +1575,12 @@ export function buildFilteredProjectsScript(
   try {
     const resultJson = app.evaluateJavascript(${JSON.stringify(omniJsSource)});
     const result = JSON.parse(resultJson);
+
+    // OMN-218: propagate an in-script error envelope (e.g. the folder-not-found guard)
+    // verbatim rather than mangling it into a success shape with undefined rows.
+    if (result && result.error) {
+      return resultJson;
+    }
 
     return JSON.stringify({
       projects: result.projects,
@@ -1940,10 +1973,16 @@ export function buildTaskCountScript(filter: TaskFilter = {}, options: TaskCount
   // Check if the filter needs tags - only fetch tags if the filter uses them
   const needsTags = filterCode.predicate.includes('taskTags');
 
+  // OMN-218: countOnly parity with the list path — any unresolvable folder PATH (top-level
+  // or OR-branch, review round 2) fails loudly instead of silently counting 0.
+  // folder:null / folderTopLevel is a different (boolean) flag and stays a valid 0-count.
+  const folderGuard = emitFolderNotFoundGuardsForFilter(normalizedFilter, 'folder');
+
   // Count runs in OmniJS (see JSDoc): one bridge round-trip, no per-task IPC.
   const omniJsSource = `
 (() => {
   try {
+    ${folderGuard}
     const startTime = Date.now();
     const maxScan = ${maxScan};
     let count = 0;

--- a/src/omnifocus/scripts/tasks/list-tasks-ast.ts
+++ b/src/omnifocus/scripts/tasks/list-tasks-ast.ts
@@ -90,6 +90,12 @@ export function buildListTasksScriptV4(params: {
     const resultJson = app.evaluateJavascript(${JSON.stringify(generatedScript.script)});
     const result = JSON.parse(resultJson);
 
+    // OMN-218: propagate an in-script error envelope (e.g. the folder-not-found guard)
+    // verbatim rather than wrapping it into a success shape with undefined tasks.
+    if (result && result.error) {
+      return resultJson;
+    }
+
     // Return with metadata
     return JSON.stringify({
       tasks: result.tasks,

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -12,7 +12,12 @@ import {
   resolveEffectiveTaskFields,
   resolveEffectiveProjectFields,
 } from '../../contracts/ast/script-builder.js';
-import { isScriptSuccess, isScriptError, type ScriptResult } from '../../omnifocus/script-result-types.js';
+import {
+  isScriptSuccess,
+  isScriptError,
+  type ScriptResult,
+  type ScriptError,
+} from '../../omnifocus/script-result-types.js';
 import {
   listResultSchema,
   CountResultSchema,
@@ -247,6 +252,23 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
 // TASK_DATE_FIELDS contract in `src/tools/tasks/task-query-pipeline.ts`.
 const PROJECT_DATE_FIELDS = ['dueDate', 'completionDate', 'nextReviewDate', 'lastReviewDate'] as const;
 
+/**
+ * OMN-218: detect the in-script folder-existence guard's error envelope. The guard
+ * (emitFolderNotFoundGuard) returns `{ error:true, details:{ code:'FOLDER_NOT_FOUND' } }`;
+ * `detectKnownErrorShape` preserves the code inside `details` (a top-level `code` would be
+ * dropped). Callers map this to a loud NOT_FOUND instead of a generic SCRIPT_ERROR, so an
+ * unresolvable folder reference never masquerades as a valid-but-empty result.
+ *
+ * Takes `ScriptError` (not `ScriptResult`) — every call site is already inside an
+ * `if (!isScriptSuccess(result))` block, which narrows the discriminated union for free.
+ * A type predicate here lets callers use `result.error`/`result.details` directly instead
+ * of re-checking `isScriptError` at each site.
+ */
+function isFolderNotFoundError(result: ScriptError): result is ScriptError & { details: { code: 'FOLDER_NOT_FOUND' } } {
+  const details = result.details;
+  return typeof details === 'object' && details !== null && (details as { code?: unknown }).code === 'FOLDER_NOT_FOUND';
+}
+
 export class OmniFocusReadTool extends BaseTool<typeof ReadSchema, unknown> {
   name = 'omnifocus_read';
   description = `Query OmniFocus data with flexible filtering. Returns tasks, projects, tags, perspectives, or folders.
@@ -279,7 +301,7 @@ FILTER OPERATORS:
 - text: { contains: "..." }, { matches: "regex" } — full-text: matches name OR note
 - name: { contains: "..." }, { matches: "regex" } — name ONLY (never matches note content)
 - boolean: flagged, blocked, available, inInbox
-- folder (tasks AND projects queries): "<Parent : Child path>" matches the folder SUBTREE (a bare name is a single-segment path; case-insensitive substring per segment); null = top-level only (no containing folder). On tasks queries it matches the folder ancestry of the task's containing project (inbox tasks excluded). status: "on_hold" is still rejected on tasks queries with guidance (query projects first, then tasks by projectId)
+- folder (tasks AND projects queries): "<Parent : Child path>" (or "Parent/Child" — both ':' and '/' separators are accepted, so a path copied from a folders query round-trips) matches the folder SUBTREE (a bare name is a single-segment path; case-insensitive substring per segment); an unresolvable folder path returns a NOT_FOUND error rather than a silent empty result; null = top-level only (no containing folder). On tasks queries it matches the folder ancestry of the task's containing project (inbox tasks excluded). status: "on_hold" is still rejected on tasks queries with guidance (query projects first, then tasks by projectId)
 - logic: { OR: [...] }, { AND: [...] }; NOT supports ONLY { status: "completed" } or { status: "active" } — anything else is rejected. For tag exclusion use tags: { none: [...] }; for flag exclusion use flagged: false. A terminal status: "dropped"/"completed" inside an OR branch is rejected (tasks exclude those by default, so the branch would never match) — put it at the top level instead
 - Projects filters: status, completed, flagged, name, text, folder, id. AND merges; OR: [...] returns the union of its branches; NOT: { status: "active"|"on_hold"|"completed"|"dropped" } matches the complement of that status over the four project states (broader than the tasks NOT, which is completed/active only).
 
@@ -437,6 +459,26 @@ PERFORMANCE:
     }
   }
 
+  /**
+   * OMN-218: shared NOT_FOUND mapping for the folder-existence guard's error envelope.
+   * Single source of truth for all 4 call sites (tasks list, tasks count, projects list,
+   * projects/tags/folders count-only tail) so the message/hint can't drift out of sync.
+   */
+  private folderNotFoundResponse(
+    entityType: 'tasks' | 'projects' | 'tags' | 'folders',
+    result: ScriptError & { details: { code: 'FOLDER_NOT_FOUND' } },
+    timer: OperationTimerV2,
+  ): unknown {
+    return createErrorResponseV2(
+      entityType,
+      'NOT_FOUND',
+      result.error,
+      "Check the folder name; run a folders query to see exact paths (both ':' and '/' separators are accepted).",
+      result.details,
+      timer.toMetadata(),
+    );
+  }
+
   private async handleTaskQuery(compiled: CompiledQuery): Promise<unknown> {
     if (compiled.type !== 'tasks') throw new Error('handleTaskQuery: wrong type');
     const timer = new OperationTimerV2();
@@ -463,6 +505,11 @@ PERFORMANCE:
     const result = await this.execJson(script, TASK_LIST_SCHEMA);
 
     if (!isScriptSuccess(result)) {
+      // OMN-218: an unresolvable folder reference fails loudly (NOT_FOUND), not as an
+      // opaque SCRIPT_ERROR or a silent empty result.
+      if (isFolderNotFoundError(result)) {
+        return this.folderNotFoundResponse('tasks', result, timer);
+      }
       return createErrorResponseV2(
         'tasks',
         'SCRIPT_ERROR',
@@ -616,6 +663,10 @@ PERFORMANCE:
     const result = await this.execJson(script, CountResultSchema);
 
     if (!isScriptSuccess(result)) {
+      // OMN-218: unresolvable folder → loud NOT_FOUND (parity with the list path).
+      if (isFolderNotFoundError(result)) {
+        return this.folderNotFoundResponse('tasks', result, timer);
+      }
       return createErrorResponseV2(
         'tasks',
         'SCRIPT_ERROR',
@@ -844,6 +895,11 @@ PERFORMANCE:
     timer: OperationTimerV2,
   ): unknown {
     if (!isScriptSuccess(result)) {
+      // OMN-218: unresolvable folder → loud NOT_FOUND (parity with the list path).
+      // Only projects carries a folder path; tags/folders never emit this code.
+      if (isFolderNotFoundError(result)) {
+        return this.folderNotFoundResponse(entityType, result, timer);
+      }
       return createErrorResponseV2(
         entityType,
         'SCRIPT_ERROR',
@@ -944,6 +1000,11 @@ PERFORMANCE:
     const result = await this.execJson(generatedScript.script, PROJECT_LIST_SCHEMA);
 
     if (!isScriptSuccess(result)) {
+      // OMN-218: an unresolvable folder reference fails loudly (NOT_FOUND), not as an
+      // opaque SCRIPT_ERROR or a silent empty result.
+      if (isFolderNotFoundError(result)) {
+        return this.folderNotFoundResponse('projects', result, timer);
+      }
       return createErrorResponseV2(
         'projects',
         'SCRIPT_ERROR',

--- a/src/tools/unified/schemas/read-schema.ts
+++ b/src/tools/unified/schemas/read-schema.ts
@@ -124,7 +124,7 @@ const filterFields = {
   // folder SUBTREE (shared emitter, src/contracts/ast/folder-path-match.ts), and
   // tasks queries SUPPORT folder (was OMN-162 reject) — the task's containing
   // project's folder ancestry, inbox excluded. Bare name = single-segment path.
-  folder: z.union([z.string(), z.null()]).optional(), // "<Parent : Child path>" = subtree match (OMN-167); null = top-level only (OMN-96). tasks queries (OMN-167): folder of the task's containing project, subtree, inbox excluded. projects queries: subtree path match. folders queries (OMN-170): "<name>" = parent folder name, null = top-level folders.
+  folder: z.union([z.string(), z.null()]).optional(), // "<Parent : Child path>" = subtree match (OMN-167; OMN-218: "/" separator accepted too, so a folders-query path round-trips); null = top-level only (OMN-96). tasks queries (OMN-167): folder of the task's containing project, subtree, inbox excluded. projects queries: subtree path match; an unresolvable path errors NOT_FOUND (OMN-218). folders queries (OMN-170): "<name>" = parent folder name, null = top-level folders.
 };
 
 // Flat filter: base fields only, no logical operators.

--- a/tests/unit/contracts/ast/folder-path-match.test.ts
+++ b/tests/unit/contracts/ast/folder-path-match.test.ts
@@ -252,4 +252,28 @@ describe('emitFolderNotFoundGuardsForFilter — collects folder paths across OR 
     const out = emitFolderNotFoundGuardsForFilter({ orBranches: [{ folderName: 'Typo' }] } as any, 'folderName');
     expect(out).toContain('Typo');
   });
+
+  // OMN-218 /code-review high (PR #168): dedup must operate on the NORMALIZED path
+  // (lowercased, segment-parsed), not the raw string — otherwise the same real folder
+  // referenced via different separators/casing emits redundant guard closures.
+  it('dedupes the same folder referenced via `:` and `/` separators (one guard, not two)', () => {
+    const out = emitFolderNotFoundGuardsForFilter(
+      { folder: 'Personal/Bills', orBranches: [{ folder: 'Personal : Bills' }] } as any,
+      'folder',
+    );
+    expect((out.match(/FOLDER_NOT_FOUND/g) || []).length).toBe(1);
+  });
+
+  it('dedupes the same folder referenced via different casing/whitespace', () => {
+    const out = emitFolderNotFoundGuardsForFilter(
+      { folder: 'Personal / Bills', orBranches: [{ folder: 'PERSONAL/BILLS' }] } as any,
+      'folder',
+    );
+    expect((out.match(/FOLDER_NOT_FOUND/g) || []).length).toBe(1);
+  });
+
+  it('still emits two guards for genuinely distinct folders', () => {
+    const out = emitFolderNotFoundGuardsForFilter({ folder: 'A', orBranches: [{ folder: 'B' }] } as any, 'folder');
+    expect((out.match(/FOLDER_NOT_FOUND/g) || []).length).toBe(2);
+  });
 });

--- a/tests/unit/contracts/ast/folder-path-match.test.ts
+++ b/tests/unit/contracts/ast/folder-path-match.test.ts
@@ -15,7 +15,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseFolderFilterPath, emitFolderPathMatch } from '../../../../src/contracts/ast/folder-path-match.js';
+import {
+  parseFolderFilterPath,
+  emitFolderPathMatch,
+  emitFolderExistsGuard,
+  emitFolderNotFoundGuard,
+  emitFolderNotFoundGuardsForFilter,
+} from '../../../../src/contracts/ast/folder-path-match.js';
 import { type FakeFolder, development, web, frontend } from './fake-folder-tree.js';
 
 /** Instantiate the emitted expression as a real predicate over a leaf folder. */
@@ -49,6 +55,34 @@ describe('parseFolderFilterPath', () => {
 
   it('throws on an empty interior segment', () => {
     expect(() => parseFolderFilterPath('A : : B')).toThrow();
+  });
+
+  // OMN-218: the `folders` query emits `/`-joined paths and the WRITE path accepts
+  // `/`; the read filter must round-trip its own output. Accept BOTH separators.
+  it('parses a `/`-joined path (the form the folders query emits)', () => {
+    expect(parseFolderFilterPath('Personal/Other Games/Shop Titans')).toEqual([
+      'personal',
+      'other games',
+      'shop titans',
+    ]);
+  });
+
+  it('trims per segment around `/` regardless of spacing', () => {
+    expect(parseFolderFilterPath('Development / Web')).toEqual(['development', 'web']);
+  });
+
+  it('accepts a mixed `:` and `/` path (both are separators)', () => {
+    expect(parseFolderFilterPath('Personal : Other Games/Shop Titans')).toEqual([
+      'personal',
+      'other games',
+      'shop titans',
+    ]);
+  });
+
+  it('throws on an empty segment from a leading/trailing/doubled slash', () => {
+    expect(() => parseFolderFilterPath('/Web')).toThrow();
+    expect(() => parseFolderFilterPath('Development/')).toThrow();
+    expect(() => parseFolderFilterPath('A//B')).toThrow();
   });
 });
 
@@ -95,5 +129,127 @@ describe('emitFolderPathMatch — generated source hygiene', () => {
 
   it('does not contain a backtick (would break JXA → OmniJS template interpolation)', () => {
     expect(emitFolderPathMatch('LEAF', 'Development : Web').includes('`')).toBe(false);
+  });
+
+  // OMN-218: the `:` and `/` forms of the SAME path must emit byte-identical code —
+  // both surfaces (tasks + projects) inherit this emitter, so the round-trip of a
+  // `/`-joined folders-query path must generate exactly the `:`-form's predicate.
+  it('emits byte-identical code for the `:` and `/` forms of the same path', () => {
+    expect(emitFolderPathMatch('LEAF', 'Development/Web')).toBe(emitFolderPathMatch('LEAF', 'Development : Web'));
+  });
+
+  // OMN-218 refactor guard: emitFolderExistsGuard reuses emitFolderPathMatch's per-folder
+  // chain predicate, so extracting the shared helper must not change the row-matcher's
+  // emitted string. Pin the exact output before/after the refactor (spec §5).
+  it('emits the exact expected string for a two-segment path (refactor lock)', () => {
+    expect(emitFolderPathMatch('LEAF', 'Development : Web')).toBe(
+      `(() => { const segs = ["development","web"]; let a = (LEAF); while (a) { let f = a, ok = true; for (let i = segs.length - 1; i >= 0; i--) { if (!f || !((f.name || '').toLowerCase().includes(segs[i]))) { ok = false; break; } f = f.parent; } if (ok) return true; a = a.parent; } return false; })()`,
+    );
+  });
+});
+
+/**
+ * emitFolderExistsGuard — OMN-218 fix (b). Emits an OmniJS boolean expression that is
+ * `true` iff `flattenedFolders` contains at least one folder whose ancestor chain matches
+ * `path` (i.e. the path RESOLVES to a real folder). Uses the SAME per-folder chain
+ * predicate as emitFolderPathMatch, so a folder resolves iff a row under it could match.
+ *
+ * Instantiate the expression over a synthetic `flattenedFolders` array (the OmniJS global)
+ * to validate runtime behavior, mirroring the emitFolderPathMatch harness above.
+ */
+function existsGuard(path: string): (folders: FakeFolder[]) => boolean {
+  const expr = emitFolderExistsGuard(path);
+  return new Function('flattenedFolders', `return (${expr});`) as (folders: FakeFolder[]) => boolean;
+}
+
+describe('emitFolderExistsGuard — generated existence check', () => {
+  const allFolders = [development, web, frontend];
+
+  it('is true when the path resolves to an existing folder (single segment)', () => {
+    expect(existsGuard('Development')(allFolders)).toBe(true);
+  });
+
+  it('is true when a multi-segment path resolves', () => {
+    expect(existsGuard('Development : Web')(allFolders)).toBe(true);
+    expect(existsGuard('Development/Web')(allFolders)).toBe(true); // `/` form resolves too
+  });
+
+  it('is false when the path does not resolve to any folder', () => {
+    expect(existsGuard('No Such Folder')(allFolders)).toBe(false);
+    expect(existsGuard('Web : Development')(allFolders)).toBe(false); // reversed chain
+  });
+
+  it('is true for a leaf folder that exists even though it has no descendants', () => {
+    // "empty ≠ unresolvable": a real folder with no matching rows still RESOLVES.
+    expect(existsGuard('Frontend')(allFolders)).toBe(true);
+  });
+
+  it('is false against an empty folder set', () => {
+    expect(existsGuard('Development')([])).toBe(false);
+  });
+
+  it('does not contain a backtick (JXA → OmniJS template safety)', () => {
+    expect(emitFolderExistsGuard('Development : Web').includes('`')).toBe(false);
+  });
+});
+
+/**
+ * OMN-218 review round 2: a folder path nested in an OR branch must be guarded too —
+ * `emitFolderNotFoundGuard` alone only ever saw the top-level key, so
+ * `{ OR: [{ folder: "Typo" }, { flagged: true }] }` silently dropped the typo'd branch
+ * instead of erroring. `emitFolderNotFoundGuardsForFilter` walks top-level + orBranches
+ * (recursively) and emits one guard per distinct path found.
+ */
+describe('emitFolderNotFoundGuardsForFilter — collects folder paths across OR branches', () => {
+  it('emits nothing when the filter has no folder path anywhere', () => {
+    expect(emitFolderNotFoundGuardsForFilter({}, 'folder')).toBe('');
+    expect(emitFolderNotFoundGuardsForFilter({ flagged: true } as any, 'folder')).toBe('');
+  });
+
+  it('emits nothing for folder:null (top-level-only) or folderTopLevel — non-string values', () => {
+    expect(emitFolderNotFoundGuardsForFilter({ folder: null } as any, 'folder')).toBe('');
+    expect(emitFolderNotFoundGuardsForFilter({ folderTopLevel: true } as any, 'folder')).toBe('');
+  });
+
+  it('emits one guard for a top-level string folder path', () => {
+    const out = emitFolderNotFoundGuardsForFilter({ folder: 'Development' } as any, 'folder');
+    expect(out).toContain('FOLDER_NOT_FOUND');
+    expect(out).toBe(emitFolderNotFoundGuard('Development'));
+  });
+
+  it('emits a guard for a folder path nested in an OR branch even when absent at top level', () => {
+    const out = emitFolderNotFoundGuardsForFilter(
+      { orBranches: [{ folder: 'Typo Folder' }, { flagged: true }] } as any,
+      'folder',
+    );
+    expect(out).toContain('FOLDER_NOT_FOUND');
+    expect(out).toContain('Typo Folder');
+  });
+
+  it('emits guards for BOTH a top-level path and a distinct OR-branch path', () => {
+    const out = emitFolderNotFoundGuardsForFilter({ folder: 'A', orBranches: [{ folder: 'B' }] } as any, 'folder');
+    expect(out).toContain('"a"');
+    expect(out).toContain('"b"');
+  });
+
+  it('dedupes when the same path appears at top level and in an OR branch', () => {
+    const out = emitFolderNotFoundGuardsForFilter(
+      { folder: 'Development', orBranches: [{ folder: 'Development' }] } as any,
+      'folder',
+    );
+    expect((out.match(/FOLDER_NOT_FOUND/g) || []).length).toBe(1);
+  });
+
+  it('recurses into nested OR branches (OR within OR)', () => {
+    const out = emitFolderNotFoundGuardsForFilter(
+      { orBranches: [{ orBranches: [{ folder: 'Deeply Nested' }] }] } as any,
+      'folder',
+    );
+    expect(out).toContain('Deeply Nested');
+  });
+
+  it('works with the projects folderName key', () => {
+    const out = emitFolderNotFoundGuardsForFilter({ orBranches: [{ folderName: 'Typo' }] } as any, 'folderName');
+    expect(out).toContain('Typo');
   });
 });

--- a/tests/unit/contracts/ast/omn-218-folder-exists-guard.test.ts
+++ b/tests/unit/contracts/ast/omn-218-folder-exists-guard.test.ts
@@ -1,0 +1,140 @@
+/**
+ * OMN-218 fix (b) — the folder-existence guard is injected into BOTH read-script
+ * builders when (and only when) a string folder PATH filter is present, so an
+ * unresolvable folder reference fails loudly (FOLDER_NOT_FOUND) instead of returning
+ * a silent `success:true, total_count:0`.
+ *
+ * These are codegen-presence tests (the scripts run only inside OmniFocus). The guard's
+ * RUNTIME behavior is covered by the emitFolderExistsGuard predicate tests in
+ * folder-path-match.test.ts; the tool-layer mapping is covered by the OmniFocusReadTool
+ * unit tests; end-to-end is the live `/verify`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildFilteredTasksScript,
+  buildFilteredProjectsScript,
+  buildTaskCountScript,
+  buildInboxScript,
+} from '../../../../src/contracts/ast/script-builder.js';
+import { buildListTasksScriptV4 } from '../../../../src/omnifocus/scripts/tasks/list-tasks-ast.js';
+import type { NormalizedTaskFilter, ProjectFilter, TaskFilter } from '../../../../src/contracts/filters.js';
+
+const CODE = 'FOLDER_NOT_FOUND';
+const EXISTS = 'flattenedFolders.some';
+
+describe('OMN-218: projects-side folder-existence guard', () => {
+  it('injects the existence guard + FOLDER_NOT_FOUND envelope for a string folder path', () => {
+    const { script } = buildFilteredProjectsScript({ folderName: 'Personal/Other Games' } as ProjectFilter);
+    expect(script).toContain(EXISTS);
+    expect(script).toContain(CODE);
+  });
+
+  it('does NOT inject the guard when no folder filter is present', () => {
+    const { script } = buildFilteredProjectsScript({} as ProjectFilter);
+    expect(script).not.toContain(CODE);
+  });
+
+  it('does NOT inject the guard for the top-level-only (folder:null) path', () => {
+    const { script } = buildFilteredProjectsScript({ topLevelOnly: true } as ProjectFilter);
+    expect(script).not.toContain(CODE);
+  });
+
+  it('the outer JXA wrapper passes an in-script error envelope through', () => {
+    const { script } = buildFilteredProjectsScript({ folderName: 'X' } as ProjectFilter);
+    expect(script).toContain('result.error');
+  });
+});
+
+describe('OMN-218: tasks-side folder-existence guard', () => {
+  it('injects the existence guard + FOLDER_NOT_FOUND envelope for a string folder path', () => {
+    const { script } = buildFilteredTasksScript({ folder: 'Personal/Other Games' } as NormalizedTaskFilter);
+    expect(script).toContain(EXISTS);
+    expect(script).toContain(CODE);
+  });
+
+  it('does NOT inject the guard when no folder filter is present', () => {
+    const { script } = buildFilteredTasksScript({} as NormalizedTaskFilter);
+    expect(script).not.toContain(CODE);
+  });
+
+  it('does NOT inject the guard for the top-level (folderTopLevel) path', () => {
+    const { script } = buildFilteredTasksScript({ folderTopLevel: true } as NormalizedTaskFilter);
+    expect(script).not.toContain(CODE);
+  });
+
+  it('the V4 JXA wrapper passes an in-script error envelope through', () => {
+    // buildFilteredTasksScript returns only the inner OmniJS program; the JXA wrapper
+    // that must forward the error lives in buildListTasksScriptV4.
+    const wrapped = buildListTasksScriptV4({ filter: { folder: 'X' } as NormalizedTaskFilter });
+    expect(wrapped).toContain('result.error');
+  });
+});
+
+describe('OMN-218: tasks-count folder-existence guard (countOnly parity)', () => {
+  // Sibling of the list path: an unresolvable folder must not silently return count 0.
+  it('injects the guard + FOLDER_NOT_FOUND envelope for a string folder path', () => {
+    const { script } = buildTaskCountScript({ folder: 'Personal/Other Games' });
+    expect(script).toContain(EXISTS);
+    expect(script).toContain(CODE);
+  });
+
+  it('does NOT inject the guard when no folder filter is present', () => {
+    const { script } = buildTaskCountScript({});
+    expect(script).not.toContain(CODE);
+  });
+
+  it('does NOT inject the guard for the top-level (folderTopLevel) path', () => {
+    const { script } = buildTaskCountScript({ folderTopLevel: true });
+    expect(script).not.toContain(CODE);
+  });
+});
+
+// OMN-218 review round 2: two gaps the first pass missed.
+describe('OMN-218 review round 2: folder path nested in an OR branch', () => {
+  it('tasks list: guards a folder path that only appears inside an OR branch', () => {
+    const { script } = buildFilteredTasksScript({
+      orBranches: [{ folder: 'Typo Folder' }, { flagged: true }],
+    } as NormalizedTaskFilter);
+    expect(script).toContain(CODE);
+    expect(script).toContain('Typo Folder');
+  });
+
+  it('projects list: guards a folderName that only appears inside an OR branch', () => {
+    const { script } = buildFilteredProjectsScript({
+      orBranches: [{ folderName: 'Typo Folder' }, { name: 'x' }],
+    } as ProjectFilter);
+    expect(script).toContain(CODE);
+    expect(script).toContain('Typo Folder');
+  });
+
+  it('tasks count: guards a folder path that only appears inside an OR branch', () => {
+    const { script } = buildTaskCountScript({
+      orBranches: [{ folder: 'Typo Folder' }, { flagged: true }],
+    } as TaskFilter);
+    expect(script).toContain(CODE);
+    expect(script).toContain('Typo Folder');
+  });
+});
+
+describe('OMN-218 review round 2: inbox mode + folder filter', () => {
+  it('buildInboxScript injects the existence guard for a string folder path', () => {
+    const { script } = buildInboxScript({ folder: 'Typo Folder' } as TaskFilter);
+    expect(script).toContain(EXISTS);
+    expect(script).toContain(CODE);
+    expect(script).toContain('Typo Folder');
+  });
+
+  it('buildInboxScript does NOT inject the guard when no folder filter is present', () => {
+    const { script } = buildInboxScript({} as TaskFilter);
+    expect(script).not.toContain(CODE);
+  });
+
+  it('the V4 wrapper routes mode:"inbox" + a folder filter through the guarded inbox builder', () => {
+    const wrapped = buildListTasksScriptV4({
+      filter: { folder: 'Typo Folder', inInbox: true } as NormalizedTaskFilter,
+      mode: 'inbox',
+    });
+    expect(wrapped).toContain(CODE);
+  });
+});

--- a/tests/unit/contracts/ast/omn-218-folder-exists-guard.test.ts
+++ b/tests/unit/contracts/ast/omn-218-folder-exists-guard.test.ts
@@ -138,3 +138,45 @@ describe('OMN-218 review round 2: inbox mode + folder filter', () => {
     expect(wrapped).toContain(CODE);
   });
 });
+
+// OMN-218 /code-review high (PR #168): countOnly is routed BEFORE the id short-circuit
+// in OmniFocusReadTool (compiled.countOnly checked before filter.id), so an
+// {id, folder} countOnly query reaches buildTaskCountScript/buildFilteredProjectsScript
+// directly instead of the dedicated id-lookup builder — unlike the non-countOnly path,
+// where id already short-circuits BEFORE these builders ever see a folder value.
+// buildTaskByIdScript documents "the id filter is the sole selector (sibling keys are
+// ignored)"; the count builders must honor that same convention so id+folder+countOnly
+// doesn't newly hard-error where id+folder without countOnly silently ignores folder.
+describe('OMN-218 review (PR #168): folder guard skipped when filter.id is present', () => {
+  it('buildTaskCountScript does NOT guard folder when id is also set', () => {
+    const { script } = buildTaskCountScript({ id: 'abc123', folder: 'Typo Folder' });
+    expect(script).not.toContain(CODE);
+  });
+
+  it('buildTaskCountScript DOES guard folder when id is absent (regression check)', () => {
+    const { script } = buildTaskCountScript({ folder: 'Typo Folder' });
+    expect(script).toContain(CODE);
+  });
+
+  it('buildFilteredProjectsScript does NOT guard folderName when id is also set', () => {
+    const { script } = buildFilteredProjectsScript({ id: 'abc123', folderName: 'Typo Folder' } as ProjectFilter);
+    expect(script).not.toContain(CODE);
+  });
+
+  it('buildFilteredProjectsScript DOES guard folderName when id is absent (regression check)', () => {
+    const { script } = buildFilteredProjectsScript({ folderName: 'Typo Folder' } as ProjectFilter);
+    expect(script).toContain(CODE);
+  });
+});
+
+// OMN-218 /code-review high (PR #168): the guard collector deduped on the raw filter
+// string, not the normalized (lowercased, segment-parsed) path — so "Personal/Bills"
+// and "Personal : Bills" (same real folder, different separator) emitted two redundant
+// existence-guard closures instead of one. Dedup behavior itself is exercised at the
+// collector level (folder-path-match.test.ts) — two different string values for the
+// SAME field on separate OR branches trips an unrelated, pre-existing validator bug
+// (`detectContradictions` doesn't respect OR-branch scoping; confirmed general, not
+// folder-specific, e.g. `{OR:[{projectId:'A'},{projectId:'B'}]}` also throws on `main`
+// today) when routed through the full generateFilterCode/validate pipeline, so a
+// builder-level (`buildFilteredTasksScript`) dedup demonstration can't be constructed
+// without tripping that orthogonal defect. Flagged separately; out of scope here.

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -1850,4 +1850,92 @@ describe('OmniFocusReadTool', () => {
       expect(occurrences).toBe(1);
     });
   });
+
+  // ─── OMN-218: unresolvable folder reference → loud NOT_FOUND ────────
+  describe('OMN-218 folder-not-found mapping', () => {
+    const folderNotFoundResult = {
+      success: false as const,
+      error: "Folder not found: No Such Folder. Verify the folder exists; both ':' and '/' separators are accepted.",
+      context: 'Script reported an error',
+      details: { code: 'FOLDER_NOT_FOUND', folder: 'No Such Folder' },
+    } satisfies ScriptResult;
+
+    it('maps a FOLDER_NOT_FOUND script error to a NOT_FOUND response (projects)', async () => {
+      execJsonSpy.mockResolvedValueOnce(folderNotFoundResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', filters: { folder: 'No Such Folder' } },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_FOUND');
+      expect(result.error.message).toContain('Folder not found');
+    });
+
+    it('maps a FOLDER_NOT_FOUND script error to a NOT_FOUND response (tasks)', async () => {
+      execJsonSpy.mockResolvedValueOnce(folderNotFoundResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { folder: 'No Such Folder' } },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_FOUND');
+      expect(result.error.message).toContain('Folder not found');
+    });
+
+    it('an existing-but-empty folder still returns success with zero rows (empty ≠ unresolvable)', async () => {
+      // The guard fires only on unresolvable folders; a real folder with no matching
+      // projects returns a normal empty success, NOT a NOT_FOUND error.
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: { projects: [], metadata: { total_available: 0 } },
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', filters: { folder: 'Real Empty Folder' } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.projects).toHaveLength(0);
+    });
+
+    it('maps FOLDER_NOT_FOUND to NOT_FOUND on a tasks countOnly query', async () => {
+      execJsonSpy.mockResolvedValueOnce(folderNotFoundResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { folder: 'No Such Folder' }, countOnly: true },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_FOUND');
+      expect(result.error.message).toContain('Folder not found');
+    });
+
+    it('maps FOLDER_NOT_FOUND to NOT_FOUND on a projects countOnly query', async () => {
+      execJsonSpy.mockResolvedValueOnce(folderNotFoundResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', filters: { folder: 'No Such Folder' }, countOnly: true },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_FOUND');
+      expect(result.error.message).toContain('Folder not found');
+    });
+
+    it('a generic (non-folder) script error still maps to SCRIPT_ERROR, not NOT_FOUND', async () => {
+      execJsonSpy.mockResolvedValueOnce({
+        success: false,
+        error: 'OmniFocus not running',
+      } satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'projects', filters: { folder: 'Anything' } },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('SCRIPT_ERROR');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the two OMN-218 defects in the greenlit minimal-scope spec (`Technical/specs/OMN-218-read-folder-separator-and-loud-error.md`):

- **Separator round-trip.** The read `folder` filter previously split only on `:`. A `/`-joined path emitted by the `folders` query (or accepted by the write path) silently round-tripped to zero matches — indistinguishable from a genuinely empty folder. `parseFolderFilterPath` now accepts both `:` and `/`.
- **Silent-empty → loud NOT_FOUND.** An unresolvable folder reference now returns a `NOT_FOUND` error (mirroring the write path's `"Folder not found"` guard) instead of `success:true, total_count:0`. A new shared `emitFolderExistsGuard`/`emitFolderNotFoundGuard` reuses the exact chain predicate the row matcher already uses, so a folder "resolves" iff a row under it could match — an existing-but-empty folder still returns success (empty ≠ unresolvable).

## Scope note: extended past the spec's minimal scope

The spec covered only the **list** paths (tasks, projects). While implementing I found `countOnly:true` would have been left silently returning count 0 on the same unresolvable folder — a new list-vs-count inconsistency the spec didn't anticipate. Extended the guard to `buildTaskCountScript` and the shared `countOnlyFromResult` (projects/tags/folders count-only tail) so all four surfaces are consistent.

## Two self-invoked `/code-review high`/`medium` pre-review passes found and fixed 3 real issues before this PR:

1. **OR-branch blind spot (CONFIRMED, high).** The guard only checked the top-level `filter.folder`/`folderName`; a folder value nested in `filters:{OR:[{folder:"Typo"}, ...]}` was invisible to it. Fixed via a new `emitFolderNotFoundGuardsForFilter(filter, key)` that recursively walks `orBranches` (including OR-within-OR) and dedupes paths — consolidating what were 3 independently-hand-rolled ternaries into one shared derivation.
2. **Inbox-mode blind spot (CONFIRMED, high).** `mode:'inbox'`/`filter.inInbox` routes to a third script builder (`buildInboxScript`) that hadn't been touched at all, so a folder filter + inbox mode bypassed the guard entirely. Now wired in.
3. **Duplicated NOT_FOUND mapping (CONFIRMED, cleanup).** The tool-layer FOLDER_NOT_FOUND→NOT_FOUND mapping was copy-pasted at 4 call sites; consolidated into one `folderNotFoundResponse` helper, and `isFolderNotFoundError` became a proper type predicate.

## Known, accepted tradeoff (flagged by review, not changed)

Widening the separator to accept `/` means a folder **literally named** with a `/` in it (e.g. `"Errands/Home"`) now mis-splits into two segments instead of matching as one literal string. This mirrors a **pre-existing** limitation already on the write path (`resolveFolderFlexible`/`parseFolderPath` in `mutation/snippets.ts` already accepted `/` before this PR) — it's read/write symmetry, not a new failure mode. It was the explicit, researched scope decision in the greenlit spec (102-agent deep-research pass concluding "accept both, drop neither, symmetric with write") and is disclosed in the emitter's docstring. Not reverted — reverting would reopen the round-trip bug this PR exists to close.

## Test plan

- [x] `npm run build` / `npx tsc --noEmit` clean
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npm run test:unit` — 3545/3545 passing (pre-push hook re-verified)
- [x] TDD throughout: RED confirmed before every GREEN, including both review-round fixes
- [ ] **Live `/verify` still owed** (per spec §4.4 — this is the RISKY half, no OmniFocus in CI):
  1. `projects` filter `folder:"Personal/Other Games/Shop Titans"` (the `/`-form) now returns the real projects
  2. The `:`-form of the same path returns the same result
  3. An unresolvable folder now returns `NOT_FOUND`, not empty success
  4. An existing-but-empty folder still returns `success:true,total_count:0`
  5. Same four for `type:"tasks"`, plus a folder value inside an `OR` branch, plus `mode:"inbox"` + folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)