### PR TITLE
feat(OMN-228): connect stdio transport before cache warm — gate tool calls on the warm promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,8 +113,14 @@ export async function runServer() {
     },
   });
 
-  // Warm cache BEFORE accepting requests to prevent concurrent osascript execution
-  // This ensures batch operations don't run concurrently with cache warming
+  // OMN-228: the warm runs in the BACKGROUND so the transport connects (and the
+  // MCP initialize handshake answers) immediately instead of sitting behind a
+  // 13-60s warm inside the client's ~30s connect window. Tool calls gate on
+  // `startupGate` (see registerTools), which preserves the invariant the old
+  // blocking warm enforced: no MCP-originated osascript runs concurrently with
+  // the warm queries. The gate always resolves — a failed warm must never wedge
+  // the server.
+  let startupGate: Promise<void> = Promise.resolve();
   if (isCIEnvironment && !forceCacheWarming) {
     logger.info('Cache warming disabled in CI environment (no OmniFocus access)');
   } else if (isTestEnvironment && !forceCacheWarming) {
@@ -125,31 +131,43 @@ export async function runServer() {
     if (forceCacheWarming) {
       logger.info('Cache warming enabled via ENABLE_CACHE_WARMING override');
     }
-    logger.info('Warming cache before accepting requests...');
-    try {
-      await cacheWarmer.warmCache();
-      logger.info('Cache warming completed successfully');
-      // Emit cache statistics after warm‑up to verify hit‑rate potential
-      const stats = cacheManager.getStats();
-      logger.debug('Post‑warm cache stats:', JSON.stringify(stats));
-    } catch (error) {
-      logger.warn('Cache warming failed:', error);
-    }
+    logger.info('Warming cache in background; transport connects immediately (OMN-228)...');
+    const warmPromise = (async () => {
+      try {
+        await cacheWarmer.warmCache();
+        logger.info('Cache warming completed successfully');
+        // Emit cache statistics after warm‑up to verify hit‑rate potential
+        const stats = cacheManager.getStats();
+        logger.debug('Post‑warm cache stats:', JSON.stringify(stats));
+      } catch (error) {
+        logger.warn('Cache warming failed:', error);
+      }
+    })();
+    startupGate = warmPromise;
+    // Track the warm as a pending operation so the stdin-EOF shutdown path
+    // still runs it to completion — the of-mcp-redeploy pre-warm
+    // (node dist/index.js < /dev/null) depends on the full warm finishing
+    // before the process exits.
+    pendingOperations.add(warmPromise);
+    void warmPromise.finally(() => pendingOperations.delete(warmPromise));
   }
+  // warmEnd now marks warm LAUNCH, not completion — the STARTUP COMPLETE line's
+  // `warm` segment measures launch cost (~0ms); warm duration is logged
+  // separately by the cache-warmer on completion.
   startupTimer.mark('warmEnd');
 
   // Check if we're running in HTTP mode
   if (cliConfig.httpMode) {
-    await runHttpServer(cacheManager, cliConfig);
+    await runHttpServer(cacheManager, cliConfig, startupGate);
   } else {
-    await runStdioServer(cacheManager);
+    await runStdioServer(cacheManager, startupGate);
   }
 }
 
 /**
  * Runs the server in stdio mode (original behavior)
  */
-async function runStdioServer(cacheManager: CacheManager) {
+async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<void>) {
   logger.info('Starting server in stdio mode');
 
   // Create server instance with MCP 2025-11-25 metadata
@@ -172,7 +190,7 @@ async function runStdioServer(cacheManager: CacheManager) {
   );
 
   // Register all tools and prompts AFTER server creation but BEFORE connection
-  await registerTools(stdioServer, cacheManager, pendingOperations);
+  await registerTools(stdioServer, cacheManager, pendingOperations, startupGate);
   registerPrompts(stdioServer);
   startupTimer.mark('registerEnd');
 
@@ -238,7 +256,7 @@ async function runStdioServer(cacheManager: CacheManager) {
 /**
  * Runs the server in HTTP mode
  */
-async function runHttpServer(cacheManager: CacheManager, cliConfig: CLIConfig) {
+async function runHttpServer(cacheManager: CacheManager, cliConfig: CLIConfig, startupGate: Promise<void>) {
   logger.info('Starting server in HTTP mode', {
     port: cliConfig.port,
     host: cliConfig.host,
@@ -256,7 +274,7 @@ async function runHttpServer(cacheManager: CacheManager, cliConfig: CLIConfig) {
   }
 
   // Create session manager
-  const sessionManager = new SessionManager(cacheManager, cliConfig.authToken);
+  const sessionManager = new SessionManager(cacheManager, cliConfig.authToken, undefined, startupGate);
   sessionManager.startCleanupInterval();
 
   // Create HTTP server manager

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export async function runServer() {
   }
   startupTimer.mark('permsEnd');
 
-  // Warm cache with frequently accessed data (blocking — awaited before the transport connects)
+  // Warm cache with frequently accessed data (backgrounded — see OMN-228 block below)
   // Disable cache warming in CI environments (Linux, no OmniFocus), test mode, or benchmark mode
   // ENABLE_CACHE_WARMING=true overrides test mode (for integration tests that want realistic behavior)
   const isCIEnvironment = process.env.CI === 'true' || process.platform === 'linux';
@@ -148,8 +148,18 @@ export async function runServer() {
     // still runs it to completion — the of-mcp-redeploy pre-warm
     // (node dist/index.js < /dev/null) depends on the full warm finishing
     // before the process exits.
+    // Consequence (accepted): a real client that disconnects mid-warm delays
+    // exit until the warm settles (bounded by the warm timeout above) — an
+    // improvement over the old unbounded orphan, but slower than an instant
+    // exit. Both cases present as identical stdin EOFs; exiting early for
+    // real clients would need an explicit signal (e.g. an env var set by the
+    // redeploy script) — not added until the delay is observed to matter.
     pendingOperations.add(warmPromise);
-    void warmPromise.finally(() => pendingOperations.delete(warmPromise));
+    logger.debug(`Added cache warm to pending operations (size: ${pendingOperations.size})`);
+    void warmPromise.finally(() => {
+      pendingOperations.delete(warmPromise);
+      logger.debug(`Removed cache warm from pending operations (size: ${pendingOperations.size})`);
+    });
   }
   // warmEnd now marks warm LAUNCH, not completion — the STARTUP COMPLETE line's
   // `warm` segment measures launch cost (~0ms); warm duration is logged

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,9 +221,15 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
       }
     }
 
-    // Close server connection cleanly, allowing transport to flush responses
+    // Close server connection cleanly, allowing transport to flush responses.
+    // Wrapped: on an EPIPE-triggered exit the pipe is already dead and the
+    // flush may itself throw — that must not prevent the exit.
     logger.info('Closing server connection...');
-    await stdioServer.close();
+    try {
+      await stdioServer.close();
+    } catch (error) {
+      logger.warn('Server close failed during shutdown (continuing to exit):', error);
+    }
 
     logger.info('Exiting gracefully per MCP specification');
     process.exit(0);
@@ -237,11 +243,15 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
     gracefulExit('stdin stream closed');
   });
 
-  // Handle EPIPE errors when Claude Desktop disconnects abruptly
+  // Handle EPIPE errors when Claude Desktop disconnects abruptly.
+  // OMN-228 review: EPIPE routes through gracefulExit (not an immediate
+  // process.exit) so an in-flight background cache warm in pendingOperations
+  // drains before exit — otherwise the warm's osascript child is orphaned
+  // mid-script, exactly the gap the pendingOperations tracking closes for
+  // the stdin-EOF path.
   process.stdout.on('error', (err: Error & { code?: string }) => {
     if (err.code === 'EPIPE') {
-      logger.info('stdout EPIPE - client disconnected, exiting gracefully');
-      process.exit(0);
+      gracefulExit('stdout EPIPE - client disconnected');
     } else {
       logger.error('stdout error:', err);
       process.exit(1);
@@ -250,8 +260,7 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
 
   process.stderr.on('error', (err: Error & { code?: string }) => {
     if (err.code === 'EPIPE') {
-      logger.info('stderr EPIPE - client disconnected, exiting gracefully');
-      process.exit(0);
+      gracefulExit('stderr EPIPE - client disconnected');
     } else {
       console.error('stderr error:', err);
       process.exit(1);
@@ -273,7 +282,11 @@ async function runHttpServer(cacheManager: CacheManager, cliConfig: CLIConfig, s
     authEnabled: !!cliConfig.authToken,
   });
 
-  // Validate CLI configuration
+  // Validate CLI configuration.
+  // OMN-228 review note: this exit deliberately does NOT drain the background
+  // cache warm — a config typo should fail fast, not wait out a 13-60s warm.
+  // The warm's in-flight osascript (if any) runs its one script to completion
+  // and exits on its own; the orphan is bounded by the script timeout.
   try {
     validateCLIConfig(cliConfig);
   } catch (error) {
@@ -298,6 +311,14 @@ async function runHttpServer(cacheManager: CacheManager, cliConfig: CLIConfig, s
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
+    // OMN-228 review: a listen failure (port in use) is a real deployment
+    // scenario — drain the in-flight background cache warm before exiting so
+    // its osascript child isn't orphaned against OmniFocus's single
+    // automation channel right when the operator retries the start.
+    if (pendingOperations.size > 0) {
+      logger.info(`Waiting for ${pendingOperations.size} pending operations (cache warm) before exit...`);
+      await Promise.allSettled([...pendingOperations]);
+    }
     process.exit(1);
   }
   startupTimer.mark('ready');

--- a/src/omnifocus/OmniAutomation.ts
+++ b/src/omnifocus/OmniAutomation.ts
@@ -53,6 +53,13 @@ export class OmniAutomation {
       timeout || (process.env.OMNIFOCUS_SCRIPT_TIMEOUT ? parseInt(process.env.OMNIFOCUS_SCRIPT_TIMEOUT, 10) : 120000); // Default 120 seconds
   }
 
+  // OMN-228 concurrency note: there is NO serialization lock here. During
+  // startup, the no-concurrent-osascript invariant is enforced one layer up —
+  // MCP tool dispatch awaits the startupGate (src/tools/index.ts) while the
+  // cache warm's own execute() calls run ungated (they ARE the warm). Any NEW
+  // code path that reaches execute() outside tool dispatch (resource handlers,
+  // HTTP diagnostics, direct tool instantiation) must either gate on the warm
+  // or tolerate racing it.
   public async execute<T = unknown>(script: string): Promise<T> {
     // Use empirical size monitoring for better feedback
     const sizeAnalysis = monitorScriptSize(script, 'jxa');

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -31,13 +31,20 @@ export class SessionManager {
   private authToken?: string;
   private sessionTimeout: number;
   private cleanupInterval?: ReturnType<typeof setInterval>;
+  private startupGate?: Promise<void>;
 
-  constructor(cacheManager: CacheManager, authToken?: string, sessionTimeout: number = 30 * 60 * 1000) {
+  constructor(
+    cacheManager: CacheManager,
+    authToken?: string,
+    sessionTimeout: number = 30 * 60 * 1000,
+    startupGate?: Promise<void>,
+  ) {
     this.sessions = new Map();
     this.cacheManager = cacheManager;
     this.pendingOperations = new Set();
     this.authToken = authToken;
     this.sessionTimeout = sessionTimeout;
+    this.startupGate = startupGate;
 
     // Initialize pending operations tracking
     setPendingOperationsTracker(this.pendingOperations);
@@ -112,7 +119,7 @@ export class SessionManager {
     );
 
     // Register tools and prompts for this session
-    await registerTools(server, this.cacheManager, this.pendingOperations);
+    await registerTools(server, this.cacheManager, this.pendingOperations, this.startupGate);
     registerPrompts(server);
 
     // Connect the server to the transport

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -32,8 +32,13 @@ function supportsCorrelation(tool: Tool): tool is Tool & CorrelationCapable {
   return 'withCorrelation' in tool && typeof (tool as Tool & Record<string, unknown>).withCorrelation === 'function';
 }
 
-// eslint-disable-next-line sonarjs/deprecation
-export function registerTools(server: Server, cache: CacheManager, pendingOperations?: Set<Promise<unknown>>): void {
+export function registerTools(
+  // eslint-disable-next-line sonarjs/deprecation
+  server: Server,
+  cache: CacheManager,
+  pendingOperations?: Set<Promise<unknown>>,
+  startupGate?: Promise<void>,
+): void {
   logger.info(
     'OmniFocus MCP v3.0.0 - Unified Builder API: 4 tools (omnifocus_read, omnifocus_write, omnifocus_analyze, system)',
   );
@@ -101,6 +106,14 @@ export function registerTools(server: Server, cache: CacheManager, pendingOperat
 
     // Create execution promise and track it to prevent premature server exit
     const executionPromise = (async () => {
+      // OMN-228: the transport connects before the startup cache warm finishes;
+      // tool calls wait here until the warm completes so no MCP-originated
+      // osascript runs concurrently with the warm queries. The gate is built
+      // never-rejecting, but .catch defends against a future caller passing a
+      // rejectable promise — a failed warm must never wedge tool dispatch.
+      if (startupGate) {
+        await startupGate.catch(() => {});
+      }
       try {
         // Pass correlation context to the tool if it supports it
         let result: unknown;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -109,10 +109,19 @@ export function registerTools(
       // OMN-228: the transport connects before the startup cache warm finishes;
       // tool calls wait here until the warm completes so no MCP-originated
       // osascript runs concurrently with the warm queries. The gate is built
-      // never-rejecting, but .catch defends against a future caller passing a
-      // rejectable promise — a failed warm must never wedge tool dispatch.
+      // never-rejecting; if a future caller passes a rejectable promise the
+      // rejection is logged loudly but must never wedge tool dispatch.
       if (startupGate) {
-        await startupGate.catch(() => {});
+        const gateStart = Date.now();
+        await startupGate.catch((error: unknown) => {
+          correlatedLogger.warn('Startup gate rejected; proceeding with tool execution', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+        const gateWaitMs = Date.now() - gateStart;
+        if (gateWaitMs > 100) {
+          correlatedLogger.info(`Tool ${name} waited ${gateWaitMs}ms for the startup cache warm`);
+        }
       }
       try {
         // Pass correlation context to the tool if it supports it

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -123,6 +123,9 @@ export function registerTools(
           correlatedLogger.info(`Tool ${name} waited ${gateWaitMs}ms for the startup cache warm`);
         }
       }
+      // executionTime is measured from AFTER the gate so it reports actual
+      // tool work; gate wait is logged separately above (OMN-228 review).
+      const execStart = Date.now();
       try {
         // Pass correlation context to the tool if it supports it
         let result: unknown;
@@ -136,7 +139,7 @@ export function registerTools(
         }
 
         // Log successful execution with timing
-        const executionTime = Date.now() - startTime;
+        const executionTime = Date.now() - execStart;
         correlatedLogger.info(`Tool execution completed: ${name}`, {
           executionTime,
           success: true,
@@ -152,7 +155,7 @@ export function registerTools(
         };
       } catch (error) {
         // Log execution failure with timing and correlation
-        const executionTime = Date.now() - startTime;
+        const executionTime = Date.now() - execStart;
         correlatedLogger.error(`Tool execution failed: ${name}`, {
           executionTime,
           success: false,

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -73,7 +73,7 @@ const getVersionInfoMock = vi.fn(() => ({
 
 const registerPromptsMock = vi.fn();
 let lastRegisteredPendingOps: Set<Promise<unknown>> | undefined;
-const registerToolsMock = vi.fn(async (_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+const registerToolsMock = vi.fn((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
   lastRegisteredPendingOps = pendingOps;
 });
 
@@ -119,7 +119,7 @@ vi.mock('../../src/omnifocus/OmniAutomation.js', () => ({
   setPendingOperationsTracker: setPendingOperationsTrackerMock,
 }));
 
-function resetEnv(overrides: NodeJS.ProcessEnv = {}) {
+function resetEnv(overrides: Record<string, string | undefined> = {}) {
   process.env = { ...originalEnv, ...overrides };
 }
 
@@ -148,7 +148,7 @@ describe('server entrypoint', () => {
     cacheWarmerInstances.length = 0;
     CacheWarmerMock.mockClear();
     registerToolsMock.mockClear();
-    registerToolsMock.mockImplementation(async (_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
       lastRegisteredPendingOps = pendingOps;
     });
     registerPromptsMock.mockClear();
@@ -167,6 +167,107 @@ describe('server entrypoint', () => {
     process.stdin.removeAllListeners('close');
     process.stdout.removeAllListeners('error');
     process.stderr.removeAllListeners('error');
+  });
+
+  it('connects the transport before cache warming completes (OMN-228)', async () => {
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development', CI: 'false' });
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const warmDeferred = createDeferred<{ enabled: boolean; results: unknown[] }>();
+    CacheWarmerMock.mockImplementationOnce((_cache, options) => {
+      const instance = { warmCache: vi.fn(() => warmDeferred.promise), options };
+      cacheWarmerInstances.push(instance);
+      return instance;
+    });
+    const { runServer } = await importEntry();
+
+    // runServer must return (transport connected) while the warm is still in flight
+    await runServer();
+
+    expect(serverConnectMock).toHaveBeenCalledTimes(1);
+    expect(cacheWarmerInstances[0].warmCache).toHaveBeenCalledTimes(1);
+
+    // The warm must be tracked as a pending operation so the stdin-EOF
+    // pre-warm path (node dist/index.js < /dev/null) waits for it to finish.
+    expect(lastRegisteredPendingOps?.size).toBe(1);
+
+    warmDeferred.resolve({ enabled: true, results: [] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(lastRegisteredPendingOps?.size).toBe(0);
+  });
+
+  it('passes a startup gate to registerTools that opens when the warm completes (OMN-228)', async () => {
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development', CI: 'false' });
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const warmDeferred = createDeferred<{ enabled: boolean; results: unknown[] }>();
+    CacheWarmerMock.mockImplementationOnce((_cache, options) => {
+      const instance = { warmCache: vi.fn(() => warmDeferred.promise), options };
+      cacheWarmerInstances.push(instance);
+      return instance;
+    });
+    let capturedGate: Promise<void> | undefined;
+    registerToolsMock.mockImplementation(
+      (_server, _cache, pendingOps: Set<Promise<unknown>>, startupGate?: Promise<void>) => {
+        lastRegisteredPendingOps = pendingOps;
+        capturedGate = startupGate;
+      },
+    );
+    const { runServer } = await importEntry();
+
+    await runServer();
+
+    expect(capturedGate).toBeInstanceOf(Promise);
+    let gateOpen = false;
+    void capturedGate!.then(() => {
+      gateOpen = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(gateOpen).toBe(false);
+
+    warmDeferred.resolve({ enabled: true, results: [] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(gateOpen).toBe(true);
+  });
+
+  it('opens the startup gate even when the warm fails (OMN-228)', async () => {
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development', CI: 'false' });
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    CacheWarmerMock.mockImplementationOnce((_cache, options) => {
+      const instance = { warmCache: vi.fn(() => Promise.reject(new Error('warm exploded'))), options };
+      cacheWarmerInstances.push(instance);
+      return instance;
+    });
+    let capturedGate: Promise<void> | undefined;
+    registerToolsMock.mockImplementation(
+      (_server, _cache, pendingOps: Set<Promise<unknown>>, startupGate?: Promise<void>) => {
+        lastRegisteredPendingOps = pendingOps;
+        capturedGate = startupGate;
+      },
+    );
+    const { runServer } = await importEntry();
+
+    await runServer();
+
+    // Gate must resolve (not reject, not hang) so tools are never blocked forever
+    await expect(capturedGate).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(lastRegisteredPendingOps?.size).toBe(0);
+  });
+
+  it('passes an already-open gate when warming is disabled (OMN-228)', async () => {
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'test', SANDBOX_GUARD_ENABLED: 'true' });
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    let capturedGate: Promise<void> | undefined;
+    registerToolsMock.mockImplementation(
+      (_server, _cache, pendingOps: Set<Promise<unknown>>, startupGate?: Promise<void>) => {
+        lastRegisteredPendingOps = pendingOps;
+        capturedGate = startupGate;
+      },
+    );
+    const { runServer } = await importEntry();
+
+    await runServer();
+
+    await expect(capturedGate).resolves.toBeUndefined();
   });
 
   it('initializes the server, registers tools, and warms the cache', async () => {
@@ -188,7 +289,12 @@ describe('server entrypoint', () => {
     expect(registerPromptsMock).toHaveBeenCalledTimes(1);
     expect(registerToolsMock).toHaveBeenCalledTimes(1);
     expect(lastRegisteredPendingOps).toBeInstanceOf(Set);
-    expect(registerToolsMock).toHaveBeenCalledWith(expect.any(Object), cacheManager, lastRegisteredPendingOps);
+    expect(registerToolsMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      cacheManager,
+      lastRegisteredPendingOps,
+      expect.any(Promise),
+    );
     expect(cacheWarmer.options.enabled).toBe(true);
     expect(cacheWarmer.warmCache).toHaveBeenCalledTimes(1);
     expect(cacheManager.getStats).toHaveBeenCalledTimes(1);
@@ -214,7 +320,7 @@ describe('server entrypoint', () => {
     // vitest-inherited NODE_ENV='test' would trip assertSandboxGuardAtStartup().
     resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development' });
     const deferred = createDeferred<void>();
-    registerToolsMock.mockImplementation(async (_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
       lastRegisteredPendingOps = pendingOps;
     });
     const { runServer } = await importEntry();

--- a/tests/unit/tools/index-tools-registration.test.ts
+++ b/tests/unit/tools/index-tools-registration.test.ts
@@ -3,9 +3,11 @@ import { registerTools } from '../../../src/tools/index.js';
 import { CacheManager } from '../../../src/cache/CacheManager.js';
 import { ListToolsRequestSchema, CallToolRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 
+type RequestHandler = (request: unknown) => Promise<any>;
+
 class FakeServer {
-  handlers = new Map<any, Function>();
-  setRequestHandler(schema: any, handler: Function) {
+  handlers = new Map<any, RequestHandler>();
+  setRequestHandler(schema: any, handler: RequestHandler) {
     this.handlers.set(schema, handler);
   }
 }
@@ -18,7 +20,7 @@ describe('tools/index registerTools', () => {
     registerTools(server, cache);
 
     // List tools
-    const listHandler = server.handlers.get(ListToolsRequestSchema) as Function;
+    const listHandler = server.handlers.get(ListToolsRequestSchema) as RequestHandler;
     expect(listHandler).toBeTypeOf('function');
     const list = await listHandler({});
     expect(Array.isArray(list.tools)).toBe(true);
@@ -35,7 +37,49 @@ describe('tools/index registerTools', () => {
     expect(names).toEqual(['omnifocus_read', 'omnifocus_write', 'omnifocus_analyze', 'system']);
 
     // Call unknown tool → McpError
-    const callHandler = server.handlers.get(CallToolRequestSchema) as Function;
+    const callHandler = server.handlers.get(CallToolRequestSchema) as RequestHandler;
     await expect(callHandler({ params: { name: 'unknown', arguments: {} } })).rejects.toBeInstanceOf(McpError);
+  });
+
+  it('holds tool calls behind the startup gate until it opens (OMN-228)', async () => {
+    const server = new FakeServer() as any;
+    const cache = new CacheManager();
+    let openGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+
+    registerTools(server, cache, undefined, gate);
+
+    // list_tools must NOT wait for the gate (handshake/tool-discovery stays instant)
+    const listHandler = server.handlers.get(ListToolsRequestSchema) as RequestHandler;
+    const list = await listHandler({});
+    expect(list.tools.length).toBe(4);
+
+    // A tool call issued while the gate is held must not settle...
+    const callHandler = server.handlers.get(CallToolRequestSchema) as RequestHandler;
+    let settled = false;
+    const callPromise = callHandler({ params: { name: 'system', arguments: { operation: 'version' } } }).finally(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+
+    // ...and must execute once the gate opens.
+    openGate();
+    const result = await callPromise;
+    expect(settled).toBe(true);
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('executes tool calls immediately when no gate is provided (OMN-228)', async () => {
+    const server = new FakeServer() as any;
+    const cache = new CacheManager();
+
+    registerTools(server, cache);
+
+    const callHandler = server.handlers.get(CallToolRequestSchema) as RequestHandler;
+    const result = await callHandler({ params: { name: 'system', arguments: { operation: 'version' } } });
+    expect(result.content[0].type).toBe('text');
   });
 });


### PR DESCRIPTION
## Problem

The MCP `initialize` handshake waited behind the full cache warm (~13s hot / ~60s cold), inside the client's ~30s connect window. Any in-flight warm on OmniFocus's single automation channel (e.g. a background-daemon spare respawning after `of-mcp-redeploy`'s kill-step) pushed a manual `/mcp reconnect` past the window — reliably failing twice before the third attempt succeeded. Full diagnosis on the ticket.

## Change

- `runServer` launches the warm in the **background** and threads a never-rejecting `startupGate` promise down both transport paths (stdio + HTTP `SessionManager`).
- `registerTools` awaits the gate at the top of each tool execution — preserving the invariant the blocking warm enforced (**no MCP-originated osascript concurrent with warm queries**). `initialize` and `tools/list` do not wait.
- The warm is tracked in `pendingOperations`, so the stdin-EOF pre-warm path (`node dist/index.js < /dev/null`, which `of-mcp-redeploy` depends on) still runs the full warm before exiting.
- A failed warm resolves the gate — never wedges dispatch.

Deadlock audit: the warm's own queries call `OmniAutomation` directly and never pass through tool dispatch, so they cannot wait on their own gate.

## Verification

- Unit: 3,569 passing (4 new startup tests in `tests/unit/index.test.ts`, 2 new gate-ordering tests in `tests/unit/tools/index-tools-registration.test.ts`). Lint clean.
- **Live seam probe** (real OmniFocus, real warm): `initialize` answered in **359ms** with the warm in flight; `tools/list` 2ms; a tool call sent at t=361ms was gated **13.8s** and succeeded immediately after `Cache warming completed` (t=14.1s) — correct ordering, no concurrent osascript.
- **Pre-warm path**: `node dist/index.js < /dev/null` → `STARTUP COMPLETE 318ms` but process exited only after the full warm (4/4 ops, 11.9s) — `of-mcp-redeploy` semantics preserved.

## Notes for reviewer

- `STARTUP COMPLETE`'s `warm` segment now measures warm **launch** (~0ms), not duration; warm duration stays on the cache-warmer's own completion line.
- The log line `Warming cache before accepting requests...` became `Warming cache in background; transport connects immediately (OMN-228)...` — `of-mcp-redeploy`'s display grep for the old phrase will drop one cosmetic line (everything else it greps is unchanged).
- Acceptance criterion 1 (first-try reconnect with ≥2 live clients) is only verifiable post-deploy.

Closes OMN-228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)