### PR TITLE
fix(OMN-223): extend task summary-suppression to text/name narrow lookups

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -564,9 +564,16 @@ PERFORMANCE:
     // Project fields (after counting)
     tasks = projectFields(tasks, compiled.fields);
 
+    // OMN-223: suppress the dashboard summary on narrow lookups, mirroring the
+    // project side's rule (name || text || id → no summary). The id key is
+    // handled by the fast path above and never reaches here; it stays in the
+    // guard for parity and as defense against future routing changes.
+    const isNarrowLookup = Boolean(filter.name || filter.text || filter.id);
+
     return createTaskResponseV2('tasks', tasks, metadata, {
       population: totalMatched,
       offset: compiled.offset || 0,
+      summary: !isNarrowLookup,
     });
   }
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -176,9 +176,6 @@ function resolveFieldsMode(
 }
 
 /**
- * Build the full task query: resolve mode, augment filters, inject fields, build script.
- */
-/**
  * OMN-19/OMN-223: a filter targeting specific items by name, text, or id is a
  * "narrow lookup" — the dashboard summary block is noise there and is suppressed.
  * Shared by the task and project paths so the rule has a single edit point.
@@ -189,6 +186,9 @@ function isNarrowLookupFilter(filter: { name?: unknown; text?: unknown; id?: unk
   return Boolean(filter.name || filter.text || filter.id);
 }
 
+/**
+ * Build the full task query: resolve mode, augment filters, inject fields, build script.
+ */
 function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 'minimal' | 'detailed' | 'explicit' } {
   if (compiled.type !== 'tasks') throw new Error('buildTaskQuery: wrong type');
   const limit = compiled.limit || 25;

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -178,6 +178,17 @@ function resolveFieldsMode(
 /**
  * Build the full task query: resolve mode, augment filters, inject fields, build script.
  */
+/**
+ * OMN-19/OMN-223: a filter targeting specific items by name, text, or id is a
+ * "narrow lookup" — the dashboard summary block is noise there and is suppressed.
+ * Shared by the task and project paths so the rule has a single edit point.
+ * Top-level keys only: text/name inside OR branches do not narrow (both paths;
+ * tracked as OMN-229).
+ */
+function isNarrowLookupFilter(filter: { name?: unknown; text?: unknown; id?: unknown }): boolean {
+  return Boolean(filter.name || filter.text || filter.id);
+}
+
 function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 'minimal' | 'detailed' | 'explicit' } {
   if (compiled.type !== 'tasks') throw new Error('buildTaskQuery: wrong type');
   const limit = compiled.limit || 25;
@@ -565,10 +576,10 @@ PERFORMANCE:
     tasks = projectFields(tasks, compiled.fields);
 
     // OMN-223: suppress the dashboard summary on narrow lookups, mirroring the
-    // project side's rule (name || text || id → no summary). The id key is
-    // handled by the fast path above and never reaches here; it stays in the
-    // guard for parity and as defense against future routing changes.
-    const isNarrowLookup = Boolean(filter.name || filter.text || filter.id);
+    // project side's rule. The id key is handled by the fast path above and
+    // never reaches here; it stays in the shared predicate for parity and as
+    // defense against future routing changes.
+    const isNarrowLookup = isNarrowLookupFilter(filter);
 
     return createTaskResponseV2('tasks', tasks, metadata, {
       population: totalMatched,
@@ -972,7 +983,7 @@ PERFORMANCE:
     // Status- and folder-only browses still return the summary — those look
     // dashboard-ish and users may be scanning review state. See Linear OMN-19
     // for the full option trade-off (explicit param vs heuristic vs slim mode).
-    const isNarrowLookup = Boolean(projectFilter.name || projectFilter.text || projectFilter.id);
+    const isNarrowLookup = isNarrowLookupFilter(projectFilter);
 
     // Build cache key
     const cacheParams = { ...projectFilter, limit, includeStats };

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -460,6 +460,87 @@ describe('OmniFocusReadTool', () => {
     });
   });
 
+  // ─── OMN-223: task summary suppression on narrow lookups ───────
+  // Extends the OMN-19 rule (projects: name || text || id → no summary) to the
+  // task main query path. OMN-219 covered only the id fast path; text/name task
+  // lookups still emitted the full dashboard summary — inconsistent with projects.
+  describe('OMN-223 task summary suppression on narrow lookups', () => {
+    const tasksPayload = {
+      success: true as const,
+      data: {
+        tasks: [{ id: 't1', name: 'Review budget', completed: false, flagged: false, blocked: false }],
+        metadata: { total_matched: 1 },
+      },
+    };
+
+    it('strips summary when text.contains filter is present (lookup-by-text)', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { text: { contains: 'budget' } } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
+    });
+
+    it('strips summary when name.contains filter is present (lookup-by-name)', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { name: { contains: 'budget' } } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
+    });
+
+    it('strips summary on mode:"search" with a text filter', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', mode: 'search', filters: { text: { contains: 'budget' } } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
+    });
+
+    it('preserves summary for broad browses (no narrow filter)', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks' },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+      expect(result.summary.total_count).toBe(1);
+    });
+
+    it('preserves summary for flagged-only browses (dashboard-like)', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', filters: { flagged: true } },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+    });
+
+    it('preserves summary for mode-only browses (mode:"overdue")', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: { type: 'tasks', mode: 'overdue' },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+    });
+  });
+
   // ─── OMN-40: project id-lookup correctness ─────────────────────
 
   describe('OMN-40 project id-lookup', () => {


### PR DESCRIPTION
## Summary

Extends the OMN-19 narrow-lookup rule (projects: `name || text || id` → no dashboard summary) to the **task main query path**, closing the asymmetry OMN-219 left open. OMN-219 suppressed the summary only on the task **id fast path**; a task query with `filters.text` or `filters.name` (including `mode:'search'`) still emitted the full dashboard summary block.

## Change

One guard at the task response call site in `OmniFocusReadTool.handleTaskQuery`:

```ts
const isNarrowLookup = Boolean(filter.name || filter.text || filter.id);
// → createTaskResponseV2(..., { ..., summary: !isNarrowLookup })
```

**Why these keys:** the ticket asked to verify the task analogues of the project side's `name`/`text`/`id`. The compiled `TaskFilter` carries exactly `text`/`name` (via `transformTextFilters`) and `id`. `mode:'search'` carries no term of its own — the search text rides in `filters.text`/`filters.name` and search mode passes filters through unchanged — so the filter-key check covers it with no mode special-casing.

**Coverage notes:**
- `id` never actually reaches this site (id fast path returns earlier, already `summary:false` since OMN-219) — kept in the guard for parity and as defense against routing changes.
- `forecast_past` re-enters `handleTaskQuery` after its OR rewrite, so the guard covers it with no second call site.
- Mode-only browses (`overdue`, `today`, `flagged`, …) keep their summary: `augmentFilterForMode` only injects date/boolean keys, never text — pinned by test.
- Top-level filter keys only, mirroring the project side (OR-branch text does not suppress) — deliberate parity, not an oversight.

## Contract change

Per the ticket's scope note: this is a **response-shape change** for text/search task queries (a class that previously received a summary), deliberately split out of OMN-219 so it gets its own review.

## Testing

TDD: 3 red tests (text-contains, name-contains, `mode:'search'`+text — all watched fail) + 3 pins on preserved broad-browse behavior (no filter, flagged-only, mode-only). Full suite: 3,569 unit tests green, lint clean at `--max-warnings=0`, build clean. Pure response post-processing — unit-testable via the `execJson` spy, no live `/verify` needed (per ticket).

Closes OMN-223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## /code-review high outcome (2026-07-03)

Three findings, all CONFIRMED by independent verification; dispositions agreed with Kip:

1. **OR-branch text/name lookups still get the summary** — real gap, but it exists identically on the **project** path (its guard predates OR support), so fixing tasks-only here would create a new asymmetry. **Filed as OMN-229** covering both paths; the shared predicate below is the single edit point it will change.
2. **Suppressing the summary also drops the `summary.key_insight` truncation sentence** ("Showing X of Y matching tasks (truncated)") on narrow lookups that exceed the limit. **Accepted — no change**: this is the same tradeoff shipped on the project path since OMN-19, and `metadata.truncated` / `metadata.total_count` / `truncation_message` remain authoritative.
3. **Duplicated predicate** — **fixed** (`31360a99`): extracted a shared `isNarrowLookupFilter()` used by both `handleTaskQuery` and `handleProjectQuery`. Behavior-neutral; pinned by the existing OMN-19 + OMN-223 test blocks (3,569 unit tests green).
