### PR TITLE
fix(OMN-229): narrow-lookup summary suppression walks OR branches (tasks + projects)

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -176,14 +176,27 @@ function resolveFieldsMode(
 }
 
 /**
- * OMN-19/OMN-223: a filter targeting specific items by name, text, or id is a
- * "narrow lookup" — the dashboard summary block is noise there and is suppressed.
- * Shared by the task and project paths so the rule has a single edit point.
- * Top-level keys only: text/name inside OR branches do not narrow (both paths;
- * tracked as OMN-229).
+ * OMN-19/OMN-223/OMN-229: a filter targeting specific items by name, text, or id
+ * is a "narrow lookup" — the dashboard summary block is noise there and is
+ * suppressed. Shared by the task and project paths so the rule has a single
+ * edit point. An OR filter narrows iff EVERY branch narrows (a branch with
+ * only broad keys, e.g. {flagged: true}, means the caller may get a
+ * dashboard-shaped slice); branches are checked recursively since a branch
+ * may itself carry orBranches.
  */
-function isNarrowLookupFilter(filter: { name?: unknown; text?: unknown; id?: unknown }): boolean {
-  return Boolean(filter.name || filter.text || filter.id);
+interface NarrowLookupFilter {
+  name?: unknown;
+  text?: unknown;
+  id?: unknown;
+  orBranches?: NarrowLookupFilter[];
+}
+
+export function isNarrowLookupFilter(filter: NarrowLookupFilter): boolean {
+  if (filter.name || filter.text || filter.id) return true;
+  if (filter.orBranches && filter.orBranches.length > 0) {
+    return filter.orBranches.every((branch) => isNarrowLookupFilter(branch));
+  }
+  return false;
 }
 
 /**

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OmniFocusReadTool } from '../../../../src/tools/unified/OmniFocusReadTool.js';
+import { OmniFocusReadTool, isNarrowLookupFilter } from '../../../../src/tools/unified/OmniFocusReadTool.js';
 import { CacheManager } from '../../../../src/cache/CacheManager.js';
 import type { ScriptResult } from '../../../../src/omnifocus/script-result-types.js';
 
@@ -538,6 +538,113 @@ describe('OmniFocusReadTool', () => {
 
       expect(result.success).toBe(true);
       expect(result.summary).toBeDefined();
+    });
+  });
+
+  // ─── OMN-229: OR-branch narrow-lookup summary suppression ──────
+  // Extends the OMN-19/OMN-223 rule to OR-composed filters. QueryCompiler
+  // routes OR conditions into filter.orBranches rather than merging them into
+  // top-level text/name, so an OR-composed narrow lookup (e.g. text.contains
+  // 'meeting' OR text.contains 'budget') used to keep the full summary. Rule:
+  // an OR filter narrows iff EVERY branch narrows.
+  describe('OMN-229 OR-branch narrow-lookup summary suppression', () => {
+    const tasksPayload = {
+      success: true as const,
+      data: {
+        tasks: [{ id: 't1', name: 'Review budget', completed: false, flagged: false, blocked: false }],
+        metadata: { total_matched: 1 },
+      },
+    };
+
+    const projectsPayload = {
+      success: true as const,
+      data: {
+        projects: [{ id: 'p1', name: 'OmniFocus MCP', status: 'active' }],
+        metadata: { total_available: 1 },
+      },
+    };
+
+    it('strips summary for tasks when OR composes two text-narrow branches', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: {
+          type: 'tasks',
+          filters: {
+            OR: [{ text: { contains: 'meeting' } }, { text: { contains: 'budget' } }],
+          },
+        },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
+    });
+
+    it('strips summary for projects when OR composes two text-narrow branches', async () => {
+      execJsonSpy.mockResolvedValueOnce(projectsPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: {
+          type: 'projects',
+          filters: {
+            OR: [{ text: { contains: 'meeting' } }, { name: { contains: 'budget' } }],
+          },
+        },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect('summary' in result).toBe(false); // OMN-220: pin key-absence, not just `=== undefined`
+    });
+
+    it('preserves summary when one OR branch is broad-only (e.g. {flagged: true})', async () => {
+      execJsonSpy.mockResolvedValueOnce(tasksPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: {
+          type: 'tasks',
+          filters: {
+            OR: [{ text: { contains: 'budget' } }, { flagged: true }],
+          },
+        },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+    });
+
+    it('preserves summary for projects when one OR branch is broad-only (e.g. {flagged: true})', async () => {
+      execJsonSpy.mockResolvedValueOnce(projectsPayload satisfies ScriptResult);
+
+      const result = (await tool.execute({
+        query: {
+          type: 'projects',
+          filters: {
+            OR: [{ name: { contains: 'budget' } }, { flagged: true }],
+          },
+        },
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+    });
+
+    // Nested OR branches aren't reachable through the public schema today (one
+    // level only), but TaskFilter/ProjectFilter.orBranches is recursive by type
+    // — pin the predicate's own recursion directly against the compiled shape.
+    it('treats a nested OR branch (every sub-branch narrow) as narrow', () => {
+      expect(
+        isNarrowLookupFilter({
+          orBranches: [{ text: 'meeting' }, { orBranches: [{ name: 'budget' }, { id: 't1' }] }],
+        }),
+      ).toBe(true);
+    });
+
+    it('treats a nested OR branch with a broad-only leaf as not narrow', () => {
+      expect(
+        isNarrowLookupFilter({
+          orBranches: [{ text: 'meeting' }, { orBranches: [{ name: 'budget' }, {}] }],
+        }),
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
## What
Extends the narrow-lookup summary-suppression rule (OMN-19/OMN-223) to filters composed with `OR`. `QueryCompiler.transformFilters` routes OR conditions into `filter.orBranches` (a `TaskFilter[]`/`ProjectFilter[]`) rather than merging them into top-level `text`/`name`, so an OR-composed narrow lookup (e.g. `OR: [{text:{contains:'meeting'}}, {text:{contains:'budget'}}]`) kept the full dashboard summary even though the identical single-term or AND-composed search correctly suppressed it. The project path had the identical gap.

## Why
A caller doing a narrow, text-driven OR lookup gets noise from a summary block meant for dashboard/review browses — same rationale as the original OMN-19/OMN-223 rule, just missing this one compiled shape.

## Approach
Rule: an OR filter counts as narrow **iff every branch** contains at least one narrowing key (`name`/`text`/`id`). A branch with only broad keys (e.g. `{flagged: true}`) means the caller may get a dashboard-shaped slice, so the summary stays.

Extended the shared `isNarrowLookupFilter` predicate in `src/tools/unified/OmniFocusReadTool.ts` — the single edit point already used by both the task and project response paths — to walk `orBranches` and apply the same rule recursively (an orBranch may itself carry `orBranches`, per the recursive `TaskFilter`/`ProjectFilter` type).

## Tests added (`tests/unit/tools/unified/OmniFocusReadTool.test.ts`)
- OR of two text-narrow branches suppresses summary — tasks
- OR of two text-narrow branches suppresses summary — projects
- OR with one broad-only branch (`{flagged: true}`) keeps the summary — tasks
- OR with one broad-only branch keeps the summary — projects
- Nested OR branches (every sub-branch narrow) → narrow
- Nested OR branches with a broad-only leaf → not narrow

All previously-passing top-level name/text/id behavior is unchanged. `npm run build` and `npm run test:unit` are green (151 files / 3581 tests).

Closes OMN-229

🤖 Generated with [Claude Code](https://claude.com/claude-code)