### PR TITLE
fix(OMN-227): detectTautologies walks nested OR under AND (orBranches shape)

### DIFF
--- a/src/contracts/ast/validator.ts
+++ b/src/contracts/ast/validator.ts
@@ -239,17 +239,25 @@ function collectAndScope(node: AndNode, comparisons: ComparisonNode[], orBoundar
   }
 }
 
-function checkScopeForContradictions(comparisons: ComparisonNode[], errors: ValidationError[]): void {
+/**
+ * Group the values of `==` comparisons by field. Shared by contradiction
+ * detection (AND scopes) and tautology detection (OR nodes) so the two
+ * detectors can't drift on how they aggregate.
+ */
+function groupEqualityComparisonsByField(comparisons: ComparisonNode[]): Map<string, unknown[]> {
   const fieldValues = new Map<string, unknown[]>();
-
   for (const comp of comparisons) {
     if (comp.operator === '==') {
-      const key = comp.field;
-      const values = fieldValues.get(key) || [];
+      const values = fieldValues.get(comp.field) || [];
       values.push(comp.value);
-      fieldValues.set(key, values);
+      fieldValues.set(comp.field, values);
     }
   }
+  return fieldValues;
+}
+
+function checkScopeForContradictions(comparisons: ComparisonNode[], errors: ValidationError[]): void {
+  const fieldValues = groupEqualityComparisonsByField(comparisons);
 
   for (const [field, values] of fieldValues) {
     if (values.length > 1 && hasContradiction(values)) {
@@ -302,16 +310,8 @@ function visitForTautologies(node: FilterNode, warnings: ValidationWarning[]): v
 }
 
 function checkOrForTautology(node: OrNode, warnings: ValidationWarning[]): void {
-  const comparisons = node.children.filter((c): c is ComparisonNode => c.type === 'comparison' && c.operator === '==');
-
-  const fieldValues = new Map<string, unknown[]>();
-
-  for (const comp of comparisons) {
-    const key = comp.field;
-    const values = fieldValues.get(key) || [];
-    values.push(comp.value);
-    fieldValues.set(key, values);
-  }
+  const comparisons = node.children.filter((c): c is ComparisonNode => c.type === 'comparison');
+  const fieldValues = groupEqualityComparisonsByField(comparisons);
 
   for (const [field, values] of fieldValues) {
     // For boolean fields, true OR false is a tautology

--- a/src/contracts/ast/validator.ts
+++ b/src/contracts/ast/validator.ts
@@ -279,9 +279,30 @@ function hasContradiction(values: unknown[]): boolean {
  * Detect tautologies like: completed: true OR completed: false
  */
 function detectTautologies(ast: FilterNode, warnings: ValidationWarning[]): void {
-  if (ast.type !== 'or') return;
+  visitForTautologies(ast, warnings);
+}
 
-  const comparisons = ast.children.filter((c): c is ComparisonNode => c.type === 'comparison' && c.operator === '==');
+/**
+ * Walk `and`/`or` edges looking for `or` nodes to check. Mirrors the
+ * OMN-226 `detectContradictions` walk shape: `or` nodes are recursed into
+ * (an OR's branches can themselves hide degenerate ORs), `and` nodes are
+ * transparent, and `not` is an opaque boundary — matching the pre-OMN-227
+ * bare-root-OR-only behavior for negated subtrees.
+ */
+function visitForTautologies(node: FilterNode, warnings: ValidationWarning[]): void {
+  switch (node.type) {
+    case 'and':
+      node.children.forEach((child) => visitForTautologies(child, warnings));
+      break;
+    case 'or':
+      checkOrForTautology(node, warnings);
+      node.children.forEach((child) => visitForTautologies(child, warnings));
+      break;
+  }
+}
+
+function checkOrForTautology(node: OrNode, warnings: ValidationWarning[]): void {
+  const comparisons = node.children.filter((c): c is ComparisonNode => c.type === 'comparison' && c.operator === '==');
 
   const fieldValues = new Map<string, unknown[]>();
 

--- a/tests/unit/contracts/ast/validator.test.ts
+++ b/tests/unit/contracts/ast/validator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { validateFilterAST } from '../../../../src/contracts/ast/validator.js';
+import { buildAST } from '../../../../src/contracts/ast/builder.js';
 import type { FilterNode } from '../../../../src/contracts/ast/types.js';
 
 describe('validateFilterAST', () => {
@@ -281,6 +282,100 @@ describe('validateFilterAST', () => {
 
       // Tautology is a warning, not an error (filter will work, just always matches)
       expect(result.warnings.some((w) => w.code === 'TAUTOLOGY')).toBe(true);
+    });
+  });
+
+  describe('tautologies — nested OR under AND (OMN-227)', () => {
+    it('warns on the orBranches shape AND(defaults, OR(completed==true, completed==false))', () => {
+      // Direct validator-level repro of the ticket's degenerate shape.
+      const ast: FilterNode = {
+        type: 'and',
+        children: [
+          { type: 'comparison', field: 'task.flagged', operator: '==', value: true },
+          {
+            type: 'or',
+            children: [
+              { type: 'comparison', field: 'task.completed', operator: '==', value: true },
+              { type: 'comparison', field: 'task.completed', operator: '==', value: false },
+            ],
+          },
+        ],
+      };
+      const result = validateFilterAST(ast);
+
+      expect(result.warnings.some((w) => w.code === 'TAUTOLOGY')).toBe(true);
+    });
+
+    it('warns via the builder path: orBranches composed alongside another filter key', () => {
+      // Mirrors real query construction: buildAST always produces
+      // AND(defaults, OR(...)) once any base condition sits beside orBranches.
+      const ast = buildAST({
+        flagged: true,
+        orBranches: [{ completed: true }, { completed: false }],
+      });
+
+      expect(ast.type).toBe('and');
+      const result = validateFilterAST(ast);
+
+      expect(result.warnings.some((w) => w.code === 'TAUTOLOGY')).toBe(true);
+    });
+
+    it('still finds an OR nested under another OR', () => {
+      // OR(inInbox==true, OR(completed==true, completed==false))
+      const ast: FilterNode = {
+        type: 'or',
+        children: [
+          { type: 'comparison', field: 'task.inInbox', operator: '==', value: true },
+          {
+            type: 'or',
+            children: [
+              { type: 'comparison', field: 'task.completed', operator: '==', value: true },
+              { type: 'comparison', field: 'task.completed', operator: '==', value: false },
+            ],
+          },
+        ],
+      };
+      const result = validateFilterAST(ast);
+
+      expect(result.warnings.some((w) => w.code === 'TAUTOLOGY')).toBe(true);
+    });
+
+    it('does not warn for an OR hidden under a NOT (opaque boundary)', () => {
+      // NOT(OR(completed==true, completed==false)) — NOT is opaque, matching
+      // detectContradictions' treatment of NOT as a boundary.
+      const ast: FilterNode = {
+        type: 'not',
+        child: {
+          type: 'or',
+          children: [
+            { type: 'comparison', field: 'task.completed', operator: '==', value: true },
+            { type: 'comparison', field: 'task.completed', operator: '==', value: false },
+          ],
+        },
+      };
+      const result = validateFilterAST(ast);
+
+      expect(result.warnings.filter((w) => w.code === 'TAUTOLOGY')).toHaveLength(0);
+    });
+
+    it('does not warn for a non-degenerate OR nested under AND', () => {
+      // AND(flagged==true, OR(project==AAA, project==BBB)) — ordinary "A or B", not a tautology
+      const ast: FilterNode = {
+        type: 'and',
+        children: [
+          { type: 'comparison', field: 'task.flagged', operator: '==', value: true },
+          {
+            type: 'or',
+            children: [
+              { type: 'comparison', field: 'task.containingProject', operator: '==', value: 'AAA' },
+              { type: 'comparison', field: 'task.containingProject', operator: '==', value: 'BBB' },
+            ],
+          },
+        ],
+      };
+      const result = validateFilterAST(ast);
+
+      expect(result.warnings.filter((w) => w.code === 'TAUTOLOGY')).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## What

`detectTautologies` in `src/contracts/ast/validator.ts` early-returned unless the AST *root* was an `or` node,
so it only inspected direct children of a bare root OR. Every real `orBranches` query composes as
`AND(defaults, OR(...))` (see `buildAST` in `src/contracts/ast/builder.ts`), so a degenerate always-true OR
nested under AND — e.g. `orBranches: [{completed: true}, {completed: false}]` — never got the TAUTOLOGY
warning that an equivalent bare root `OR(completed==true, completed==false)` already receives.

## Why

Spawned from the OMN-226 pre-review (PR #169). OMN-226 gave the sibling `detectContradictions` a scope-aware
tree walk; `detectTautologies` still only handled the bare-root-OR shape, missing the shape real queries
actually take.

## Approach

Generalized `detectTautologies` with the same walk shape OMN-226 gave `detectContradictions`:
- Recurse through `and`/`or` edges looking for `or` nodes.
- Each `or` node found is checked independently for the boolean true-OR-false pattern among its own direct
  `==` comparison children (extracted into `checkOrForTautology`, matching the pre-existing per-OR check).
- `not` remains an opaque boundary — an OR hidden under a NOT is not inspected, mirroring
  `detectContradictions`' NOT handling.
- Warning-only semantics unchanged: still a `ValidationWarning` with code `TAUTOLOGY`, never an error. No
  changes to `detectContradictions` or to error/throw semantics anywhere.

## Tests added

In `tests/unit/contracts/ast/validator.test.ts`, new describe block `tautologies — nested OR under AND (OMN-227)`:
- AND-wrapped shape `AND(flagged==true, OR(completed==true, completed==false))` warns TAUTOLOGY (direct
  validator-level repro of the ticket).
- Same shape via the real `buildAST` path (`orBranches` composed alongside another filter key) warns TAUTOLOGY.
- An OR nested under another OR is still found.
- An OR hidden under a NOT does **not** warn (opaque boundary, no regression).
- A non-degenerate OR nested under AND (different fields) does **not** warn.
- Existing bare-root-OR warning test still passes (no regression).

`npm run build && npm run test:unit`: 151 test files, 3580 tests, all green. Pre-push hooks (typecheck, lint,
test:unit) also green.

## Test plan
- [x] `npm run build`
- [x] `npm run test:unit` (151 files / 3580 tests passing)
- [ ] Kip: `/code-review` gate before merge

Closes OMN-227

🤖 Generated with [Claude Code](https://claude.com/claude-code)