### PR TITLE
fix(OMN-222): add projected-only fields to OmniFocusTask interface, close the as-keyof masking gap

### DIFF
--- a/src/contracts/responses.ts
+++ b/src/contracts/responses.ts
@@ -134,7 +134,7 @@ export interface RepetitionRuleData {
   ruleString?: string | null;
   scheduleType?: string | null;
   anchorDateKey?: string | null;
-  catchUpAutomatically?: boolean;
+  catchUpAutomatically?: boolean | null;
 }
 
 // =============================================================================

--- a/src/omnifocus/types.ts
+++ b/src/omnifocus/types.ts
@@ -2,6 +2,8 @@
  * Basic type definitions for OmniFocus MCP
  */
 
+import type { RepetitionRuleData } from '../contracts/responses.js';
+
 // Basic OmniFocus entity types
 export interface OmniFocusTask {
   id: string;
@@ -26,9 +28,21 @@ export interface OmniFocusTask {
   inInbox?: boolean;
   // OMN-207: read-side parity with the write side. Reported as the raw stored
   // property on every task (not conditional on children) — see the decision
-  // record in src/contracts/ast/script-builder.ts. Other projected fields
-  // (isProjectRoot, hasNote, plannedDate, repetitionRule) are still absent from
-  // this interface and reach projectFields() via the `as keyof` cast; closing
-  // that pre-existing gap is out of scope for OMN-207.
+  // record in src/contracts/ast/script-builder.ts.
   sequential?: boolean;
+  // OMN-222: remaining fields projectFields() can emit via the `field as keyof
+  // OmniFocusTask` cast in task-query-pipeline.ts. Types verified against the
+  // projection cases in src/contracts/ast/script-builder.ts.
+  isProjectRoot?: boolean; // OMN-153: true when task.project !== null (task IS a project root)
+  hasNote?: boolean; // OMN-130: cheap presence marker, true when the task has non-empty note text
+  plannedDate?: string; // OMN-62: OF 4.7+ planned date, ISO string
+  repetitionRule?: RepetitionRuleData; // modern (v4.7+) repetition rule shape, null when task has none
+  // Mode-injected fields: not selectable via TaskFieldEnum's `fields:[...]` (so
+  // they never reach the `as keyof` cast), but auto-added to the script
+  // projection for specific query modes and passed through unprojected when no
+  // explicit `fields` selection is made — so they can legitimately appear on a
+  // task row returned to callers.
+  effectivePlannedDate?: string; // details:true — OF 4.7+ effective planned date, ISO string
+  reason?: 'overdue' | 'due_soon' | 'flagged' | null; // today mode — category the task was bucketed under
+  daysOverdue?: number; // today mode — 0 when not overdue
 }

--- a/src/omnifocus/types.ts
+++ b/src/omnifocus/types.ts
@@ -35,14 +35,14 @@ export interface OmniFocusTask {
   // projection cases in src/contracts/ast/script-builder.ts.
   isProjectRoot?: boolean; // OMN-153: true when task.project !== null (task IS a project root)
   hasNote?: boolean; // OMN-130: cheap presence marker, true when the task has non-empty note text
-  plannedDate?: string; // OMN-62: OF 4.7+ planned date, ISO string
-  repetitionRule?: RepetitionRuleData; // modern (v4.7+) repetition rule shape, null when task has none
+  plannedDate?: string | null; // OMN-62: OF 4.7+ planned date, ISO string, null when task has none
+  repetitionRule?: RepetitionRuleData | null; // modern (v4.7+) repetition rule shape, null when task has none
   // Mode-injected fields: not selectable via TaskFieldEnum's `fields:[...]` (so
   // they never reach the `as keyof` cast), but auto-added to the script
   // projection for specific query modes and passed through unprojected when no
   // explicit `fields` selection is made — so they can legitimately appear on a
   // task row returned to callers.
-  effectivePlannedDate?: string; // details:true — OF 4.7+ effective planned date, ISO string
+  effectivePlannedDate?: string | null; // details:true — OF 4.7+ effective planned date, ISO string, null when task has none
   reason?: 'overdue' | 'due_soon' | 'flagged' | null; // today mode — category the task was bucketed under
   daysOverdue?: number; // today mode — 0 when not overdue
 }

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -25,6 +25,18 @@ type _TaskFieldsAreKnownKeys =
 const _taskFieldsAreKnownKeys: _TaskFieldsAreKnownKeys = true;
 void _taskFieldsAreKnownKeys;
 
+// Mode-injected fields live outside TaskFieldEnum (spliced into scriptFields by
+// OmniFocusReadTool per query mode), so the guard above can't see them. Pin the
+// known set here: adding one to the splice without an OmniFocusTask member
+// fails this line instead of reopening the drift gap. (Making the splice list
+// itself the single source of truth is OMN follow-up work.)
+const _modeInjectedFieldsAreKnownKeys: ReadonlyArray<keyof OmniFocusTask> = [
+  'effectivePlannedDate',
+  'reason',
+  'daysOverdue',
+];
+void _modeInjectedFieldsAreKnownKeys;
+
 // =============================================================================
 // MODE-SPECIFIC FILTER AUGMENTATION
 // =============================================================================
@@ -406,7 +418,7 @@ export function countTodayCategories(tasks: OmniFocusTask[]): TodayCategoryCount
     dueSoonCount = 0,
     flaggedCount = 0;
   for (const task of tasks) {
-    const reason = (task as unknown as Record<string, unknown>).reason;
+    const reason = task.reason;
     if (reason === 'overdue') overdueCount++;
     else if (reason === 'due_soon') dueSoonCount++;
     else if (reason === 'flagged') flaggedCount++;

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -10,6 +10,20 @@
 import type { OmniFocusTask } from '../../omnifocus/types.js';
 import type { TaskFilter } from '../../contracts/filters.js';
 import type { SortOption } from './filter-types.js';
+import type { TaskFieldEnum } from '../unified/schemas/read-schema.js';
+import type { z } from 'zod';
+
+// OMN-222: compile-time guard closing the `as keyof OmniFocusTask` masking gap
+// below. If a future TaskFieldEnum member (the set callers can request via
+// `fields:[...]`) is added without a matching OmniFocusTask interface member,
+// this line fails to build instead of silently widening the cast at runtime.
+// One-directional on purpose: OmniFocusTask legitimately carries members
+// (id, name, completed, ...) that aren't user-selectable, so the reverse
+// direction is expected to have extras.
+type _TaskFieldsAreKnownKeys =
+  Exclude<z.output<typeof TaskFieldEnum>, keyof OmniFocusTask> extends never ? true : never;
+const _taskFieldsAreKnownKeys: _TaskFieldsAreKnownKeys = true;
+void _taskFieldsAreKnownKeys;
 
 // =============================================================================
 // MODE-SPECIFIC FILTER AUGMENTATION
@@ -290,6 +304,13 @@ export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[])
 
     selectedFields.forEach((field) => {
       if (field in task) {
+        // OMN-222: selectedFields is `string[]` at this call site (CompiledQuery.fields
+        // is shared across query types), so this cast can't be narrowed away without a
+        // wider refactor of that shared type. The `_taskFieldsAreKnownKeys` guard above
+        // makes drift safe: every literal TaskFieldEnum can emit is asserted to be a
+        // real OmniFocusTask member at compile time, so a future field added to the
+        // enum without a matching interface member fails the build there instead of
+        // silently widening this cast.
         const typedField = field as keyof OmniFocusTask;
         (projectedTask as Record<string, unknown>)[field] = task[typedField];
       }

--- a/tests/unit/tools/tasks/task-query-pipeline.test.ts
+++ b/tests/unit/tools/tasks/task-query-pipeline.test.ts
@@ -562,6 +562,48 @@ describe('projectFields', () => {
     expect(result[0].id).toBe('1');
     expect(result[0].estimatedMinutes).toBeUndefined();
   });
+
+  // OMN-222: pin projection of fields added to OmniFocusTask to close the
+  // `as keyof OmniFocusTask` masking gap — these previously reached
+  // projectFields() only via the widening cast, absent from the interface.
+  it('projects newly-typed fields (isProjectRoot, hasNote, plannedDate, repetitionRule)', () => {
+    const tasksWithNewFields: OmniFocusTask[] = [
+      {
+        id: '2',
+        name: 'Task Two',
+        completed: false,
+        flagged: false,
+        blocked: false,
+        isProjectRoot: true,
+        hasNote: true,
+        plannedDate: '2026-01-15',
+        repetitionRule: {
+          ruleString: 'FREQ=DAILY',
+          scheduleType: 'DueDate',
+          anchorDateKey: null,
+          catchUpAutomatically: false,
+        },
+      },
+    ];
+
+    const result = projectFields(tasksWithNewFields, [
+      'id',
+      'isProjectRoot',
+      'hasNote',
+      'plannedDate',
+      'repetitionRule',
+    ]);
+
+    expect(result[0].isProjectRoot).toBe(true);
+    expect(result[0].hasNote).toBe(true);
+    expect(result[0].plannedDate).toBe('2026-01-15');
+    expect(result[0].repetitionRule).toEqual({
+      ruleString: 'FREQ=DAILY',
+      scheduleType: 'DueDate',
+      anchorDateKey: null,
+      catchUpAutomatically: false,
+    });
+  });
 });
 
 describe('scoreForSmartSuggest', () => {

--- a/tests/unit/tools/tasks/task-query-pipeline.test.ts
+++ b/tests/unit/tools/tasks/task-query-pipeline.test.ts
@@ -604,6 +604,35 @@ describe('projectFields', () => {
       catchUpAutomatically: false,
     });
   });
+
+  // OMN-222 review follow-up: the projection emits explicit null (not undefined)
+  // for absent nullable fields, and mode-injected fields (effectivePlannedDate)
+  // sit outside TaskFieldEnum — pin both so the interface can't silently narrow.
+  it('projects null-valued nullable fields and mode-injected effectivePlannedDate', () => {
+    const tasksWithNulls: OmniFocusTask[] = [
+      {
+        id: '3',
+        name: 'Task Three',
+        completed: false,
+        flagged: false,
+        blocked: false,
+        plannedDate: null,
+        effectivePlannedDate: null,
+        repetitionRule: {
+          ruleString: null,
+          scheduleType: null,
+          anchorDateKey: null,
+          catchUpAutomatically: null,
+        },
+      },
+    ];
+
+    const result = projectFields(tasksWithNulls, ['id', 'plannedDate', 'effectivePlannedDate', 'repetitionRule']);
+
+    expect(result[0].plannedDate).toBeNull();
+    expect(result[0].effectivePlannedDate).toBeNull();
+    expect(result[0].repetitionRule?.catchUpAutomatically).toBeNull();
+  });
 });
 
 describe('scoreForSmartSuggest', () => {


### PR DESCRIPTION
## Summary

`projectFields()` in `src/tools/tasks/task-query-pipeline.ts` does `field as keyof OmniFocusTask` — this compiles regardless of whether the field literal is actually a member of `OmniFocusTask`, silently masking any gap between the interface and the fields the pipeline can actually emit. OMN-207 closed the gap for `sequential`; this ticket closes the rest.

## Field inventory (re-derived from code, not from the ticket's stale list)

Authoritative source: `TASK_FIELDS` / `TaskFieldEnum` in `src/tools/unified/schemas/read-schema.ts` — the only field names that can appear in `compiled.fields` (validated by Zod before reaching `projectFields()`), which is the value actually fed into the `as keyof` cast.

**Added (previously missing, reachable via the cast):**
| Field | Type | Verified from |
| --- | --- | --- |
| `isProjectRoot` | `boolean` | `script-builder.ts` case `'isProjectRoot'`: `task.project !== null` |
| `hasNote` | `boolean` | `script-builder.ts` case `'hasNote'` |
| `plannedDate` | `string` | `script-builder.ts` case `'plannedDate'`: `task.plannedDate.toISOString()`, matches `dueDate`'s existing type |
| `repetitionRule` | `RepetitionRuleData` (imported from `src/contracts/responses.ts`, reused rather than redeclared) | `script-builder.ts` case `'repetitionRule'`: `{ ruleString, scheduleType, anchorDateKey, catchUpAutomatically }` |

**Also added (bonus — real runtime fields, but *not* reachable via the cast):** `effectivePlannedDate`, `reason`, `daysOverdue`. These are auto-injected into the script's field list for `details:true` / `mode:'today'` but are **not** members of `TaskFieldEnum`, so they can never appear in `compiled.fields` and never hit the `as keyof` cast. They *do* pass through unprojected when a caller makes no explicit `fields` selection, though, so they can legitimately appear on a task row typed as `OmniFocusTask` — added for interface accuracy. Types verified against `script-builder.ts`: `reason: 'overdue' | 'due_soon' | 'flagged' | null`, `daysOverdue: number` (0 default, never absent), `effectivePlannedDate: string` (same shape as `plannedDate`).

**Excluded, needs decision:** none — every field surfaced by the review's candidate list resolved to an unambiguous type from a single script-builder projection case.

**Already present:** `id`, `name`, `completed`, `flagged`, `blocked`, `available`, `estimatedMinutes`, `dueDate`, `deferDate`, `completionDate`, `added`, `modified`, `dropDate`, `note`, `projectId`, `project`, `tags`, `parentTaskId`, `parentTaskName`, `inInbox`, `sequential`.

## The cast

Tightened rather than removed (removing it would require changing `projectFields`'s `selectedFields: string[]` param, which is `CompiledQuery.fields: string[]` — shared across task/project query types — a wider refactor out of scope here). Instead added a one-directional compile-time guard next to the cast:

```ts
type _TaskFieldsAreKnownKeys =
  Exclude<z.output<typeof TaskFieldEnum>, keyof OmniFocusTask> extends never ? true : never;
const _taskFieldsAreKnownKeys: _TaskFieldsAreKnownKeys = true;
```

If a future `TaskFieldEnum` member is added without a matching `OmniFocusTask` member, this fails the build instead of silently widening the cast at runtime — the same `SameKeys`-style pattern already used in `write-schema.ts`.

## Validation

- `npm run build` — clean
- `npm run lint` (`--max-warnings=0`) — clean
- `npm run test:unit` — 3576/3576 passing (added one test in `tests/unit/tools/tasks/task-query-pipeline.test.ts` pinning projection of the four newly-typed fields)

Zero behavior change: TypeScript interface additions (erased at runtime), one import, a compile-time-only guard, and comment updates.

Closes OMN-222

🤖 Generated with [Claude Code](https://claude.com/claude-code)