### PR TITLE
test(OMN-202): mutation-testing follow-ups for src/contracts/ast/

### DIFF
--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -31,7 +31,17 @@ import { validateMutationProgram } from './mutation/validator.js';
 // =============================================================================
 // TEST SANDBOX GUARD
 // =============================================================================
-
+// OMN-202: this whole section is test-infrastructure — it only executes when
+// isTestMode() is true (NODE_ENV==='test' && SANDBOX_GUARD_ENABLED==='true'),
+// gating integration-test writes to the real OmniFocus sandbox. Mutating it
+// measures test-harness coverage, not product-code defect detection, and was
+// deflating this file's mutation score with noise (mutation-testing baseline
+// OMN-201). Excluded from `mutate` via these
+// Stryker comment directives rather than a stryker.config.json path/glob
+// exclusion because the guard lives inline in this product file alongside the
+// real script builders below (SCRIPT BUILDERS section) — a file-level
+// exclusion would also blind mutation testing to those.
+// Stryker disable all
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -446,6 +456,7 @@ export function markProjectAsValidated(projectId: string): void {
 export function markTaskAsValidated(taskId: string): void {
   validatedTaskIds.add(taskId);
 }
+// Stryker restore all
 
 // =============================================================================
 // TYPES

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -209,6 +209,58 @@ describe('buildFilteredTasksScript', () => {
     });
   });
 
+  // OMN-202: mutation testing (OMN-201 baseline) found the four date-field
+  // `case` labels in generateFieldProjection unpinned — a regression that
+  // swapped one date field's source property for another's (or dropped its
+  // toISOString()/null-guard) would not be caught. Each assertion below pins
+  // BOTH the field's own OmniJS source property (so a mutant reading the wrong
+  // task property, e.g. `deferDate` falling through to read `task.dueDate`,
+  // is caught) AND the exact key it projects to (so a mutant emitting the
+  // wrong output key is caught).
+  describe('date field projections (OMN-202)', () => {
+    it('projects dueDate reading task.dueDate with ISO/null guard', () => {
+      const result = buildFilteredTasksScript({}, { fields: ['id', 'dueDate'] });
+      expect(result.script).toContain('dueDate: task.dueDate ? task.dueDate.toISOString() : null');
+    });
+
+    it('projects deferDate reading task.deferDate with ISO/null guard', () => {
+      const result = buildFilteredTasksScript({}, { fields: ['id', 'deferDate'] });
+      expect(result.script).toContain('deferDate: task.deferDate ? task.deferDate.toISOString() : null');
+    });
+
+    it('projects plannedDate reading task.plannedDate with ISO/null guard', () => {
+      const result = buildFilteredTasksScript({}, { fields: ['id', 'plannedDate'] });
+      expect(result.script).toContain('plannedDate: task.plannedDate ? task.plannedDate.toISOString() : null');
+    });
+
+    it('projects completionDate reading task.completionDate with ISO/null guard', () => {
+      const result = buildFilteredTasksScript({}, { fields: ['id', 'completionDate'] });
+      expect(result.script).toContain('completionDate: task.completionDate ? task.completionDate.toISOString() : null');
+    });
+
+    it('requesting all four date fields together emits four distinct, non-cross-contaminated projections', () => {
+      // Guards against a mutant that makes one case fall through to another
+      // (e.g. `case 'deferDate':` dropping through into the `case 'dueDate':`
+      // body) — each key must read its OWN source property, not a sibling's.
+      const result = buildFilteredTasksScript(
+        {},
+        { fields: ['id', 'dueDate', 'deferDate', 'plannedDate', 'completionDate'] },
+      );
+      expect(result.script).toContain('dueDate: task.dueDate ? task.dueDate.toISOString() : null');
+      expect(result.script).toContain('deferDate: task.deferDate ? task.deferDate.toISOString() : null');
+      expect(result.script).toContain('plannedDate: task.plannedDate ? task.plannedDate.toISOString() : null');
+      expect(result.script).toContain('completionDate: task.completionDate ? task.completionDate.toISOString() : null');
+      // Each field's projection appears exactly once — a fallthrough mutant
+      // that duplicates one field's projection line under two case labels
+      // would push one of these counts to 2.
+      const occurrences = (needle: string) => result.script.split(needle).length - 1;
+      expect(occurrences('dueDate: task.dueDate')).toBe(1);
+      expect(occurrences('deferDate: task.deferDate')).toBe(1);
+      expect(occurrences('plannedDate: task.plannedDate')).toBe(1);
+      expect(occurrences('completionDate: task.completionDate')).toBe(1);
+    });
+  });
+
   describe('text filters', () => {
     it('generates script with text search', () => {
       const filter: TaskFilter = { text: 'review', textOperator: 'CONTAINS' };

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -218,24 +218,15 @@ describe('buildFilteredTasksScript', () => {
   // is caught) AND the exact key it projects to (so a mutant emitting the
   // wrong output key is caught).
   describe('date field projections (OMN-202)', () => {
-    it('projects dueDate reading task.dueDate with ISO/null guard', () => {
-      const result = buildFilteredTasksScript({}, { fields: ['id', 'dueDate'] });
-      expect(result.script).toContain('dueDate: task.dueDate ? task.dueDate.toISOString() : null');
-    });
-
-    it('projects deferDate reading task.deferDate with ISO/null guard', () => {
-      const result = buildFilteredTasksScript({}, { fields: ['id', 'deferDate'] });
-      expect(result.script).toContain('deferDate: task.deferDate ? task.deferDate.toISOString() : null');
-    });
-
-    it('projects plannedDate reading task.plannedDate with ISO/null guard', () => {
-      const result = buildFilteredTasksScript({}, { fields: ['id', 'plannedDate'] });
-      expect(result.script).toContain('plannedDate: task.plannedDate ? task.plannedDate.toISOString() : null');
-    });
-
-    it('projects completionDate reading task.completionDate with ISO/null guard', () => {
-      const result = buildFilteredTasksScript({}, { fields: ['id', 'completionDate'] });
-      expect(result.script).toContain('completionDate: task.completionDate ? task.completionDate.toISOString() : null');
+    it.each([
+      ['dueDate'],
+      ['deferDate'],
+      ['plannedDate'],
+      ['completionDate'],
+      ['effectivePlannedDate'],
+    ])('projects %s reading task.%s with ISO/null guard', (field) => {
+      const result = buildFilteredTasksScript({}, { fields: ['id', field] });
+      expect(result.script).toContain(`${field}: task.${field} ? task.${field}.toISOString() : null`);
     });
 
     it('requesting all four date fields together emits four distinct, non-cross-contaminated projections', () => {

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -218,16 +218,13 @@ describe('buildFilteredTasksScript', () => {
   // is caught) AND the exact key it projects to (so a mutant emitting the
   // wrong output key is caught).
   describe('date field projections (OMN-202)', () => {
-    it.each([
-      ['dueDate'],
-      ['deferDate'],
-      ['plannedDate'],
-      ['completionDate'],
-      ['effectivePlannedDate'],
-    ])('projects %s reading task.%s with ISO/null guard', (field) => {
-      const result = buildFilteredTasksScript({}, { fields: ['id', field] });
-      expect(result.script).toContain(`${field}: task.${field} ? task.${field}.toISOString() : null`);
-    });
+    it.each([['dueDate'], ['deferDate'], ['plannedDate'], ['completionDate'], ['effectivePlannedDate']])(
+      'projects %s reading task.%s with ISO/null guard',
+      (field) => {
+        const result = buildFilteredTasksScript({}, { fields: ['id', field] });
+        expect(result.script).toContain(`${field}: task.${field} ? task.${field}.toISOString() : null`);
+      },
+    );
 
     it('requesting all four date fields together emits four distinct, non-cross-contaminated projections', () => {
       // Guards against a mutant that makes one case fall through to another

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -209,7 +209,7 @@ describe('buildFilteredTasksScript', () => {
     });
   });
 
-  // OMN-202: mutation testing (OMN-201 baseline) found the four date-field
+  // OMN-202: mutation testing (OMN-201 baseline) found the date-field
   // `case` labels in generateFieldProjection unpinned — a regression that
   // swapped one date field's source property for another's (or dropped its
   // toISOString()/null-guard) would not be caught. Each assertion below pins
@@ -226,18 +226,21 @@ describe('buildFilteredTasksScript', () => {
       },
     );
 
-    it('requesting all four date fields together emits four distinct, non-cross-contaminated projections', () => {
+    it('requesting all five date fields together emits five distinct, non-cross-contaminated projections', () => {
       // Guards against a mutant that makes one case fall through to another
       // (e.g. `case 'deferDate':` dropping through into the `case 'dueDate':`
       // body) — each key must read its OWN source property, not a sibling's.
       const result = buildFilteredTasksScript(
         {},
-        { fields: ['id', 'dueDate', 'deferDate', 'plannedDate', 'completionDate'] },
+        { fields: ['id', 'dueDate', 'deferDate', 'plannedDate', 'completionDate', 'effectivePlannedDate'] },
       );
       expect(result.script).toContain('dueDate: task.dueDate ? task.dueDate.toISOString() : null');
       expect(result.script).toContain('deferDate: task.deferDate ? task.deferDate.toISOString() : null');
       expect(result.script).toContain('plannedDate: task.plannedDate ? task.plannedDate.toISOString() : null');
       expect(result.script).toContain('completionDate: task.completionDate ? task.completionDate.toISOString() : null');
+      expect(result.script).toContain(
+        'effectivePlannedDate: task.effectivePlannedDate ? task.effectivePlannedDate.toISOString() : null',
+      );
       // Each field's projection appears exactly once — a fallthrough mutant
       // that duplicates one field's projection line under two case labels
       // would push one of these counts to 2.
@@ -246,6 +249,7 @@ describe('buildFilteredTasksScript', () => {
       expect(occurrences('deferDate: task.deferDate')).toBe(1);
       expect(occurrences('plannedDate: task.plannedDate')).toBe(1);
       expect(occurrences('completionDate: task.completionDate')).toBe(1);
+      expect(occurrences('effectivePlannedDate: task.effectivePlannedDate')).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Two small follow-ups from the OMN-201 mutation-testing baseline (full `src/contracts/ast/` = 74.22%):

**Item 1 — `script-builder.ts` date-field `case` labels (baseline 62%).** The `dueDate` / `deferDate` / `plannedDate` / `completionDate` projection cases in `generateFieldProjection` had no dedicated assertions — a regression that swapped one date field's source property for another's (a fallthrough-style mutation), or dropped the `toISOString()`/null-guard, would not be caught. Added 5 pin tests in `tests/unit/contracts/ast/script-builder.test.ts` (`describe('date field projections (OMN-202)')`), each asserting the exact generated projection string for one field, plus a combined test asserting all four are present, distinct, and each occurs exactly once (guards against a case falling through into a sibling's body).

**Item 2 — exclude the sandbox-guard test-harness from `mutate` (`mutation-script-builder.ts`, baseline 54%).** The `TEST SANDBOX GUARD` section (`SANDBOX_FOLDER_NAME`, `executeGuardJXA`, `getSandboxFolderId`, `isProjectInSandbox`, etc.) only executes when `isTestMode()` is true (`NODE_ENV==='test' && SANDBOX_GUARD_ENABLED==='true'`) — it's test-infrastructure gating integration-test writes to the real OmniFocus sandbox, not product behavior, and its survivors were measurement noise deflating the file's score. Since these symbols live inline in a product file (`mutation-script-builder.ts`) alongside the real script builders — not a separate test-harness file — used Stryker comment directives (`// Stryker disable all` / `// Stryker restore all`) bracketing just the `TEST SANDBOX GUARD` section, rather than a `stryker.config.json` path/glob exclusion that would also blind mutation testing to the real builders below it.

## Hand-mutation spot-check (item 1)

Per the ticket, verified the new tests actually kill mutants, not just avoid throwing:

- **deferDate**: temporarily changed `case 'deferDate':` to read `task.dueDate` instead of `task.deferDate` (fallthrough-style mutation) → 2 of the new tests failed as expected. Reverted.
- **completionDate**: temporarily changed `case 'completionDate':` to read `task.plannedDate` instead of `task.completionDate` → 2 of the new tests failed as expected. Reverted.

`git diff` on `script-builder.ts` is clean (no product changes shipped) — confirms this is test-only.

## Scoped mutation run (evidence, not required)

`npx stryker run --mutate "src/contracts/ast/script-builder.ts"` (full file, ~1 min):

- **69.09%** (494 killed / 201 survived / 20 no-coverage), up from the 62% baseline.
- None of the surviving mutants are in the four date-field `case` branches (lines ~256–272) — confirms those are now pinned/killed.
- Remaining survivors are in `buildFilteredProjectsScript`'s count-optimization path (`isEmptyFilterValue`, `needsTags`, `optimization` string) and a `.trim()` mutant — out of scope per the ticket (not chasing equivalent-mutant/low-value survivors).

## Validation

- `npm run build` — clean
- `npm run test:unit` — 3580/3580 passing (incl. the 5 new tests, green immediately as pin tests)
- Did **not** run full `npm run test:mutation` or `npm run test:integration` per guardrails.

Closes OMN-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)