### PR TITLE
test(OMN-223): count-honesty aligns with narrow-lookup summary suppression

### DIFF
--- a/tests/integration/count-honesty.test.ts
+++ b/tests/integration/count-honesty.test.ts
@@ -193,8 +193,11 @@ d('OMN-154: count-honesty contract (C11 shape)', () => {
     // D3: total_matched must NOT be present
     expect('total_matched' in meta, 'metadata.total_matched must be absent (D3)').toBe(false);
 
-    // summary.total_count alignment
-    expect(result.summary?.total_count, 'summary.total_count must equal full population').toBe(TASK_COUNT);
+    // OMN-223: a top-level name filter is a narrow lookup — the dashboard
+    // summary block is deliberately suppressed for this query shape, so the
+    // count-honesty contract lives entirely in metadata (asserted above).
+    // Pin the suppression so an accidental summary revival is caught here.
+    expect(result.summary, 'summary must be suppressed on name narrow lookups (OMN-223)').toBeUndefined();
   }, 60_000);
 
   it('R4 agreement: countOnly reports same total_count as full query', async () => {


### PR DESCRIPTION
## Why

The first full integration run after OMN-223 merged (run on the OMN-181 branch this morning) failed `count-honesty.test.ts` C11: it asserts `summary.total_count` on a `name: {contains}` query, but OMN-223 (#172) deliberately suppresses the dashboard summary on top-level name/text narrow lookups. Integration CI is a placeholder, so the conflict was latent on main.

## What

One assertion: C11 now pins the OMN-223 suppression (`summary` undefined) instead of asserting summary/metadata alignment. The count-honesty contract (R1/R2/D3) is fully asserted via `metadata`, which is unaffected.

## Alternative considered

Narrowing OMN-223's suppression to exact-match lookups only (excluding `contains` searches) would restore the summary here — rejected as this PR's call since OMN-223's shipped wording covers text/name narrow lookups generally; flag if you want that revisited.

## Verification

- Failing assertion reproduced in the 2026-07-06 09:12 integration run (177 passed / 1 failed, this test).
- Full integration re-run pending on the OMN-181 branch; this fix will be exercised by the next integration pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)