### PR TITLE
docs(OMN-230): single-source the tag-assignment pipeline description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,11 @@ JXA `task.tags = …` and `task.addTags()` silently no-op. Assign tags via OmniJ
 (`src/contracts/ast/mutation-script-builder.ts`) or the AST tag builders
 (`src/contracts/ast/tag-mutation-script-builder.ts`).
 
+**Pipeline:** `mutation-script-builder.ts` / `tag-mutation-script-builder.ts` (entry points) route into
+`mutation/defs.ts` (`MUTATION_DEFS` lowering builds an `assignTags` AST node), which `mutation/emitter.ts` emits as
+OmniJS `addTag()` / `removeTag()` calls inside `evaluateJavascript`. This is the single authoritative description of the
+pipeline — other docs should link here rather than restate it.
+
 ## Code & Writing Standards
 
 - **TypeScript only** - Never create `.js` files. Follow existing patterns in the codebase.

--- a/docs/dev/PATTERNS.md
+++ b/docs/dev/PATTERNS.md
@@ -42,11 +42,12 @@ should show `{oneOf: [...]}`, not `{type: "string"}`.
 // ❌ JXA methods fail silently
 task.addTags(tags);
 
-// ✅ Bridge works — OmniJS addTag(), emitted by src/contracts/ast/mutation/emitter.ts
-// (routed from src/contracts/ast/mutation/defs.ts; entry points are
-// src/contracts/ast/mutation-script-builder.ts and tag-mutation-script-builder.ts)
-task.addTag(tag); // inside evaluateJavascript
+// ✅ Bridge works — OmniJS addTag() inside evaluateJavascript
+task.addTag(tag);
 ```
+
+Entry points: `src/contracts/ast/mutation-script-builder.ts`, `tag-mutation-script-builder.ts`. Full pipeline
+description: repo CLAUDE.md → "🏷️ Tag Operations".
 
 ---
 

--- a/docs/dev/PATTERN_INDEX.md
+++ b/docs/dev/PATTERN_INDEX.md
@@ -85,8 +85,7 @@ Single osascript execution.
 Notes:
 
 - Only `added` has a date-range filter; **no `modified` filter exists**.
-- Mutation pipeline: `mutation-script-builder.ts` (entry points) -> `mutation/defs.ts` (`MUTATION_DEFS` lowering,
-  `assignTags`, repetition wiring) -> `mutation/emitter.ts` (emits OmniJS `addTag`).
+- Tag-assignment pipeline (entry points -> lowering -> emission): see repo CLAUDE.md -> "🏷️ Tag Operations".
 
 ---
 


### PR DESCRIPTION
## What
The tag-assignment mechanism (JXA `addTags()`/`task.tags=` silently no-op → OmniJS `addTag()` via the mutation pipeline) was described at three sites with differing depth and drifting detail:

- `CLAUDE.md` → "🏷️ Tag Operations"
- `docs/dev/PATTERNS.md` → "Tags Not Working"
- `docs/dev/PATTERN_INDEX.md` → "Use Case Reference" table + a pipeline note below it

## Why
Three descriptions of the same pipeline invite drift — a fix or refactor updates one site and leaves the others stale. `CLAUDE.md` is loaded every session, so it's the natural single source of truth for the full routing narrative.

## Approach
- `CLAUDE.md` "Tag Operations" is now the canonical, most detailed description: entry points (`mutation-script-builder.ts`, `tag-mutation-script-builder.ts`) → `mutation/defs.ts` (`MUTATION_DEFS` lowering builds an `assignTags` AST node) → `mutation/emitter.ts` (emits OmniJS `addTag()`/`removeTag()`).
- `PATTERNS.md` "Tags Not Working" keeps the symptom table and code snippet, trims the routing narrative, and links back to CLAUDE.md.
- `PATTERN_INDEX.md` keeps the "Use Case Reference" table row (entry-point files stay in the cell, per the quick-lookup convention) and reduces the pipeline note below it to a pointer.
- Verified every file/symbol referenced against the actual code with grep — `addTag`/`removeTag` emission is in `mutation/emitter.ts`, routing/lowering is in `mutation/defs.ts` (`MUTATION_DEFS`, `lowerTagChanges`, `assignTags`).

Closes OMN-230

## Test plan
- [x] `npx prettier --write` on all touched files
- [x] `npm run test:unit` — 152 files / 3605 tests passed
- [x] `tests/unit/docs/claude-md-paths.test.ts` passes (path-reference guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)