### PR TITLE
fix(OMN-236): parseCLIArgs errors on unknown flags; warn on --http without MCP_AUTH_TOKEN

### DIFF
--- a/docs/user/TROUBLESHOOTING.md
+++ b/docs/user/TROUBLESHOOTING.md
@@ -131,9 +131,8 @@ Build first with `npm run build` if Inspector fails.
 
 #### Verify installation
 
-```bash
-node dist/index.js --version
-```
+There is no `--version` CLI flag (unknown flags exit with an error). Verify via the MCP `system` tool's `version`
+operation below, or `node dist/index.js --help`.
 
 #### Test connection
 

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -68,6 +68,10 @@ export function parseCLIArgs(): CLIConfig {
         printHelp();
         process.exit(0);
         break;
+      default:
+        logger.error(`unknown argument: ${args[i]}`);
+        process.stderr.write(getUsageText());
+        process.exit(1);
     }
   }
 
@@ -98,14 +102,22 @@ export function validateCLIConfig(config: CLIConfig): void {
     if (!config.host || config.host.trim() === '') {
       throw new Error('Host cannot be empty in HTTP mode.');
     }
+
+    if (!config.authToken) {
+      logger.warn(
+        'HTTP transport is enabled with NO authentication (MCP_AUTH_TOKEN is not set) — ' +
+          'any client that can reach this endpoint can call every tool with no credential check. ' +
+          'Set MCP_AUTH_TOKEN to require a bearer token, or ensure this endpoint is not reachable off-host.',
+      );
+    }
   }
 }
 
 /**
- * Prints help information for the CLI
+ * Usage text shared by --help (stdout) and the unknown-argument error path (stderr)
  */
-export function printHelp(): void {
-  console.log(`
+function getUsageText(): string {
+  return `
 Usage: omnifocus-mcp-cached [options]
 
 Options:
@@ -132,5 +144,12 @@ Examples:
   export MCP_AUTH_TOKEN=$(openssl rand -hex 32)
   export MCP_PORT=3000
   node dist/index.js --http
-`);
+`;
+}
+
+/**
+ * Prints help information for the CLI
+ */
+export function printHelp(): void {
+  console.log(getUsageText());
 }

--- a/tests/unit/utils/cli.test.ts
+++ b/tests/unit/utils/cli.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parseCLIArgs, validateCLIConfig, DEFAULT_CLI_CONFIG, type CLIConfig } from '../../../src/utils/cli.js';
+
+describe('parseCLIArgs', () => {
+  const origArgv = process.argv;
+  const origAuthToken = process.env.MCP_AUTH_TOKEN;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    delete process.env.MCP_AUTH_TOKEN;
+    delete process.env.MCP_PORT;
+    delete process.env.MCP_HOST;
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.argv = origArgv;
+    if (origAuthToken === undefined) delete process.env.MCP_AUTH_TOKEN;
+    else process.env.MCP_AUTH_TOKEN = origAuthToken;
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('errors and exits nonzero on an unrecognized flag', () => {
+    process.argv = ['node', 'dist/index.js', '--auth-token', 'secret'];
+    expect(() => parseCLIArgs()).toThrow('EXIT:1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: omnifocus-mcp-cached'));
+  });
+
+  it('does not misfire the default case on a value consumed by --port/--host', () => {
+    process.argv = ['node', 'dist/index.js', '--port', '3111', '--host', '127.0.0.1'];
+    const config = parseCLIArgs();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(config.port).toBe(3111);
+    expect(config.host).toBe('127.0.0.1');
+  });
+
+  it('accepts --http alongside a valid --port/--host pair without exiting', () => {
+    process.argv = ['node', 'dist/index.js', '--http', '--port', '4000'];
+    const config = parseCLIArgs();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(config.httpMode).toBe(true);
+    expect(config.port).toBe(4000);
+  });
+
+  it('still exits 0 for --help (unchanged behavior)', () => {
+    process.argv = ['node', 'dist/index.js', '--help'];
+    expect(() => parseCLIArgs()).toThrow('EXIT:0');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('validateCLIConfig — --http without MCP_AUTH_TOKEN', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns loudly on stderr when httpMode is set and authToken is absent', () => {
+    const config: CLIConfig = { ...DEFAULT_CLI_CONFIG, httpMode: true, authToken: undefined };
+    validateCLIConfig(config);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('NO authentication'));
+  });
+
+  it('does not warn when authToken is present', () => {
+    const config: CLIConfig = { ...DEFAULT_CLI_CONFIG, httpMode: true, authToken: 'set-token' };
+    validateCLIConfig(config);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn in stdio mode regardless of authToken', () => {
+    const config: CLIConfig = { ...DEFAULT_CLI_CONFIG, httpMode: false, authToken: undefined };
+    validateCLIConfig(config);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/cli.test.ts
+++ b/tests/unit/utils/cli.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import { parseCLIArgs, validateCLIConfig, DEFAULT_CLI_CONFIG, type CLIConfig } from '../../../src/utils/cli.js';
 
 describe('parseCLIArgs', () => {
   const origArgv = process.argv;
   const origAuthToken = process.env.MCP_AUTH_TOKEN;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
-  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: MockInstance<typeof process.exit>;
+  let stderrSpy: MockInstance<typeof process.stderr.write>;
 
   beforeEach(() => {
     delete process.env.MCP_AUTH_TOKEN;
@@ -56,7 +56,7 @@ describe('parseCLIArgs', () => {
 });
 
 describe('validateCLIConfig — --http without MCP_AUTH_TOKEN', () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: MockInstance<typeof process.stderr.write>;
 
   beforeEach(() => {
     warnSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);


### PR DESCRIPTION
## What

- `parseCLIArgs` (`src/utils/cli.ts`) now has a `default:` case in its argument switch: any unrecognized flag prints `unknown argument: <arg>` plus usage to stderr and exits with code 1, instead of being silently skipped.
- `validateCLIConfig` now warns (via `logger.warn`, stderr) when `--http` is enabled and no `MCP_AUTH_TOKEN` is set. Non-fatal by design — localhost/dev without a token is a legitimate use case; this just makes the gap visible instead of silent.
- Refactored the inline usage string out of `printHelp()` into `getUsageText()` so both `--help` (stdout) and the new unknown-argument error path (stderr) share one source of truth.

## Why

Gate-review finding on #171: the CLI arg switch had no default case, so a mistyped or nonexistent flag (e.g. `--auth-token` instead of the `MCP_AUTH_TOKEN` env var) was silently ignored and the server started normally. Combined with `http-server.ts` skipping bearer validation entirely when no token is configured, a user could believe auth was configured when it wasn't — a fail-silent gap at the process boundary.

## Testable behavior

`parseCLIArgs()` still calls `process.exit()` directly (matching the existing `--help` idiom), so tests mock `process.exit` to throw a sentinel error (`EXIT:<code>`) and assert on it via `expect(() => parseCLIArgs()).toThrow(...)` — this keeps the test process alive while still exercising the real exit-code path.

New tests in `tests/unit/utils/cli.test.ts`:
- unrecognized flag → `exit(1)` + usage on stderr
- `--port 3111 --host 127.0.0.1` does **not** misfire the new `default:` case on the consumed values (pins the `consumeNextArg`/`i++` interaction)
- `--http --port 4000` parses cleanly, no exit
- `--help` still exits 0 (regression guard)
- `validateCLIConfig`: warns on stderr for `--http` + no token, silent when a token is present, silent in stdio mode

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit` — 153 files / 3612 tests passed
- [ ] Kip: `/code-review` gate before merge

Closes OMN-236

🤖 Generated with [Claude Code](https://claude.com/claude-code)