### PR TITLE
refactor(OMN-234): compose test-support harnesses over StdioJsonRpcTransport

### DIFF
--- a/tests/support/claude-code-mcp.ts
+++ b/tests/support/claude-code-mcp.ts
@@ -2,10 +2,16 @@
 /**
  * Test script to verify that Claude Code can use our MCP server
  * This provides command-line testing without needing Claude Desktop
+ *
+ * OMN-234: composes `StdioJsonRpcTransport` (the shared spawn/id-correlation
+ * core) instead of carrying its own `pendingRequests` copy. What stays HERE
+ * (client-specific, not owned by the transport): the `NODE_ENV=test`-only
+ * env (no sandbox guard vars), `protocolVersion: '2024-11-05'`, the
+ * stderr/child `error` listeners, and non-graceful (`kill()`-style) cleanup.
  */
 
-import { spawn, ChildProcess } from 'child_process';
-import { createInterface, Interface } from 'readline';
+import type { spawn } from 'child_process';
+import { StdioJsonRpcTransport } from '../integration/helpers/stdio-jsonrpc-transport.js';
 
 console.log('Claude Code MCP Integration Test');
 console.log('================================');
@@ -78,42 +84,36 @@ const CONFIG: TestConfig = {
   ],
 };
 
-class MCPTester {
-  private server: ChildProcess | null = null;
-  private messageId: number = 0;
-  private pendingRequests: Map<number, (response: MCPResponse) => void> = new Map();
+export interface MCPTesterOptions {
+  /** Test seam only: substitute for `child_process.spawn`. See `StdioJsonRpcTransport`. */
+  spawnFn?: typeof spawn;
+}
+
+export class MCPTester {
+  private readonly transport: StdioJsonRpcTransport;
   private _testResults: TestResult[] = [];
   get testResults(): TestResult[] {
     return this._testResults;
   }
 
+  constructor(options: MCPTesterOptions = {}) {
+    this.transport = new StdioJsonRpcTransport({
+      serverPath: CONFIG.serverPath,
+      spawnOptions: { stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } },
+      spawnFn: options.spawnFn,
+    });
+  }
+
   async start(): Promise<void> {
     console.log(`Starting MCP server: ${CONFIG.serverPath}`);
 
-    this.server = spawn('node', [CONFIG.serverPath], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, NODE_ENV: 'test' },
-    });
+    this.transport.start();
 
-    const rl: Interface = createInterface({
-      input: this.server.stdout!,
-      crlfDelay: Infinity,
-    });
-
-    rl.on('line', (line: string) => {
-      try {
-        const response: MCPResponse = JSON.parse(line);
-        this.handleResponse(response);
-      } catch {
-        // Ignore non-JSON output
-      }
-    });
-
-    this.server.stderr!.on('data', (data: Buffer) => {
+    this.transport.child.stderr!.on('data', (data: Buffer) => {
       console.error('Server error:', data.toString());
     });
 
-    this.server.on('error', (error: Error) => {
+    this.transport.child.on('error', (error: Error) => {
       console.error('Failed to start server:', error);
       process.exit(1);
     });
@@ -146,12 +146,7 @@ class MCPTester {
       console.log(`   Server: ${response.result.serverInfo.name} v${response.result.serverInfo.version}`);
 
       // Send initialized notification
-      this.server!.stdin!.write(
-        JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'notifications/initialized',
-        }) + '\n',
-      );
+      this.transport.sendNotification('notifications/initialized');
 
       return true;
     } else {
@@ -241,35 +236,11 @@ class MCPTester {
   }
 
   async sendRequest(request: MCPRequest, timeout: number = 10000): Promise<MCPResponse> {
-    return new Promise((resolve, reject) => {
-      const requestId = request.id!;
-
-      // Store the resolver
-      this.pendingRequests.set(requestId, resolve);
-
-      // Send the request
-      this.server!.stdin!.write(JSON.stringify(request) + '\n');
-
-      // Set timeout
-      setTimeout(() => {
-        if (this.pendingRequests.has(requestId)) {
-          this.pendingRequests.delete(requestId);
-          reject(new Error(`Request ${requestId} timed out after ${timeout}ms`));
-        }
-      }, timeout);
-    });
-  }
-
-  handleResponse(response: MCPResponse): void {
-    if (response.id && this.pendingRequests.has(response.id)) {
-      const resolver = this.pendingRequests.get(response.id)!;
-      this.pendingRequests.delete(response.id);
-      resolver(response);
-    }
+    return this.transport.sendRequest(request as unknown as { id: number; [k: string]: unknown }, timeout);
   }
 
   nextId(): number {
-    return ++this.messageId;
+    return this.transport.nextId();
   }
 
   delay(ms: number): Promise<void> {
@@ -306,9 +277,7 @@ class MCPTester {
   }
 
   async cleanup(): Promise<void> {
-    if (this.server && !this.server.killed) {
-      this.server.kill();
-    }
+    await this.transport.close({ graceful: false });
   }
 }
 
@@ -343,4 +312,8 @@ async function runTest(): Promise<void> {
   }
 }
 
-runTest();
+// Only auto-run when executed directly (e.g. `npx tsx tests/support/claude-code-mcp.ts`),
+// not when imported by a unit test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void runTest();
+}

--- a/tests/support/claude-code-mcp.ts
+++ b/tests/support/claude-code-mcp.ts
@@ -12,6 +12,8 @@
 
 import type { spawn } from 'child_process';
 import { StdioJsonRpcTransport } from '../integration/helpers/stdio-jsonrpc-transport.js';
+import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
 
 console.log('Claude Code MCP Integration Test');
 console.log('================================');
@@ -236,6 +238,11 @@ export class MCPTester {
   }
 
   async sendRequest(request: MCPRequest, timeout: number = 10000): Promise<MCPResponse> {
+    if (request.id === undefined) {
+      // The transport keys its pending map on a numeric id; an id-less request
+      // would sit keyed on undefined until timeout. Fail fast instead.
+      throw new Error('sendRequest requires request.id — use nextId()');
+    }
     return this.transport.sendRequest(request as unknown as { id: number; [k: string]: unknown }, timeout);
   }
 
@@ -314,6 +321,23 @@ async function runTest(): Promise<void> {
 
 // Only auto-run when executed directly (e.g. `npx tsx tests/support/claude-code-mcp.ts`),
 // not when imported by a unit test.
-if (import.meta.url === `file://${process.argv[1]}`) {
+
+/**
+ * Robust "run directly, not imported" check (OMN-234 gate review): the naive
+ * `import.meta.url === \`file://${argv[1]}\`` breaks on percent-encoded
+ * characters (spaces, non-ASCII) and symlinked paths, silently turning a
+ * direct run into an exit-0 no-op. pathToFileURL handles encoding;
+ * realpathSync resolves symlinks on the argv side.
+ */
+function isRunDirectly(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isRunDirectly()) {
   void runTest();
 }

--- a/tests/support/gherkin-test-runner.ts
+++ b/tests/support/gherkin-test-runner.ts
@@ -2,10 +2,16 @@
 /**
  * Gherkin-style test runner for OmniFocus MCP
  * Executes BDD scenarios against the MCP server
+ *
+ * OMN-234: composes `StdioJsonRpcTransport` (the shared spawn/id-correlation
+ * core) instead of carrying its own `pendingRequests` copy. What stays HERE
+ * (client-specific, not owned by the transport): the `NODE_ENV=test`-only
+ * env, the `DEBUG`-gated stderr listener, `protocolVersion: '2024-11-05'`,
+ * and non-graceful (`kill()`-style) cleanup.
  */
 
-import { spawn, ChildProcess } from 'child_process';
-import { createInterface, Interface } from 'readline';
+import type { spawn } from 'child_process';
+import { StdioJsonRpcTransport } from '../integration/helpers/stdio-jsonrpc-transport.js';
 
 interface MCPRequest {
   jsonrpc: '2.0';
@@ -69,10 +75,13 @@ interface TestContext {
   [key: string]: any;
 }
 
-class GherkinTestRunner {
-  private server: ChildProcess | null = null;
-  private messageId: number = 0;
-  private pendingRequests: Map<number, (response: MCPResponse) => void> = new Map();
+export interface GherkinTestRunnerOptions {
+  /** Test seam only: substitute for `child_process.spawn`. See `StdioJsonRpcTransport`. */
+  spawnFn?: typeof spawn;
+}
+
+export class GherkinTestRunner {
+  private readonly transport: StdioJsonRpcTransport;
   private context: TestContext = {}; // Shared context between steps
   private _results: TestResults = {
     scenarios: [],
@@ -84,30 +93,21 @@ class GherkinTestRunner {
     return this._results;
   }
 
+  constructor(options: GherkinTestRunnerOptions = {}) {
+    this.transport = new StdioJsonRpcTransport({
+      serverPath: './dist/index.js',
+      spawnOptions: { stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } },
+      spawnFn: options.spawnFn,
+    });
+  }
+
   async start(): Promise<void> {
     console.log('🥒 Gherkin Test Runner for OmniFocus MCP');
     console.log('========================================\n');
 
-    this.server = spawn('node', ['./dist/index.js'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, NODE_ENV: 'test' },
-    });
+    this.transport.start();
 
-    const rl: Interface = createInterface({
-      input: this.server.stdout!,
-      crlfDelay: Infinity,
-    });
-
-    rl.on('line', (line: string) => {
-      try {
-        const response: MCPResponse = JSON.parse(line);
-        this.handleResponse(response);
-      } catch {
-        // Ignore non-JSON
-      }
-    });
-
-    this.server.stderr!.on('data', (data: Buffer) => {
+    this.transport.child.stderr!.on('data', (data: Buffer) => {
       if (process.env.DEBUG) {
         console.error('Server error:', data.toString());
       }
@@ -139,12 +139,7 @@ class GherkinTestRunner {
     }
 
     // Send initialized notification
-    this.server!.stdin!.write(
-      JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'notifications/initialized',
-      }) + '\n',
-    );
+    this.transport.sendNotification('notifications/initialized');
 
     await this.delay(100);
   }
@@ -403,31 +398,11 @@ class GherkinTestRunner {
   }
 
   async sendRequest(request: MCPRequest, timeout: number = 10000): Promise<MCPResponse> {
-    return new Promise((resolve, reject) => {
-      const requestId = request.id!;
-
-      this.pendingRequests.set(requestId, resolve);
-      this.server!.stdin!.write(JSON.stringify(request) + '\n');
-
-      setTimeout(() => {
-        if (this.pendingRequests.has(requestId)) {
-          this.pendingRequests.delete(requestId);
-          reject(new Error(`Request ${requestId} timed out`));
-        }
-      }, timeout);
-    });
-  }
-
-  handleResponse(response: MCPResponse): void {
-    if (response.id && this.pendingRequests.has(response.id)) {
-      const resolver = this.pendingRequests.get(response.id)!;
-      this.pendingRequests.delete(response.id);
-      resolver(response);
-    }
+    return this.transport.sendRequest(request as unknown as { id: number; [k: string]: unknown }, timeout);
   }
 
   nextId(): number {
-    return ++this.messageId;
+    return this.transport.nextId();
   }
 
   delay(ms: number): Promise<void> {
@@ -457,9 +432,7 @@ class GherkinTestRunner {
   }
 
   async cleanup(): Promise<void> {
-    if (this.server && !this.server.killed) {
-      this.server.kill();
-    }
+    await this.transport.close({ graceful: false });
   }
 }
 
@@ -538,15 +511,19 @@ async function runTests(): Promise<void> {
   }
 }
 
-// Handle command line args
-if (process.argv[2] === '--help') {
-  console.log('Usage: node test/gherkin-test-runner.js [--verbose]');
-  console.log('  --verbose    Show detailed server output');
-  process.exit(0);
-}
+// Only auto-run when executed directly (e.g. `npx tsx tests/support/gherkin-test-runner.ts`),
+// not when imported by a unit test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  // Handle command line args
+  if (process.argv[2] === '--help') {
+    console.log('Usage: node test/gherkin-test-runner.js [--verbose]');
+    console.log('  --verbose    Show detailed server output');
+    process.exit(0);
+  }
 
-if (process.argv[2] === '--verbose') {
-  process.env.DEBUG = 'true';
-}
+  if (process.argv[2] === '--verbose') {
+    process.env.DEBUG = 'true';
+  }
 
-runTests();
+  void runTests();
+}

--- a/tests/support/gherkin-test-runner.ts
+++ b/tests/support/gherkin-test-runner.ts
@@ -12,6 +12,8 @@
 
 import type { spawn } from 'child_process';
 import { StdioJsonRpcTransport } from '../integration/helpers/stdio-jsonrpc-transport.js';
+import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
 
 interface MCPRequest {
   jsonrpc: '2.0';
@@ -398,6 +400,11 @@ export class GherkinTestRunner {
   }
 
   async sendRequest(request: MCPRequest, timeout: number = 10000): Promise<MCPResponse> {
+    if (request.id === undefined) {
+      // The transport keys its pending map on a numeric id; an id-less request
+      // would sit keyed on undefined until timeout. Fail fast instead.
+      throw new Error('sendRequest requires request.id — use nextId()');
+    }
     return this.transport.sendRequest(request as unknown as { id: number; [k: string]: unknown }, timeout);
   }
 
@@ -513,7 +520,24 @@ async function runTests(): Promise<void> {
 
 // Only auto-run when executed directly (e.g. `npx tsx tests/support/gherkin-test-runner.ts`),
 // not when imported by a unit test.
-if (import.meta.url === `file://${process.argv[1]}`) {
+
+/**
+ * Robust "run directly, not imported" check (OMN-234 gate review): the naive
+ * `import.meta.url === \`file://${argv[1]}\`` breaks on percent-encoded
+ * characters (spaces, non-ASCII) and symlinked paths, silently turning a
+ * direct run into an exit-0 no-op. pathToFileURL handles encoding;
+ * realpathSync resolves symlinks on the argv side.
+ */
+function isRunDirectly(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isRunDirectly()) {
   // Handle command line args
   if (process.argv[2] === '--help') {
     console.log('Usage: node test/gherkin-test-runner.js [--verbose]');

--- a/tests/unit/helpers/fake-child.ts
+++ b/tests/unit/helpers/fake-child.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared fake ChildProcess double for unit-testing everything composed over
+ * StdioJsonRpcTransport (the transport itself, MCPTester, GherkinTestRunner).
+ *
+ * ONE copy on purpose (OMN-234 gate review): three per-file near-copies meant
+ * a change to the transport's child-process contract (new stream, pid read,
+ * exit semantics) could be fixed in one double while the other suites kept
+ * passing against a stale one. Extend HERE, not in the test files.
+ *
+ * Mirrors real Node semantics the transport relies on:
+ * - `killed` turns true only via OUR OWN kill() — never on self-exit.
+ * - self-exit (crash/clean exit) sets exitCode and fires 'exit'; use
+ *   `selfExit()` to emulate it.
+ */
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { vi } from 'vitest';
+
+export interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stdin: PassThrough;
+  stderr: PassThrough;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: string | null;
+  kill: (signal?: string) => void;
+  /** Emulate the child dying on its own (crash/clean exit) — the case `killed` never reports. */
+  selfExit: (code?: number) => void;
+  /** Every chunk written to stdin, captured for assertions. */
+  writes: string[];
+}
+
+export function makeFakeChild(): FakeChild {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const stderr = new PassThrough();
+  const writes: string[] = [];
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = stdout;
+  child.stdin = stdin;
+  child.stderr = stderr;
+  child.killed = false;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.writes = writes;
+  // Capture writes instead of letting them vanish into a PassThrough with no reader.
+  const realWrite = stdin.write.bind(stdin);
+  stdin.write = ((chunk: unknown, ...rest: unknown[]) => {
+    writes.push(String(chunk));
+    return realWrite(chunk as string, ...(rest as []));
+  }) as typeof stdin.write;
+  child.kill = vi.fn((signal?: string) => {
+    child.killed = true;
+    process.nextTick(() => {
+      child.signalCode = signal ?? 'SIGTERM';
+      child.emit('exit', null, child.signalCode);
+    });
+  });
+  child.selfExit = (code = 1) => {
+    child.exitCode = code;
+    child.emit('exit', code, null);
+  };
+  return child;
+}
+
+/** Push one JSON line onto the child's stdout (a server → client frame). */
+export function sendLine(child: FakeChild, obj: unknown): void {
+  child.stdout.write(JSON.stringify(obj) + '\n');
+}

--- a/tests/unit/integration-helpers/stdio-jsonrpc-transport.test.ts
+++ b/tests/unit/integration-helpers/stdio-jsonrpc-transport.test.ts
@@ -1,62 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { PassThrough } from 'stream';
-import { EventEmitter } from 'events';
 import { StdioJsonRpcTransport } from '../../integration/helpers/stdio-jsonrpc-transport.js';
+import { makeFakeChild, sendLine, type FakeChild } from '../helpers/fake-child.js';
 
 /**
  * OMN-181 — unit coverage for the extracted stdio JSON-RPC correlation core.
  * Pins the OMN-146 regression guard (route by id, not first-line-wins) without
  * needing a live `node dist/index.js` child — the whole point of this test.
  */
-
-interface FakeChild extends EventEmitter {
-  stdout: PassThrough;
-  stdin: PassThrough;
-  killed: boolean;
-  exitCode: number | null;
-  signalCode: string | null;
-  kill: (signal?: string) => void;
-  /** Emulate the child dying on its own (crash/clean exit) — the case `killed` never reports. */
-  selfExit: (code?: number) => void;
-  writes: string[];
-}
-
-function makeFakeChild(): FakeChild {
-  const stdout = new PassThrough();
-  const stdin = new PassThrough();
-  const writes: string[] = [];
-  const child = new EventEmitter() as FakeChild;
-  child.stdout = stdout;
-  child.stdin = stdin;
-  child.killed = false;
-  child.exitCode = null;
-  child.signalCode = null;
-  child.writes = writes;
-  // Capture writes instead of letting them vanish into a PassThrough with no reader.
-  const realWrite = stdin.write.bind(stdin);
-  stdin.write = ((chunk: any, ...rest: any[]) => {
-    writes.push(String(chunk));
-    return realWrite(chunk, ...(rest as []));
-  }) as typeof stdin.write;
-  child.kill = vi.fn((signal?: string) => {
-    child.killed = true;
-    process.nextTick(() => {
-      child.signalCode = signal ?? 'SIGTERM';
-      child.emit('exit', null, child.signalCode);
-    });
-  });
-  child.selfExit = (code = 1) => {
-    // Mirrors real Node semantics: `killed` stays false; exitCode is set and
-    // 'exit' fires.
-    child.exitCode = code;
-    child.emit('exit', code, null);
-  };
-  return child;
-}
-
-function sendLine(child: FakeChild, obj: unknown): void {
-  child.stdout.write(JSON.stringify(obj) + '\n');
-}
 
 describe('StdioJsonRpcTransport', () => {
   let child: FakeChild;

--- a/tests/unit/support/claude-code-mcp.test.ts
+++ b/tests/unit/support/claude-code-mcp.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { MCPTester } from '../../support/claude-code-mcp.js';
+
+/**
+ * OMN-234 — unit coverage for MCPTester composing StdioJsonRpcTransport
+ * (rather than carrying its own `pendingRequests` copy). Mirrors the
+ * FakeChild pattern from `stdio-jsonrpc-transport.test.ts`, exercised
+ * through MCPTester's own public API (`sendRequest`/`nextId`).
+ */
+
+interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stdin: PassThrough;
+  stderr: PassThrough;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: string | null;
+  kill: (signal?: string) => void;
+}
+
+function makeFakeChild(): FakeChild {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const stderr = new PassThrough();
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = stdout;
+  child.stdin = stdin;
+  child.stderr = stderr;
+  child.killed = false;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn((signal?: string) => {
+    child.killed = true;
+    process.nextTick(() => {
+      child.signalCode = signal ?? 'SIGTERM';
+      child.emit('exit', null, child.signalCode);
+    });
+  });
+  return child;
+}
+
+function sendLine(child: FakeChild, obj: unknown): void {
+  child.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+describe('MCPTester (composed over StdioJsonRpcTransport)', () => {
+  it('routes interleaved responses to the request with the matching id through sendRequest/nextId', async () => {
+    const child = makeFakeChild();
+    const tester = new MCPTester({ spawnFn: (() => child) as any });
+
+    vi.useFakeTimers();
+    try {
+      const startPromise = tester.start();
+      await vi.advanceTimersByTimeAsync(500);
+      await startPromise;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const idA = tester.nextId();
+    const idB = tester.nextId();
+
+    const pA = tester.sendRequest({ jsonrpc: '2.0', id: idA, method: 'tools/call' });
+    const pB = tester.sendRequest({ jsonrpc: '2.0', id: idB, method: 'tools/call' });
+
+    // Respond out of order: B's answer arrives first.
+    sendLine(child, { jsonrpc: '2.0', id: idB, result: { who: 'B' } });
+    sendLine(child, { jsonrpc: '2.0', id: idA, result: { who: 'A' } });
+
+    const [a, b] = await Promise.all([pA, pB]);
+    expect(a.result.who).toBe('A');
+    expect(b.result.who).toBe('B');
+
+    await tester.cleanup();
+  });
+
+  it('resolves a response for request id 0 (the old `if (response.id && ...)` truthy check dropped this)', async () => {
+    const child = makeFakeChild();
+    const tester = new MCPTester({ spawnFn: (() => child) as any });
+
+    vi.useFakeTimers();
+    try {
+      const startPromise = tester.start();
+      await vi.advanceTimersByTimeAsync(500);
+      await startPromise;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // nextId() starts at 1 in MCPTester's normal flow, so drive id 0 directly
+    // to pin the id-0 regression the migration fixes.
+    const promise = tester.sendRequest({ jsonrpc: '2.0', id: 0, method: 'tools/call' });
+    sendLine(child, { jsonrpc: '2.0', id: 0, result: { ok: true } });
+
+    const response = await promise;
+    expect(response.result.ok).toBe(true);
+
+    await tester.cleanup();
+  });
+});

--- a/tests/unit/support/claude-code-mcp.test.ts
+++ b/tests/unit/support/claude-code-mcp.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { PassThrough } from 'stream';
-import { EventEmitter } from 'events';
 import { MCPTester } from '../../support/claude-code-mcp.js';
+import { makeFakeChild, sendLine } from '../helpers/fake-child.js';
 
 /**
  * OMN-234 — unit coverage for MCPTester composing StdioJsonRpcTransport
@@ -9,41 +8,6 @@ import { MCPTester } from '../../support/claude-code-mcp.js';
  * FakeChild pattern from `stdio-jsonrpc-transport.test.ts`, exercised
  * through MCPTester's own public API (`sendRequest`/`nextId`).
  */
-
-interface FakeChild extends EventEmitter {
-  stdout: PassThrough;
-  stdin: PassThrough;
-  stderr: PassThrough;
-  killed: boolean;
-  exitCode: number | null;
-  signalCode: string | null;
-  kill: (signal?: string) => void;
-}
-
-function makeFakeChild(): FakeChild {
-  const stdout = new PassThrough();
-  const stdin = new PassThrough();
-  const stderr = new PassThrough();
-  const child = new EventEmitter() as FakeChild;
-  child.stdout = stdout;
-  child.stdin = stdin;
-  child.stderr = stderr;
-  child.killed = false;
-  child.exitCode = null;
-  child.signalCode = null;
-  child.kill = vi.fn((signal?: string) => {
-    child.killed = true;
-    process.nextTick(() => {
-      child.signalCode = signal ?? 'SIGTERM';
-      child.emit('exit', null, child.signalCode);
-    });
-  });
-  return child;
-}
-
-function sendLine(child: FakeChild, obj: unknown): void {
-  child.stdout.write(JSON.stringify(obj) + '\n');
-}
 
 describe('MCPTester (composed over StdioJsonRpcTransport)', () => {
   it('routes interleaved responses to the request with the matching id through sendRequest/nextId', async () => {

--- a/tests/unit/support/gherkin-test-runner.test.ts
+++ b/tests/unit/support/gherkin-test-runner.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { PassThrough } from 'stream';
-import { EventEmitter } from 'events';
+import { describe, it, expect } from 'vitest';
 import { GherkinTestRunner } from '../../support/gherkin-test-runner.js';
+import { makeFakeChild, sendLine, type FakeChild } from '../helpers/fake-child.js';
 
 /**
  * OMN-234 — unit coverage for GherkinTestRunner composing
@@ -11,41 +10,6 @@ import { GherkinTestRunner } from '../../support/gherkin-test-runner.js';
  * public API (`sendRequest`/`nextId`) — does not drive `start()`/`initialize()`
  * (those require a real MCP handshake response) or a real child process.
  */
-
-interface FakeChild extends EventEmitter {
-  stdout: PassThrough;
-  stdin: PassThrough;
-  stderr: PassThrough;
-  killed: boolean;
-  exitCode: number | null;
-  signalCode: string | null;
-  kill: (signal?: string) => void;
-}
-
-function makeFakeChild(): FakeChild {
-  const stdout = new PassThrough();
-  const stdin = new PassThrough();
-  const stderr = new PassThrough();
-  const child = new EventEmitter() as FakeChild;
-  child.stdout = stdout;
-  child.stdin = stdin;
-  child.stderr = stderr;
-  child.killed = false;
-  child.exitCode = null;
-  child.signalCode = null;
-  child.kill = vi.fn((signal?: string) => {
-    child.killed = true;
-    process.nextTick(() => {
-      child.signalCode = signal ?? 'SIGTERM';
-      child.emit('exit', null, child.signalCode);
-    });
-  });
-  return child;
-}
-
-function sendLine(child: FakeChild, obj: unknown): void {
-  child.stdout.write(JSON.stringify(obj) + '\n');
-}
 
 describe('GherkinTestRunner (composed over StdioJsonRpcTransport)', () => {
   /** Drives `start()` (which performs the real `initialize()` MCP handshake) to completion by answering its id-1 request, using only the runner's public API. */

--- a/tests/unit/support/gherkin-test-runner.test.ts
+++ b/tests/unit/support/gherkin-test-runner.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { GherkinTestRunner } from '../../support/gherkin-test-runner.js';
+
+/**
+ * OMN-234 — unit coverage for GherkinTestRunner composing
+ * StdioJsonRpcTransport (rather than carrying its own `pendingRequests`
+ * copy). Mirrors the FakeChild pattern from
+ * `stdio-jsonrpc-transport.test.ts`, exercised through the runner's own
+ * public API (`sendRequest`/`nextId`) — does not drive `start()`/`initialize()`
+ * (those require a real MCP handshake response) or a real child process.
+ */
+
+interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stdin: PassThrough;
+  stderr: PassThrough;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: string | null;
+  kill: (signal?: string) => void;
+}
+
+function makeFakeChild(): FakeChild {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const stderr = new PassThrough();
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = stdout;
+  child.stdin = stdin;
+  child.stderr = stderr;
+  child.killed = false;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn((signal?: string) => {
+    child.killed = true;
+    process.nextTick(() => {
+      child.signalCode = signal ?? 'SIGTERM';
+      child.emit('exit', null, child.signalCode);
+    });
+  });
+  return child;
+}
+
+function sendLine(child: FakeChild, obj: unknown): void {
+  child.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+describe('GherkinTestRunner (composed over StdioJsonRpcTransport)', () => {
+  /** Drives `start()` (which performs the real `initialize()` MCP handshake) to completion by answering its id-1 request, using only the runner's public API. */
+  async function startRunner(child: FakeChild): Promise<GherkinTestRunner> {
+    const runner = new GherkinTestRunner({ spawnFn: (() => child) as any });
+    const startPromise = runner.start();
+    sendLine(child, { jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'fake', version: '0' } } });
+    await startPromise;
+    return runner;
+  }
+
+  it('routes interleaved responses to the request with the matching id through sendRequest/nextId', async () => {
+    const child = makeFakeChild();
+    const runner = await startRunner(child);
+
+    const idA = runner.nextId();
+    const idB = runner.nextId();
+
+    const pA = runner.sendRequest({ jsonrpc: '2.0', id: idA, method: 'tools/call' });
+    const pB = runner.sendRequest({ jsonrpc: '2.0', id: idB, method: 'tools/call' });
+
+    // Respond out of order: B's answer arrives first.
+    sendLine(child, { jsonrpc: '2.0', id: idB, result: { who: 'B' } });
+    sendLine(child, { jsonrpc: '2.0', id: idA, result: { who: 'A' } });
+
+    const [a, b] = await Promise.all([pA, pB]);
+    expect(a.result.who).toBe('A');
+    expect(b.result.who).toBe('B');
+
+    await runner.cleanup();
+  });
+
+  it('resolves a response for request id 0 (the old `if (response.id && ...)` truthy check dropped this)', async () => {
+    const child = makeFakeChild();
+    const runner = await startRunner(child);
+
+    const promise = runner.sendRequest({ jsonrpc: '2.0', id: 0, method: 'tools/call' });
+    sendLine(child, { jsonrpc: '2.0', id: 0, result: { ok: true } });
+
+    const response = await promise;
+    expect(response.result.ok).toBe(true);
+
+    await runner.cleanup();
+  });
+});


### PR DESCRIPTION
## What

Migrates `tests/support/claude-code-mcp.ts` (`MCPTester`) and `tests/support/gherkin-test-runner.ts` (`GherkinTestRunner`) to compose the shared `StdioJsonRpcTransport` (`tests/integration/helpers/stdio-jsonrpc-transport.ts`, extracted in OMN-181) instead of each carrying its own private `messageId` / `pendingRequests` / `handleResponse` copy.

## Why

Both harnesses' hand-rolled `handleResponse` used `if (response.id && this.pendingRequests.has(response.id))` — a truthy check that silently drops a response for request id `0`. This was flagged in the PR #179 gate review as a latent copy of the bug `StdioJsonRpcTransport` already fixes canonically (`typeof id === 'number'`) for `MCPTestClient` and `UnifiedTestServer`. These two remaining copies were the last holdouts.

## What stayed local (client-specific policy, per the transport's docblock)

- `MCPTester`: `NODE_ENV=test`-only env (no sandbox guard vars), `protocolVersion: '2024-11-05'`, its own stderr/`error` listeners, non-graceful (`kill()`-style) cleanup.
- `GherkinTestRunner`: same env/protocolVersion policy, `DEBUG`-gated stderr listener, non-graceful cleanup.

Both classes gained a `spawnFn` test seam (mirroring `StdioJsonRpcTransportOptions`) and were exported (previously module-private) so they're unit-testable; their auto-run at the bottom of each file is now guarded behind `import.meta.url === file://${process.argv[1]}` so importing them in a test doesn't spawn a real server/`process.exit()`. Public API (`start`, `initialize`, `sendRequest`, `nextId`, `callTool`, `cleanup`, etc.) is unchanged. No other files import these two scripts (checked); `generate-test-report.ts` only references `gherkin-test-runner.js` in a printed string, not an import.

## Tests

Added `tests/unit/support/claude-code-mcp.test.ts` and `tests/unit/support/gherkin-test-runner.test.ts`, mirroring the `FakeChild` pattern from `tests/unit/integration-helpers/stdio-jsonrpc-transport.test.ts`. Each pins, through the harness's own public API:
- out-of-order response routing by request id
- the id-0 regression the migration fixes (previously silently dropped)

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit` — 154 files / 3609 tests pass
- [ ] `/code-review` gate (per project workflow norms)

Closes OMN-234

🤖 Generated with [Claude Code](https://claude.com/claude-code)