### PR TITLE
refactor(OMN-232): MODE_INJECTED_FIELDS as the type-checked splice source of truth

### DIFF
--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -25,17 +25,16 @@ type _TaskFieldsAreKnownKeys =
 const _taskFieldsAreKnownKeys: _TaskFieldsAreKnownKeys = true;
 void _taskFieldsAreKnownKeys;
 
-// Mode-injected fields live outside TaskFieldEnum (spliced into scriptFields by
-// OmniFocusReadTool per query mode), so the guard above can't see them. Pin the
-// known set here: adding one to the splice without an OmniFocusTask member
-// fails this line instead of reopening the drift gap. (Making the splice list
-// itself the single source of truth is OMN follow-up work.)
-const _modeInjectedFieldsAreKnownKeys: ReadonlyArray<keyof OmniFocusTask> = [
-  'effectivePlannedDate',
-  'reason',
-  'daysOverdue',
-];
-void _modeInjectedFieldsAreKnownKeys;
+// OMN-232: today mode's category-bucketing fields live outside TaskFieldEnum
+// (they're spliced into scriptFields by OmniFocusReadTool per query mode, not
+// selected by the caller), so the guard above can't see them. This is the single
+// source of truth for that splice: OmniFocusReadTool spreads MODE_INJECTED_FIELDS
+// instead of repeating the literals, and the `satisfies` clause fails the build
+// if a field is added here that isn't on OmniFocusTask — closing the drift gap
+// the old `_modeInjectedFieldsAreKnownKeys` stopgap only detected after the fact.
+export const MODE_INJECTED_FIELDS = ['reason', 'daysOverdue', 'modified'] as const satisfies ReadonlyArray<
+  keyof OmniFocusTask
+>;
 
 // =============================================================================
 // MODE-SPECIFIC FILTER AUGMENTATION

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -52,6 +52,7 @@ import {
   projectFields,
   scoreForSmartSuggest,
   countTodayCategories,
+  MODE_INJECTED_FIELDS,
   type TaskQueryMode,
 } from '../tasks/task-query-pipeline.js';
 import { buildTagsScript } from '../../contracts/ast/tag-script-builder.js';
@@ -235,7 +236,7 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
 
   // Today mode needs extra fields for category counting
   if (mode === 'today') {
-    scriptFields = [...new Set([...scriptFields, 'reason', 'daysOverdue', 'modified'])];
+    scriptFields = [...new Set([...scriptFields, ...MODE_INJECTED_FIELDS])];
   }
 
   // OMN-130 #3: smart_suggest scoring uses task.available (+30 pts). Force-inject

--- a/tests/unit/tools/unified/OmniFocusReadTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusReadTool.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OmniFocusReadTool, isNarrowLookupFilter } from '../../../../src/tools/unified/OmniFocusReadTool.js';
 import { CacheManager } from '../../../../src/cache/CacheManager.js';
 import type { ScriptResult } from '../../../../src/omnifocus/script-result-types.js';
+import { MODE_INJECTED_FIELDS } from '../../../../src/tools/tasks/task-query-pipeline.js';
 
 vi.mock('../../../../src/cache/CacheManager');
 vi.mock('../../../../src/omnifocus/OmniAutomation');
@@ -1028,10 +1029,12 @@ describe('OmniFocusReadTool', () => {
       });
 
       const scriptArg = execJsonSpy.mock.calls[0][0] as string;
-      // Should have today-specific fields
-      expect(scriptArg).toContain('reason');
-      expect(scriptArg).toContain('daysOverdue');
-      expect(scriptArg).toContain('modified');
+      // OMN-232: pin against the exported MODE_INJECTED_FIELDS source of truth
+      // rather than repeating the literals, so this test fails if the splice
+      // site in OmniFocusReadTool drifts from the constant it's meant to use.
+      for (const field of MODE_INJECTED_FIELDS) {
+        expect(scriptArg).toContain(field);
+      }
       // But not all detail fields (note shouldn't be there)
       expect(scriptArg).not.toContain('estimatedMinutes');
     });


### PR DESCRIPTION
## What

Mode-injected task fields (`reason`, `daysOverdue`, `modified`) were ad-hoc
string literals spliced into `scriptFields` for `today` mode in
`OmniFocusReadTool.ts`, uncheckable against `OmniFocusTask` by any guard. A
stopgap `_modeInjectedFieldsAreKnownKeys` const in `task-query-pipeline.ts`
separately pinned `effectivePlannedDate`/`reason`/`daysOverdue` as
`keyof OmniFocusTask`, but nothing tied that check to the actual splice, so
the two could drift silently.

This PR hoists an exported `MODE_INJECTED_FIELDS` const
(`task-query-pipeline.ts`), typed via
`as const satisfies ReadonlyArray<keyof OmniFocusTask>`. `OmniFocusReadTool`
now spreads it at the splice site instead of repeating the literals, so
adding a field to the splice that isn't on `OmniFocusTask` fails the build.
The old stopgap is deleted — subsumed by the new const.

## `modified` — already on the interface

The ticket flagged that the splice also injects `modified` and asked me to
check whether it's on `OmniFocusTask`. It already is
(`src/omnifocus/types.ts`, `modified?: string`), and it's also already a
member of `TASK_FIELDS`/`TaskFieldEnum` (user-selectable), so it's
independently covered by the existing `_taskFieldsAreKnownKeys` guard. No
interface change needed — included it in `MODE_INJECTED_FIELDS` anyway since
it's part of the same splice.

## `effectivePlannedDate` — not actually mode-injected

The old stopgap also pinned `effectivePlannedDate`, but it isn't spliced by
query mode at all — it's a member of the untyped `DETAIL_FIELDS` /
`MINIMAL_FIELDS` string arrays in `script-builder.ts` (gated by
`details:true`, not `mode`). Those arrays aren't checked against
`OmniFocusTask` anywhere, which is a separate and wider drift class (the
whole default-field-list mechanism, not just mode splices). Out of scope
here; flagging as a candidate follow-up rather than silently dropping the
one field-level check the old stopgap happened to give it.

## Other splice sites audited

Two other conditional single-field splices exist in the same function:

- `isProjectRoot` (forced in when `includeProjectRoot:true`)
- `available` (forced in for `smart_suggest` mode)

Both fields are already members of `TASK_FIELDS`/`TaskFieldEnum`, so they're
already covered by the existing `_taskFieldsAreKnownKeys` compile-time guard
— no drift gap there. Left as-is.

## Test

Strengthened the existing "merges today mode extra fields into
MINIMAL_FIELDS" test in `OmniFocusReadTool.test.ts` to iterate
`MODE_INJECTED_FIELDS` itself rather than repeating the literal field names,
so the test fails if the splice site drifts from the constant it's supposed
to use.

Closes OMN-232

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit` (3605 passed)
- [ ] `/code-review` gate before merge (per repo norms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)