### PR TITLE
feat(OMN-233): byte budget for raw data.tasks + return-limit measurement script

### DIFF
--- a/docs/dev/SCRIPT_SIZE_LIMITS.md
+++ b/docs/dev/SCRIPT_SIZE_LIMITS.md
@@ -26,6 +26,11 @@ assumption was only **3.6%** of actual JXA capacity!
 - **Test Method:** JXA wrapper calling `app.evaluateJavascript(omniJSScript)`
 - **Boundary Testing:** All scripts 261,118-261,130 chars passed
 - **Confidence:** High (matches our tag assignment bridge usage)
+- **Direction measured:** INPUT only — the size of OmniJS source handed INTO `evaluateJavascript()`. The RETURN path
+  (how large a value `evaluateJavascript()` can hand back to JXA) has never been separately measured; it is measurable
+  via `scripts/measure-bridge-return-limit.ts` (pending — run manually, supervised, against live OmniFocus).
+  `RAW_DATA_BYTE_BUDGET` in `src/omnifocus/scripts/analytics/workflow-analysis-v3.ts` (OMN-233) is an extrapolation from
+  this input-side figure until that script has been run.
 
 ### Method Comparison
 

--- a/scripts/measure-bridge-return-limit.ts
+++ b/scripts/measure-bridge-return-limit.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env npx tsx
+/**
+ * Measure the OmniJS bridge RETURN-path size limit.
+ *
+ * docs/dev/SCRIPT_SIZE_LIMITS.md documents an empirically-measured limit for
+ * the evaluateJavascript() INPUT side (~261,124 chars, the size of the OmniJS
+ * source string JXA can hand to the bridge). That measurement says nothing
+ * about the RETURN side — how large a string evaluateJavascript() can hand
+ * BACK to JXA. workflow-analysis-v3.ts (OMN-233) extrapolates a conservative
+ * RAW_DATA_BYTE_BUDGET from the input-side figure because the return path has
+ * never been separately measured. This script closes that gap.
+ *
+ * Method (mirrors docs/dev/SCRIPT_SIZE_LIMITS.md's binary-search approach,
+ * applied to the opposite data-flow direction):
+ *   1. Build a JXA wrapper script that calls
+ *      `app.evaluateJavascript(omniJsSnippet)`, where the OmniJS snippet
+ *      constructs a string of exactly N characters and returns it.
+ *   2. The JXA wrapper JSON.stringifies the returned string and writes it to
+ *      stdout (the exact path our MCP server's OmniAutomation.ts uses:
+ *      spawn('osascript', ['-l', 'JavaScript']) + stdin piping).
+ *   3. Binary search N between a known-good floor and a known-bad ceiling
+ *      until the search window is within TOLERANCE_CHARS, recording the
+ *      largest N that (a) exits 0, (b) round-trips the exact expected length
+ *      back through JSON.parse.
+ *
+ * This measures the full round trip (evaluateJavascript return -> JXA
+ * JSON.stringify -> stdout -> our node-side JSON.parse), which is the
+ * relevant limit for data.tasks in workflow-analysis-v3.ts: that payload
+ * takes exactly this path. It does not isolate which layer fails first if
+ * failure occurs (evaluateJavascript's own return-size limit vs. stdout pipe
+ * buffering vs. JSON.stringify inside JXA) — see the printed diagnostics on a
+ * failing boundary run for a hint, but treat the reported number as the
+ * limit for OUR usage pattern, not a fundamental platform constant.
+ *
+ * DO NOT RUN THIS UNSUPERVISED. It requires a live, unlocked OmniFocus
+ * instance (evaluateJavascript executes against the real app) and repeatedly
+ * spawns osascript processes near the failure boundary, which can be slow
+ * and, per SCRIPT_SIZE_LIMITS.md's prior boundary testing, occasionally
+ * flaky right at the edge. Kip runs this manually, supervised:
+ *
+ *   npx tsx scripts/measure-bridge-return-limit.ts
+ *
+ * Optional env vars:
+ *   MEASURE_FLOOR=<n>      starting known-good size (default 10000)
+ *   MEASURE_CEILING=<n>    starting known-bad size (default 400000)
+ *   MEASURE_TOLERANCE=<n>  binary-search stop window, in chars (default 1024)
+ *   MEASURE_TIMEOUT_MS=<n> per-attempt osascript timeout (default 20000)
+ *
+ * On completion, replace RAW_DATA_BYTE_BUDGET in
+ * src/omnifocus/scripts/analytics/workflow-analysis-v3.ts with a figure
+ * derived from the measured boundary (leave headroom below it — don't set
+ * the budget AT the measured ceiling), and update the comments there and in
+ * docs/dev/SCRIPT_SIZE_LIMITS.md to cite the new measurement in place of the
+ * "extrapolated, pending measurement" language.
+ */
+
+import { spawn } from 'child_process';
+
+interface AttemptResult {
+  size: number;
+  success: boolean;
+  detail: string;
+}
+
+const FLOOR = parseInt(process.env.MEASURE_FLOOR || '10000', 10);
+const CEILING = parseInt(process.env.MEASURE_CEILING || '400000', 10);
+const TOLERANCE = parseInt(process.env.MEASURE_TOLERANCE || '1024', 10);
+const TIMEOUT_MS = parseInt(process.env.MEASURE_TIMEOUT_MS || '20000', 10);
+
+function buildWrapperScript(size: number): string {
+  // OmniJS snippet: build a string of exactly `size` characters and return it.
+  // JXA snippet: call the bridge, JSON.stringify the result, print it.
+  // Matches our production execution pattern (OmniAutomation.ts): a JXA IIFE
+  // that calls Application('OmniFocus').evaluateJavascript(...) and prints
+  // JSON via console.log so stdout is the sole channel back to node.
+  return `
+    (() => {
+      const app = Application('OmniFocus');
+      const omniJsSnippet = \`
+        (() => {
+          return 'x'.repeat(${size});
+        })()
+      \`;
+      const result = app.evaluateJavascript(omniJsSnippet);
+      return JSON.stringify({ length: result.length });
+    })()
+  `;
+}
+
+function runAttempt(size: number): Promise<AttemptResult> {
+  return new Promise((resolve) => {
+    const script = buildWrapperScript(size);
+    const proc = spawn('osascript', ['-l', 'JavaScript'], { timeout: TIMEOUT_MS });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (error) => {
+      resolve({ size, success: false, detail: `spawn error: ${error.message}` });
+    });
+
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        resolve({ size, success: false, detail: `exit ${code}: ${stderr.trim().slice(0, 300)}` });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout.trim());
+        if (parsed && parsed.length === size) {
+          resolve({ size, success: true, detail: 'round-trip length matched' });
+        } else {
+          resolve({
+            size,
+            success: false,
+            detail: `length mismatch: expected ${size}, got ${parsed && parsed.length}`,
+          });
+        }
+      } catch (e) {
+        resolve({
+          size,
+          success: false,
+          detail: `JSON.parse failed: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+    });
+
+    proc.stdin.write(script);
+    proc.stdin.end();
+  });
+}
+
+async function binarySearch(): Promise<void> {
+  console.log('Measuring OmniJS bridge RETURN-path size limit.');
+  console.log(`Floor: ${FLOOR}  Ceiling: ${CEILING}  Tolerance: ${TOLERANCE}  Timeout: ${TIMEOUT_MS}ms\n`);
+
+  const floorResult = await runAttempt(FLOOR);
+  if (!floorResult.success) {
+    console.error(`FLOOR size ${FLOOR} already fails (${floorResult.detail}). Lower MEASURE_FLOOR and retry.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`✓ floor ${FLOOR} succeeds (${floorResult.detail})`);
+
+  const ceilingResult = await runAttempt(CEILING);
+  if (ceilingResult.success) {
+    console.error(`CEILING size ${CEILING} still succeeds (${ceilingResult.detail}). Raise MEASURE_CEILING and retry.`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`✓ ceiling ${CEILING} fails as expected (${ceilingResult.detail})\n`);
+
+  let low = FLOOR;
+  let high = CEILING;
+
+  while (high - low > TOLERANCE) {
+    const mid = Math.floor((low + high) / 2);
+    const result = await runAttempt(mid);
+    if (result.success) {
+      console.log(`  ${mid.toLocaleString()} chars: OK`);
+      low = mid;
+    } else {
+      console.log(`  ${mid.toLocaleString()} chars: FAIL (${result.detail})`);
+      high = mid;
+    }
+  }
+
+  console.log(`\nBoundary found within ${TOLERANCE} chars:`);
+  console.log(`  Largest known-good: ${low.toLocaleString()} chars`);
+  console.log(`  Smallest known-bad: ${high.toLocaleString()} chars`);
+  console.log(
+    `\nUpdate RAW_DATA_BYTE_BUDGET in src/omnifocus/scripts/analytics/workflow-analysis-v3.ts using a figure ` +
+      `well below ${low.toLocaleString()} (leave headroom for insights/patterns/recommendations sharing the ` +
+      'same return payload), and record this measurement in docs/dev/SCRIPT_SIZE_LIMITS.md.',
+  );
+}
+
+binarySearch().catch((error) => {
+  console.error('Measurement run failed:', error);
+  process.exitCode = 1;
+});

--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -65,16 +65,26 @@ export const WORKFLOW_ANALYSIS_V3 = `
           // only protects the raw-record echo (currently unreachable in prod —
           // includeRawData is hardcoded false by OmniFocusAnalyzeTool — and
           // OMN-200 removed the old 1000-task cap that used to bound this array
-          // incidentally). The ~261KB figure is EXTRAPOLATED from the measured
-          // evaluateJavascript INPUT-size limit (EMPIRICAL_LIMITS.omniJsBridge
-          // in script-size-monitor.ts; SCRIPT_SIZE_LIMITS.md) — the return-path
-          // limit has not been separately measured. Count-capping is typical-case
-          // headroom, not a byte bound: ~330 bytes/record observed for a realistic
-          // task (id, name, project, tags, dates) → 500 records ≈ 165KB, but
-          // name/project/tags are unbounded strings. Add byte accounting before
-          // ever flipping includeRawData on.
+          // incidentally).
+          // OMN-233: byte accounting is now in place (RAW_DATA_BYTE_BUDGET
+          // below) — push is gated on BOTH the count cap and a running byte
+          // tally, since name/project/tags are unbounded strings and a
+          // count-only cap can't bound payload size. The budget itself is
+          // EXTRAPOLATED pending measurement: the ~261,124-char figure is the
+          // measured evaluateJavascript INPUT-size limit
+          // (EMPIRICAL_LIMITS.omniJsBridge in script-size-monitor.ts;
+          // SCRIPT_SIZE_LIMITS.md) — the RETURN-path limit (this payload flows
+          // FROM OmniJS back TO JXA, the opposite direction) has never been
+          // separately measured. Before ever flipping includeRawData on, run
+          // scripts/measure-bridge-return-limit.ts against live OmniFocus and
+          // replace RAW_DATA_BYTE_BUDGET with a measured figure.
           const MAX_RAW_DATA_TASKS = 500;
+          // Conservative fraction of the (unmeasured) ~261,124-char bridge
+          // ceiling, leaving headroom for insights/patterns/recommendations
+          // that share the same JSON.stringify() return payload.
+          const RAW_DATA_BYTE_BUDGET = 150000;
           let rawDataTaskCount = 0;
+          let rawDataBytesUsed = 0;
           const data = {
             tasks: [],
             tasksTruncated: false,
@@ -341,14 +351,16 @@ export const WORKFLOW_ANALYSIS_V3 = `
               });
 
               // Include task data if requested
-              // OMN-208: cap at push time so the OmniJS-side array never grows
-              // past MAX_RAW_DATA_TASKS, regardless of DB size. Counting past
-              // the cap (instead of stopping) lets data.tasksTruncated report
-              // an accurate "N more omitted" figure without re-scanning.
+              // OMN-208/OMN-233: cap at push time on BOTH the task-count cap
+              // and a running byte tally, so the OmniJS-side array never
+              // grows past MAX_RAW_DATA_TASKS or RAW_DATA_BYTE_BUDGET,
+              // regardless of DB size or record size. Counting past the cap
+              // (instead of stopping) lets data.tasksTruncated report an
+              // accurate "N more omitted" figure without re-scanning.
               if (includeRawData) {
                 rawDataTaskCount++;
-                if (rawDataTaskCount <= MAX_RAW_DATA_TASKS) {
-                  data.tasks.push({
+                if (!data.tasksTruncated) {
+                  const rawDataRecord = {
                     id: task.id.primaryKey || 'unknown',
                     name: task.name || 'Unnamed Task',
                     completed,
@@ -362,9 +374,17 @@ export const WORKFLOW_ANALYSIS_V3 = `
                     tags,
                     dueDate: dueDate ? dueDate.toISOString() : null,
                     deferDate: deferDate ? deferDate.toISOString() : null
-                  });
-                } else {
-                  data.tasksTruncated = true;
+                  };
+                  const rawDataRecordBytes = JSON.stringify(rawDataRecord).length;
+                  if (
+                    data.tasks.length < MAX_RAW_DATA_TASKS &&
+                    rawDataBytesUsed + rawDataRecordBytes <= RAW_DATA_BYTE_BUDGET
+                  ) {
+                    data.tasks.push(rawDataRecord);
+                    rawDataBytesUsed += rawDataRecordBytes;
+                  } else {
+                    data.tasksTruncated = true;
+                  }
                 }
               }
 
@@ -841,12 +861,14 @@ export const WORKFLOW_ANALYSIS_V3 = `
             deferralDetails: deferredTaskDetails.slice().sort(function(a, b) { return b.deferDays - a.deferDays; }).slice(0, 10)
           };
 
-          // OMN-208: surface how many raw records were omitted by the cap above.
-          // 0 when includeRawData is false (data.tasks was never populated) or
-          // when the population is within the cap. Keyed off tasksTruncated so
-          // this can't desync from the loop's cap comparison.
+          // OMN-208/OMN-233: surface how many raw records were omitted by the
+          // caps above (count cap OR byte budget, whichever hit first). 0 when
+          // includeRawData is false (data.tasks was never populated) or when
+          // the population is within both caps. Keyed off tasksTruncated and
+          // the actual pushed length — not a second independent cap
+          // comparison — so this can't desync from the loop's gating.
           data.tasksOmittedCount = data.tasksTruncated
-            ? rawDataTaskCount - MAX_RAW_DATA_TASKS
+            ? rawDataTaskCount - data.tasks.length
             : 0;
 
           return JSON.stringify({

--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -85,6 +85,20 @@ export const WORKFLOW_ANALYSIS_V3 = `
           const RAW_DATA_BYTE_BUDGET = 150000;
           let rawDataTaskCount = 0;
           let rawDataBytesUsed = 0;
+          // True UTF-8 byte length — JS String.length counts UTF-16 code units,
+          // undercounting CJK (3 bytes vs 1 unit) and astral emoji (4 vs 2).
+          // UTF-8 bytes >= UTF-16 units for every string, so this is conservative
+          // whichever unit the (unmeasured) bridge limit actually binds on.
+          // Code-point arithmetic: OmniJS has no TextEncoder/Buffer.
+          function utf8ByteLength(str) {
+            let bytes = 0;
+            for (let i = 0; i < str.length; i++) {
+              const cp = str.codePointAt(i);
+              if (cp > 0xffff) i++; // astral: consumed a surrogate pair
+              bytes += cp <= 0x7f ? 1 : cp <= 0x7ff ? 2 : cp <= 0xffff ? 3 : 4;
+            }
+            return bytes;
+          }
           const data = {
             tasks: [],
             tasksTruncated: false,
@@ -375,7 +389,7 @@ export const WORKFLOW_ANALYSIS_V3 = `
                     dueDate: dueDate ? dueDate.toISOString() : null,
                     deferDate: deferDate ? deferDate.toISOString() : null
                   };
-                  const rawDataRecordBytes = JSON.stringify(rawDataRecord).length;
+                  const rawDataRecordBytes = utf8ByteLength(JSON.stringify(rawDataRecord));
                   if (
                     data.tasks.length < MAX_RAW_DATA_TASKS &&
                     rawDataBytesUsed + rawDataRecordBytes <= RAW_DATA_BYTE_BUDGET

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -642,9 +642,11 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(source).toMatch(
         /data\.tasks\.length < MAX_RAW_DATA_TASKS &&\s*\n\s*rawDataBytesUsed \+ rawDataRecordBytes <= RAW_DATA_BYTE_BUDGET/,
       );
-      // The running byte tally is measured via JSON.stringify on the actual
-      // record shape that gets pushed, not an estimate.
-      expect(source).toMatch(/const rawDataRecordBytes = JSON\.stringify\(rawDataRecord\)\.length;/);
+      // The running byte tally measures true UTF-8 bytes of the actual record
+      // shape that gets pushed — NOT String.length, which counts UTF-16 code
+      // units and undercounts CJK/emoji names by 1.5-3x (gate-review finding).
+      expect(source).toMatch(/const rawDataRecordBytes = utf8ByteLength\(JSON\.stringify\(rawDataRecord\)\);/);
+      expect(source).toMatch(/function utf8ByteLength\(str\)/);
       // Once truncated, the loop stops building/measuring further records
       // (perf: avoid JSON.stringify on records we won't push).
       expect(source).toMatch(/if \(!data\.tasksTruncated\) {/);

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -613,13 +613,11 @@ describe('OmniFocusAnalyzeTool', () => {
       const source = fs.readFileSync('src/omnifocus/scripts/analytics/workflow-analysis-v3.ts', 'utf-8');
       // Cap constant exists and is a bounded few-hundred figure, not full-DB size.
       expect(source).toMatch(/const MAX_RAW_DATA_TASKS = 500;/);
-      // Push is gated on the running count vs the cap (cap-at-push, not slice-at-return).
-      expect(source).toMatch(/if \(rawDataTaskCount <= MAX_RAW_DATA_TASKS\)/);
-      // A truncation marker is set once the cap is exceeded, so a future consumer
+      // A truncation marker is set once a cap is exceeded, so a future consumer
       // of includeRawData can tell the raw slice is partial.
       expect(source).toMatch(/data\.tasksTruncated = true;/);
-      // Omitted-count is keyed off the truncation flag (not a second independent
-      // cap comparison), so the two can't desync.
+      // Omitted-count is keyed off the truncation flag and the actual pushed
+      // length (not a second independent cap comparison), so the two can't desync.
       expect(source).toMatch(/data\.tasksOmittedCount = data\.tasksTruncated/);
       // Critical invariant: the aggregate metrics loop must still iterate the FULL
       // population — only the raw data.tasks echo is capped. OMN-200 removed the
@@ -627,6 +625,36 @@ describe('OmniFocusAnalyzeTool', () => {
       // this cap must not reintroduce that regression.
       expect(source).toMatch(/const maxTasksToProcess = totalTasks;/);
       expect(source).not.toMatch(/maxTasksToProcess = MAX_RAW_DATA_TASKS/);
+    });
+
+    it('OMN-233: gates the raw data.tasks push on both a count cap and a byte budget', async () => {
+      const fs = await import('fs');
+      const source = fs.readFileSync('src/omnifocus/scripts/analytics/workflow-analysis-v3.ts', 'utf-8');
+      // Byte budget constant exists, is comfortably under the ~261,124-char
+      // measured OmniJS bridge INPUT limit (return-path unmeasured — see
+      // scripts/measure-bridge-return-limit.ts), and leaves headroom for the
+      // rest of the response payload (insights/patterns/recommendations).
+      expect(source).toMatch(/const RAW_DATA_BYTE_BUDGET = 150000;/);
+      // Push is gated on BOTH conditions: still under the count cap AND still
+      // under the byte budget. Neither cap alone is sufficient — count caps
+      // don't bound unbounded name/project/tags strings, and a byte-only cap
+      // could still admit an unbounded number of tiny records.
+      expect(source).toMatch(
+        /data\.tasks\.length < MAX_RAW_DATA_TASKS &&\s*\n\s*rawDataBytesUsed \+ rawDataRecordBytes <= RAW_DATA_BYTE_BUDGET/,
+      );
+      // The running byte tally is measured via JSON.stringify on the actual
+      // record shape that gets pushed, not an estimate.
+      expect(source).toMatch(/const rawDataRecordBytes = JSON\.stringify\(rawDataRecord\)\.length;/);
+      // Once truncated, the loop stops building/measuring further records
+      // (perf: avoid JSON.stringify on records we won't push).
+      expect(source).toMatch(/if \(!data\.tasksTruncated\) {/);
+      // Omitted-count must reflect whichever cap tripped first (count OR
+      // bytes) by diffing against the actual pushed length, not re-deriving
+      // from MAX_RAW_DATA_TASKS alone (which would be wrong when the byte
+      // budget truncates before the count cap does).
+      expect(source).toMatch(
+        /data\.tasksOmittedCount = data\.tasksTruncated\s*\n\s*\? rawDataTaskCount - data\.tasks\.length\s*\n\s*: 0;/,
+      );
     });
   });
 


### PR DESCRIPTION
## What

- Gates the `data.tasks` raw-record push in `workflow-analysis-v3.ts` on **both** the existing `MAX_RAW_DATA_TASKS = 500` count cap and a new `RAW_DATA_BYTE_BUDGET = 150000` running byte tally (measured via `JSON.stringify(record).length` at push time).
- `tasksTruncated`/`tasksOmittedCount` now reflect whichever cap trips first — omitted count is derived from the actual pushed length (`rawDataTaskCount - data.tasks.length`), not re-derived from the count constant alone, so it stays correct even when the byte budget truncates before the count cap would.
- Adds `scripts/measure-bridge-return-limit.ts`: binary-searches the actual `evaluateJavascript()` RETURN-path size limit (mirrors the INPUT-side method in `docs/dev/SCRIPT_SIZE_LIMITS.md`, applied to the opposite data-flow direction). **Not run** — needs live, unlocked OmniFocus; supervised manual run only.
- Updates `SCRIPT_SIZE_LIMITS.md` to flag that the documented ~261,124-char limit is INPUT-only, and point at the new script for the unmeasured return side.
- Extends the OMN-208 source-guard tests in `OmniFocusAnalyzeTool.test.ts` to pin the new budget constant, the dual-condition gating, and the updated omitted-count derivation.

## Why

Gate review on PR #178 flagged that `MAX_RAW_DATA_TASKS=500` was a count cap standing in for an unmeasured byte limit: records contain unbounded strings (`name`/`project`/`tags`), so 500 records can exceed the OmniJS bridge's return-path capacity even though the count looks conservative. The path is currently unreachable in production (`includeRawData` is hardcoded `false` in `OmniFocusAnalyzeTool.ts`), so this closes the gap before that flag is ever flipped on.

## Before enabling `includeRawData`

Run `scripts/measure-bridge-return-limit.ts` against live OmniFocus (supervised — see script header), then replace the extrapolated `RAW_DATA_BYTE_BUDGET` in `workflow-analysis-v3.ts` with a figure derived from the measurement, and update the accompanying comments / `SCRIPT_SIZE_LIMITS.md` entry.

## Test plan

- [x] `npm run build`
- [x] `npm run test:unit` — 152 files / 3606 tests passed
- [x] `npx prettier --write` on touched files
- [ ] `npm run test:integration` — not run (not required for this change; no integration surface touched)
- [ ] `scripts/measure-bridge-return-limit.ts` — intentionally NOT run (needs live OmniFocus, supervised)

Closes OMN-233

🤖 Generated with [Claude Code](https://claude.com/claude-code)