### PR TITLE
fix(OMN-237): type-check DETAIL_FIELDS/MINIMAL_FIELDS against OmniFocusTask

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -28,6 +28,7 @@ import { buildAST } from './builder.js';
 import { sanitizeForScriptComment } from './bridge-escape.js';
 import { emitFolderNotFoundGuardsForFilter } from './folder-path-match.js';
 import { ACTIONABLE_STATUSES } from './types.js';
+import type { OmniFocusTask } from '../../omnifocus/types.js';
 
 // =============================================================================
 // TYPES
@@ -90,6 +91,11 @@ export interface GeneratedScript {
  * alternative but rejected — it is redundant with the full `note` field in
  * DETAIL_FIELDS and contradicts the token-cost goal of the lean default.
  * `hasNote` answers "is there context?"; the client requests `note` if yes.
+ *
+ * OMN-237: `as const satisfies ReadonlyArray<keyof OmniFocusTask>` closes the
+ * same interface-drift class OMN-222/OMN-232 closed for TaskFieldEnum and
+ * MODE_INJECTED_FIELDS — a field added or renamed here without a matching
+ * OmniFocusTask member now fails the build instead of compiling green.
  */
 export const MINIMAL_FIELDS = [
   'id',
@@ -102,7 +108,7 @@ export const MINIMAL_FIELDS = [
   'project',
   'available',
   'hasNote',
-];
+] as const satisfies ReadonlyArray<keyof OmniFocusTask>;
 
 /**
  * Heavier fields gated behind details=true or explicit field selection.
@@ -115,6 +121,12 @@ export const MINIMAL_FIELDS = [
  *
  * Enforced by the parity test in
  * `tests/unit/architecture/schema-impl-parity.test.ts`.
+ *
+ * OMN-237: `as const satisfies ReadonlyArray<keyof OmniFocusTask>` — see
+ * MINIMAL_FIELDS above. This is also the compile-time guard that
+ * `effectivePlannedDate` (detail-gated via `details:true`) stays a real
+ * OmniFocusTask member; OMN-232 deliberately dropped a runtime stopgap pin
+ * for it in favor of this class of fix.
  */
 export const DETAIL_FIELDS = [
   'note',
@@ -139,12 +151,14 @@ export const DETAIL_FIELDS = [
   // (OMN-198/206). Cheap boolean; reachable via details:true (DETAIL, not the
   // thin MINIMAL default) — mirrors `sequential` in DETAIL_PROJECT_FIELDS.
   'sequential',
-];
+] as const satisfies ReadonlyArray<keyof OmniFocusTask>;
 
 /**
  * Full field set — union of MINIMAL + DETAIL. Preserves backward compatibility.
  */
-export const DEFAULT_FIELDS = [...MINIMAL_FIELDS, ...DETAIL_FIELDS];
+export const DEFAULT_FIELDS = [...MINIMAL_FIELDS, ...DETAIL_FIELDS] as const satisfies ReadonlyArray<
+  keyof OmniFocusTask
+>;
 
 /**
  * Maximum characters for truncated note content in thin-default responses.
@@ -185,8 +199,8 @@ export const DETAIL_PROJECT_FIELDS = [
  */
 export function resolveEffectiveTaskFields(userFields: string[] | undefined, details: boolean | undefined): string[] {
   if (userFields && userFields.length > 0) return userFields;
-  if (details) return DEFAULT_FIELDS;
-  return MINIMAL_FIELDS;
+  if (details) return [...DEFAULT_FIELDS];
+  return [...MINIMAL_FIELDS];
 }
 
 /**

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -1191,7 +1191,7 @@ describe('field set constants', () => {
   });
 
   it('MINIMAL_FIELDS and DETAIL_FIELDS do not overlap', () => {
-    const overlap = MINIMAL_FIELDS.filter((f) => DETAIL_FIELDS.includes(f));
+    const overlap = MINIMAL_FIELDS.filter((f) => (DETAIL_FIELDS as readonly string[]).includes(f));
     expect(overlap).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- `MINIMAL_FIELDS`, `DETAIL_FIELDS`, and `DEFAULT_FIELDS` in `src/contracts/ast/script-builder.ts` were plain string arrays, never checked against `keyof OmniFocusTask`. A field added or renamed there without a matching `OmniFocusTask` interface member compiled and tested green — the same interface-drift class OMN-222/OMN-232 closed for `TaskFieldEnum` and `MODE_INJECTED_FIELDS`, in a third location.
- Typed all three arrays `as const satisfies ReadonlyArray<keyof OmniFocusTask>`, mirroring OMN-232's pattern. `effectivePlannedDate` (detail-gated via `details:true`) is a real `OmniFocusTask` member, so it's now covered at compile time — closing the gap OMN-232 deliberately left by dropping its runtime stopgap pin.
- `resolveEffectiveTaskFields` now returns fresh mutable copies (`[...DEFAULT_FIELDS]` / `[...MINIMAL_FIELDS]`) since the source arrays are now readonly tuples; callers only ever reassign (never in-place mutate) so behavior is unchanged.
- One existing test (`MINIMAL_FIELDS and DETAIL_FIELDS do not overlap`) needed a `(DETAIL_FIELDS as readonly string[]).includes(f)` cast since the two tuples now have disjoint literal-union element types.

Closes OMN-237

## Test plan
- [x] RED: temporarily added a bogus field to `MINIMAL_FIELDS` and confirmed `npm run build` passed (proving the pre-fix arrays weren't type-checked) — see PR discussion/commit history for the demonstration, reverted before commit.
- [x] GREEN: re-added the bogus field after applying the `satisfies` fix and confirmed `npm run build` now fails with `TS2322`/`TS1360` at both `MINIMAL_FIELDS` and derived `DEFAULT_FIELDS` — reverted before commit.
- [x] `npm run build`
- [x] `npm run typecheck:test`
- [x] `npm run test:unit` (155 files / 3623 tests passed)