### PR TITLE
fix(OMN-238): replace fragile file:// direct-run guards in scripts/

### DIFF
--- a/scripts/diagnose-failures.ts
+++ b/scripts/diagnose-failures.ts
@@ -10,6 +10,7 @@
 import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
+import { isRunDirectly } from './lib/run-directly.js';
 import { parseFailureLog } from '../src/diagnostics/failure-log.js';
 import { clusterFailures, isIgnored } from '../src/diagnostics/clustering.js';
 import {
@@ -340,8 +341,7 @@ async function main(): Promise<void> {
 }
 
 // Guard: only run main() when this file is the direct entry point, not when imported by tests.
-// tsx preserves the .ts extension in import.meta.url, so match against the raw argv[1] path.
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isRunDirectly(import.meta.url)) {
   void main().catch((e: unknown) => {
     console.error('[diagnose-failures] fatal:', e);
     process.exit(1);

--- a/scripts/lib/run-directly.ts
+++ b/scripts/lib/run-directly.ts
@@ -15,10 +15,19 @@ import { pathToFileURL } from 'node:url';
 import { realpathSync } from 'node:fs';
 
 export function isRunDirectly(importMetaUrl: string): boolean {
-  if (!process.argv[1]) return false;
+  const entry = process.argv[1];
+  if (!entry) return false;
+  let resolved: string;
   try {
-    return importMetaUrl === pathToFileURL(realpathSync(process.argv[1])).href;
-  } catch {
-    return false;
+    resolved = realpathSync(entry);
+  } catch (err) {
+    // realpath can fail (dangling symlink, EACCES, virtual/bundled entry path).
+    // Fall back to comparing the unresolved path — deterministic like the old
+    // guard — instead of returning false, which would silently no-op a direct run.
+    console.error(
+      `[run-directly] realpathSync(${JSON.stringify(entry)}) failed (${String(err)}); comparing unresolved path`,
+    );
+    resolved = entry;
   }
+  return importMetaUrl === pathToFileURL(resolved).href;
 }

--- a/scripts/lib/run-directly.ts
+++ b/scripts/lib/run-directly.ts
@@ -1,0 +1,24 @@
+/**
+ * Robust "run directly, not imported" check (OMN-234 gate review; hoisted for
+ * OMN-238). The naive `import.meta.url === \`file://${argv[1]}\`` breaks on
+ * percent-encoded characters (spaces, non-ASCII) and symlinked paths, silently
+ * turning a direct run into an exit-0 no-op. `pathToFileURL` handles encoding;
+ * `realpathSync` resolves symlinks on the argv side.
+ *
+ * Canonical copy: also duplicated (with a pointer back here) in
+ * `tests/support/claude-code-mcp.ts` and `tests/support/gherkin-test-runner.ts`,
+ * and inlined in `scripts/measure-actual-script-sizes.js` (plain JS, can't
+ * import this TS module without a loader).
+ */
+
+import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+
+export function isRunDirectly(importMetaUrl: string): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return importMetaUrl === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/list-prompts.ts
+++ b/scripts/list-prompts.ts
@@ -7,6 +7,7 @@
 import { readdir, readFile, stat } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { isRunDirectly } from './lib/run-directly.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -414,6 +415,6 @@ async function main(): Promise<void> {
 }
 
 // Run the CLI
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isRunDirectly(import.meta.url)) {
   main().catch(console.error);
 }

--- a/scripts/measure-actual-script-sizes.js
+++ b/scripts/measure-actual-script-sizes.js
@@ -21,12 +21,21 @@ import { realpathSync } from 'node:fs';
  * plain JS run via `node`, not `tsx`, and can't import a `.ts` module.
  */
 function isRunDirectly(importMetaUrl) {
-  if (!process.argv[1]) return false;
+  const entry = process.argv[1];
+  if (!entry) return false;
+  let resolved;
   try {
-    return importMetaUrl === pathToFileURL(realpathSync(process.argv[1])).href;
-  } catch {
-    return false;
+    resolved = realpathSync(entry);
+  } catch (err) {
+    // realpath can fail (dangling symlink, EACCES, virtual/bundled entry path).
+    // Fall back to comparing the unresolved path — deterministic like the old
+    // guard — instead of returning false, which would silently no-op a direct run.
+    console.error(
+      `[run-directly] realpathSync(${JSON.stringify(entry)}) failed (${String(err)}); comparing unresolved path`,
+    );
+    resolved = entry;
   }
+  return importMetaUrl === pathToFileURL(resolved).href;
 }
 
 console.log('📏 Measuring Actual Script Sizes in Codebase\n');

--- a/scripts/measure-actual-script-sizes.js
+++ b/scripts/measure-actual-script-sizes.js
@@ -9,6 +9,25 @@
 
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+
+/**
+ * Robust "run directly, not imported" check (OMN-234 gate review; OMN-238).
+ * The naive `import.meta.url === \`file://${argv[1]}\`` breaks on
+ * percent-encoded characters (spaces, non-ASCII) and symlinked paths,
+ * silently turning a direct run into an exit-0 no-op. Copied inline here
+ * (canonical version: `scripts/lib/run-directly.ts`) because this file is
+ * plain JS run via `node`, not `tsx`, and can't import a `.ts` module.
+ */
+function isRunDirectly(importMetaUrl) {
+  if (!process.argv[1]) return false;
+  try {
+    return importMetaUrl === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}
 
 console.log('📏 Measuring Actual Script Sizes in Codebase\n');
 
@@ -241,6 +260,6 @@ async function analyzeScriptSizes() {
 }
 
 // Run the analysis
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isRunDirectly(import.meta.url)) {
   analyzeScriptSizes().catch(console.error);
 }

--- a/scripts/setup-real-llm-testing.ts
+++ b/scripts/setup-real-llm-testing.ts
@@ -8,6 +8,7 @@
 
 import { Ollama } from 'ollama';
 import { spawn } from 'child_process';
+import { isRunDirectly } from './lib/run-directly.js';
 
 interface TestModel {
   name: string;
@@ -247,6 +248,6 @@ async function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isRunDirectly(import.meta.url)) {
   main().catch(console.error);
 }

--- a/tests/support/claude-code-mcp.ts
+++ b/tests/support/claude-code-mcp.ts
@@ -328,14 +328,26 @@ async function runTest(): Promise<void> {
  * characters (spaces, non-ASCII) and symlinked paths, silently turning a
  * direct run into an exit-0 no-op. pathToFileURL handles encoding;
  * realpathSync resolves symlinks on the argv side.
+ *
+ * Duplicate of the canonical `scripts/lib/run-directly.ts` (kept local to avoid
+ * test-support importing from scripts/) — keep the logic in sync with it.
  */
 function isRunDirectly(): boolean {
-  if (!process.argv[1]) return false;
+  const entry = process.argv[1];
+  if (!entry) return false;
+  let resolved: string;
   try {
-    return import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
-  } catch {
-    return false;
+    resolved = realpathSync(entry);
+  } catch (err) {
+    // realpath can fail (dangling symlink, EACCES, virtual/bundled entry path).
+    // Fall back to comparing the unresolved path — deterministic like the old
+    // guard — instead of returning false, which would silently no-op a direct run.
+    console.error(
+      `[run-directly] realpathSync(${JSON.stringify(entry)}) failed (${String(err)}); comparing unresolved path`,
+    );
+    resolved = entry;
   }
+  return import.meta.url === pathToFileURL(resolved).href;
 }
 
 if (isRunDirectly()) {

--- a/tests/support/gherkin-test-runner.ts
+++ b/tests/support/gherkin-test-runner.ts
@@ -527,14 +527,26 @@ async function runTests(): Promise<void> {
  * characters (spaces, non-ASCII) and symlinked paths, silently turning a
  * direct run into an exit-0 no-op. pathToFileURL handles encoding;
  * realpathSync resolves symlinks on the argv side.
+ *
+ * Duplicate of the canonical `scripts/lib/run-directly.ts` (kept local to avoid
+ * test-support importing from scripts/) — keep the logic in sync with it.
  */
 function isRunDirectly(): boolean {
-  if (!process.argv[1]) return false;
+  const entry = process.argv[1];
+  if (!entry) return false;
+  let resolved: string;
   try {
-    return import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
-  } catch {
-    return false;
+    resolved = realpathSync(entry);
+  } catch (err) {
+    // realpath can fail (dangling symlink, EACCES, virtual/bundled entry path).
+    // Fall back to comparing the unresolved path — deterministic like the old
+    // guard — instead of returning false, which would silently no-op a direct run.
+    console.error(
+      `[run-directly] realpathSync(${JSON.stringify(entry)}) failed (${String(err)}); comparing unresolved path`,
+    );
+    resolved = entry;
   }
+  return import.meta.url === pathToFileURL(resolved).href;
 }
 
 if (isRunDirectly()) {


### PR DESCRIPTION
## Summary
- The naive `import.meta.url === \`file://${process.argv[1]}\`` direct-execution guard breaks on percent-encoded characters (spaces/non-ASCII) and symlinked paths — it silently no-ops instead of running. Flagged in the PR #185 (OMN-234) gate review, which fixed the two instances it introduced but left pre-existing ones in `scripts/`.
- Hoisted the robust `pathToFileURL(realpathSync(argv[1]))` comparison (already used in `tests/support/claude-code-mcp.ts` / `gherkin-test-runner.ts`) into `scripts/lib/run-directly.ts`, alongside the existing `scripts/lib/ollama-lifecycle.ts` / `suite-timing.ts` pattern.
- Wired it into the three affected TS scripts: `scripts/diagnose-failures.ts`, `scripts/list-prompts.ts`, `scripts/setup-real-llm-testing.ts`.
- `scripts/measure-actual-script-sizes.js` is plain JS run via `node` (not `tsx`), so it can't import a `.ts` module — the check is copied inline there with a comment pointing back at the canonical `scripts/lib/run-directly.ts`.
- Swept the whole repo (`grep -rn 'file://'`, excluding node_modules/dist) — confirmed no other live occurrences of the fragile idiom remain; the only other hits are doc-comment references describing the old pattern (in `tests/support/`, already fixed by #185, and in the new util's own docstring).

## Evidence
- **RED repro:** ran a symlinked script through a space-containing directory — old guard (`import.meta.url === \`file://${argv[1]}\``) returned `false` (silent no-op); new `isRunDirectly()` logic returned `true`.
- **Live direct-run smoke test** (before/after wiring), all executed correctly, no silent no-op:
  - `npx tsx scripts/list-prompts.ts --format=json` → printed prompt JSON
  - `npx tsx scripts/diagnose-failures.ts --help` → ran main()
  - `npx tsx scripts/setup-real-llm-testing.ts` → ran validate flow
  - `node scripts/measure-actual-script-sizes.js` → printed script-size report
- Gates (all green):
  - `npm run build` ✅
  - `npm run typecheck:test` ✅
  - `npm run test:unit` ✅ — 155 files / 3623 tests passed
- `npx prettier --write` on all touched files — no changes needed (already formatted).

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck:test`
- [x] `npm run test:unit`
- [x] Direct-run smoke test on each of the 4 touched scripts
- [x] Repo-wide grep confirms no remaining fragile `file://` guard instances

Closes OMN-238