### PR TITLE
refactor(OMN-241): projectFields returns honest ProjectedTask type

### DIFF
--- a/src/omnifocus/types.ts
+++ b/src/omnifocus/types.ts
@@ -46,3 +46,17 @@ export interface OmniFocusTask {
   reason?: 'overdue' | 'due_soon' | 'flagged' | null; // today mode — category the task was bucketed under
   daysOverdue?: number; // today mode — 0 when not overdue
 }
+
+/**
+ * OMN-241: honest type for the output of `projectFields()` in
+ * task-query-pipeline.ts. A projected task is a partial slice of
+ * OmniFocusTask — only `id` plus the caller-selected fields are
+ * guaranteed present. Previously projectFields() built this same
+ * shape (Partial<OmniFocusTask> & {id}) but cast it `as OmniFocusTask`,
+ * lying to the type system: downstream code could read any field as if
+ * it were always populated, with no compile-time signal that most
+ * fields are conditionally absent. Consumers that need specific fields
+ * beyond `id` must narrow (e.g. `if (task.name) ...`) or accept
+ * ProjectedTask and only touch fields they've checked.
+ */
+export type ProjectedTask = Partial<OmniFocusTask> & Pick<OmniFocusTask, 'id'>;

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -7,7 +7,7 @@
  * Used by OmniFocusReadTool (unified read path).
  */
 
-import type { OmniFocusTask } from '../../omnifocus/types.js';
+import type { OmniFocusTask, ProjectedTask } from '../../omnifocus/types.js';
 import type { TaskFilter } from '../../contracts/filters.js';
 import type { SortOption } from './filter-types.js';
 import type { TaskFieldEnum } from '../unified/schemas/read-schema.js';
@@ -302,16 +302,13 @@ export function sortTasks(tasks: OmniFocusTask[], sortOptions?: SortOption[]): O
  * Project task fields based on user selection for performance optimization.
  * Always includes 'id' if any fields are selected.
  */
-export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[]): OmniFocusTask[] {
+export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[]): (OmniFocusTask | ProjectedTask)[] {
   if (!selectedFields || selectedFields.length === 0) {
     return tasks;
   }
 
   return tasks.map((task) => {
-    const projectedTask: Partial<OmniFocusTask> = {};
-
-    // Always include id for task identity (even if not explicitly requested)
-    projectedTask.id = task.id;
+    const projectedTask: ProjectedTask = { id: task.id };
 
     selectedFields.forEach((field) => {
       if (field in task) {
@@ -327,7 +324,10 @@ export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[])
       }
     });
 
-    return projectedTask as OmniFocusTask;
+    // OMN-241: return the honest partial shape — no `as OmniFocusTask` cast.
+    // Callers that need a specific field beyond `id` must narrow (check
+    // presence) rather than assume it's always populated.
+    return projectedTask;
   });
 }
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -586,8 +586,11 @@ PERFORMANCE:
       metadata.flagged_count = counts.flaggedCount;
     }
 
-    // Project fields (after counting)
-    tasks = projectFields(tasks, compiled.fields);
+    // Project fields (after counting). OMN-241: projectFields() now returns the
+    // honest partial shape (OmniFocusTask | ProjectedTask), so this is a
+    // separate variable rather than reassigning `tasks` (which other code
+    // above relies on being OmniFocusTask[]).
+    const projectedTasks = projectFields(tasks, compiled.fields);
 
     // OMN-223: suppress the dashboard summary on narrow lookups, mirroring the
     // project side's rule. The id key is handled by the fast path above and
@@ -595,7 +598,7 @@ PERFORMANCE:
     // defense against future routing changes.
     const isNarrowLookup = isNarrowLookupFilter(filter);
 
-    return createTaskResponseV2('tasks', tasks, metadata, {
+    return createTaskResponseV2('tasks', projectedTasks, metadata, {
       population: totalMatched,
       offset: compiled.offset || 0,
       summary: !isNarrowLookup,

--- a/tests/unit/tools/tasks/task-query-pipeline.test.ts
+++ b/tests/unit/tools/tasks/task-query-pipeline.test.ts
@@ -633,6 +633,23 @@ describe('projectFields', () => {
     expect(result[0].effectivePlannedDate).toBeNull();
     expect(result[0].repetitionRule?.catchUpAutomatically).toBeNull();
   });
+
+  // OMN-241: type-level guard (compiled, never executed) pinning that
+  // projectFields()'s output is NOT assignable to full OmniFocusTask without
+  // narrowing. Mirrors the `_taskFieldsAreKnownKeys` compile-time-guard style
+  // above in task-query-pipeline.ts: a `// @ts-expect-error` here fails the
+  // build (via `npm run typecheck:test`) if projectFields() ever regresses to
+  // a blanket `as OmniFocusTask` cast, silently re-widening the return type.
+  it('type-level: projected output is not assignable to OmniFocusTask without narrowing', () => {
+    function _typeGuard(selected: ReturnType<typeof projectFields>) {
+      // @ts-expect-error - ProjectedTask (Partial<OmniFocusTask> & {id}) must
+      // NOT be assignable to OmniFocusTask: most fields are optional/absent.
+      const _fullTask: OmniFocusTask[] = selected;
+      void _fullTask;
+    }
+    void _typeGuard;
+    expect(true).toBe(true);
+  });
 });
 
 describe('scoreForSmartSuggest', () => {


### PR DESCRIPTION
Closes OMN-241

## Summary
`projectFields()` in `src/tools/tasks/task-query-pipeline.ts` built a `Partial<OmniFocusTask>` containing only `id` + caller-selected fields, then cast it `as OmniFocusTask` — lying to the type system so downstream code couldn't tell "field absent" from "field empty."

This PR (option 3 from the ticket — minimal honest type):

1. Adds `export type ProjectedTask = Partial<OmniFocusTask> & Pick<OmniFocusTask, 'id'>` next to `OmniFocusTask` in `src/omnifocus/types.ts`.
2. Changes `projectFields()` to return `(OmniFocusTask | ProjectedTask)[]` (still `OmniFocusTask[]` unchanged when no fields are selected) and removes the `as OmniFocusTask` cast.
3. Adds a compile-time type-level test (mirrors the OMN-222 `_taskFieldsAreKnownKeys` guard style) asserting `projectFields()`'s output is NOT assignable to `OmniFocusTask[]` without narrowing (`@ts-expect-error`, verified to actually trigger — removing it fails `typecheck:test`).

Built on top of PR #175 (OMN-222), which added the projected-only fields (`isProjectRoot`, `hasNote`, `plannedDate`, `repetitionRule`, mode-injected fields) to `OmniFocusTask` and closed the `as keyof` masking gap that fed into this cast. This PR closes the second half — the return-type cast itself.

## Compile-error audit (the actual scope-check for this refactor)

Removing the cast and rebuilding surfaced exactly **one** consumer that needed a change:

- **`OmniFocusReadTool.handleTaskQuery`** (`src/tools/unified/OmniFocusReadTool.ts`, ~line 590): reassigned the shared `let tasks` variable (typed `OmniFocusTask[]`, used earlier by `scoreForSmartSuggest`/`sortTasks`/`countTodayCategories`, which all require full `OmniFocusTask[]`) with the projection result. **Resolution:** introduced a separate `const projectedTasks = projectFields(tasks, compiled.fields)` binding instead of reassigning `tasks`, so upstream full-task consumers keep their `OmniFocusTask[]` type and only the final `createTaskResponseV2` call (generic over `<T>`, so it happily accepts the narrower type) receives the projected/possibly-partial rows.

The other three call sites (`executeIdLookup`, and the project-side `projectFieldsOnResult` used at the two remaining sites) already bound the result to a fresh local (`projectedTasks`) rather than reassigning a full-task variable, so they needed no change — `createTaskResponseV2`/`createListResponseV2` are generic and accept `ProjectedTask[]` directly.

No consumer needed widening to accept `ProjectedTask` while reading unrequested fields — none were found reading fields without a corresponding `fields:[...]` inclusion, so no behavior-masking bugs were surfaced by this audit.

## Explicitly out of scope
The `noteTruncated` flag on truncated project notes (touches OmniJS codegen) is intentionally excluded — will be split to a follow-up ticket by the orchestrator.

## Runtime behavior
No behavior change — same fields projected, same values, same JSON shape. This is a type-only refactor.

## Test evidence

```
npm run build            # tsc — clean
npm run typecheck:test   # tsc -p tsconfig.test.json --noEmit — clean
npm run test:unit        # 155 files / 3624 tests passed (was 3623; +1 new type-level test)
```

`npx prettier --write` run on all touched files (no changes needed — already formatted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)