### PR TITLE
fix(OMN-239): report partial rollback with orphaned item IDs instead of unconditional rolledBack:true

### DIFF
--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -1820,6 +1820,10 @@ SAFETY:
     if (options.atomicOperation && failedCount > 0) {
       const { rollbackFailures } = await this.rollbackBatchCreations(resolver);
       const cleanRollback = rollbackFailures.length === 0;
+      // OMN-239: creates happened either way — a clean rollback still performed
+      // creates+deletes, and a partial rollback leaves orphaned items in the DB.
+      // Either way stale read caches must not survive to their TTL.
+      this.invalidateBatchCaches(items, batchResults, resolver);
       return {
         success: false,
         created: 0,
@@ -2235,24 +2239,34 @@ SAFETY:
    * vs. which ones survived the "rollback" — silently swallowing the failure
    * (as before) let the batch response claim `rolledBack: true` while an
    * orphaned object sat in the database with no client-visible signal.
+   *
+   * execJson does NOT reject on a script-level failure — it resolves with a
+   * ScriptResult carrying `success: false` + an error. A bare try/catch around
+   * the call would only ever catch a thrown rejection (e.g. the osascript
+   * process itself failing to spawn) and would misclassify every in-band
+   * script error as a successful rollback. Both failure shapes are real and
+   * both must land in `rollbackFailures`.
    */
   private async rollbackBatchCreations(resolver: TempIdResolver): Promise<{
-    rolledBack: Array<{ type: 'project' | 'task'; realId: string }>;
     rollbackFailures: Array<{ type: 'project' | 'task'; realId: string; error: string }>;
   }> {
     const createdItems = resolver.getCreatedIds();
     this.logger.warn(`Rolling back ${createdItems.length} created items`);
 
-    const rolledBack: Array<{ type: 'project' | 'task'; realId: string }> = [];
     const rollbackFailures: Array<{ type: 'project' | 'task'; realId: string; error: string }> = [];
 
     for (let i = createdItems.length - 1; i >= 0; i--) {
       const item = createdItems[i];
       try {
         const generatedScript = await buildDeleteScript(item.type, item.realId);
-        await this.execJson(generatedScript.script, DeleteResultSchema);
-        this.logger.debug(`Rolled back ${item.type}: ${item.realId}`);
-        rolledBack.push({ type: item.type, realId: item.realId });
+        const result = await this.execJson(generatedScript.script, DeleteResultSchema);
+        if (isScriptError(result)) {
+          const errorMessage = typeof result.error === 'string' ? result.error : 'Rollback delete script failed';
+          this.logger.error(`Failed to rollback ${item.type} ${item.realId}: ${errorMessage}`);
+          rollbackFailures.push({ type: item.type, realId: item.realId, error: errorMessage });
+        } else {
+          this.logger.debug(`Rolled back ${item.type}: ${item.realId}`);
+        }
       } catch (error) {
         this.logger.error(`Failed to rollback ${item.type} ${item.realId}:`, error);
         rollbackFailures.push({
@@ -2263,7 +2277,7 @@ SAFETY:
       }
     }
 
-    return { rolledBack, rollbackFailures };
+    return { rollbackFailures };
   }
 
   private validateTagManageParams(

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -144,6 +144,9 @@ BATCH OPERATIONS:
 - createSequentially: true (respects dependencies)
 - returnMapping: true (returns tempId → realId map)
 - stopOnError: true (halt on first failure)
+- atomicOperation: false (best-effort rollback of prior creations if any fail; if a
+  compensating delete itself fails, the response reports rolledBack: "partial" plus a
+  rollbackFailures list of orphaned items — never assume a clean undo without checking)
 - Example with subtasks:
   { "mutation": { "operation": "batch", "operations": [
     { "operation": "create", "target": "task", "data": { "name": "Parent", "tempId": "p1", "project": "My Project" } },
@@ -1636,18 +1639,40 @@ SAFETY:
       // operation:'unknown'/error:'undefined'. The halt/rollback itself is a
       // compact phase-level error; errors[] is reserved for that shape.
       if (createResult.success === false && createResult.rolledBack) {
-        // Successes were undone by the rollback — mark them so the flattened
-        // rows don't claim surviving creates.
+        // OMN-239: a compensating delete can itself fail — that item is still
+        // sitting in OmniFocus, not "rolled back". Only mark a success row as
+        // undone when its rollback delete actually succeeded; orphaned items
+        // stay `success: true` with a warning so the client can see and clean
+        // them up, instead of being lied to about a clean rollback.
+        const orphanedRealIds = new Set((createResult.rollbackFailures ?? []).map((f) => f.realId));
         results.created.push({
           ...createResult,
-          results: createResult.results.map((r) =>
-            r.success ? { ...r, success: false, error: 'Created, then rolled back (atomicOperation)' } : r,
-          ),
+          results: createResult.results.map((r) => {
+            if (!r.success) return r;
+            if (r.realId && orphanedRealIds.has(r.realId)) {
+              return {
+                ...r,
+                warnings: [
+                  ...(r.warnings ?? []),
+                  'Rollback delete failed: this item was NOT removed and may be orphaned in OmniFocus',
+                ],
+              };
+            }
+            return { ...r, success: false, error: 'Created, then rolled back (atomicOperation)' };
+          }),
         });
-        results.errors.push({
-          phase: 'create',
-          error: `Atomic batch rolled back: ${createResult.failed} of ${createResult.totalItems} creates failed; all created items were removed`,
-        });
+        if (createResult.rolledBack === 'partial') {
+          const orphanList = (createResult.rollbackFailures ?? []).map((f) => `${f.type}:${f.realId}`).join(', ');
+          results.errors.push({
+            phase: 'create',
+            error: `Atomic batch rollback PARTIALLY failed: ${createResult.failed} of ${createResult.totalItems} creates failed; ${createResult.rollbackFailures?.length ?? 0} created item(s) could NOT be removed and remain in OmniFocus (orphaned): ${orphanList}`,
+          });
+        } else {
+          results.errors.push({
+            phase: 'create',
+            error: `Atomic batch rolled back: ${createResult.failed} of ${createResult.totalItems} creates failed; all created items were removed`,
+          });
+        }
         if (compiled.stopOnError) hadError = true;
       } else if (createResult.failed > 0 && compiled.stopOnError) {
         results.created.push(createResult);
@@ -1743,7 +1768,10 @@ SAFETY:
     totalItems: number;
     results: BatchItemCreationResult[];
     mapping?: Record<string, string>;
-    rolledBack?: boolean;
+    /** OMN-239: `true` only when every compensating delete succeeded; `'partial'` when at least one failed. */
+    rolledBack?: boolean | 'partial';
+    /** OMN-239: present only when `rolledBack === 'partial'` — items that survived the rollback attempt. */
+    rollbackFailures?: Array<{ type: 'project' | 'task'; realId: string; error: string }>;
   }> {
     const resolver = new TempIdResolver();
     const batchResults: BatchItemCreationResult[] = [];
@@ -1790,14 +1818,16 @@ SAFETY:
     // Step 5: Handle atomic operation rollback if needed
     const failedCount = resolver.getFailedCount();
     if (options.atomicOperation && failedCount > 0) {
-      await this.rollbackBatchCreations(resolver);
+      const { rollbackFailures } = await this.rollbackBatchCreations(resolver);
+      const cleanRollback = rollbackFailures.length === 0;
       return {
         success: false,
         created: 0,
         failed: failedCount,
         totalItems: items.length,
         results: batchResults,
-        rolledBack: true,
+        rolledBack: cleanRollback ? true : 'partial',
+        ...(cleanRollback ? {} : { rollbackFailures }),
       };
     }
 
@@ -2199,10 +2229,22 @@ SAFETY:
 
   /**
    * Rollback all created items in reverse order (children first, parents last).
+   *
+   * OMN-239: a compensating delete can itself fail, leaving the item orphaned
+   * in OmniFocus. Callers must know exactly which items were actually removed
+   * vs. which ones survived the "rollback" — silently swallowing the failure
+   * (as before) let the batch response claim `rolledBack: true` while an
+   * orphaned object sat in the database with no client-visible signal.
    */
-  private async rollbackBatchCreations(resolver: TempIdResolver): Promise<void> {
+  private async rollbackBatchCreations(resolver: TempIdResolver): Promise<{
+    rolledBack: Array<{ type: 'project' | 'task'; realId: string }>;
+    rollbackFailures: Array<{ type: 'project' | 'task'; realId: string; error: string }>;
+  }> {
     const createdItems = resolver.getCreatedIds();
     this.logger.warn(`Rolling back ${createdItems.length} created items`);
+
+    const rolledBack: Array<{ type: 'project' | 'task'; realId: string }> = [];
+    const rollbackFailures: Array<{ type: 'project' | 'task'; realId: string; error: string }> = [];
 
     for (let i = createdItems.length - 1; i >= 0; i--) {
       const item = createdItems[i];
@@ -2210,10 +2252,18 @@ SAFETY:
         const generatedScript = await buildDeleteScript(item.type, item.realId);
         await this.execJson(generatedScript.script, DeleteResultSchema);
         this.logger.debug(`Rolled back ${item.type}: ${item.realId}`);
+        rolledBack.push({ type: item.type, realId: item.realId });
       } catch (error) {
         this.logger.error(`Failed to rollback ${item.type} ${item.realId}:`, error);
+        rollbackFailures.push({
+          type: item.type,
+          realId: item.realId,
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     }
+
+    return { rolledBack, rollbackFailures };
   }
 
   private validateTagManageParams(

--- a/src/tools/unified/schemas/batch-schemas.ts
+++ b/src/tools/unified/schemas/batch-schemas.ts
@@ -47,7 +47,11 @@ export const BatchCreateSchema = z.object({
   atomicOperation: coerceBoolean()
     .optional()
     .default(false)
-    .describe('Rollback all creations if any fail (default: false)'),
+    .describe(
+      'Best-effort rollback of prior creations if any fail (default: false). ' +
+        'If a compensating delete itself fails, the response reports rolledBack: "partial" ' +
+        'plus a rollbackFailures list of orphaned items — check for it rather than assuming a clean undo.',
+    ),
 
   returnMapping: coerceBoolean().optional().default(true).describe('Return tempId -> realId mapping (default: true)'),
 

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -1073,6 +1073,123 @@ describe('OmniFocusWriteTool task operations', () => {
       buildSpy.mockRestore();
     });
 
+    it('OMN-239: a delete failure mid-rollback reports partial rollback with orphaned item IDs, not unconditional success', async () => {
+      const buildSpy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+        script: 'mock batch script',
+        operation: 'create',
+        target: 'task',
+        description: 'mock',
+      });
+      // Call 1: batch create — t1 and t2 succeed, t3 fails (triggers atomic rollback).
+      // Rollback runs in reverse creation order: t2's delete first, then t1's.
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: 'real-2', success: true },
+              { tempId: 't3', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        // Rollback delete for t2 fails — it stays orphaned in OmniFocus.
+        .mockRejectedValueOnce(new Error('Delete failed: item is locked'))
+        // Rollback delete for t1 succeeds.
+        .mockResolvedValueOnce({ success: true, data: {} });
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: true,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+            { operation: 'create', target: 'task', data: { tempId: 't3', name: 'C', parentTaskId: 'MISSING' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      const items = result.data.results as Array<Record<string, unknown>>;
+
+      // t2's delete failed — it must NOT be reported as a successfully-undone
+      // create (that would lie about an orphaned object). It must remain
+      // visibly flagged so the client can surface/clean it up.
+      const orphaned = items.find((r) => r.tempId === 't2');
+      expect(orphaned).toBeDefined();
+      expect(orphaned!.success).toBe(true);
+      expect(String((orphaned as { warnings?: string[] }).warnings)).toMatch(
+        /orphan|not (?:be )?remov|rollback.*fail/i,
+      );
+
+      // t1's delete succeeded — it's genuinely rolled back.
+      const undone = items.find((r) => r.tempId === 't1');
+      expect(undone).toBeDefined();
+      expect(undone!.success).toBe(false);
+      expect(String(undone!.error)).toContain('rolled back');
+
+      // The phase-level error must not claim a clean, full rollback, and must
+      // name the orphaned item so it's actionable.
+      const rollbackError = items.find(
+        (r) => r.operation === 'create' && r.id === null && !('tempId' in r) && typeof r.error === 'string',
+      );
+      expect(rollbackError).toBeDefined();
+      expect(String(rollbackError!.error)).not.toMatch(/^Atomic batch rolled back:/);
+      expect(String(rollbackError!.error)).toContain('real-2');
+      buildSpy.mockRestore();
+    });
+
+    it('OMN-239 control: when every rollback delete succeeds, the batch still reports a full clean rollback', async () => {
+      const buildSpy = vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+        script: 'mock batch script',
+        operation: 'create',
+        target: 'task',
+        description: 'mock',
+      });
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        .mockResolvedValue({ success: true, data: {} });
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: true,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B', parentTaskId: 'MISSING' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      const items = result.data.results as Array<Record<string, unknown>>;
+      const undone = items.find((r) => r.tempId === 't1');
+      expect(undone!.success).toBe(false);
+      expect(String(undone!.error)).toContain('rolled back');
+      // No orphan warnings anywhere — the rollback was clean.
+      expect(items.some((r) => JSON.stringify((r as { warnings?: string[] }).warnings ?? '').match(/orphan/i))).toBe(
+        false,
+      );
+      const rollbackError = items.find(
+        (r) => r.operation === 'create' && r.id === null && !('tempId' in r) && typeof r.error === 'string',
+      );
+      expect(String(rollbackError!.error)).toContain('Atomic batch rolled back:');
+      buildSpy.mockRestore();
+    });
+
     it('slow path: batch task create passes repetitionRule to the builder with NO second script', async () => {
       // repetitionRule on an item forces the per-item path; the rule must ride
       // the create script itself (applyRepetitionRuleSilently is gone).

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -1228,6 +1228,169 @@ describe('OmniFocusWriteTool task operations', () => {
     });
   });
 
+  describe('OMN-239: batch create atomicOperation rollback honesty', () => {
+    // All-task batch → fast path: ONE create script call, then (on failure) one
+    // buildDeleteScript + execJson round-trip per successfully-created item.
+    // Response shape is FLATTENED (batch-response-flatten.ts): per-item create
+    // rows plus one phase-level error row — there is no top-level `errors` array
+    // and rolledBack/rollbackFailures never appear directly in the response, so
+    // assertions below read the per-item warning and the phase-level error string.
+    function mockFastPathCreate() {
+      return vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+        script: 'mock batch script',
+        operation: 'create',
+        target: 'task',
+        description: 'mock',
+      });
+    }
+
+    it('resolved script-error rollback delete is reported as orphaned, not silently treated as rolled back (execJson does not reject on in-band failure)', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+      const deleteSpy = vi.spyOn(scriptBuilder, 'buildDeleteScript').mockResolvedValue({
+        script: 'mock delete script',
+        operation: 'delete',
+        target: 'task',
+        description: 'mock',
+      });
+
+      execJsonSpy
+        // Step 4: batch create — t1 succeeds, t2 fails
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        // Step 5 rollback: compensating delete for real-1 RESOLVES with an
+        // in-band script error (not a thrown rejection) — this is the shape
+        // execJson actually returns on script-level failure.
+        .mockResolvedValueOnce(createScriptError('Task is locked', 'delete'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: false,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      const rows = result.data.results as Array<Record<string, unknown>>;
+
+      // real-1 survived the failed compensating delete — it must stay success:true
+      // with a loud orphan warning, NOT be silently counted as cleanly rolled back.
+      const orphanRow = rows.find((r) => r.tempId === 't1');
+      expect(orphanRow?.success).toBe(true);
+      expect(orphanRow?.warnings).toEqual(expect.arrayContaining([expect.stringContaining('orphaned')]));
+
+      // Phase-level error names the PARTIAL failure and the specific orphaned id.
+      const phaseError = rows.find((r) => r.operation === 'create' && r.id === null && !('tempId' in r));
+      expect(phaseError?.error).toContain('PARTIALLY failed');
+      expect(phaseError?.error).toContain('real-1');
+
+      buildBatchSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+
+    it('thrown rejection from the compensating delete is also reported as orphaned (both failure modes handled)', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+      const deleteSpy = vi.spyOn(scriptBuilder, 'buildDeleteScript').mockResolvedValue({
+        script: 'mock delete script',
+        operation: 'delete',
+        target: 'task',
+        description: 'mock',
+      });
+
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        // This time the delete call itself throws (e.g. osascript spawn failure).
+        .mockRejectedValueOnce(new Error('osascript ENOENT'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: false,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      const rows = result.data.results as Array<Record<string, unknown>>;
+      const orphanRow = rows.find((r) => r.tempId === 't1');
+      expect(orphanRow?.success).toBe(true);
+      expect(orphanRow?.warnings).toEqual(expect.arrayContaining([expect.stringContaining('orphaned')]));
+      const phaseError = rows.find((r) => r.operation === 'create' && r.id === null && !('tempId' in r));
+      expect(phaseError?.error).toContain('PARTIALLY failed');
+      expect(phaseError?.error).toContain('real-1');
+
+      buildBatchSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+
+    it('invalidates caches on the partial-rollback path (creates + compensating deletes touched the DB either way)', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+      const deleteSpy = vi.spyOn(scriptBuilder, 'buildDeleteScript').mockResolvedValue({
+        script: 'mock delete script',
+        operation: 'delete',
+        target: 'task',
+        description: 'mock',
+      });
+
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        // Clean rollback this time — delete succeeds.
+        .mockResolvedValueOnce(createScriptSuccess({ taskId: 'real-1', deleted: true }));
+
+      await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: false,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      });
+
+      expect(mockCache.invalidateTaskQueries).toHaveBeenCalledWith(['today', 'inbox']);
+      expect(mockCache.invalidate).toHaveBeenCalledWith('analytics');
+
+      buildBatchSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+  });
+
   describe('project complete', () => {
     it('completes a project via buildCompleteScript and invalidates cache', async () => {
       // Clean AST envelope — no inner `success` key (spec §2.3)


### PR DESCRIPTION
Closes OMN-239

## Summary
`rollbackBatchCreations()` in `OmniFocusWriteTool.ts` used to try/catch each compensating delete during atomic batch-create rollback and only log failures — the batch response then reported `rolledBack: true` unconditionally, even if a delete failed and left an orphaned object in OmniFocus with no client-visible signal.

- `rollbackBatchCreations` now returns `{ rolledBack: Array<{type, realId}>, rollbackFailures: Array<{type, realId, error}> }` instead of `void`.
- `executeBatchCreates`'s response `rolledBack` field is now `boolean | 'partial'`: `true` only when every compensating delete succeeded, `'partial'` when at least one failed — plus a `rollbackFailures` array in that case.
- In the batch-create response builder, per-item rows that survived a failed rollback delete stay `success: true` (they still exist in OmniFocus) with a warning flagging them as orphaned, rather than being falsely marked as rolled back. The phase-level error message names the orphaned `type:realId` pairs.
- When every delete succeeds, behavior is unchanged (`rolledBack: true`, all successes marked undone).
- Updated the `atomicOperation` description in both the Zod schema (`batch-schemas.ts`) and the write tool's user-facing description string to document the best-effort/partial-rollback semantics honestly (dual-schema rule in CLAUDE.md — the hand-crafted `inputSchema` carries no field descriptions for batch flags today, so no change needed there).

## Test plan
- [x] TDD: added a RED test (delete fails mid-rollback → orphaned item must stay `success:true` with a warning, phase error must not claim a clean rollback and must name the orphaned real ID) plus a control test (all deletes succeed → unchanged `rolledBack: true` behavior). Confirmed RED before implementing.
- [x] `npm run build` — passes
- [x] `npm run typecheck:test` — passes
- [x] `npm run test:unit` — 155 files / 3625 tests passed
- [ ] `npm run test:integration` — not run per task instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)