### PR TITLE
feat(OMN-243): top-level orphanedItems on partial-rollback batch responses

### DIFF
--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -102,6 +102,12 @@ interface BatchItemCreationResult {
   warnings?: string[];
 }
 
+/** OMN-243: orphan summary attached to batch responses when rolledBack === 'partial'. */
+interface BatchOrphanedItems {
+  count: number;
+  ids: Array<{ type: 'project' | 'task'; realId: string }>;
+}
+
 export class OmniFocusWriteTool extends BaseTool<typeof WriteSchema, unknown> {
   name = 'omnifocus_write';
   description = `Create, update, complete, or delete OmniFocus tasks and projects.
@@ -1506,7 +1512,7 @@ SAFETY:
     let tempIdMapping: Record<string, string> = {};
     let createdCount = 0;
     let hadError = false;
-    let orphanedItems: { count: number; ids: Array<{ type: 'project' | 'task'; realId: string }> } | undefined;
+    let orphanedItems: BatchOrphanedItems | undefined;
 
     // Phase 1: Creates (inline batch create with hierarchy support)
     if (createOps.length > 0 && !hadError) {
@@ -1627,12 +1633,12 @@ SAFETY:
      *  distinguish "nothing persisted, safe to retry" from "some items persisted,
      *  retrying the whole batch will duplicate them" without digging into
      *  per-item warnings. */
-    orphanedItems?: { count: number; ids: Array<{ type: 'project' | 'task'; realId: string }> };
+    orphanedItems?: BatchOrphanedItems;
   }> {
     let tempIdMapping: Record<string, string> = {};
     let createdCount = 0;
     let hadError = false;
-    let orphanedItems: { count: number; ids: Array<{ type: 'project' | 'task'; realId: string }> } | undefined;
+    let orphanedItems: BatchOrphanedItems | undefined;
 
     try {
       let autoTempIdCounter = 0;

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -146,7 +146,10 @@ BATCH OPERATIONS:
 - stopOnError: true (halt on first failure)
 - atomicOperation: false (best-effort rollback of prior creations if any fail; if a
   compensating delete itself fails, the response reports rolledBack: "partial" plus a
-  rollbackFailures list of orphaned items — never assume a clean undo without checking)
+  rollbackFailures list of orphaned items — never assume a clean undo without checking.
+  A top-level data.orphanedItems { count, ids } also appears on the batch response in
+  that case — check it before retrying the whole batch, or you will duplicate the
+  items that already persisted)
 - Example with subtasks:
   { "mutation": { "operation": "batch", "operations": [
     { "operation": "create", "target": "task", "data": { "name": "Parent", "tempId": "p1", "project": "My Project" } },
@@ -1506,6 +1509,7 @@ SAFETY:
     let tempIdMapping: Record<string, string> = {};
     let createdCount = 0;
     let hadError = false;
+    let orphanedItems: { count: number; ids: Array<{ type: 'project' | 'task'; realId: string }> } | undefined;
 
     // Phase 1: Creates (inline batch create with hierarchy support)
     if (createOps.length > 0 && !hadError) {
@@ -1513,6 +1517,7 @@ SAFETY:
       createdCount = createPhase.createdCount;
       tempIdMapping = createPhase.tempIdMapping;
       hadError = createPhase.hadError;
+      orphanedItems = createPhase.orphanedItems;
     }
 
     // Phase 2-4: Updates, completes, deletes — route through inline handlers
@@ -1557,6 +1562,7 @@ SAFETY:
         },
         results: flattenBatchResults(results),
         ...(Object.keys(tempIdMapping).length > 0 ? { tempIdMapping } : {}),
+        ...(orphanedItems ? { orphanedItems } : {}),
       },
       metadata: {
         operation: 'batch',
@@ -1603,10 +1609,21 @@ SAFETY:
     createOps: Extract<CompiledMutation, { operation: 'batch' }>['operations'],
     compiled: Extract<CompiledMutation, { operation: 'batch' }>,
     results: { created: unknown[]; errors: unknown[] },
-  ): Promise<{ createdCount: number; tempIdMapping: Record<string, string>; hadError: boolean }> {
+  ): Promise<{
+    createdCount: number;
+    tempIdMapping: Record<string, string>;
+    hadError: boolean;
+    /** OMN-243: present only when the atomic rollback was partial — items still
+     *  sitting in OmniFocus after a failed compensating delete. Lets a caller
+     *  distinguish "nothing persisted, safe to retry" from "some items persisted,
+     *  retrying the whole batch will duplicate them" without digging into
+     *  per-item warnings. */
+    orphanedItems?: { count: number; ids: Array<{ type: 'project' | 'task'; realId: string }> };
+  }> {
     let tempIdMapping: Record<string, string> = {};
     let createdCount = 0;
     let hadError = false;
+    let orphanedItems: { count: number; ids: Array<{ type: 'project' | 'task'; realId: string }> } | undefined;
 
     try {
       let autoTempIdCounter = 0;
@@ -1663,9 +1680,18 @@ SAFETY:
         });
         if (createResult.rolledBack === 'partial') {
           const orphanList = (createResult.rollbackFailures ?? []).map((f) => `${f.type}:${f.realId}`).join(', ');
+          const orphanCount = createResult.rollbackFailures?.length ?? 0;
+          // OMN-243: surface the orphan situation to the batch phase caller so it
+          // can land at the TOP LEVEL of the batch response (data.orphanedItems) —
+          // a caller checking only top-level success/created must not conclude
+          // "nothing persisted" and retry the whole batch, duplicating these items.
+          orphanedItems = {
+            count: orphanCount,
+            ids: (createResult.rollbackFailures ?? []).map((f) => ({ type: f.type, realId: f.realId })),
+          };
           results.errors.push({
             phase: 'create',
-            error: `Atomic batch rollback PARTIALLY failed: ${createResult.failed} of ${createResult.totalItems} creates failed; ${createResult.rollbackFailures?.length ?? 0} created item(s) could NOT be removed and remain in OmniFocus (orphaned): ${orphanList}`,
+            error: `ORPHANED: ${orphanCount} created item(s) could NOT be removed and remain in OmniFocus: ${orphanList}. Atomic batch rollback PARTIALLY failed: ${createResult.failed} of ${createResult.totalItems} creates failed.`,
           });
         } else {
           results.errors.push({
@@ -1702,7 +1728,7 @@ SAFETY:
       if (compiled.stopOnError) hadError = true;
     }
 
-    return { createdCount, tempIdMapping, hadError };
+    return { createdCount, tempIdMapping, hadError, orphanedItems };
   }
 
   /**

--- a/src/tools/unified/schemas/batch-schemas.ts
+++ b/src/tools/unified/schemas/batch-schemas.ts
@@ -50,7 +50,9 @@ export const BatchCreateSchema = z.object({
     .describe(
       'Best-effort rollback of prior creations if any fail (default: false). ' +
         'If a compensating delete itself fails, the response reports rolledBack: "partial" ' +
-        'plus a rollbackFailures list of orphaned items — check for it rather than assuming a clean undo.',
+        'plus a rollbackFailures list of orphaned items — check for it rather than assuming a clean undo. ' +
+        'A top-level data.orphanedItems { count, ids } also appears in that case — check it before ' +
+        'retrying the whole batch, or you will duplicate items that already persisted.',
     ),
 
   returnMapping: coerceBoolean().optional().default(true).describe('Return tempId -> realId mapping (default: true)'),

--- a/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusWriteTool.test.ts
@@ -1391,6 +1391,180 @@ describe('OmniFocusWriteTool task operations', () => {
     });
   });
 
+  describe('OMN-243: top-level orphanedItems on partial-rollback batch responses', () => {
+    function mockFastPathCreate() {
+      return vi.spyOn(scriptBuilder, 'buildBatchCreateTasksScript').mockResolvedValue({
+        script: 'mock batch script',
+        operation: 'create',
+        target: 'task',
+        description: 'mock',
+      });
+    }
+
+    it('partial rollback surfaces a top-level orphanedItems count + ids so callers do not retry and duplicate', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+      const deleteSpy = vi.spyOn(scriptBuilder, 'buildDeleteScript').mockResolvedValue({
+        script: 'mock delete script',
+        operation: 'delete',
+        target: 'task',
+        description: 'mock',
+      });
+
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        // Compensating delete for real-1 fails in-band (script-error shape) — orphaned.
+        .mockResolvedValueOnce(createScriptError('Task is locked', 'delete'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: false,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.data.summary.created).toBe(0);
+      expect(result.data.orphanedItems).toBeDefined();
+      expect(result.data.orphanedItems.count).toBe(1);
+      expect(result.data.orphanedItems.ids).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'task', realId: 'real-1' })]),
+      );
+
+      buildBatchSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+
+    it('control: a clean rollback (rolledBack: true) does NOT carry a top-level orphanedItems field', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+      const deleteSpy = vi.spyOn(scriptBuilder, 'buildDeleteScript').mockResolvedValue({
+        script: 'mock delete script',
+        operation: 'delete',
+        target: 'task',
+        description: 'mock',
+      });
+
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        // Compensating delete succeeds — clean rollback, nothing orphaned.
+        .mockResolvedValueOnce(createScriptSuccess({ taskId: 'real-1', deleted: true }));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: false,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect('orphanedItems' in result.data).toBe(false);
+
+      buildBatchSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+
+    it('control: a non-atomic batch failure does NOT carry a top-level orphanedItems field', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+
+      execJsonSpy.mockResolvedValueOnce({
+        success: true,
+        data: {
+          results: [
+            { tempId: 't1', taskId: 'real-1', success: true },
+            { tempId: 't2', taskId: null, success: false, error: 'boom' },
+          ],
+        },
+      });
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: false,
+          stopOnError: true,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect('orphanedItems' in result.data).toBe(false);
+
+      buildBatchSpy.mockRestore();
+    });
+
+    it('phase-level error message leads with the orphan warning as its first sentence', async () => {
+      const buildBatchSpy = mockFastPathCreate();
+      const deleteSpy = vi.spyOn(scriptBuilder, 'buildDeleteScript').mockResolvedValue({
+        script: 'mock delete script',
+        operation: 'delete',
+        target: 'task',
+        description: 'mock',
+      });
+
+      execJsonSpy
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            results: [
+              { tempId: 't1', taskId: 'real-1', success: true },
+              { tempId: 't2', taskId: null, success: false, error: 'boom' },
+            ],
+          },
+        })
+        .mockResolvedValueOnce(createScriptError('Task is locked', 'delete'));
+
+      const result = (await tool.execute({
+        mutation: {
+          operation: 'batch',
+          target: 'task',
+          atomicOperation: true,
+          stopOnError: false,
+          operations: [
+            { operation: 'create', target: 'task', data: { tempId: 't1', name: 'A' } },
+            { operation: 'create', target: 'task', data: { tempId: 't2', name: 'B' } },
+          ],
+        },
+      })) as any;
+
+      const rows = result.data.results as Array<Record<string, unknown>>;
+      const phaseError = rows.find((r) => r.operation === 'create' && r.id === null && !('tempId' in r));
+      expect(String(phaseError?.error)).toMatch(/^orphan/i);
+
+      buildBatchSpy.mockRestore();
+      deleteSpy.mockRestore();
+    });
+  });
+
   describe('project complete', () => {
     it('completes a project via buildCompleteScript and invalidates cache', async () => {
       // Clean AST envelope — no inner `success` key (spec §2.3)


### PR DESCRIPTION
Closes OMN-243

## Summary
Building on OMN-239 (PR #192): when an atomic batch create fails and the compensating rollback delete ALSO fails, the response reports top-level `success: false` / `created: 0` — but items that couldn't be deleted are still honestly reported as `success: true` deep in `data.results[].warnings`. A caller checking only top-level `success`/`created` would conclude nothing persisted and retry the whole batch, duplicating the orphaned items.

This PR adds a **top-level `data.orphanedItems`** field to the batch response:

- Present **only** when `rolledBack === 'partial'`: `{ count: number, ids: Array<{ type: 'project'|'task', realId: string }> }`, derived from the existing `rollbackFailures` computed in `executeBatchCreatePhase`.
- **Absent** when rollback is clean (`rolledBack: true`) or the batch isn't atomic — existing response shapes stay byte-identical (verified by two control tests).
- The phase-level error message (`data.results[].error` for the phase-level row) now leads with the orphan warning as its **first sentence** (`ORPHANED: N created item(s)...`) instead of burying it after the "PARTIALLY failed" clause.
- Docs: extended the `atomicOperation` Zod description in `batch-schemas.ts` and the tool description string in `OmniFocusWriteTool.ts` to mention the new top-level signal.
- `inputSchema` (hand-crafted MCP advertisement): verified `atomicOperation` is still bare `{ type: 'boolean' }` with no per-field description, same as after OMN-239 — no change needed there.

## Test plan
- [x] TDD: added a new describe block "OMN-243: top-level orphanedItems on partial-rollback batch responses" in `tests/unit/tools/unified/OmniFocusWriteTool.test.ts` with 4 tests (RED confirmed before implementation — 2 of 4 initially failed on the missing field / message ordering, 2 controls passed immediately since the field was absent by default).
- [x] `npm run build` — passes
- [x] `npm run typecheck:test` — passes
- [x] `npm run test:unit` — 156 files / 3694 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)