### PR TITLE
feat(OMN-242): emit noteTruncated flag when project note truncation fires

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -1373,8 +1373,10 @@ function generateProjectFieldProjection(fields: string[], context?: { noteTrunca
         break;
       case 'note':
         if (noteTruncateLength && noteTruncateLength > 0) {
+          // OMN-242: signal truncation via a sibling flag, only emitted when it
+          // actually fired, so responses stay byte-identical for the common case.
           projections.push(
-            `note: (() => { const n = project.note || ""; return n.length > ${noteTruncateLength} ? n.substring(0, ${noteTruncateLength}) + "..." : n; })()`,
+            `...(() => { const n = project.note || ""; const truncated = n.length > ${noteTruncateLength}; return truncated ? { note: n.substring(0, ${noteTruncateLength}) + "...", noteTruncated: true } : { note: n }; })()`,
           );
         } else {
           projections.push('note: project.note || ""');

--- a/src/contracts/responses.ts
+++ b/src/contracts/responses.ts
@@ -122,6 +122,8 @@ export interface ProjectData {
   effectivePlannedDate?: string | null;
   completionDate?: string | null;
   note?: string;
+  /** OMN-242: present (true) only when `note` was truncated to `noteTruncateLength`; absent otherwise */
+  noteTruncated?: boolean;
   sequential?: boolean;
   reviewInterval?: number | null;
   lastReviewed?: string | null;

--- a/src/omnifocus/response-schemas/read.ts
+++ b/src/omnifocus/response-schemas/read.ts
@@ -134,6 +134,10 @@ export const ProjectRowSchema = z
     status: z.string().optional(),
     flagged: z.boolean().optional(),
     note: z.string().optional(),
+    // OMN-242: sibling flag emitted alongside `note` ONLY when truncation
+    // actually fired at runtime (n.length > noteTruncateLength). Not its own
+    // switch case — piggybacks on the 'note' case in generateProjectFieldProjection.
+    noteTruncated: z.boolean().optional(),
     dueDate: isoDateOrNull.optional(),
     deferDate: isoDateOrNull.optional(),
     folder: z.string().nullable().optional(),

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -333,7 +333,7 @@ FILTER OPERATORS:
 RESPONSE CONTROL:
 - Default returns minimal fields (id, name, flagged, completed, dueDate, deferDate, tags, project, available, hasNote)
 - details: true returns all fields with full notes
-- fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true)
+- fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true; projects only: a truncated note carries a sibling noteTruncated: true — absent when the note was returned in full)
 - ID lookup always returns all fields with full notes
 - fields are type-specific; requesting a field of the other type (e.g. reviewInterval on tasks) returns a guided error
 - fields (tasks): id, name, completed, flagged, blocked, available, hasNote, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox, sequential

--- a/tests/unit/contracts/ast/script-builder.test.ts
+++ b/tests/unit/contracts/ast/script-builder.test.ts
@@ -1370,6 +1370,55 @@ describe('note truncation in project field projection', () => {
   });
 });
 
+// OMN-242: `note` alone can't distinguish "short note" from "silently truncated
+// note" — the projected object needs a sibling flag that only appears when
+// truncation actually fired at runtime.
+describe('OMN-242: noteTruncated flag on project note truncation', () => {
+  it('emits runtime logic that adds noteTruncated:true only on the truncated branch', () => {
+    const result = buildFilteredProjectsScript(
+      {},
+      {
+        fields: ['id', 'note'],
+        noteTruncateLength: 200,
+      },
+    );
+
+    const inner = recoverInnerProgram(result.script);
+    // Truncation is a runtime decision (depends on each project's actual note
+    // length), so the emitted script must branch: truncated notes carry the
+    // flag, the else branch (untruncated, even though a limit is configured)
+    // does not.
+    expect(inner).toContain('noteTruncated: true');
+    expect(inner).toContain('truncated = n.length > 200');
+    expect(inner).toMatch(
+      /truncated \? \{ note: n\.substring\(0, 200\) \+ "\.\.\.", noteTruncated: true \} : \{ note: n \}/,
+    );
+  });
+
+  it('does not emit noteTruncated at all when noteTruncateLength is not set', () => {
+    const result = buildFilteredProjectsScript(
+      {},
+      {
+        fields: ['id', 'note'],
+      },
+    );
+
+    expect(recoverInnerProgram(result.script)).not.toContain('noteTruncated');
+  });
+
+  it('does not emit noteTruncated when noteTruncateLength is 0', () => {
+    const result = buildFilteredProjectsScript(
+      {},
+      {
+        fields: ['id', 'note'],
+        noteTruncateLength: 0,
+      },
+    );
+
+    expect(recoverInnerProgram(result.script)).not.toContain('noteTruncated');
+  });
+});
+
 // =============================================================================
 // PREAMBLE AND WARNING ASSEMBLY TESTS
 // =============================================================================

--- a/tests/unit/omnifocus/projection-parity.test.ts
+++ b/tests/unit/omnifocus/projection-parity.test.ts
@@ -80,7 +80,7 @@ describe('TaskRowSchema ↔ generateFieldProjection switch-case parity', () => {
 // ---------------------------------------------------------------------------
 
 describe('ProjectRowSchema ↔ generateProjectFieldProjection switch-case parity', () => {
-  it('switch case labels are a subset of ProjectRowSchema.shape; difference is exactly {taskCounts, nextTask, stats}', () => {
+  it('switch case labels are a subset of ProjectRowSchema.shape; difference is exactly {taskCounts, nextTask, stats, noteTruncated}', () => {
     // Slice: from `function generateProjectFieldProjection` to the next top-level function
     const slice = sliceBetweenFunctions(
       scriptBuilderSrc,
@@ -97,8 +97,10 @@ describe('ProjectRowSchema ↔ generateProjectFieldProjection switch-case parity
       `Switch has labels not in ProjectRowSchema.shape: ${missingFromSchema.join(', ')}`,
     ).toEqual([]);
 
-    // The difference (schema keys NOT in the switch) must be exactly these three
-    const expectedExtra = new Set(['taskCounts', 'nextTask', 'stats']);
+    // The difference (schema keys NOT in the switch) must be exactly these four.
+    // noteTruncated (OMN-242) piggybacks on the 'note' case rather than being
+    // its own switch label — it's emitted conditionally within that case body.
+    const expectedExtra = new Set(['taskCounts', 'nextTask', 'stats', 'noteTruncated']);
     const actualExtra = new Set([...schemaKeys].filter((k) => !switchLabels.has(k)));
 
     expect(actualExtra).toEqual(expectedExtra);


### PR DESCRIPTION
Closes OMN-242

## Summary
- `generateProjectFieldProjection()` (`src/contracts/ast/script-builder.ts`) previously truncated a project's `note` field silently when `noteTruncateLength` was set — a consumer couldn't distinguish "short note" from "truncated note".
- The emitted OmniJS `note` case now branches at runtime on `n.length > noteTruncateLength`: when truncation actually fires, the projected object gets `note` (truncated) **and** `noteTruncated: true`. When it doesn't fire (short note, or no limit configured), the object gets only `note` — no `noteTruncated` key at all, so untruncated responses stay byte-identical.
- `ProjectData` (`src/contracts/responses.ts`) gains `noteTruncated?: boolean`.
- `ProjectRowSchema` (`src/omnifocus/response-schemas/read.ts`, `.strict()`) gains `noteTruncated: z.boolean().optional()` — without this the new key would be rejected outright, since `.strict()` closes the key set.
- `OmniFocusReadTool`'s user-facing description line for `fields: [...]` now documents the flag (inputSchema itself is unchanged — this isn't a request parameter, only new output shape).

## ⚠️ OmniJS codegen — reviewers please gate HIGH
This touches the OmniJS text this repo generates and hands to `evaluateJavascript`, not just TypeScript. The truncation decision is now a runtime branch inside the emitted script (per-project note length), not a build-time branch — please double check the emitted object-literal spread (`...(() => {...})()`) reads correctly as valid OmniJS and that the `.strict()` schema widening is the only schema change needed.

## Test evidence
- TDD: added `describe('OMN-242: noteTruncated flag on project note truncation')` in `tests/unit/contracts/ast/script-builder.test.ts`. Confirmed RED first (stashed the script-builder.ts change, ran the new tests, 1 failed as expected on the flag assertion), then restored the implementation and confirmed GREEN.
- Updated `tests/unit/omnifocus/projection-parity.test.ts`: `noteTruncated` is a schema key with no matching switch-case label (it piggybacks on the existing `'note'` case), so the parity test's expected "extra" key set grows from `{taskCounts, nextTask, stats}` to include `noteTruncated`.
- Three gates, all green:
  - `npm run build` — passes
  - `npm run typecheck:test` — passes
  - `npm run test:unit` — 156 files / 3693 tests passed

## Judgment calls
- Only the **project** projection got the flag, per ticket scope — task note truncation (`generateFieldProjection`) has the same silent-truncation shape but was explicitly out of scope here; flagging in case a follow-up ticket is wanted.
- Used object-spread (`...(() => {...})()`) rather than a flat ternary because the flag's presence needs to be conditional on the key itself (absent vs. present), not just its value — this pattern already exists elsewhere in `script-builder.ts` (search `limited: false` for a prior example) so it's an established idiom here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)