### PR TITLE
test: semantic agreement pins for divergent-parallel-paths (available, count-parity, inbox defaults)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,8 @@ multiple machines or sessions).
 - Before merge, **stop and have Kip run `/code-review`** (user-invoked slash command → main-loop Opus); gate the merge
   on a Safe/Approved verdict. Do **not** dispatch a `superpowers:code-reviewer` subagent — `/code-review` can't be
   model-dispatched, and a `~/.claude` hook blocks the old reviewer (which would also run on the pinned Sonnet model).
-- Merge via `gh pr merge --squash --auto` — never `--admin`.
+- Merge via `gh pr merge --squash` after Kip's explicit per-PR go-ahead — never `--admin`. The repo has auto-merge
+  disabled, so `--auto` fails with "Auto merge is not allowed"; wait for CI green, then merge plainly.
 - `git pull --rebase` before `git push` (work spans multiple machines/sessions).
 
 ## Debugging & Investigation

--- a/tests/unit/contracts/ast/filter-projection-agreement.test.ts
+++ b/tests/unit/contracts/ast/filter-projection-agreement.test.ts
@@ -18,7 +18,6 @@
  * 3. inbox ⟺ list agreement on the shared default exclusions.
  */
 
-import * as vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import {
   buildFilteredTasksScript,
@@ -27,98 +26,8 @@ import {
 } from '../../../../src/contracts/ast/script-builder.js';
 import type { TaskFilter } from '../../../../src/contracts/filters.js';
 import { ACTIONABLE_STATUSES } from '../../../../src/contracts/ast/types.js';
-
-// ─── Sandbox stubs ───────────────────────────────────────────────────────────
-
-// Full status enum — the generated scripts reference these via property access.
-const Task = {
-  Status: {
-    Available: 'Available',
-    Blocked: 'Blocked',
-    Completed: 'Completed',
-    Dropped: 'Dropped',
-    DueSoon: 'DueSoon',
-    Next: 'Next',
-    Overdue: 'Overdue',
-  },
-} as const;
-
-type StatusName = keyof typeof Task.Status;
-
-interface StubTask {
-  id: { primaryKey: string };
-  name: string;
-  flagged: boolean;
-  completed: boolean;
-  taskStatus: string;
-  inInbox: boolean;
-  tags: unknown[];
-  dueDate: null;
-  deferDate: null;
-  containingProject: null;
-  project: null | { name: string };
-}
-
-function stubTask(name: string, overrides: Partial<StubTask> = {}): StubTask {
-  return {
-    id: { primaryKey: `id-${name}` },
-    name,
-    flagged: false,
-    completed: false,
-    taskStatus: Task.Status.Available,
-    inInbox: false,
-    tags: [],
-    dueDate: null,
-    deferDate: null,
-    containingProject: null,
-    project: null, // non-null = project root (OMN-153)
-    ...overrides,
-  };
-}
-
-/** Run a generated LIST/INBOX script (raw OmniJS IIFE) against stub collections. */
-function runListScript(
-  script: string,
-  tasks: StubTask[],
-): { tasks: Array<Record<string, unknown>>; count: number; total_matched: number } {
-  const sandbox: Record<string, unknown> = {
-    flattenedTasks: tasks,
-    inbox: tasks.filter((t) => t.inInbox),
-    Task,
-    JSON,
-    Date,
-  };
-  return JSON.parse(vm.runInNewContext(script, sandbox) as string) as {
-    tasks: Array<Record<string, unknown>>;
-    count: number;
-    total_matched: number;
-  };
-}
-
-/**
- * Run a generated COUNT script. Unlike the list script, count is JXA-wrapped:
- * `Application('OmniFocus').evaluateJavascript(<omnijs source>)`. The stub
- * routes evaluateJavascript back into the same sandbox, so the test exercises
- * the real bridge shape rather than fishing the inner source out with a regex.
- */
-function runCountScript(script: string, tasks: StubTask[]): { count: number; error?: boolean; message?: string } {
-  const sandbox: Record<string, unknown> = {
-    flattenedTasks: tasks,
-    inbox: tasks.filter((t) => t.inInbox),
-    Task,
-    JSON,
-    Date,
-  };
-  const context = vm.createContext(sandbox);
-  sandbox.Application = () => ({
-    evaluateJavascript: (src: string) => vm.runInContext(src, context),
-  });
-  return JSON.parse(vm.runInContext(script, context) as string) as {
-    count: number;
-    error?: boolean;
-    message?: string;
-  };
-}
+import { Task, stubTask, runListScript, runCountScript } from './omnijs-vm-fixture.js';
+import type { StubTask, StatusName } from './omnijs-vm-fixture.js';
 
 function ids(rows: Array<Record<string, unknown>>): string[] {
   return rows.map((r) => String(r.id)).sort();

--- a/tests/unit/contracts/ast/filter-projection-agreement.test.ts
+++ b/tests/unit/contracts/ast/filter-projection-agreement.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Divergent-parallel-paths agreement pins.
+ *
+ * One conceptual property emitted by two independent generators is a recurring
+ * defect class in this repo (OMN-130 available filter vs projection; OMN-52
+ * countOnly vs list defaults; OMN-153 export-path root leak). String tests on
+ * each side can both pass while the SEMANTICS diverge — these tests execute the
+ * generated OmniJS in node:vm and assert the two paths AGREE on the same rows,
+ * so a one-sided regression (a literal replacing the shared constant, an extra
+ * condition on one side, a default applied in only one builder) fails here even
+ * when every per-side string pin still passes.
+ *
+ * 1. available: WHERE (filter predicate) ⟺ SELECT (projected value) agreement
+ *    across the full Task.Status matrix.
+ * 2. list ⟺ count agreement: buildTaskCountScript counts exactly the rows
+ *    buildFilteredTasksScript matches, across a matrix of filters, including
+ *    the auto-injected completed/dropped/project-root defaults.
+ * 3. inbox ⟺ list agreement on the shared default exclusions.
+ */
+
+import * as vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import {
+  buildFilteredTasksScript,
+  buildInboxScript,
+  buildTaskCountScript,
+} from '../../../../src/contracts/ast/script-builder.js';
+import type { TaskFilter } from '../../../../src/contracts/filters.js';
+import { ACTIONABLE_STATUSES } from '../../../../src/contracts/ast/types.js';
+
+// ─── Sandbox stubs ───────────────────────────────────────────────────────────
+
+// Full status enum — the generated scripts reference these via property access.
+const Task = {
+  Status: {
+    Available: 'Available',
+    Blocked: 'Blocked',
+    Completed: 'Completed',
+    Dropped: 'Dropped',
+    DueSoon: 'DueSoon',
+    Next: 'Next',
+    Overdue: 'Overdue',
+  },
+} as const;
+
+type StatusName = keyof typeof Task.Status;
+
+interface StubTask {
+  id: { primaryKey: string };
+  name: string;
+  flagged: boolean;
+  completed: boolean;
+  taskStatus: string;
+  inInbox: boolean;
+  tags: unknown[];
+  dueDate: null;
+  deferDate: null;
+  containingProject: null;
+  project: null | { name: string };
+}
+
+function stubTask(name: string, overrides: Partial<StubTask> = {}): StubTask {
+  return {
+    id: { primaryKey: `id-${name}` },
+    name,
+    flagged: false,
+    completed: false,
+    taskStatus: Task.Status.Available,
+    inInbox: false,
+    tags: [],
+    dueDate: null,
+    deferDate: null,
+    containingProject: null,
+    project: null, // non-null = project root (OMN-153)
+    ...overrides,
+  };
+}
+
+/** Run a generated LIST/INBOX script (raw OmniJS IIFE) against stub collections. */
+function runListScript(
+  script: string,
+  tasks: StubTask[],
+): { tasks: Array<Record<string, unknown>>; count: number; total_matched: number } {
+  const sandbox: Record<string, unknown> = {
+    flattenedTasks: tasks,
+    inbox: tasks.filter((t) => t.inInbox),
+    Task,
+    JSON,
+    Date,
+  };
+  return JSON.parse(vm.runInNewContext(script, sandbox) as string) as {
+    tasks: Array<Record<string, unknown>>;
+    count: number;
+    total_matched: number;
+  };
+}
+
+/**
+ * Run a generated COUNT script. Unlike the list script, count is JXA-wrapped:
+ * `Application('OmniFocus').evaluateJavascript(<omnijs source>)`. The stub
+ * routes evaluateJavascript back into the same sandbox, so the test exercises
+ * the real bridge shape rather than fishing the inner source out with a regex.
+ */
+function runCountScript(script: string, tasks: StubTask[]): { count: number; error?: boolean; message?: string } {
+  const sandbox: Record<string, unknown> = {
+    flattenedTasks: tasks,
+    inbox: tasks.filter((t) => t.inInbox),
+    Task,
+    JSON,
+    Date,
+  };
+  const context = vm.createContext(sandbox);
+  sandbox.Application = () => ({
+    evaluateJavascript: (src: string) => vm.runInContext(src, context),
+  });
+  return JSON.parse(vm.runInContext(script, context) as string) as {
+    count: number;
+    error?: boolean;
+    message?: string;
+  };
+}
+
+function ids(rows: Array<Record<string, unknown>>): string[] {
+  return rows.map((r) => String(r.id)).sort();
+}
+
+// ─── 1. available: WHERE ⟺ SELECT agreement ────────────────────────────────
+
+describe('available: filter predicate agrees with projected value (OMN-130 divergence class)', () => {
+  // One task per status — the full matrix, so any status the two sides
+  // classify differently produces a disagreement here.
+  const statusMatrix: StubTask[] = (Object.keys(Task.Status) as StatusName[]).map((s) =>
+    stubTask(`status-${s}`, {
+      taskStatus: Task.Status[s],
+      completed: s === 'Completed',
+    }),
+  );
+
+  it('filters {available:true} returns exactly the rows whose projected available is true', () => {
+    const filtered = runListScript(
+      buildFilteredTasksScript({ available: true }, { fields: ['id', 'available'] }).script,
+      statusMatrix,
+    );
+    const unfiltered = runListScript(
+      buildFilteredTasksScript({}, { fields: ['id', 'available'] }).script,
+      statusMatrix,
+    );
+
+    const projectedAvailable = ids(unfiltered.tasks.filter((t) => t.available === true));
+    expect(ids(filtered.tasks)).toEqual(projectedAvailable);
+    // Non-vacuity floor: the agreement must be over a non-trivial split.
+    expect(filtered.tasks.length).toBeGreaterThan(0);
+    expect(filtered.tasks.length).toBeLessThan(unfiltered.tasks.length);
+  });
+
+  it('filters {available:false} returns exactly the rows whose projected available is false', () => {
+    const filtered = runListScript(
+      buildFilteredTasksScript({ available: false }, { fields: ['id', 'available'] }).script,
+      statusMatrix,
+    );
+    const unfiltered = runListScript(
+      buildFilteredTasksScript({}, { fields: ['id', 'available'] }).script,
+      statusMatrix,
+    );
+
+    const projectedUnavailable = ids(unfiltered.tasks.filter((t) => t.available === false));
+    expect(ids(filtered.tasks)).toEqual(projectedUnavailable);
+    expect(filtered.tasks.length).toBeGreaterThan(0);
+  });
+
+  it('projected available per status matches ACTIONABLE_STATUSES membership', () => {
+    const actionable = new Set(ACTIONABLE_STATUSES.map((s) => s.replace('Task.Status.', '')));
+    const result = runListScript(
+      buildFilteredTasksScript({}, { fields: ['id', 'name', 'available'] }).script,
+      statusMatrix,
+    );
+    // Completed/Dropped rows are excluded by the shared defaults (asserted in
+    // section 3); every VISIBLE row's projected value must track membership.
+    expect(result.tasks.length).toBeGreaterThan(0);
+    for (const row of result.tasks) {
+      const status = String(row.name).replace('status-', '');
+      expect({ status, available: row.available }).toEqual({
+        status,
+        available: actionable.has(status),
+      });
+    }
+  });
+});
+
+// ─── 2. list ⟺ count agreement ──────────────────────────────────────────────
+
+describe('count script agrees with list script (OMN-52 countOnly-parity class)', () => {
+  const mixedSet: StubTask[] = [
+    stubTask('active-a'),
+    stubTask('active-b', { flagged: true }),
+    stubTask('overdue', { taskStatus: Task.Status.Overdue, flagged: true }),
+    stubTask('blocked', { taskStatus: Task.Status.Blocked }),
+    stubTask('completed', { taskStatus: Task.Status.Completed, completed: true }),
+    stubTask('dropped', { taskStatus: Task.Status.Dropped }),
+    stubTask('root', { project: { name: 'SomeProject' } }),
+    stubTask('inboxed', { inInbox: true }),
+  ];
+
+  const filterMatrix: Array<{ label: string; filter: TaskFilter }> = [
+    { label: 'empty filter (all defaults active)', filter: {} },
+    { label: 'flagged', filter: { flagged: true } },
+    { label: 'available:true', filter: { available: true } },
+    { label: 'includeProjectRoot:true', filter: { includeProjectRoot: true } },
+    { label: 'inInbox:true', filter: { inInbox: true } },
+  ];
+
+  for (const { label, filter } of filterMatrix) {
+    it(`count === list total_matched for ${label}`, () => {
+      const list = runListScript(buildFilteredTasksScript(filter, { fields: ['id'] }).script, mixedSet);
+      const count = runCountScript(buildTaskCountScript(filter).script, mixedSet);
+      expect(count.error).toBeUndefined();
+      expect(count.count).toBe(list.total_matched);
+    });
+  }
+
+  it('the matrix is non-degenerate: at least two filters produce different counts', () => {
+    // Guards the agreement suite itself against a stub set where every filter
+    // matches the same rows (agreement would then be vacuously easy).
+    const counts = filterMatrix.map(
+      ({ filter }) => runCountScript(buildTaskCountScript(filter).script, mixedSet).count,
+    );
+    expect(new Set(counts).size).toBeGreaterThan(1);
+  });
+});
+
+// ─── 3. inbox ⟺ list agreement on shared defaults ──────────────────────────
+
+describe('inbox script applies the same default exclusions as the list script (OMN-157 class)', () => {
+  const inboxSet: StubTask[] = [
+    stubTask('in-active', { inInbox: true }),
+    stubTask('in-dropped', { inInbox: true, taskStatus: Task.Status.Dropped }),
+    stubTask('in-completed', { inInbox: true, taskStatus: Task.Status.Completed, completed: true }),
+    stubTask('not-inbox'),
+  ];
+
+  it('buildInboxScript excludes dropped and completed rows by default', () => {
+    const result = runListScript(buildInboxScript({}, { fields: ['id', 'name'] }).script, inboxSet);
+    expect(ids(result.tasks)).toEqual(['id-in-active']);
+  });
+
+  it('buildInboxScript returns the same rows as buildFilteredTasksScript({inInbox:true})', () => {
+    const viaInbox = runListScript(buildInboxScript({}, { fields: ['id'] }).script, inboxSet);
+    const viaList = runListScript(buildFilteredTasksScript({ inInbox: true }, { fields: ['id'] }).script, inboxSet);
+    expect(ids(viaInbox.tasks)).toEqual(ids(viaList.tasks));
+  });
+});

--- a/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
+++ b/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
@@ -94,7 +94,7 @@ describe('OMN-130 Change 1: TaskRowSchema accepts hasNote', () => {
 // =============================================================================
 
 describe('OMN-130 Change 1: VM behavioral — hasNote projection', () => {
-  // Stub Task.Status for the OMN-157 dropped-exclusion predicate
+  // Task.Status comes from the shared omnijs-vm-fixture — extend it THERE, not locally
   const makeTask = (name: string, note: string | null, taskStatus: string = Task.Status.Available) =>
     stubTask(name, { note, taskStatus });
   const runScript = runListScript;

--- a/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
+++ b/tests/unit/contracts/ast/omn-130-read-honesty.test.ts
@@ -16,8 +16,8 @@
  * artifact — not just the script text.
  */
 
-import * as vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
+import { Task, stubTask, runListScript } from './omnijs-vm-fixture.js';
 import { buildFilteredTasksScript, MINIMAL_FIELDS } from '../../../../src/contracts/ast/script-builder.js';
 import { TaskFieldEnum } from '../../../../src/tools/unified/schemas/read-schema.js';
 import { TaskRowSchema } from '../../../../src/omnifocus/script-response-schemas.js';
@@ -95,40 +95,9 @@ describe('OMN-130 Change 1: TaskRowSchema accepts hasNote', () => {
 
 describe('OMN-130 Change 1: VM behavioral — hasNote projection', () => {
   // Stub Task.Status for the OMN-157 dropped-exclusion predicate
-  const Task = {
-    Status: {
-      Dropped: 'Dropped',
-      Available: 'Available',
-      Blocked: 'Blocked',
-      DueSoon: 'DueSoon',
-      Next: 'Next',
-      Overdue: 'Overdue',
-    },
-  };
-
-  function makeTask(name: string, note: string | null, taskStatus = Task.Status.Available) {
-    return {
-      id: { primaryKey: `id-${name}` },
-      name,
-      flagged: false,
-      completed: false,
-      taskStatus,
-      inInbox: false,
-      tags: [],
-      dueDate: null,
-      deferDate: null,
-      containingProject: null,
-      project: null,
-      note,
-    };
-  }
-
-  function runScript(script: string, tasks: unknown[]): { tasks: Array<Record<string, unknown>> } {
-    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
-    return JSON.parse(vm.runInNewContext(script, sandbox) as string) as {
-      tasks: Array<Record<string, unknown>>;
-    };
-  }
+  const makeTask = (name: string, note: string | null, taskStatus: string = Task.Status.Available) =>
+    stubTask(name, { note, taskStatus });
+  const runScript = runListScript;
 
   it('hasNote is true when task has a non-empty note', () => {
     const tasks = [makeTask('alpha', 'some context here')];
@@ -214,40 +183,8 @@ describe('OMN-130 Change 3: available projection emits 4-status membership check
 // =============================================================================
 
 describe('OMN-130 Change 3: VM behavioral — available reflects 4-status set', () => {
-  const Task = {
-    Status: {
-      Dropped: 'Dropped',
-      Available: 'Available',
-      Blocked: 'Blocked',
-      DueSoon: 'DueSoon',
-      Next: 'Next',
-      Overdue: 'Overdue',
-    },
-  };
-
-  function makeTask(name: string, taskStatus: string) {
-    return {
-      id: { primaryKey: `id-${name}` },
-      name,
-      flagged: false,
-      completed: false,
-      taskStatus,
-      inInbox: false,
-      tags: [],
-      dueDate: null,
-      deferDate: null,
-      containingProject: null,
-      project: null,
-      note: null,
-    };
-  }
-
-  function runScript(script: string, tasks: unknown[]): { tasks: Array<Record<string, unknown>> } {
-    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
-    return JSON.parse(vm.runInNewContext(script, sandbox) as string) as {
-      tasks: Array<Record<string, unknown>>;
-    };
-  }
+  const makeTask = (name: string, taskStatus: string) => stubTask(name, { taskStatus });
+  const runScript = runListScript;
 
   it('Overdue task: available=true, blocked=false', () => {
     const tasks = [makeTask('overdue', Task.Status.Overdue)];

--- a/tests/unit/contracts/ast/omnijs-vm-fixture.ts
+++ b/tests/unit/contracts/ast/omnijs-vm-fixture.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared node:vm sandbox fixture for executing generated OmniJS in unit tests.
+ *
+ * Single source of truth for the Task.Status stub, the stub-task shape, and
+ * the script runners. Before this existed, four hand-rolled copies lived in
+ * the AST test files and had already drifted from the real API (one declared
+ * a non-existent `Task.Status.Active`; two omitted `Completed`) — exactly the
+ * staleness an "agreement pin" must not inherit. Extend HERE, not per-file.
+ */
+
+import * as vm from 'node:vm';
+
+/**
+ * The real OmniFocus Task.Status members, verbatim. Generated scripts reference
+ * these via property access (`Task.Status.Dropped`); the values are opaque
+ * tokens — only identity between a stub task's `taskStatus` and the enum
+ * member matters to the predicates.
+ */
+export const Task = {
+  Status: {
+    Available: 'Available',
+    Blocked: 'Blocked',
+    Completed: 'Completed',
+    Dropped: 'Dropped',
+    DueSoon: 'DueSoon',
+    Next: 'Next',
+    Overdue: 'Overdue',
+  },
+} as const;
+
+export type StatusName = keyof typeof Task.Status;
+
+export interface StubTask {
+  id: { primaryKey: string };
+  name: string;
+  flagged: boolean;
+  completed: boolean;
+  taskStatus: string;
+  inInbox: boolean;
+  tags: unknown[];
+  dueDate: null;
+  deferDate: null;
+  containingProject: null;
+  note: string | null;
+  /** non-null marks the row as a project root (OMN-153: `task.project !== null`). */
+  project: null | { name: string };
+}
+
+export function stubTask(name: string, overrides: Partial<StubTask> = {}): StubTask {
+  return {
+    id: { primaryKey: `id-${name}` },
+    name,
+    flagged: false,
+    completed: false,
+    taskStatus: Task.Status.Available,
+    inInbox: false,
+    tags: [],
+    dueDate: null,
+    deferDate: null,
+    containingProject: null,
+    note: null,
+    project: null,
+    ...overrides,
+  };
+}
+
+function makeSandbox(tasks: StubTask[]): Record<string, unknown> {
+  return {
+    flattenedTasks: tasks,
+    // The OmniJS `inbox` global is the pre-filtered inbox collection.
+    inbox: tasks.filter((t) => t.inInbox),
+    Task,
+    JSON,
+    Date,
+  };
+}
+
+export interface ListScriptResult {
+  tasks: Array<Record<string, unknown>>;
+  count: number;
+  total_matched: number;
+}
+
+/** Run a generated LIST/INBOX script (raw OmniJS IIFE) against stub collections. */
+export function runListScript(script: string, tasks: StubTask[]): ListScriptResult {
+  return JSON.parse(vm.runInNewContext(script, makeSandbox(tasks)) as string) as ListScriptResult;
+}
+
+/**
+ * Run a generated COUNT script. Unlike the list script, count is JXA-wrapped:
+ * `Application('OmniFocus').evaluateJavascript(<omnijs source>)`. The stub
+ * routes evaluateJavascript back into the same sandbox, so the test exercises
+ * the real bridge shape rather than fishing the inner source out with a regex.
+ */
+export function runCountScript(
+  script: string,
+  tasks: StubTask[],
+): { count: number; error?: boolean; message?: string } {
+  const sandbox = makeSandbox(tasks);
+  const context = vm.createContext(sandbox);
+  sandbox.Application = () => ({
+    evaluateJavascript: (src: string) => vm.runInContext(src, context),
+  });
+  return JSON.parse(vm.runInContext(script, context) as string) as {
+    count: number;
+    error?: boolean;
+    message?: string;
+  };
+}

--- a/tests/unit/contracts/ast/project-root-exclusion.test.ts
+++ b/tests/unit/contracts/ast/project-root-exclusion.test.ts
@@ -21,8 +21,8 @@
  * 12. ID-lookup (buildTaskByIdScript / details=true) always carries isProjectRoot in its projection
  */
 
-import * as vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
+import { stubTask, runListScript } from './omnijs-vm-fixture.js';
 import {
   buildFilteredTasksScript,
   buildInboxScript,
@@ -187,35 +187,13 @@ describe('OMN-153: TaskRowSchema', () => {
 // =============================================================================
 
 describe('OMN-153: VM behavioral — project-root exclusion and isProjectRoot marker', () => {
-  // Minimal sandbox matching what the generated script touches.
-  // Task.Status is needed for the OMN-157 dropped-exclusion predicate.
-  const Task = { Status: { Dropped: 'Dropped', Active: 'Active' } };
-
-  const regularTask = (name: string) => ({
-    id: { primaryKey: `id-${name}` },
-    name,
-    flagged: false,
-    completed: false,
-    taskStatus: Task.Status.Active,
-    inInbox: false,
-    tags: [],
-    dueDate: null,
-    deferDate: null,
-    containingProject: null,
-    // project: null → NOT a project root (normal task)
-    project: null,
-  });
-
-  const rootTask = (name: string) => ({
-    ...regularTask(name),
-    // project: non-null → IS a project root (task.project !== null in OmniJS)
-    project: { name: 'MyProject' },
-  });
-
-  function runScript(script: string, tasks: unknown[]): { tasks: unknown[]; count: number; total_matched: number } {
-    const sandbox: Record<string, unknown> = { flattenedTasks: tasks, inbox: tasks, Task, JSON };
-    return JSON.parse(vm.runInNewContext(script, sandbox) as string);
-  }
+  // Shared vm fixture (omnijs-vm-fixture.ts). The old local stub declared a
+  // status member that does not exist in the real OmniFocus enum — regular
+  // tasks just need any non-Dropped, non-Completed status, which the
+  // fixture's Available default is.
+  const regularTask = (name: string) => stubTask(name);
+  const rootTask = (name: string) => stubTask(name, { project: { name: 'MyProject' } });
+  const runScript = runListScript;
 
   it('default script: excludes the root row, returns only regular tasks', () => {
     const tasks = [regularTask('alpha'), regularTask('beta'), rootTask('ProjectRoot')];


### PR DESCRIPTION
Behavior-pinning pass over the repo's most-recurrent codegen hazard: **one conceptual property emitted by two independent generators** (the `project_divergent_parallel_paths` memory class). String pins on each side can both stay green while the semantics diverge — OMN-130 (available filter vs projection), OMN-52 (countOnly vs list defaults), and OMN-157 (inbox dropped default) were all this class.

**What's new** (`tests/unit/contracts/ast/filter-projection-agreement.test.ts`, 11 tests): executes the generated OmniJS in `node:vm` (extending the existing project-root-exclusion harness) and asserts the pairs **agree on the same rows**:

1. `{available:true}`/`{available:false}` filter results ≡ rows whose *projected* `available` is true/false, over the full 7-status matrix; plus projected value ≡ `ACTIONABLE_STATUSES` membership.
2. `buildTaskCountScript(f).count` ≡ `buildFilteredTasksScript(f).total_matched` across a 5-filter matrix over a mixed set (completed/dropped/root/inbox rows) — the count script runs through a real `Application().evaluateJavascript` stub, exercising the bridge shape.
3. `buildInboxScript` rows ≡ list-script `{inInbox:true}` rows, including the dropped/completed defaults.

**Mutation-verified**: reintroducing each historical bug fails its pins (single-status projection → 3 ✗; count without `applyHonestyDefaults` → 3 ✗; inbox without the dropped default → 2 ✗); source restored clean (`git diff` empty before commit).

**Also**: one CLAUDE.md correction — the merge norm said `--squash --auto`, but the repo has auto-merge disabled (verified live today: `--auto` fails with "Auto merge is not allowed"). Now states plain `--squash` after Kip's per-PR go-ahead.

Non-vacuity guards: each agreement asserts a non-trivial split (filtered ⊂ universe; ≥2 distinct counts across the filter matrix) so a degenerate stub set can't make agreement vacuous.

Gates: build, lint `--max-warnings=0`, prettier, full unit suite 3,708 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)