### PR TITLE
perf(test): OMN-186 Phase-1 fixture-hook profiler (FIXTURE_PROFILE=1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/dev/integration-test-timing-baseline.json
 reports/mutation/
 .stryker-tmp/
 stryker.log
+
+# OMN-186 fixture-profiler output (FIXTURE_PROFILE=1 runs; machine-specific)
+tests/integration/fixture-profile.jsonl

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -107,3 +107,27 @@ npx vitest tests/integration --run --reporter=json --outputFile.json=/tmp/pertes
 
 Because the wall is fixture-noise-dominated, **compare the per-class test-body subtotal on a quiet host** (check
 `loadavg`), not the raw wall. The id-read-back subtotal (~152 s post-OMN-185) is the most stable, attributable signal.
+
+### Profiling the fixture overhead itself (OMN-186 Phase 1)
+
+The test-body profile above cannot locate the ~400–490 s of non-test-body overhead — hooks aren't in vitest's per-test
+`duration`. The fixture profiler (`tests/integration/helpers/fixture-profiler.ts`) times the fixture-machinery leaf
+calls (`ensureSandboxFolder`, `fullCleanup`, shared-server init/reuse/shutdown) and appends one JSON line per call:
+
+```bash
+npm run build
+FIXTURE_PROFILE=1 npx vitest tests/integration --run
+# log: tests/integration/fixture-profile.jsonl (override with FIXTURE_PROFILE_LOG); delete between runs — it appends
+
+# per-op totals
+jq -s 'group_by(.op) | map({op: .[0].op, calls: length, total_s: ((map(.ms) | add) / 1000 | round)})' \
+  tests/integration/fixture-profile.jsonl
+
+# per-file totals (worst offenders first)
+jq -s 'group_by(.file) | map({file: .[0].file, total_s: ((map(.ms) | add) / 1000 | round)}) | sort_by(-.total_s)' \
+  tests/integration/fixture-profile.jsonl
+```
+
+Entries are `{file, hook, op, ms, at, failed?}`; `file` is `"(global)"` for globalSetup/globalTeardown calls. The flag
+off (default) is a pure pass-through — normal runs are untouched. This profile is the decision gate for OMN-186 Phase 2
+(per-run fixture epoch): proceed only if teardown-dominated.

--- a/tests/integration/helpers/fixture-profiler.ts
+++ b/tests/integration/helpers/fixture-profiler.ts
@@ -71,11 +71,17 @@ function currentTestFile(): string {
 }
 
 let warnedWriteFailure = false;
+// Ensure the log directory once per run, not per profiled call — the profiler
+// measures fixture overhead, so it must not add a syscall to every event.
+let logDirEnsured = false;
 
 function record(entry: Record<string, unknown>): void {
   try {
     const path = logPath();
-    mkdirSync(dirname(path), { recursive: true });
+    if (!logDirEnsured) {
+      mkdirSync(dirname(path), { recursive: true });
+      logDirEnsured = true;
+    }
     appendFileSync(path, `${JSON.stringify(entry)}\n`);
   } catch (err) {
     // Profiling must never fail the fixture call it wraps — but a profiled

--- a/tests/integration/helpers/fixture-profiler.ts
+++ b/tests/integration/helpers/fixture-profiler.ts
@@ -36,8 +36,12 @@ import { performance } from 'perf_hooks';
  * when the same leaf fires outside a test worker (setup-integration.ts's
  * globalSetup/globalTeardown also call fullCleanup), the recorded hook is
  * rewritten to 'global' since the per-file label would be wrong there.
+ *
+ * NOTE: this is the CALLER-side type. The `hook` field that lands in the
+ * JSONL is `FixtureHook | 'global'` (see the rewrite in profileFixture) —
+ * filter the log on 'beforeAll' | 'afterAll' | 'global' | 'globalTeardown'.
  */
-export type FixtureHook = 'beforeAll' | 'afterAll' | 'globalSetup' | 'globalTeardown';
+export type FixtureHook = 'beforeAll' | 'afterAll' | 'globalTeardown';
 
 export function fixtureProfilingEnabled(): boolean {
   return process.env.FIXTURE_PROFILE === '1';
@@ -66,13 +70,21 @@ function currentTestFile(): string {
   return '(global)';
 }
 
+let warnedWriteFailure = false;
+
 function record(entry: Record<string, unknown>): void {
   try {
     const path = logPath();
     mkdirSync(dirname(path), { recursive: true });
     appendFileSync(path, `${JSON.stringify(entry)}\n`);
-  } catch {
-    // Profiling must never fail the fixture call it wraps.
+  } catch (err) {
+    // Profiling must never fail the fixture call it wraps — but a profiled
+    // run whose log can't be written must not finish looking successful
+    // (the whole run exists to produce this file), so warn once.
+    if (!warnedWriteFailure) {
+      warnedWriteFailure = true;
+      console.warn(`[fixture-profiler] failed to write ${logPath()}: ${String(err)} — profile data will be incomplete`);
+    }
   }
 }
 

--- a/tests/integration/helpers/fixture-profiler.ts
+++ b/tests/integration/helpers/fixture-profiler.ts
@@ -1,0 +1,106 @@
+/**
+ * FIXTURE PROFILER (OMN-186 Phase 1)
+ *
+ * Env-gated hook-duration instrumentation for the integration suite's fixture
+ * machinery. The OMN-165 audit measured test BODIES (~526s of a ~1017s wall)
+ * and inferred that the remaining ~400-490s is per-file fixture setup/teardown
+ * — but hooks were never profiled, so the attribution is located nowhere. This
+ * harness times the fixture-machinery leaf calls (sandbox setup, fullCleanup,
+ * shared-server access/shutdown) and appends one JSON line per call, so a
+ * single profiled run can show where that overhead actually goes.
+ *
+ * Usage: FIXTURE_PROFILE=1 npm run test:integration
+ * Log:   FIXTURE_PROFILE_LOG (default: tests/integration/fixture-profile.jsonl)
+ * Line:  {"file","hook","op","ms","at","failed"?}
+ *
+ * Aggregate (per-op totals):
+ *   jq -s 'group_by(.op) | map({op: .[0].op, calls: length, total_s: (map(.ms) | add / 1000 | round)})' \
+ *     tests/integration/fixture-profile.jsonl
+ *
+ * Invariants:
+ * - Flag off (the default) => pure pass-through: zero writes, zero timing, no
+ *   behavior change on normal runs.
+ * - Profiling failures never fail the wrapped call — a broken log path must
+ *   not turn a green suite red.
+ * - `file` comes from vitest's expect state; calls outside a test worker
+ *   (globalSetup/globalTeardown in tests/support/setup-integration.ts) record
+ *   as "(global)".
+ */
+import { appendFileSync, mkdirSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import { performance } from 'perf_hooks';
+
+/**
+ * Where in the vitest lifecycle the profiled call runs (best-effort label).
+ * Leaf helpers pass the hook their per-file callers use (beforeAll/afterAll);
+ * when the same leaf fires outside a test worker (setup-integration.ts's
+ * globalSetup/globalTeardown also call fullCleanup), the recorded hook is
+ * rewritten to 'global' since the per-file label would be wrong there.
+ */
+export type FixtureHook = 'beforeAll' | 'afterAll' | 'globalSetup' | 'globalTeardown';
+
+export function fixtureProfilingEnabled(): boolean {
+  return process.env.FIXTURE_PROFILE === '1';
+}
+
+function logPath(): string {
+  return process.env.FIXTURE_PROFILE_LOG ?? join(process.cwd(), 'tests', 'integration', 'fixture-profile.jsonl');
+}
+
+/**
+ * Current test file (repo-relative), or "(global)" outside a test worker.
+ *
+ * Reads vitest's `expect` off globalThis (config sets `globals: true`) instead
+ * of importing it: this module is transitively loaded by the globalSetup
+ * script (tests/support/setup-integration.ts), and importing test utilities
+ * from 'vitest' outside a worker throws.
+ */
+function currentTestFile(): string {
+  try {
+    const globalExpect = (globalThis as { expect?: { getState(): { testPath?: string } } }).expect;
+    const testPath = globalExpect?.getState().testPath;
+    if (testPath) return relative(process.cwd(), testPath);
+  } catch {
+    // expect state is unavailable outside a running test worker
+  }
+  return '(global)';
+}
+
+function record(entry: Record<string, unknown>): void {
+  try {
+    const path = logPath();
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(entry)}\n`);
+  } catch {
+    // Profiling must never fail the fixture call it wraps.
+  }
+}
+
+/**
+ * Time an async fixture-machinery call and append a JSONL entry when
+ * FIXTURE_PROFILE=1. Pass-through (no timing, no I/O) otherwise. The wrapped
+ * fn's result/rejection propagates unchanged; a rejection is still recorded
+ * (failed: true) since a failing teardown costs wall time too.
+ */
+export async function profileFixture<T>(hook: FixtureHook, op: string, fn: () => Promise<T>): Promise<T> {
+  if (!fixtureProfilingEnabled()) return fn();
+
+  const file = currentTestFile();
+  const hookLabel = file === '(global)' && (hook === 'beforeAll' || hook === 'afterAll') ? 'global' : hook;
+  const start = performance.now();
+  try {
+    const result = await fn();
+    record({ file, hook: hookLabel, op, ms: Math.round(performance.now() - start), at: new Date().toISOString() });
+    return result;
+  } catch (err) {
+    record({
+      file,
+      hook: hookLabel,
+      op,
+      ms: Math.round(performance.now() - start),
+      at: new Date().toISOString(),
+      failed: true,
+    });
+    throw err;
+  }
+}

--- a/tests/integration/helpers/sandbox-manager.ts
+++ b/tests/integration/helpers/sandbox-manager.ts
@@ -13,6 +13,7 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { profileFixture } from './fixture-profiler.js';
 
 // OMN-147: args-array execFile (not shell `exec`) so the script is passed as an
 // argv element — no shell quoting to get wrong — and every spawn carries a child
@@ -148,6 +149,11 @@ export async function getSandboxInfo(): Promise<SandboxInfo> {
  * Create the sandbox folder if it doesn't exist
  */
 export async function ensureSandboxFolder(): Promise<string> {
+  // OMN-186: per-file setup cost — profiled when FIXTURE_PROFILE=1
+  return profileFixture('beforeAll', 'ensureSandboxFolder', ensureSandboxFolderImpl);
+}
+
+async function ensureSandboxFolderImpl(): Promise<string> {
   const info = await getSandboxInfo();
   if (info.exists && info.folderId) {
     return info.folderId;
@@ -670,6 +676,13 @@ async function deleteTestTags(): Promise<{ deleted: number; errors: string[] }> 
  * 7. Delete __test- tags (must be after tasks/projects so tags aren't referenced)
  */
 export async function fullCleanup(): Promise<CleanupReport> {
+  // OMN-186: per-file teardown cost (the suspected ~400-490s pool) — profiled
+  // when FIXTURE_PROFILE=1. Also fires from globalSetup/globalTeardown, where
+  // the profiler records hook 'global' instead of 'afterAll'.
+  return profileFixture('afterAll', 'fullCleanup', fullCleanupImpl);
+}
+
+async function fullCleanupImpl(): Promise<CleanupReport> {
   const startTime = Date.now();
   const report: CleanupReport = {
     inboxTasksDeleted: 0,

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -14,6 +14,7 @@
 
 import { MCPTestClient } from './mcp-test-client.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
+import { profileFixture } from './fixture-profiler.js';
 
 let sharedClient: MCPTestClient | null = null;
 let initPromise: Promise<MCPTestClient> | null = null;
@@ -148,6 +149,14 @@ async function warmupOmniFocus(client: MCPTestClient): Promise<void> {
  * between test files.
  */
 export async function getSharedClient(): Promise<MCPTestClient> {
+  // OMN-186: first access pays server start + cache warm + OmniFocus warm;
+  // later per-file accesses pay a cache clear. Split ops so a profiled run
+  // (FIXTURE_PROFILE=1) can tell the one-time warm from the per-file cost.
+  const op = sharedClient || initPromise ? 'getSharedClient.reuse' : 'getSharedClient.init';
+  return profileFixture('beforeAll', op, getSharedClientImpl);
+}
+
+async function getSharedClientImpl(): Promise<MCPTestClient> {
   if (sharedClient) {
     // Clear cache between test file accesses to prevent pollution
     if (!isFirstAccess) {
@@ -180,15 +189,18 @@ export async function getSharedClient(): Promise<MCPTestClient> {
  * Shutdown the shared server (called by teardown script)
  */
 export async function shutdownSharedClient(): Promise<void> {
-  if (sharedClient) {
-    console.log('🧹 Shutting down shared MCP server...');
-    await sharedClient.thoroughCleanup();
-    await sharedClient.stop();
-    sharedClient = null;
-    initPromise = null;
-    isFirstAccess = true; // Reset for next test run
-    console.log('✅ Shared MCP server shutdown complete');
-  }
+  // OMN-186: end-of-run cost — profiled when FIXTURE_PROFILE=1
+  return profileFixture('globalTeardown', 'shutdownSharedClient', async () => {
+    if (sharedClient) {
+      console.log('🧹 Shutting down shared MCP server...');
+      await sharedClient.thoroughCleanup();
+      await sharedClient.stop();
+      sharedClient = null;
+      initPromise = null;
+      isFirstAccess = true; // Reset for next test run
+      console.log('✅ Shared MCP server shutdown complete');
+    }
+  });
 }
 
 /**

--- a/tests/unit/integration-helpers/fixture-profiler.test.ts
+++ b/tests/unit/integration-helpers/fixture-profiler.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the fixture-profiler integration helper (OMN-186 Phase 1).
+ *
+ * The profiler's job: when FIXTURE_PROFILE=1, time fixture-machinery calls
+ * (sandbox setup, fullCleanup, shared-server access) and append one JSON line
+ * per call to a log file, so a profiled run can locate where the ~400-490s
+ * non-test-body wall overhead actually goes. When the flag is off it must be
+ * a pure pass-through — zero behavior change on normal runs.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { profileFixture, fixtureProfilingEnabled } from '../../../tests/integration/helpers/fixture-profiler.js';
+
+let logDir: string;
+let logPath: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  logDir = mkdtempSync(join(tmpdir(), 'fixture-profiler-test-'));
+  logPath = join(logDir, 'profile.jsonl');
+  savedEnv.FIXTURE_PROFILE = process.env.FIXTURE_PROFILE;
+  savedEnv.FIXTURE_PROFILE_LOG = process.env.FIXTURE_PROFILE_LOG;
+  process.env.FIXTURE_PROFILE_LOG = logPath;
+});
+
+afterEach(() => {
+  for (const key of ['FIXTURE_PROFILE', 'FIXTURE_PROFILE_LOG'] as const) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  rmSync(logDir, { recursive: true, force: true });
+});
+
+function readEntries(): Array<Record<string, unknown>> {
+  return readFileSync(logPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('fixtureProfilingEnabled', () => {
+  it('is false when FIXTURE_PROFILE is unset', () => {
+    delete process.env.FIXTURE_PROFILE;
+    expect(fixtureProfilingEnabled()).toBe(false);
+  });
+
+  it('is true when FIXTURE_PROFILE=1', () => {
+    process.env.FIXTURE_PROFILE = '1';
+    expect(fixtureProfilingEnabled()).toBe(true);
+  });
+
+  it('is false when FIXTURE_PROFILE=0', () => {
+    process.env.FIXTURE_PROFILE = '0';
+    expect(fixtureProfilingEnabled()).toBe(false);
+  });
+});
+
+describe('profileFixture', () => {
+  it('runs the wrapped fn and returns its value without logging when disabled', async () => {
+    delete process.env.FIXTURE_PROFILE;
+    const result = await profileFixture('beforeAll', 'ensureSandboxFolder', () => Promise.resolve(42));
+    expect(result).toBe(42);
+    expect(existsSync(logPath)).toBe(false);
+  });
+
+  it('appends one JSON line with file/hook/op/ms when enabled', async () => {
+    process.env.FIXTURE_PROFILE = '1';
+    const result = await profileFixture('afterAll', 'fullCleanup', async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      return 'done';
+    });
+    expect(result).toBe('done');
+
+    const entries = readEntries();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.hook).toBe('afterAll');
+    expect(entry.op).toBe('fullCleanup');
+    expect(typeof entry.file).toBe('string');
+    expect(typeof entry.ms).toBe('number');
+    expect(entry.ms as number).toBeGreaterThanOrEqual(5);
+  });
+
+  it('appends across calls (one line per call)', async () => {
+    process.env.FIXTURE_PROFILE = '1';
+    await profileFixture('beforeAll', 'getSharedClient', () => Promise.resolve(1));
+    await profileFixture('afterAll', 'fullCleanup', () => Promise.resolve(2));
+
+    const entries = readEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.op)).toEqual(['getSharedClient', 'fullCleanup']);
+  });
+
+  it('still records the duration and rethrows when the wrapped fn fails', async () => {
+    process.env.FIXTURE_PROFILE = '1';
+    await expect(
+      profileFixture('afterAll', 'fullCleanup', () => Promise.reject(new Error('cleanup exploded'))),
+    ).rejects.toThrow('cleanup exploded');
+
+    const entries = readEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].op).toBe('fullCleanup');
+    expect(entries[0].failed).toBe(true);
+    expect(typeof entries[0].ms).toBe('number');
+  });
+
+  it('never breaks the wrapped fn when the log path is unwritable', async () => {
+    process.env.FIXTURE_PROFILE = '1';
+    process.env.FIXTURE_PROFILE_LOG = join(logDir, 'no-such-dir', 'nested', 'profile.jsonl');
+    // mkdir of the parent is expected; point at a path whose parent is a FILE to force a write failure
+    process.env.FIXTURE_PROFILE_LOG = join(logPath, 'child.jsonl');
+    await profileFixture('beforeAll', 'ensureSandboxFolder', async () => {
+      // create logPath as a regular file so the nested path cannot be created
+      const { writeFileSync } = await import('fs');
+      writeFileSync(logPath, 'occupied');
+      return 'ok';
+    }).then((result) => expect(result).toBe('ok'));
+  });
+});

--- a/tests/unit/integration-helpers/fixture-profiler.test.ts
+++ b/tests/unit/integration-helpers/fixture-profiler.test.ts
@@ -7,7 +7,7 @@
  * non-test-body wall overhead actually goes. When the flag is off it must be
  * a pure pass-through — zero behavior change on normal runs.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, readFileSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -106,16 +106,23 @@ describe('profileFixture', () => {
     expect(typeof entries[0].ms).toBe('number');
   });
 
-  it('never breaks the wrapped fn when the log path is unwritable', async () => {
+  it('never breaks the wrapped fn when the log path is unwritable, but warns once', async () => {
     process.env.FIXTURE_PROFILE = '1';
-    process.env.FIXTURE_PROFILE_LOG = join(logDir, 'no-such-dir', 'nested', 'profile.jsonl');
-    // mkdir of the parent is expected; point at a path whose parent is a FILE to force a write failure
+    // point at a path whose parent is a FILE so mkdir/append must fail
     process.env.FIXTURE_PROFILE_LOG = join(logPath, 'child.jsonl');
-    await profileFixture('beforeAll', 'ensureSandboxFolder', async () => {
-      // create logPath as a regular file so the nested path cannot be created
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
       const { writeFileSync } = await import('fs');
       writeFileSync(logPath, 'occupied');
-      return 'ok';
-    }).then((result) => expect(result).toBe('ok'));
+      const first = await profileFixture('beforeAll', 'ensureSandboxFolder', () => Promise.resolve('ok'));
+      expect(first).toBe('ok');
+      // second failing write must NOT warn again (warn-once)
+      const second = await profileFixture('beforeAll', 'ensureSandboxFolder', () => Promise.resolve('ok2'));
+      expect(second).toBe('ok2');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain('[fixture-profiler]');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## What

Env-gated hook-duration instrumentation for the integration suite's fixture machinery — **Phase 1 (PR-A) of the OMN-186 spec** (`Technical/specs/OMN-186-fixture-epoch.md` §2), per Kip's 2026-07-06 greenlight comment (Phase-1 profiler ONLY; Phase 2 stays gated on the profiled run).

## Why

The OMN-165 audit measured test bodies (~526s of a ~1017s wall) and *inferred* that the remaining ~400–490s is per-file fixture setup/teardown — but hooks were never profiled, so the attribution is located nowhere. This harness produces the profile that is the ticket's decision gate: proceed to the Phase-2 fixture epoch only if teardown-dominated.

## Approach

- New `tests/integration/helpers/fixture-profiler.ts`: `profileFixture(hook, op, fn)` times a call with `performance.now()` and appends `{file, hook, op, ms, at, failed?}` JSON lines to `tests/integration/fixture-profile.jsonl` (override: `FIXTURE_PROFILE_LOG`). Gated on `FIXTURE_PROFILE=1` — **flag off (default) is a pure pass-through**, so normal runs are untouched.
- Instrumented at the **fixture-machinery leaf calls**, so zero test-body edits: `ensureSandboxFolder` (beforeAll), `fullCleanup` (afterAll; records hook `global` when fired from globalSetup/globalTeardown), `getSharedClient` (split `*.init` vs `*.reuse` so the one-time server+OmniFocus warm is distinguishable from the per-file cache clear), `shutdownSharedClient` (globalTeardown).
- `file` resolves via `globalThis.expect.getState().testPath` (NOT an `import { expect } from 'vitest'` — this module is transitively loaded by the globalSetup script, where importing test utilities throws); `"(global)"` outside a worker.
- Profiling failures never fail the wrapped call (a broken log path must not turn a green suite red); a rejecting fixture call is still recorded with `failed: true` since failing teardowns cost wall time too.
- PERFORMANCE.md documents the run recipe + jq aggregations (per-op, per-file); log path gitignored.

## Not in this PR (deliberate)

- **No fixture-machinery behavior change** — the Phase-2 per-run epoch (globalSetup/teardown sandbox sharing) is gated on the profile numbers + a fresh decision (spec §3/§4; OMN-143 invariants govern).
- **The profiled run itself** — the ~17-min suite can't run in the unattended loop; it needs Kip on a quiet host: `FIXTURE_PROFILE=1 npx vitest tests/integration --run` (after `npm run build`).

## Testing

- TDD: 8 new unit tests (`tests/unit/integration-helpers/fixture-profiler.test.ts`) — env gating, pass-through when disabled, JSONL shape, append semantics, error propagation + `failed` flag, unwritable-log resilience.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3705/3705 ✅ · `npm run lint` ✅ (integration suite deliberately not run in-loop).

Closes OMN-186? **No** — advances it; the ticket stays open for the profiled run + Phase-2 decision. Part of OMN-186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)