### PR TITLE
fix(OMN-168): mutation-field-alias leniency recovers flattened target_id envelope (PR-1)

### DIFF
--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -97,6 +97,32 @@ function tryParseObjectString(s: string): Record<string, unknown> | undefined {
 }
 
 /**
+ * Leniency #4 worker: rename `target_id` → `id` inside a mutation object, and
+ * inside `mutation.data` (so the #3 hoist composes). Returns the rewritten
+ * mutation, or undefined when nothing was renamed. Collision-safe: a position
+ * carrying BOTH names is left untouched.
+ */
+function aliasMutationFields(m: Record<string, unknown>): Record<string, unknown> | undefined {
+  const newMutation: Record<string, unknown> = { ...m };
+  let aliased = false;
+  if (newMutation.target_id !== undefined && newMutation.id === undefined) {
+    newMutation.id = newMutation.target_id;
+    delete newMutation.target_id;
+    aliased = true;
+  }
+  if (isPlainObject(newMutation.data)) {
+    const d: Record<string, unknown> = { ...newMutation.data };
+    if (d.target_id !== undefined && d.id === undefined) {
+      d.id = d.target_id;
+      delete d.target_id;
+      newMutation.data = d;
+      aliased = true;
+    }
+  }
+  return aliased ? newMutation : undefined;
+}
+
+/**
  * Pure, side-effect-free transform: apply the bounded leniencies to `args`.
  * Returns the rewritten args plus the names of the leniencies applied (empty if
  * nothing was recognized as repairable).
@@ -126,43 +152,73 @@ function normalizeArgs(args: unknown, hint: NormalizationHint): { args: unknown;
     applied.push('wrapper-lift');
   }
 
+  // ── Leniency #4: mutation-field-alias (OMN-168) ────────────────────────────
+  // qwen-class models emit `target_id` where the mutation schema says `id`
+  // (recorded 2026-06-12 failure: root `{operation:'complete', target_id}` — #1
+  // lifts it, then strict re-validation dies on the field NAME). Rename
+  // `target_id` → `id` inside the mutation, and inside `mutation.data` so #3's
+  // hoist composes. Collision-safe: a position carrying BOTH names is left
+  // untouched (the original strict error stands). Runs after #1 (needs the
+  // wrapper present), before #3 (hoist keys off `data.id`). Note `delete`
+  // accepts `target_id` natively (OMN-71) and passes strict-first, so canonical
+  // delete payloads never reach this code.
+  if (hint.wrapperKey === 'mutation' && isPlainObject(current) && isPlainObject(current.mutation)) {
+    const aliasedMutation = aliasMutationFields(current.mutation);
+    if (aliasedMutation !== undefined) {
+      current = { ...current, mutation: aliasedMutation };
+      applied.push('mutation-field-alias');
+    }
+  }
+
   // ── Leniency #3: data-hoist on non-create mutations ────────────────────────
   // Small models nest `id` inside `data` on complete/update/delete (the create
   // shape) instead of placing it at the mutation level. Hoist `id` out of `data`;
   // for update, map any remaining `data` fields → `changes`; for complete/delete,
   // drop the emptied `data` (those operations don't carry it).
   if (hint.wrapperKey === 'mutation' && isPlainObject(current) && isPlainObject(current.mutation)) {
-    const m = current.mutation;
-    const op = m.operation;
-    if (
-      (op === 'complete' || op === 'update' || op === 'delete') &&
-      m.id === undefined &&
-      isPlainObject(m.data) &&
-      typeof m.data.id === 'string'
-    ) {
-      const data = { ...m.data };
-      const id = data.id as string;
-      delete data.id;
-      const newMutation: Record<string, unknown> = { ...m, id };
-      delete newMutation.data;
-      // Don't silently drop residual fields the model nested in `data` (OMN-97
-      // anti-pattern). update: remaining → `changes` (the canonical field name).
-      // complete: remaining (e.g. completionDate) are top-level fields, spread them
-      // up. delete: takes no other fields, so leftovers are dropped — strict
-      // re-validation would reject them anyway, leaving the original error intact.
-      if (Object.keys(data).length > 0) {
-        if (op === 'update') {
-          newMutation.changes = data;
-        } else if (op === 'complete') {
-          Object.assign(newMutation, data);
-        }
-      }
-      current = { ...current, mutation: newMutation };
+    const hoistedMutation = hoistDataId(current.mutation);
+    if (hoistedMutation !== undefined) {
+      current = { ...current, mutation: hoistedMutation };
       applied.push('data-hoist-id');
     }
   }
 
   return { args: current, applied };
+}
+
+/**
+ * Leniency #3 worker: hoist `data.id` to the mutation level on non-create
+ * operations. Returns the rewritten mutation, or undefined when the shape
+ * doesn't match.
+ */
+function hoistDataId(m: Record<string, unknown>): Record<string, unknown> | undefined {
+  const op = m.operation;
+  if (
+    (op !== 'complete' && op !== 'update' && op !== 'delete') ||
+    m.id !== undefined ||
+    !isPlainObject(m.data) ||
+    typeof m.data.id !== 'string'
+  ) {
+    return undefined;
+  }
+  const data = { ...m.data };
+  const id = data.id as string;
+  delete data.id;
+  const newMutation: Record<string, unknown> = { ...m, id };
+  delete newMutation.data;
+  // Don't silently drop residual fields the model nested in `data` (OMN-97
+  // anti-pattern). update: remaining → `changes` (the canonical field name).
+  // complete: remaining (e.g. completionDate) are top-level fields, spread them
+  // up. delete: takes no other fields, so leftovers are dropped — strict
+  // re-validation would reject them anyway, leaving the original error intact.
+  if (Object.keys(data).length > 0) {
+    if (op === 'update') {
+      newMutation.changes = data;
+    } else if (op === 'complete') {
+      Object.assign(newMutation, data);
+    }
+  }
+  return newMutation;
 }
 
 /**

--- a/tests/unit/tools/normalization/normalize-input.test.ts
+++ b/tests/unit/tools/normalization/normalize-input.test.ts
@@ -209,3 +209,67 @@ describe('leniency #3 — data-hoist on non-create mutations (malformed-in → c
     expect(r.applied).toEqual([]);
   });
 });
+
+describe('leniency #4 — mutation-field-alias (OMN-168)', () => {
+  it('recovers the recorded qwen complete artifact: root {operation, target_id} (2026-06-12)', () => {
+    // Verbatim shape from the OMN-168 ticket: strict error was
+    // "mutation: Required; (root): Unrecognized key(s): 'operation', 'target_id'",
+    // which fully determines the root keys. Wrapper-lift alone left the lifted
+    // mutation failing strict on the field name; the alias closes it.
+    const r = parseWithNormalization(
+      WriteSchema,
+      { operation: 'complete', target_id: 'task-abc123' },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('wrapper-lift');
+    expect(r.applied).toContain('mutation-field-alias');
+    expect(r.data).toMatchObject({ mutation: { operation: 'complete', id: 'task-abc123' } });
+  });
+
+  it('aliases target_id → id inside an already-wrapped mutation (no lift needed)', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'complete', target: 'task', target_id: 'task-xyz' } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual(['mutation-field-alias']);
+    expect(r.data).toMatchObject({ mutation: { operation: 'complete', target: 'task', id: 'task-xyz' } });
+  });
+
+  it('composes with data-hoist: update with data.target_id + residual fields', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { operation: 'update', data: { target_id: 'task-42', note: 'hello' } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual(['wrapper-lift', 'mutation-field-alias', 'data-hoist-id']);
+    expect(r.data).toMatchObject({
+      mutation: { operation: 'update', id: 'task-42', changes: { note: 'hello' } },
+    });
+  });
+
+  it('collision-safe: both id and target_id present → leniency skipped, original error stands', () => {
+    const args = { mutation: { operation: 'complete', target: 'task', id: 'a', target_id: 'b' } };
+    const original = WriteSchema.safeParse(args);
+    expect(original.success).toBe(false);
+
+    const r = parseWithNormalization(WriteSchema, args, 'omnifocus_write');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+    expect(JSON.stringify(r.error!.issues)).toBe(JSON.stringify((original as z.SafeParseError<unknown>).error.issues));
+  });
+
+  it('does NOT touch delete, where target_id is a native schema-level alias (OMN-71)', () => {
+    // Strict-first: this shape is already valid, so normalization never runs.
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'delete', target: 'task', target_id: 'del-1' } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

**PR-1 of the OMN-168 greenlit PR-1/PR-2 pair** (spec: `Technical/specs/OMN-168-conformance-normalization-rebaseline.md` §2–3; Kip's 2026-07-06 greenlight comment). Adds leniency #4 `mutation-field-alias` to the OMN-122 normalize-then-strict layer.

## The evidence, and its limit (important for review)

The three 2026-06-12 qwen failures' raw payloads were never persisted (the probe records Zod issue strings, not tool-call args — verified in `scripts/llm-conformance-probe.ts`). But strict Zod errors list **all** unrecognized root keys, so the recorded strings fully determine root shapes:

| Case | Recorded error | Root shape | Covered here? |
|------|----------------|-----------|---------------|
| complete | `mutation: Required; (root): Unrecognized key(s): 'operation', 'target_id'` | `{operation, target_id}` — **fully determined** | ✅ this PR |
| create-task-tags | `… Unrecognized key(s): 'data'` | `{data: ???}` — no discriminant at root, wrapper-lift can't fire, contents of `data` unknown | ❌ underdetermined |
| flag-update | `… Unrecognized key(s): 'data'` | same | ❌ underdetermined |

Per the spec's own rule ("derive from artifacts, do NOT guess; if they can't be found, escalate rather than reconstruct"), this PR implements only the artifact-determined alias. The two `data`-only cases are split to a child ticket (probe artifact capture) + the supervised re-baseline, tracked on OMN-168.

## Approach

- `{operation:'complete', target_id}` → #1 wrapper-lift already fires → strict re-validation was dying on the field **name** (complete accepts `id`; `target_id` is a delete-only schema alias from OMN-71). Leniency #4 renames `target_id → id` inside the mutation, and inside `mutation.data` so #3's data-hoist composes (spec-requested combined-shape test included).
- **Collision-safe:** a position carrying both `id` and `target_id` is left untouched — the original strict error stands.
- **Strict-first untouched:** canonical payloads (including delete's native `target_id`) pass on the first strict parse and never reach the normalizer. No Zod/inputSchema change (dual-schema untouched, per spec §4).
- Telemetry name `mutation-field-alias` is stable (part of the observable `applied[]`).
- Extracted the #3 and #4 bodies into helpers (`hoistDataId`, `aliasMutationFields`) — the inline block tripped the sonarjs cognitive-complexity cap. #3's logic is byte-equivalent, just relocated.

## Testing

- TDD: 5 new tests in the existing normalization suite — the verbatim recorded `complete` artifact, wrapped-no-lift, the spec's combined alias+hoist shape, collision skip (original-error preservation), and delete's native-alias non-interaction.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3702/3702 ✅ · `npm run lint` ✅ (0 warnings).
- **Acceptance is unit tests on artifact-derived shapes, not a probe score** (spec §4) — the score belongs to Kip's supervised re-baseline run after merge+deploy.

Part of OMN-168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)