### PR TITLE
docs(OMN-168): conformance gate rule — same-day main control, never a recorded number (PR-2)

### DIFF
--- a/docs/dev/SUITE_TIMING_LOG.md
+++ b/docs/dev/SUITE_TIMING_LOG.md
@@ -50,6 +50,23 @@ contention vs. a genuine slowdown. Metrics with no prior same-suite history are 
 tail -5 ~/.local/state/of-mcp-suite-timing/runs.jsonl | jq .
 ```
 
+## Conformance gate rule — same-day control, never a recorded number (OMN-168)
+
+Conformance **scores** are not drift-stable the way timing is: the probed surface (tool descriptions, schemas, the
+normalization layer) moves with unrelated merges, and the probe is documented as not bit-reproducible. On 2026-06-12 the
+published qwen2.5:7b baseline silently drifted when an unrelated PR changed read-tool description text; a branch gate
+comparing against the recorded number would have indicted the wrong commit. Only a concurrent control run on main showed
+the drop was pre-existing.
+
+The rule, when a branch gates on `npm run conformance`:
+
+1. Run the probe on the branch AND on same-day `main` (the control). Compare branch vs control, not branch vs a recorded
+   score.
+2. Re-baseline (`npm run baseline:conformance`) after any merge that touches the conformance surface — tool
+   descriptions, advertised schemas, or `src/tools/normalization/`.
+3. Treat any published score (including this file's historical table) as **history, not a bar** — the current support
+   bar is the latest recorded baseline row in the suite-timing log, valid only until the surface next moves.
+
 ---
 
 ## Historical seed rows (OMN-173, pre-JSONL — archived)

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -6,6 +6,15 @@
  * tool-calling, with NO fallback substitution and NO execution. This is the "support
  * contract" tool: a model that scores below the bar is below spec, not a server bug.
  *
+ * GATE RULE (OMN-168): when this probe gates a branch, compare against a SAME-DAY control
+ * run on main — NEVER against a recorded baseline number alone. The probed surface (tool
+ * descriptions, schemas, normalization) drifts with unrelated merges: on 2026-06-12 the
+ * published qwen baseline had silently drifted when #95 changed read-tool descriptions,
+ * and only a concurrent main control run stopped the branch being blamed for a
+ * pre-existing 5-point drop. Recorded scores (the suite-timing log, docs) are history,
+ * not a gate; re-baseline (docs/dev/SUITE_TIMING_LOG.md) after any merge touching the
+ * conformance surface.
+ *
  * Unlike tests/integration/real-llm-integration.test.ts (which has fallback maps that mask
  * model failures, and is gated/exploratory), this probe grades the model's RAW tool call:
  *   1. Present the REAL advertised tool schemas (pulled from the running server's


### PR DESCRIPTION
## What

**PR-2 of the OMN-168 greenlit PR-1/PR-2 pair** (spec §3; sibling of #198, independent — mergeable in either order). Docs-only: writes the gate-procedure rule from the ticket's 2026-06-12 lesson into the two places a future gate-runner will actually look.

## Changes

- `scripts/llm-conformance-probe.ts` header: GATE RULE block — compare against a same-day main control run, never a recorded baseline number; re-baseline after any merge touching the conformance surface.
- `docs/dev/SUITE_TIMING_LOG.md`: new **Conformance gate rule (OMN-168)** section with the 3-step procedure and the drift story (published qwen score silently drifted when #95 changed read-tool descriptions; only the concurrent main control run kept the OMN-162 branch from being blamed).

## Deliberately NOT changed

The stale "95%/89%" references live only in **dated** 2026-06-12/13 specs and plans under `docs/superpowers/` — those are historical session records, and rewriting them would falsify the archive. The new SUITE_TIMING_LOG section instead establishes that any published score (including its own historical table) is history, not a bar — which retroactively covers those documents too.

## Testing

Docs + comment-only (no runtime change): `npm run build` ✅, CLAUDE.md path-guard tests ✅ (`tests/unit/docs/` 8/8).

Part of OMN-168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)