### PR TITLE
fix(OMN-136): readModifyReassign null instance warns loudly instead of silent success

### DIFF
--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -186,7 +186,16 @@ function emitSetProp(node: SetPropNode): string {
       return wrap(`${target}.${node.prop} = ${emitExpr(node.value as Expr)};`);
     case 'readModifyReassign': {
       const muts = (node.mutations ?? []).map((m) => `_rmr.${m.prop} = ${emitExpr(m.value)};`).join(' ');
-      return wrap(`{ const _rmr = ${target}.${node.prop}; if (_rmr) { ${muts} ${target}.${node.prop} = _rmr; } }`);
+      // OMN-136 fail-loud: a null target instance used to silently no-op AND
+      // report success (no else). OmniJS cannot construct the typed instance
+      // (OMN-41/OMN-58), so the value cannot be set — record a labeled OMN-137
+      // warning instead of staying quiet.
+      const nullWarning = `_warnings.push(${JSON.stringify(
+        `${node.label ?? node.prop}: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set`,
+      )});`;
+      return wrap(
+        `{ const _rmr = ${target}.${node.prop}; if (_rmr) { ${muts} ${target}.${node.prop} = _rmr; } else { ${nullWarning} } }`,
+      );
     }
     default: {
       const _x: never = node.strategy;

--- a/tests/unit/contracts/ast/mutation-script-builder.test.ts
+++ b/tests/unit/contracts/ast/mutation-script-builder.test.ts
@@ -723,7 +723,7 @@ describe('buildUpdateProjectScript (OMN-128 AST emission)', () => {
 
     const program = extractOmniJsProgram(script);
     expect(program).toContain(
-      '{ const _rmr = proj.reviewInterval; if (_rmr) { _rmr.steps = 2; _rmr.unit = "weeks"; proj.reviewInterval = _rmr; } }',
+      '{ const _rmr = proj.reviewInterval; if (_rmr) { _rmr.steps = 2; _rmr.unit = "weeks"; proj.reviewInterval = _rmr; } else { _warnings.push("reviewInterval: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set"); } }',
     );
     expect(program).not.toContain('* 24 * 60 * 60');
     expect(program).not.toContain('new Project.ReviewInterval');

--- a/tests/unit/contracts/ast/mutation/update-project.test.ts
+++ b/tests/unit/contracts/ast/mutation/update-project.test.ts
@@ -124,7 +124,7 @@ describe('buildUpdateProjectProgram — golden emission', () => {
   it('reviewInterval lowers via readModifyReassign with build-time unit conversion', () => {
     const weekly = emit({ reviewInterval: 7 });
     expect(weekly).toContain(
-      '{ const _rmr = proj.reviewInterval; if (_rmr) { _rmr.steps = 1; _rmr.unit = "weeks"; proj.reviewInterval = _rmr; } }',
+      '{ const _rmr = proj.reviewInterval; if (_rmr) { _rmr.steps = 1; _rmr.unit = "weeks"; proj.reviewInterval = _rmr; } else { _warnings.push("reviewInterval: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set"); } }',
     );
     expect(weekly).toContain('_warnings.push("reviewInterval"');
 
@@ -325,6 +325,38 @@ describe('emitted update-project program executes (vm)', () => {
     expect(sets).not.toContain('status'); // the throw fired before the recording line
   });
 
+  // OMN-136 fail-loud: the null-instance readModifyReassign case.
+  it('vm: update with reviewInterval on a project with NO interval instance warns and does not set (OMN-136)', () => {
+    const { proj, sets } = makeRecordingProject(); // stub reviewInterval getter → undefined
+    const program = emitProgram(buildUpdateProjectProgram({ projectId: 'p1', changes: { reviewInterval: 7 } }));
+    const sandbox: Record<string, unknown> = {
+      Project: { byIdentifier: () => proj, Status: PROJECT_STATUS },
+    };
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+    expectMatchesSchema(ProjectWriteResultSchema, parsed);
+    expect(parsed.updated).toBe(true); // best-effort: the update itself still succeeds
+    expect(parsed.warnings).toEqual([
+      'reviewInterval: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set',
+    ]);
+    expect(sets).not.toContain('reviewInterval');
+  });
+
+  it('vm: update with reviewInterval on a project WITH an instance mutates it and stays warning-free (OMN-136)', () => {
+    const { proj, sets } = makeRecordingProject();
+    (proj as { reviewInterval: unknown }).reviewInterval = { unit: 'months', steps: 1 };
+    const program = emitProgram(buildUpdateProjectProgram({ projectId: 'p1', changes: { reviewInterval: 14 } }));
+    const sandbox: Record<string, unknown> = {
+      Project: { byIdentifier: () => proj, Status: PROJECT_STATUS },
+    };
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+    expect(parsed.warnings).toEqual([]);
+    expect(sets).toContain('reviewInterval');
+    expect((proj as { reviewInterval: { unit: string; steps: number } }).reviewInterval).toEqual({
+      unit: 'weeks',
+      steps: 2,
+    });
+  });
+
   it('vm: rename-only happy path returns the read-back envelope with empty warnings', () => {
     const { proj } = makeRecordingProject();
     const program = emitProgram(buildUpdateProjectProgram({ projectId: 'p1', changes: { name: 'New name' } }));
@@ -361,6 +393,20 @@ describe('emitted update-project program executes (vm)', () => {
     expect(parsed.name).toBe('x'); // the other change persisted
     expect(parsed.warnings).toEqual(['folder: boom']);
     expect(sets).toContain('name');
+  });
+});
+
+// OMN-136 fail-loud: a readModifyReassign whose target instance is null used to
+// silently no-op AND report success (no else branch). Kip's 2026-07-06 decision:
+// write no-ops FAIL LOUD — the null-instance case records a labeled OMN-137
+// warning in the envelope instead of silent success. (vm-execution proofs live
+// in the vm describe above, where the recording stub is in scope.)
+describe('OMN-136 — reviewInterval null-instance is LOUD, not a silent skip', () => {
+  it('emission: the readModifyReassign block carries the labeled else-warning', () => {
+    const omnijs = emitProgram(buildUpdateProjectProgram({ projectId: 'p1', changes: { reviewInterval: 7 } }));
+    expect(omnijs).toContain(
+      'else { _warnings.push("reviewInterval: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set"); }',
+    );
   });
 });
 


### PR DESCRIPTION
## What

Implements Kip's 2026-07-06 **write no-ops FAIL LOUD** decision for the OMN-136 residual: a project update (or create) carrying `reviewInterval` against a project with **no existing ReviewInterval instance** used to silently skip the assignment and report success — the `readModifyReassign` emission (`{ const _rmr = target.prop; if (_rmr) {…} }`) simply had no else branch.

## Premise verification (what the 'silent skip' actually is)

Probed the boundary first: `reviewInterval: null` **in the request** is already rejected loudly by Zod (all three variants — null, bridge-stringified \"null\", 0). The silent skip is the **runtime null instance** documented in the ticket's 2026-06-09/06-18 comments: `emitter.ts`'s read-modify-reassign guards on existence with no else, so the op no-ops and succeeds. Same OMN-58 no-instance class that `set-review-schedule` (and now #201's port) fails loudly on — this closes the last quiet corner of that seam.

## The fix (one emitter change, both users covered)

The else branch records a labeled **OMN-137 warning** — `reviewInterval: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set` — surfacing in the envelope's `warnings[]`. Warning rather than hard error because the statement is deliberately best-effort in both its users (create/project, update/project): an interval failure must not fail the rest of the update, but it must never be silent. `SETTER-PATTERNS.md` already prescribed loud failure here; the code catches up with the doc. Kip's decision text ('explicit error/warning') covers this shape.

## Testing

- TDD: emission golden (the else-warning text) + two vm-execution proofs — no-instance case warns, does not set, update still succeeds; existing-instance case mutates `{unit, steps}` correctly and stays warning-free.
- The two exact-text emission pins (update-project golden, script-builder OMN-38 pin) updated to the new block — that's the deliberate behavior change, everything else untouched.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3700/3700 ✅ · `npm run lint` ✅.
- Live-verify (Kip, optional): update a real sandbox project that has no review interval → response carries the warning; one with an interval → interval persists, no warning.

Closes OMN-136 (re-scoped residual — the plannedDate headline shipped in OMN-128 and was not touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)