### PR TITLE
feat(OMN-246): conformance probe persists raw failing tool-call args as artifacts

### DIFF
--- a/scripts/lib/conformance-grading.ts
+++ b/scripts/lib/conformance-grading.ts
@@ -55,7 +55,9 @@ export function serializeRawArgs(args: unknown): string {
     s = args;
   } else {
     try {
-      s = JSON.stringify(args);
+      // JSON.stringify(undefined) returns the VALUE undefined, not a string —
+      // fall back to String() so an argument-less tool call can't throw here.
+      s = JSON.stringify(args) ?? String(args);
     } catch (err) {
       return `[unserializable arguments: ${String(err)}]`;
     }

--- a/scripts/lib/conformance-grading.ts
+++ b/scripts/lib/conformance-grading.ts
@@ -1,0 +1,117 @@
+// scripts/lib/conformance-grading.ts
+// Grading core of the LLM conformance probe (OMN-121/122), extracted from
+// scripts/llm-conformance-probe.ts so it is unit-testable (the probe script
+// runs main() at import time — same rationale as ollama-lifecycle.ts).
+//
+// OMN-246: every failing grade persists the model's RAW tool-call arguments
+// (`rawArgs`). The 2026-06-12 qwen failures were unrecoverable because only
+// Zod issue strings were recorded — strict errors fully determined one root
+// shape and left two forever unknown (OMN-168). rawArgs makes any future
+// failure diagnosable from the probe's own output.
+import type { ZodTypeAny } from 'zod';
+import { parseWithNormalization } from '../../src/tools/normalization/normalize-input.js';
+
+export type Outcome = 'pass' | 'no_tool_call' | 'wrong_tool' | 'schema_invalid' | 'model_error';
+
+export interface ConformanceCase {
+  id: string;
+  prompt: string;
+  /** Tool name(s) that count as a correct selection for this intent. */
+  expect: string[];
+  note: string;
+}
+
+/** Structural subset of Ollama's ToolCall — all the grader reads. */
+export interface GradableToolCall {
+  function: { name: string; arguments: unknown };
+}
+
+export interface CaseResult {
+  caseId: string;
+  outcome: Outcome;
+  toolCalled?: string;
+  /** Top Zod issues (path + message) when schema_invalid. */
+  issues?: string[];
+  /** OMN-122: leniencies the normalize-then-strict layer applied to make this pass. */
+  normalizedVia?: string[];
+  detail?: string;
+  /**
+   * OMN-246: the model's raw tool-call arguments, verbatim (JSON-serialized,
+   * capped), present on every non-pass outcome that carried arguments. This is
+   * the failure ARTIFACT — issue strings alone underdetermine the payload.
+   */
+  rawArgs?: string;
+}
+
+/** Cap on a persisted rawArgs string — big enough for any real envelope, small
+ * enough that a runaway generation can't bloat the report. */
+export const RAW_ARGS_CAP = 4_000;
+
+/** JSON-serialize a model's raw arguments for persistence; truncation and
+ * serialization failures are LOUD markers, never silent. */
+export function serializeRawArgs(args: unknown): string {
+  let s: string;
+  if (typeof args === 'string') {
+    s = args;
+  } else {
+    try {
+      s = JSON.stringify(args);
+    } catch (err) {
+      return `[unserializable arguments: ${String(err)}]`;
+    }
+  }
+  if (s.length > RAW_ARGS_CAP) {
+    return `${s.slice(0, RAW_ARGS_CAP)}…[truncated from ${s.length} chars]`;
+  }
+  return s;
+}
+
+/**
+ * Grade a model's first tool call against the advertised strict schemas via the
+ * server's REAL front door — strict first, then the normalize-then-strict layer
+ * (OMN-122). A pass that needed normalization is still a pass (the server would
+ * accept it), and the load-bearing leniencies are recorded.
+ */
+export function gradeToolCall(
+  c: ConformanceCase,
+  call: GradableToolCall | undefined,
+  schemaByTool: Record<string, ZodTypeAny>,
+): CaseResult {
+  if (!call) return { caseId: c.id, outcome: 'no_tool_call' };
+  const name = call.function.name;
+  const rawArgs = serializeRawArgs(call.function.arguments);
+  if (!c.expect.includes(name)) {
+    return { caseId: c.id, outcome: 'wrong_tool', toolCalled: name, rawArgs };
+  }
+  const schema = schemaByTool[name];
+  if (!schema) {
+    return { caseId: c.id, outcome: 'wrong_tool', toolCalled: name, detail: 'no schema registered', rawArgs };
+  }
+
+  // Ollama returns arguments as a parsed object; tolerate a stringified payload too.
+  let args: unknown = call.function.arguments;
+  if (typeof args === 'string') {
+    try {
+      args = JSON.parse(args);
+    } catch {
+      return {
+        caseId: c.id,
+        outcome: 'schema_invalid',
+        toolCalled: name,
+        issues: ['arguments not valid JSON'],
+        rawArgs,
+      };
+    }
+  }
+  const result = parseWithNormalization(schema, args, name);
+  if (result.success) {
+    return {
+      caseId: c.id,
+      outcome: 'pass',
+      toolCalled: name,
+      normalizedVia: result.applied.length ? result.applied : undefined,
+    };
+  }
+  const issues = result.error!.issues.slice(0, 4).map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
+  return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues, rawArgs };
+}

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -44,14 +44,14 @@
 import { spawn, type ChildProcess } from 'child_process';
 import { writeFileSync } from 'fs';
 import { performance } from 'perf_hooks';
-import { Ollama, type Tool, type ToolCall } from 'ollama';
+import { Ollama, type Tool } from 'ollama';
 import { isLocalhostOllamaHost, resolveNumCtx } from './lib/ollama-lifecycle.js';
 import type { ZodTypeAny } from 'zod';
+import { gradeToolCall, type CaseResult, type ConformanceCase, type Outcome } from './lib/conformance-grading.js';
 import { ReadSchema } from '../src/tools/unified/schemas/read-schema.js';
 import { WriteSchema } from '../src/tools/unified/schemas/write-schema.js';
 import { AnalyzeSchema } from '../src/tools/unified/schemas/analyze-schema.js';
 import { SystemToolSchema } from '../src/tools/system/SystemTool.js';
-import { parseWithNormalization } from '../src/tools/normalization/normalize-input.js';
 
 // ── Grading config ──────────────────────────────────────────────────────────
 
@@ -62,14 +62,6 @@ const SCHEMA_BY_TOOL: Record<string, ZodTypeAny> = {
   omnifocus_analyze: AnalyzeSchema,
   system: SystemToolSchema,
 };
-
-interface ConformanceCase {
-  id: string;
-  prompt: string;
-  /** Tool name(s) that count as a correct selection for this intent. */
-  expect: string[];
-  note: string;
-}
 
 /**
  * Representative requests across the tool surface. A handful are deliberately
@@ -324,53 +316,6 @@ async function unloadModel(ollama: Ollama, model: string): Promise<void> {
 
 // ── Grading ─────────────────────────────────────────────────────────────────
 
-type Outcome = 'pass' | 'no_tool_call' | 'wrong_tool' | 'schema_invalid' | 'model_error';
-
-interface CaseResult {
-  caseId: string;
-  outcome: Outcome;
-  toolCalled?: string;
-  /** Top Zod issues (path + message) when schema_invalid. */
-  issues?: string[];
-  /** OMN-122: leniencies the normalize-then-strict layer applied to make this pass. */
-  normalizedVia?: string[];
-  detail?: string;
-}
-
-function gradeToolCall(c: ConformanceCase, call: ToolCall | undefined): CaseResult {
-  if (!call) return { caseId: c.id, outcome: 'no_tool_call' };
-  const name = call.function.name;
-  if (!c.expect.includes(name)) {
-    return { caseId: c.id, outcome: 'wrong_tool', toolCalled: name };
-  }
-  const schema = SCHEMA_BY_TOOL[name];
-  if (!schema) return { caseId: c.id, outcome: 'wrong_tool', toolCalled: name, detail: 'no schema registered' };
-
-  // Ollama returns arguments as a parsed object; tolerate a stringified payload too.
-  let args: unknown = call.function.arguments;
-  if (typeof args === 'string') {
-    try {
-      args = JSON.parse(args);
-    } catch {
-      return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues: ['arguments not valid JSON'] };
-    }
-  }
-  // OMN-122: grade against the server's REAL front door — strict schema first, then
-  // the normalize-then-strict layer. A pass that needed normalization is still a pass
-  // (the server would accept it), and we record which leniencies were load-bearing.
-  const result = parseWithNormalization(schema, args, name);
-  if (result.success) {
-    return {
-      caseId: c.id,
-      outcome: 'pass',
-      toolCalled: name,
-      normalizedVia: result.applied.length ? result.applied : undefined,
-    };
-  }
-  const issues = result.error!.issues.slice(0, 4).map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`);
-  return { caseId: c.id, outcome: 'schema_invalid', toolCalled: name, issues };
-}
-
 // ── Per-model run ────────────────────────────────────────────────────────────
 
 /** Per-model timing (OMN-173). All values in milliseconds. */
@@ -425,7 +370,7 @@ async function probeModel(ollama: Ollama, model: string, tools: Tool[], numCtx: 
         firstCase = false;
       }
       const call = res.message.tool_calls?.[0];
-      const graded = gradeToolCall(c, call);
+      const graded = gradeToolCall(c, call, SCHEMA_BY_TOOL);
       results.push(graded);
       process.stderr.write(`${graded.outcome}${graded.toolCalled ? ` (${graded.toolCalled})` : ''}\n`);
     } catch (err) {
@@ -481,6 +426,19 @@ function buildTimingArtifact(reports: ModelReport[], timing: ProbeTiming) {
         elapsedMs: r.timing ? Math.round(r.timing.elapsedMs) : null,
         loadMs: r.timing ? Math.round(r.timing.loadMs) : null,
         caseExecMs: r.timing ? Math.round(r.timing.caseExecMs) : null,
+        // OMN-246: raw failing tool-call args ride along in the machine
+        // artifact so baseline:conformance runs capture them automatically.
+        // Additive — the consumer (record-suite-timing) reads known fields
+        // and gates only on the schema tag.
+        failures: r.results
+          .filter((x) => x.outcome !== 'pass')
+          .map((x) => ({
+            caseId: x.caseId,
+            outcome: x.outcome,
+            toolCalled: x.toolCalled ?? null,
+            issues: x.issues ?? null,
+            rawArgs: x.rawArgs ?? null,
+          })),
       };
     }),
   };
@@ -582,6 +540,24 @@ function renderReport(reports: ModelReport[], timing: ProbeTiming): string {
       lines.push('');
       for (const [name, n] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
         lines.push(`- (${n}×) ${name}`);
+      }
+      lines.push('');
+    }
+
+    // OMN-246: failure ARTIFACTS — the raw tool-call arguments for every
+    // non-pass case, fenced so the payload survives verbatim. This is what
+    // makes a failure diagnosable later (issue strings underdetermine the
+    // shape — the OMN-168 lesson).
+    const failures = r.results.filter((x) => x.rawArgs !== undefined);
+    if (failures.length) {
+      lines.push(`### ${r.model} — failure artifacts (raw tool-call arguments)`);
+      lines.push('');
+      for (const f of failures) {
+        lines.push(`- **${f.caseId}** (${f.outcome}${f.toolCalled ? ` · ${f.toolCalled}` : ''}):`);
+        lines.push('');
+        lines.push('  ```json');
+        lines.push(`  ${f.rawArgs ?? ''}`);
+        lines.push('  ```');
       }
       lines.push('');
     }

--- a/scripts/llm-conformance-probe.ts
+++ b/scripts/llm-conformance-probe.ts
@@ -555,9 +555,15 @@ function renderReport(reports: ModelReport[], timing: ProbeTiming): string {
       for (const f of failures) {
         lines.push(`- **${f.caseId}** (${f.outcome}${f.toolCalled ? ` · ${f.toolCalled}` : ''}):`);
         lines.push('');
-        lines.push('  ```json');
-        lines.push(`  ${f.rawArgs ?? ''}`);
-        lines.push('  ```');
+        // rawArgs is model-controlled and JSON never escapes backticks, so an
+        // embedded ``` would close a 3-backtick fence and corrupt the report.
+        // Size the fence one backtick longer than the longest run inside.
+        const raw = f.rawArgs ?? '';
+        const longestRun = raw.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+        const fence = '`'.repeat(Math.max(3, longestRun + 1));
+        lines.push(`  ${fence}json`);
+        lines.push(`  ${raw}`);
+        lines.push(`  ${fence}`);
       }
       lines.push('');
     }

--- a/tests/unit/scripts/conformance-grading.test.ts
+++ b/tests/unit/scripts/conformance-grading.test.ts
@@ -1,0 +1,76 @@
+// tests/unit/scripts/conformance-grading.test.ts
+// OMN-246 — the conformance probe's grader must persist the model's RAW
+// tool-call arguments on every failing case. The 2026-06-12 qwen failures were
+// unrecoverable because only Zod issue strings were recorded (OMN-168's spec
+// demanded artifact-derived fixes and half the shapes were gone); this makes
+// any future failure diagnosable from the probe's own output.
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { gradeToolCall, serializeRawArgs } from '../../../scripts/lib/conformance-grading.js';
+
+const STRICT = z.object({ query: z.object({ type: z.literal('tasks') }).strict() }).strict();
+const SCHEMAS = { omnifocus_read: STRICT };
+const CASE = { id: 'today', prompt: 'What today?', expect: ['omnifocus_read'], note: 'n' };
+
+function call(name: string, args: unknown): { function: { name: string; arguments: unknown } } {
+  return { function: { name, arguments: args } };
+}
+
+describe('gradeToolCall — rawArgs capture (OMN-246)', () => {
+  it('pass: no rawArgs recorded (report stays lean)', () => {
+    const r = gradeToolCall(CASE, call('omnifocus_read', { query: { type: 'tasks' } }), SCHEMAS);
+    expect(r.outcome).toBe('pass');
+    expect(r.rawArgs).toBeUndefined();
+  });
+
+  it('schema_invalid: rawArgs carries the verbatim argument JSON', () => {
+    const args = { data: { name: 'Buy milk', target_id: 'abc' } };
+    const r = gradeToolCall(CASE, call('omnifocus_read', args), SCHEMAS);
+    expect(r.outcome).toBe('schema_invalid');
+    expect(r.rawArgs).toBe(JSON.stringify(args));
+  });
+
+  it('wrong_tool: rawArgs carries the argument JSON too', () => {
+    const r = gradeToolCall(CASE, call('system', { operation: 'version' }), SCHEMAS);
+    expect(r.outcome).toBe('wrong_tool');
+    expect(r.rawArgs).toBe(JSON.stringify({ operation: 'version' }));
+  });
+
+  it('unparseable stringified arguments: rawArgs preserves the raw string', () => {
+    const r = gradeToolCall(CASE, call('omnifocus_read', '{"query": {'), SCHEMAS);
+    expect(r.outcome).toBe('schema_invalid');
+    expect(r.issues).toEqual(['arguments not valid JSON']);
+    expect(r.rawArgs).toBe('{"query": {');
+  });
+
+  it('no_tool_call: no rawArgs (there are no arguments)', () => {
+    const r = gradeToolCall(CASE, undefined, SCHEMAS);
+    expect(r.outcome).toBe('no_tool_call');
+    expect(r.rawArgs).toBeUndefined();
+  });
+
+  it('stringified-but-valid arguments still grade (parity with the old grader)', () => {
+    const r = gradeToolCall(CASE, call('omnifocus_read', JSON.stringify({ query: { type: 'tasks' } })), SCHEMAS);
+    expect(r.outcome).toBe('pass');
+  });
+});
+
+describe('serializeRawArgs', () => {
+  it('serializes objects to JSON and passes strings through', () => {
+    expect(serializeRawArgs({ a: 1 })).toBe('{"a":1}');
+    expect(serializeRawArgs('already a string')).toBe('already a string');
+  });
+
+  it('truncates past the cap with a loud marker (never silently)', () => {
+    const big = { note: 'x'.repeat(10_000) };
+    const out = serializeRawArgs(big);
+    expect(out.length).toBeLessThanOrEqual(4_000 + 40);
+    expect(out).toContain('…[truncated');
+  });
+
+  it('survives unserializable values', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(serializeRawArgs(cyclic)).toContain('unserializable');
+  });
+});

--- a/tests/unit/scripts/conformance-grading.test.ts
+++ b/tests/unit/scripts/conformance-grading.test.ts
@@ -73,4 +73,11 @@ describe('serializeRawArgs', () => {
     cyclic.self = cyclic;
     expect(serializeRawArgs(cyclic)).toContain('unserializable');
   });
+
+  it('survives values JSON.stringify maps to undefined (argument-less tool calls)', () => {
+    // JSON.stringify(undefined) returns the VALUE undefined — without the
+    // String() fallback this threw on `.length` and killed the case's artifact.
+    expect(serializeRawArgs(undefined)).toBe('undefined');
+    expect(serializeRawArgs(() => {})).toContain('=>');
+  });
 });


### PR DESCRIPTION
## What

Closes the evidence gap that blocked half of OMN-168: the probe recorded only Zod issue strings on failure, so the 2026-06-12 qwen payloads were structurally unrecoverable (strict errors fully determined one root shape; the two `data`-only shapes are gone forever). Every non-pass grade now persists the model's **raw tool-call arguments**.

## Changes

- **`scripts/lib/conformance-grading.ts`** (new): the grading core (`gradeToolCall`, `CaseResult`, `Outcome`, `ConformanceCase`), extracted from the probe so it's unit-testable — the probe runs `main()` at import time, same extraction rationale as `ollama-lifecycle.ts`. Logic moved verbatim except: `rawArgs` capture on `wrong_tool`/`schema_invalid` (including the unparseable-string case, which preserves the raw string), and the schema map is a parameter.
- **`serializeRawArgs`**: verbatim JSON, 4KB cap with a loud `…[truncated from N chars]` marker, loud `[unserializable…]` fallback — never silent.
- **Report**: per-model `### <model> — failure artifacts (raw tool-call arguments)` section, fenced `json` per failing case.
- **Machine artifact** (`PROBE_TIMING_JSON`): additive `failures[]` per model (`caseId`/`outcome`/`toolCalled`/`issues`/`rawArgs`), so `npm run baseline:conformance` captures artifacts automatically. Additive is safe: `record-suite-timing` gates only on the exact schema tag and reads known fields (verified).

## Why now

Parent **OMN-168**'s supervised re-baseline (Kip's step, after #198/#199 merge+deploy) will either show the two unknown qwen cases fixed by the `mutation-field-alias` leniency — or capture their payloads for the first time, unblocking the root-`data` lift design. Ideally this merges before that run.

## Testing

- TDD: 9 unit tests on the extracted grader — rawArgs on schema_invalid/wrong_tool/unparseable-string, absent on pass/no_tool_call, stringified-but-valid parity, truncation cap, unserializable fallback.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ (scripts/ is in the test tsconfig, so the extraction is type-gated) · `npm run test:unit` 3706/3706 ✅ · `npm run lint` ✅.
- The report/artifact rendering additions are exercised on the next real probe run (they need Ollama; the probe is not runnable in CI or the unattended loop).

Closes OMN-246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)