### PR TITLE
fix(OMN-245): wire noteTruncateLength through project list reads (unreachable noteTruncated flag)

### DIFF
--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -143,6 +143,13 @@ export function projectFieldsOnResult(
         out[field] = project[field];
       }
     }
+    // OMN-245: noteTruncated is a marker RIDING the note field, not a field of
+    // its own — whenever the note is projected, the truncation marker must
+    // survive projection, or the advertised "truncated notes carry the flag"
+    // contract silently breaks for explicit-fields queries.
+    if ('note' in out && project.noteTruncated === true) {
+      out.noteTruncated = true;
+    }
     return out;
   };
 
@@ -822,6 +829,9 @@ PERFORMANCE:
    * OMN-40: project id-lookup fast path. Uses Project.byIdentifier() for O(1)
    * lookup, bypasses the projects-list cache (whose key did not include id), and
    * defensively verifies the returned project's id matches the request.
+   *
+   * OMN-245: deliberately NO note truncation here — an id-lookup is a targeted
+   * fetch, so the caller gets the full note (parity with the task details path).
    */
   private async executeProjectIdLookup(projectId: string, fields: string[], timer: OperationTimerV2): Promise<unknown> {
     const generated = buildProjectByIdScript(projectId, fields);
@@ -1002,8 +1012,15 @@ PERFORMANCE:
     // for the full option trade-off (explicit param vs heuristic vs slim mode).
     const isNarrowLookup = isNarrowLookupFilter(projectFilter);
 
-    // Build cache key
-    const cacheParams = { ...projectFilter, limit, includeStats };
+    // OMN-245: mirror the task path — list reads truncate notes unless
+    // details:true (the OMN-242 noteTruncated flag marks rows where it fired).
+    const noteTruncateLength = !compiled.details ? NOTE_TRUNCATE_LENGTH : undefined;
+
+    // Build cache key. noteTruncateLength MUST participate: a truncated
+    // (details:false) and full-note (details:true) list now compile different
+    // scripts, and a shared entry would serve truncated notes to a details:true
+    // caller (or vice versa).
+    const cacheParams = { ...projectFilter, limit, includeStats, noteTruncateLength };
     const cacheKey = `projects_list_${JSON.stringify(cacheParams)}`;
 
     // Check cache
@@ -1030,6 +1047,7 @@ PERFORMANCE:
       limit,
       includeStats,
       performanceMode: includeStats ? 'normal' : 'lite',
+      noteTruncateLength,
     });
 
     const result = await this.execJson(generatedScript.script, PROJECT_LIST_SCHEMA);

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -158,6 +158,15 @@ export function projectFieldsOnResult(
   return { ...result, data: { ...data, projects: projected } };
 }
 
+/**
+ * One truncation policy for BOTH entity paths: list-style reads truncate
+ * notes unless the caller asked for details. Tasks and projects must never
+ * diverge on this — change it here, not per call site.
+ */
+function resolveNoteTruncateLength(details: boolean | undefined): number | undefined {
+  return !details ? NOTE_TRUNCATE_LENGTH : undefined;
+}
+
 // =============================================================================
 // TASK QUERY BUILDER
 // =============================================================================
@@ -255,10 +264,8 @@ function buildTaskQuery(compiled: CompiledQuery): TaskQueryPlan & { fieldsMode: 
     scriptFields = [...scriptFields, 'available'];
   }
 
-  // Note truncation: apply when not in detail mode
-  // Truncate when using minimal fields OR when user explicitly requests note without details=true
-  const shouldTruncateNotes = !compiled.details;
-  const noteTruncateLength = shouldTruncateNotes ? NOTE_TRUNCATE_LENGTH : undefined;
+  // Note truncation: shared policy — see resolveNoteTruncateLength.
+  const noteTruncateLength = resolveNoteTruncateLength(compiled.details);
 
   // Only pass user-specified sort to the script builder (not mode default sorts).
   // Mode default sorts operate on small, already-filtered sets and stay as post-hoc.
@@ -1014,7 +1021,7 @@ PERFORMANCE:
 
     // OMN-245: mirror the task path — list reads truncate notes unless
     // details:true (the OMN-242 noteTruncated flag marks rows where it fired).
-    const noteTruncateLength = !compiled.details ? NOTE_TRUNCATE_LENGTH : undefined;
+    const noteTruncateLength = resolveNoteTruncateLength(compiled.details);
 
     // Build cache key. noteTruncateLength MUST participate: a truncated
     // (details:false) and full-note (details:true) list now compile different

--- a/tests/unit/tools/unified/omn-245-project-note-truncation.test.ts
+++ b/tests/unit/tools/unified/omn-245-project-note-truncation.test.ts
@@ -1,0 +1,118 @@
+/**
+ * OMN-245: wire noteTruncateLength through project LIST reads.
+ *
+ * PR #194 (OMN-242) added the noteTruncated-flag truncation branch to
+ * generateProjectFieldProjection, but no project call site passed
+ * noteTruncateLength — the branch (and the advertised flag) was unreachable.
+ * These tests pin the wiring at the handler seam, mirroring the task path:
+ * list without details → truncate at NOTE_TRUNCATE_LENGTH; details:true and
+ * id-lookup → full note. Cache keys must not share entries across the two
+ * truncation states.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OmniFocusReadTool , projectFieldsOnResult } from '../../../../src/tools/unified/OmniFocusReadTool.js';
+import { CacheManager } from '../../../../src/cache/CacheManager.js';
+import { NOTE_TRUNCATE_LENGTH } from '../../../../src/contracts/ast/script-builder.js';
+
+function createMockCache(): CacheManager & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> } {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    invalidate: vi.fn(),
+    invalidateForTaskChange: vi.fn(),
+    invalidateProject: vi.fn(),
+    invalidateTag: vi.fn(),
+    invalidateTaskQueries: vi.fn(),
+    clear: vi.fn(),
+  } as unknown as CacheManager & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> };
+}
+
+describe('OMN-245: project list note truncation wiring', () => {
+  let tool: OmniFocusReadTool;
+  let mockCache: ReturnType<typeof createMockCache>;
+  let execJsonSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockCache = createMockCache();
+    tool = new OmniFocusReadTool(mockCache);
+    execJsonSpy = vi.fn().mockResolvedValue({
+      success: true,
+      data: { projects: [], metadata: { total_matched: 0 } },
+    });
+    vi.spyOn(tool as unknown as { execJson: unknown }, 'execJson' as never).mockImplementation(execJsonSpy as never);
+  });
+
+  async function runProjectsQuery(extra: Record<string, unknown> = {}): Promise<string> {
+    const result = (await tool.execute({
+      query: { type: 'projects', filters: { status: 'active' }, ...extra },
+    })) as unknown;
+    void result;
+    expect(execJsonSpy).toHaveBeenCalled();
+    return String(execJsonSpy.mock.calls[0][0]);
+  }
+
+  it('list WITHOUT details: generated script contains the truncation branch + noteTruncated flag', async () => {
+    const script = await runProjectsQuery();
+    expect(script).toContain('noteTruncated: true');
+    expect(script).toContain(`n.length > ${NOTE_TRUNCATE_LENGTH}`);
+  });
+
+  it('list WITH details:true: generated script returns the full note, no truncation branch', async () => {
+    const script = await runProjectsQuery({ details: true });
+    expect(script).not.toContain('noteTruncated');
+    // The OmniJS body is JSON-stringified into the JXA wrapper, so quotes are
+    // escaped — match the projection quote-agnostically.
+    expect(script).toMatch(/note: project\.note \|\| /);
+  });
+
+  it('id-lookup path never truncates (targeted fetch → full note)', async () => {
+    execJsonSpy.mockResolvedValue({
+      success: true,
+      data: { id: 'proj-1', name: 'P', note: 'x'.repeat(500) },
+    });
+    await tool.execute({ query: { type: 'projects', filters: { id: 'proj-1' } } });
+    const script = String(execJsonSpy.mock.calls[0][0]);
+    expect(script).not.toContain('noteTruncated');
+  });
+
+  it('cache key differs between details:false and details:true list queries', async () => {
+    await runProjectsQuery();
+    const keyWithout = String(mockCache.get.mock.calls.at(-1)?.[1]);
+    execJsonSpy.mockClear();
+    mockCache.get.mockClear();
+    await runProjectsQuery({ details: true });
+    const keyWith = String(mockCache.get.mock.calls.at(-1)?.[1]);
+    expect(keyWithout).not.toBe(keyWith);
+  });
+});
+
+describe('OMN-245: post-hoc projection carries the noteTruncated marker (live-verify finding)', () => {
+  const envelope = (row: Record<string, unknown>) => ({
+    success: true,
+    data: { projects: [{ id: 'p1', name: 'P', note: 'x'.repeat(200) + '...', noteTruncated: true, ...row }] },
+  });
+
+  it('keeps noteTruncated when note is among the projected fields', () => {
+    const out = projectFieldsOnResult(envelope({}), ['id', 'name', 'note']) as {
+      data: { projects: Array<Record<string, unknown>> };
+    };
+    expect(out.data.projects[0].noteTruncated).toBe(true);
+  });
+
+  it('drops noteTruncated when note is NOT projected (marker rides the note)', () => {
+    const out = projectFieldsOnResult(envelope({}), ['id', 'name']) as {
+      data: { projects: Array<Record<string, unknown>> };
+    };
+    expect(out.data.projects[0]).not.toHaveProperty('noteTruncated');
+    expect(out.data.projects[0]).not.toHaveProperty('note');
+  });
+
+  it('does not invent the marker for full notes', () => {
+    const out = projectFieldsOnResult({ success: true, data: { projects: [{ id: 'p1', name: 'P', note: 'short' }] } }, [
+      'id',
+      'note',
+    ]) as { data: { projects: Array<Record<string, unknown>> } };
+    expect(out.data.projects[0]).not.toHaveProperty('noteTruncated');
+  });
+});

--- a/tests/unit/tools/unified/omn-245-project-note-truncation.test.ts
+++ b/tests/unit/tools/unified/omn-245-project-note-truncation.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { OmniFocusReadTool , projectFieldsOnResult } from '../../../../src/tools/unified/OmniFocusReadTool.js';
+import { OmniFocusReadTool, projectFieldsOnResult } from '../../../../src/tools/unified/OmniFocusReadTool.js';
 import { CacheManager } from '../../../../src/cache/CacheManager.js';
 import { NOTE_TRUNCATE_LENGTH } from '../../../../src/contracts/ast/script-builder.js';
 


### PR DESCRIPTION
Closes the OMN-245 gap: #194's `noteTruncated` emitter existed but **no project call site passed `noteTruncateLength`** — main advertised a contract that could not fire. Implements the ticket's Kip-approved design (2026-07-06):

1. **List path wired**: `handleProjectQuery` mirrors the task path — `!compiled.details` → `NOTE_TRUNCATE_LENGTH` into `buildFilteredProjectsScript`. Deliberate behavior change: project list notes now truncate in non-details mode, at parity with tasks, detectably.
2. **Cache-key audit (ticket item 3) — real gap found + fixed**: the `projects_list` key was `{filter, limit, includeStats}`; truncated and full-note lists now compile different scripts, so `noteTruncateLength` joins the key.
3. **Id-lookup stays untruncated** deliberately (targeted fetch → full note); comment records it.
4. **Live-verify finding, fixed in-PR**: `projectFieldsOnResult` stripped the `noteTruncated` marker on explicit-`fields` queries (marker not in the field list) — truncated note delivered, flag silently gone. The marker now rides the `note` field through post-hoc projection, with 3 pins.
5. **Tool description** (ticket item 4): verified already accurate for truncation — no edit. One **pre-existing, out-of-scope** wrinkle spotted live: id-lookup *without* `fields` returns the thin default projection, while the description says "ID lookup always returns all fields" — flagging rather than scope-creeping.

**TDD**: red-first wiring tests (2 red / 2 controls green on unwired main), then green; 3 projection-marker pins from the live finding. **Live-verified** against real OmniFocus via this worktree's built dist (MCPTestClient): truncated list row = 203 chars + `noteTruncated: true`; `details:true` = full 5,906-char note, no flag; thin default projects no note; id-lookup = full note, no flag.

Gates: build, lint --max-warnings=0, prettier, full unit suite 3,715 green.

Unblocks: OMN-244 (task-note sibling — should mirror this wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)