### PR TITLE
fix(OMN-247): leniency recovery must never rewrite the mutation discriminant

### DIFF
--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -204,6 +204,19 @@ function hoistDataId(m: Record<string, unknown>): Record<string, unknown> | unde
   const data = { ...m.data };
   const id = data.id as string;
   delete data.id;
+  // OMN-247: a leniency must never rewrite dispatch. A nested operation/target
+  // that CONTRADICTS the outer value made `complete` execute as `delete` (the
+  // complete branch's spread copied it over the discriminant AFTER strict
+  // validation had already failed once) — and in the delete branch the drop
+  // silently discarded the same ambiguity. Conflicting dispatch keys abort the
+  // recovery entirely (the original strict error stands); a redundant echo of
+  // the same value is dropped so legitimate recoveries proceed.
+  for (const dispatchKey of ['operation', 'target'] as const) {
+    if (data[dispatchKey] !== undefined) {
+      if (data[dispatchKey] !== m[dispatchKey]) return undefined;
+      delete data[dispatchKey];
+    }
+  }
   const newMutation: Record<string, unknown> = { ...m, id };
   delete newMutation.data;
   // Don't silently drop residual fields the model nested in `data` (OMN-97

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -212,23 +212,35 @@ function hoistDataId(m: Record<string, unknown>): Record<string, unknown> | unde
   // recovery entirely (the original strict error stands); a redundant echo of
   // the same value is dropped so legitimate recoveries proceed.
   for (const dispatchKey of ['operation', 'target'] as const) {
-    if (data[dispatchKey] !== undefined) {
-      if (data[dispatchKey] !== m[dispatchKey]) return undefined;
-      delete data[dispatchKey];
-    }
+    const nested = data[dispatchKey];
+    if (nested === undefined) continue;
+    const outer = m[dispatchKey];
+    // Gate round 2 (OMN-75): an ABSENT outer key is not a contradiction — the
+    // nested value is the model supplying it in the wrong place, and the
+    // per-op residual handling below restores the pre-OMN-247 recovery
+    // (complete spreads it up; update routes it to `changes`, which strict
+    // re-validation then adjudicates). Only a PRESENT-and-different outer
+    // value is a dispatch conflict.
+    if (outer === undefined) continue;
+    if (nested !== outer) return undefined;
+    delete data[dispatchKey];
   }
   const newMutation: Record<string, unknown> = { ...m, id };
   delete newMutation.data;
   // Don't silently drop residual fields the model nested in `data` (OMN-97
   // anti-pattern). update: remaining → `changes` (the canonical field name).
   // complete: remaining (e.g. completionDate) are top-level fields, spread them
-  // up. delete: takes no other fields, so leftovers are dropped — strict
-  // re-validation would reject them anyway, leaving the original error intact.
+  // up. delete: takes no other fields — gate round 2: leftovers ABORT the
+  // recovery (original strict error stands) instead of being silently dropped;
+  // the old comment claimed re-validation would catch them, but `data` was
+  // deleted before re-validation ever saw the leftovers.
   if (Object.keys(data).length > 0) {
     if (op === 'update') {
       newMutation.changes = data;
     } else if (op === 'complete') {
       Object.assign(newMutation, data);
+    } else {
+      return undefined;
     }
   }
   return newMutation;

--- a/tests/unit/tools/normalization/normalize-input.test.ts
+++ b/tests/unit/tools/normalization/normalize-input.test.ts
@@ -273,3 +273,87 @@ describe('leniency #4 — mutation-field-alias (OMN-168)', () => {
     expect(r.applied).toEqual([]);
   });
 });
+
+describe('OMN-247 — leniencies must never rewrite the mutation discriminant', () => {
+  it('the confirmed hijack: complete + nested data.operation:delete is NOT recovered as a delete', () => {
+    // /code-review 2026-07-07 verified trace: strict fails (complete has no
+    // `data`), the hoist copied the residual over the top level, and the
+    // flipped object passed the DELETE schema — task deleted instead of
+    // completed. The recovery must abort: conflicting dispatch keys mean the
+    // request's intent is ambiguous, so the ORIGINAL strict error stands.
+    const args = {
+      mutation: { operation: 'complete', target: 'task', data: { id: 't1', operation: 'delete' } },
+    };
+    const original = WriteSchema.safeParse(args);
+    expect(original.success).toBe(false);
+
+    const r = parseWithNormalization(WriteSchema, args, 'omnifocus_write');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+    expect(JSON.stringify(r.error!.issues)).toBe(JSON.stringify((original as z.SafeParseError<unknown>).error.issues));
+  });
+
+  it('nested data.target conflicting with the outer target also aborts recovery', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'complete', target: 'task', data: { id: 't1', target: 'project' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('delete + conflicting nested data.operation aborts instead of silently dropping the conflict', () => {
+    // Pre-OMN-247 the delete branch dropped ALL residuals, so a nested
+    // operation:'complete' was silently discarded and the DELETE executed —
+    // the same ambiguity in the other direction.
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'delete', target: 'task', data: { id: 't1', operation: 'complete' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('a REDUNDANT echo of the outer discriminant is dropped and recovery proceeds', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'complete', target: 'task', data: { id: 't1', operation: 'complete' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual(['data-hoist-id']);
+    expect(r.data).toMatchObject({ mutation: { operation: 'complete', target: 'task', id: 't1' } });
+  });
+
+  it('legitimate complete residuals (completionDate) still hoist and spread', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      {
+        mutation: {
+          operation: 'complete',
+          target: 'task',
+          data: { id: 't1', completionDate: '2026-07-01 12:00' },
+        },
+      },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual(['data-hoist-id']);
+    expect(r.data).toMatchObject({
+      mutation: { operation: 'complete', id: 't1', completionDate: '2026-07-01 12:00' },
+    });
+  });
+
+  it('update with an echoed data.operation recovers to changes WITHOUT the dispatch key', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'update', target: 'task', data: { id: 't1', operation: 'update', note: 'hi' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual(['data-hoist-id']);
+    expect(r.data).toMatchObject({ mutation: { operation: 'update', id: 't1', changes: { note: 'hi' } } });
+  });
+});

--- a/tests/unit/tools/normalization/normalize-input.test.ts
+++ b/tests/unit/tools/normalization/normalize-input.test.ts
@@ -275,6 +275,35 @@ describe('leniency #4 — mutation-field-alias (OMN-168)', () => {
 });
 
 describe('OMN-247 — leniencies must never rewrite the mutation discriminant', () => {
+  it('gate round 2: ABSENT outer target + nested data.target is NOT a contradiction — complete recovers (OMN-75 leniency)', () => {
+    // Pre-#247 this recovered (complete spreads data.target up); the first
+    // guard draft compared nested !== undefined and aborted. Absent means
+    // "fill from nested", never "conflict".
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'complete', data: { id: 't1', target: 'project' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    const m = (r.data as { mutation: Record<string, unknown> }).mutation;
+    expect(m.id).toBe('t1');
+    expect(m.target).toBe('project');
+    expect(r.applied).toEqual(['data-hoist-id']);
+  });
+
+  it('gate round 2: delete with a residual data field ABORTS recovery — never silently drops it (OMN-97 class)', () => {
+    const args = {
+      mutation: { operation: 'delete', target: 'task', data: { id: 't1', reason: 'duplicate-of-t2' } },
+    };
+    const original = WriteSchema.safeParse(args);
+    expect(original.success).toBe(false);
+
+    const r = parseWithNormalization(WriteSchema, args, 'omnifocus_write');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+    expect(JSON.stringify(r.error!.issues)).toBe(JSON.stringify((original as z.SafeParseError<unknown>).error.issues));
+  });
+
   it('the confirmed hijack: complete + nested data.operation:delete is NOT recovered as a delete', () => {
     // /code-review 2026-07-07 verified trace: strict fails (complete has no
     // `data`), the hoist copied the residual over the top level, and the


### PR DESCRIPTION
## What

Fixes the severe finding from the 2026-07-07 `/code-review` of #198 (filed as OMN-247, pre-existing on main byte-for-byte): `hoistDataId`'s `complete` branch spreads residual `data` keys over the top-level mutation, so a nested `data.operation:'delete'` overwrites the dispatch discriminant **after strict validation already failed once** — the recovered object passes the delete schema and a malformed complete request executes as a **delete**. **STACKED on #198** (base = `feature/omn-168-pr1-mutation-field-alias`, where the helper lives); retarget to main after #198 merges.

## The guard

Before any residual handling, dispatch keys are checked against the outer envelope:

| Nested `data.operation`/`data.target` | Behavior |
|---|---|
| **Contradicts** the outer value | recovery ABORTS — the original strict error stands (ambiguous intent is not recoverable) |
| **Echoes** the outer value | dropped; recovery proceeds (legitimate small-model redundancy) |
| Absent | unchanged |

This also closes the mirror-image case the ticket's trace implies but the old code hid: the `delete` branch silently **dropped** a conflicting nested `operation:'complete'` and deleted anyway — same ambiguity, other direction. Now it aborts too.

## Why abort rather than strip on conflict

A request saying `complete` outside and `delete` inside has no determinable intent; stripping would silently pick the outer one. Failing back to the original strict error keeps the leniency layer's core invariant — bounded, evidence-backed repair only, never a guess (matches the collision-safe rule `mutation-field-alias` already follows in #198).

## Testing

- 6 new tests including the ticket's verbatim confirmed hijack trace (original-error byte-equality), `data.target` conflict, the delete-branch sibling, redundant-echo recovery, and pins that legitimate recoveries (complete+completionDate spread, update→changes) are unchanged.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3708/3708 ✅ · `npm run lint` ✅.
- **Gate (Kip, per ticket + the #199 rule):** `npm run conformance` vs a same-day main control — the leniency layer moved.

Closes OMN-247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)