### PR TITLE
feat(OMN-244): emit noteTruncated flag when task note truncation fires

### DIFF
--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -289,8 +289,11 @@ function generateFieldProjection(
         break;
       case 'note':
         if (noteTruncateLength && noteTruncateLength > 0) {
+          // OMN-244: when truncation fires, emit a sibling noteTruncated: true via
+          // conditional spread (mirrors the project projection's OMN-242 shape) —
+          // untruncated rows stay byte-identical (key absent).
           projections.push(
-            `note: (() => { const n = task.note || ""; return n.length > ${noteTruncateLength} ? n.substring(0, ${noteTruncateLength}) + "..." : n; })()`,
+            `...(() => { const n = task.note || ""; const truncated = n.length > ${noteTruncateLength}; return truncated ? { note: n.substring(0, ${noteTruncateLength}) + "...", noteTruncated: true } : { note: n }; })()`,
           );
         } else {
           projections.push('note: task.note || ""');

--- a/src/omnifocus/response-schemas/read.ts
+++ b/src/omnifocus/response-schemas/read.ts
@@ -64,6 +64,10 @@ export const TaskRowSchema = z
     // OMN-207: action-group ordering, read-side parity with the write side
     // (OMN-198/206). Emitted by the `sequential` task projection case.
     sequential: z.boolean().optional(),
+    // OMN-244: truncation marker riding the note field (piggybacks on the
+    // 'note' projection case, not its own switch label — parity test allows
+    // it as the one extra key, mirroring the project row's OMN-242 entry).
+    noteTruncated: z.boolean().optional(),
   })
   .strict();
 

--- a/src/omnifocus/types.ts
+++ b/src/omnifocus/types.ts
@@ -35,6 +35,7 @@ export interface OmniFocusTask {
   // projection cases in src/contracts/ast/script-builder.ts.
   isProjectRoot?: boolean; // OMN-153: true when task.project !== null (task IS a project root)
   hasNote?: boolean; // OMN-130: cheap presence marker, true when the task has non-empty note text
+  noteTruncated?: boolean; // OMN-244: present (true) only when the returned note was truncated
   plannedDate?: string | null; // OMN-62: OF 4.7+ planned date, ISO string, null when task has none
   repetitionRule?: RepetitionRuleData | null; // modern (v4.7+) repetition rule shape, null when task has none
   // Mode-injected fields: not selectable via TaskFieldEnum's `fields:[...]` (so

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -324,6 +324,13 @@ export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[])
       }
     });
 
+    // OMN-244: noteTruncated is a marker RIDING the note field, not a field of
+    // its own — whenever the note is projected, the truncation marker must
+    // survive projection (the #204 live-verify finding class, task side).
+    if ('note' in projectedTask && task.noteTruncated === true) {
+      (projectedTask as Record<string, unknown>).noteTruncated = true;
+    }
+
     // OMN-241: return the honest partial shape — no `as OmniFocusTask` cast.
     // Callers that need a specific field beyond `id` must narrow (check
     // presence) rather than assume it's always populated.

--- a/src/tools/tasks/task-query-pipeline.ts
+++ b/src/tools/tasks/task-query-pipeline.ts
@@ -302,6 +302,19 @@ export function sortTasks(tasks: OmniFocusTask[], sortOptions?: SortOption[]): O
  * Project task fields based on user selection for performance optimization.
  * Always includes 'id' if any fields are selected.
  */
+/**
+ * OMN-244/OMN-245: noteTruncated is a marker RIDING the note field, not a
+ * field of its own — whenever `note` survives a post-hoc projection, the
+ * marker must survive with it (the #204 live-verify bug class). ONE carry
+ * rule shared by the task and project projection paths; change it here,
+ * never per call site.
+ */
+export function carryNoteTruncatedMarker(source: Record<string, unknown>, projected: Record<string, unknown>): void {
+  if ('note' in projected && source.noteTruncated === true) {
+    projected.noteTruncated = true;
+  }
+}
+
 export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[]): (OmniFocusTask | ProjectedTask)[] {
   if (!selectedFields || selectedFields.length === 0) {
     return tasks;
@@ -324,12 +337,7 @@ export function projectFields(tasks: OmniFocusTask[], selectedFields?: string[])
       }
     });
 
-    // OMN-244: noteTruncated is a marker RIDING the note field, not a field of
-    // its own — whenever the note is projected, the truncation marker must
-    // survive projection (the #204 live-verify finding class, task side).
-    if ('note' in projectedTask && task.noteTruncated === true) {
-      (projectedTask as Record<string, unknown>).noteTruncated = true;
-    }
+    carryNoteTruncatedMarker(task as unknown as Record<string, unknown>, projectedTask as Record<string, unknown>);
 
     // OMN-241: return the honest partial shape — no `as OmniFocusTask` cast.
     // Callers that need a specific field beyond `id` must narrow (check

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -50,6 +50,7 @@ import {
   parseTasks,
   sortTasks,
   projectFields,
+  carryNoteTruncatedMarker,
   scoreForSmartSuggest,
   countTodayCategories,
   MODE_INJECTED_FIELDS,
@@ -143,13 +144,7 @@ export function projectFieldsOnResult(
         out[field] = project[field];
       }
     }
-    // OMN-245: noteTruncated is a marker RIDING the note field, not a field of
-    // its own — whenever the note is projected, the truncation marker must
-    // survive projection, or the advertised "truncated notes carry the flag"
-    // contract silently breaks for explicit-fields queries.
-    if ('note' in out && project.noteTruncated === true) {
-      out.noteTruncated = true;
-    }
+    carryNoteTruncatedMarker(project, out);
     return out;
   };
 

--- a/src/tools/unified/OmniFocusReadTool.ts
+++ b/src/tools/unified/OmniFocusReadTool.ts
@@ -347,7 +347,7 @@ FILTER OPERATORS:
 RESPONSE CONTROL:
 - Default returns minimal fields (id, name, flagged, completed, dueDate, deferDate, tags, project, available, hasNote)
 - details: true returns all fields with full notes
-- fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true; projects only: a truncated note carries a sibling noteTruncated: true — absent when the note was returned in full)
+- fields: [...] returns exactly those fields (note truncated to 200 chars unless details: true; a truncated note carries a sibling noteTruncated: true — absent when the note was returned in full; applies to tasks and projects)
 - ID lookup always returns all fields with full notes
 - fields are type-specific; requesting a field of the other type (e.g. reviewInterval on tasks) returns a guided error
 - fields (tasks): id, name, completed, flagged, blocked, available, hasNote, estimatedMinutes, dueDate, deferDate, plannedDate, completionDate, added, modified, dropDate, note, projectId, project, tags, repetitionRule, parentTaskId, parentTaskName, inInbox, sequential

--- a/tests/unit/omnifocus/projection-parity.test.ts
+++ b/tests/unit/omnifocus/projection-parity.test.ts
@@ -63,15 +63,18 @@ describe('TaskRowSchema ↔ generateFieldProjection switch-case parity', () => {
     const schemaKeys = new Set(Object.keys(TaskRowSchema.shape));
 
     const missingFromSchema = [...switchLabels].filter((k) => !schemaKeys.has(k));
-    const missingFromSwitch = [...schemaKeys].filter((k) => !switchLabels.has(k));
 
     expect(
       missingFromSchema,
       `Switch has case labels not in TaskRowSchema.shape: ${missingFromSchema.join(', ')}`,
     ).toEqual([]);
-    expect(missingFromSwitch, `TaskRowSchema.shape has keys not in switch: ${missingFromSwitch.join(', ')}`).toEqual(
-      [],
-    );
+
+    // The difference (schema keys NOT in the switch) must be exactly this one.
+    // noteTruncated (OMN-244) piggybacks on the 'note' case rather than being
+    // its own switch label — same shape as the project row's OMN-242 entry.
+    const expectedExtra = new Set(['noteTruncated']);
+    const actualExtra = new Set([...schemaKeys].filter((k) => !switchLabels.has(k)));
+    expect(actualExtra).toEqual(expectedExtra);
   });
 });
 

--- a/tests/unit/tools/unified/omn-244-task-note-truncation.test.ts
+++ b/tests/unit/tools/unified/omn-244-task-note-truncation.test.ts
@@ -1,0 +1,108 @@
+/**
+ * OMN-244: noteTruncated flag for TASK notes (sibling of OMN-242/OMN-245,
+ * mirrors merged PR #194/#204's project pattern).
+ *
+ * The task path already threads noteTruncateLength (resolveNoteTruncateLength
+ * via buildTaskQuery — #204's shared helper), but the task projection
+ * truncated silently: the same `note` field could carry a full or truncated
+ * note with no signal. These tests pin: the conditional-spread emission, the
+ * strict row schema widening, and the post-hoc projection carrying the marker
+ * (the #204 live-verify finding class, task side).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OmniFocusReadTool } from '../../../../src/tools/unified/OmniFocusReadTool.js';
+import { CacheManager } from '../../../../src/cache/CacheManager.js';
+import { NOTE_TRUNCATE_LENGTH } from '../../../../src/contracts/ast/script-builder.js';
+import { projectFields } from '../../../../src/tools/tasks/task-query-pipeline.js';
+import { TaskRowSchema } from '../../../../src/omnifocus/script-response-schemas.js';
+import type { OmniFocusTask } from '../../../../src/omnifocus/types.js';
+
+function createMockCache(): CacheManager & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> } {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    invalidate: vi.fn(),
+    invalidateForTaskChange: vi.fn(),
+    invalidateProject: vi.fn(),
+    invalidateTag: vi.fn(),
+    invalidateTaskQueries: vi.fn(),
+    clear: vi.fn(),
+  } as unknown as CacheManager & { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> };
+}
+
+describe('OMN-244: task list note truncation emits the noteTruncated marker', () => {
+  let tool: OmniFocusReadTool;
+  let execJsonSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tool = new OmniFocusReadTool(createMockCache());
+    execJsonSpy = vi.fn().mockResolvedValue({
+      success: true,
+      data: { tasks: [], metadata: { total_matched: 0 } },
+    });
+    vi.spyOn(tool as unknown as { execJson: unknown }, 'execJson' as never).mockImplementation(execJsonSpy as never);
+  });
+
+  async function runTasksQuery(extra: Record<string, unknown> = {}): Promise<string> {
+    await tool.execute({
+      query: { type: 'tasks', filters: { status: 'active' }, fields: ['id', 'name', 'note'], ...extra },
+    });
+    expect(execJsonSpy).toHaveBeenCalled();
+    return String(execJsonSpy.mock.calls[0][0]);
+  }
+
+  it('list WITHOUT details: generated script contains the truncation branch + noteTruncated flag', async () => {
+    const script = await runTasksQuery();
+    expect(script).toContain('noteTruncated: true');
+    expect(script).toContain(`n.length > ${NOTE_TRUNCATE_LENGTH}`);
+  });
+
+  it('list WITH details:true: full note, no truncation branch', async () => {
+    const script = await runTasksQuery({ details: true });
+    expect(script).not.toContain('noteTruncated');
+    expect(script).toMatch(/note: task\.note \|\| /);
+  });
+});
+
+describe('OMN-244: post-hoc projection carries the noteTruncated marker (the #204 finding class)', () => {
+  const truncatedTask = {
+    id: 't1',
+    name: 'T',
+    completed: false,
+    flagged: false,
+    blocked: false,
+    note: 'x'.repeat(200) + '...',
+    noteTruncated: true,
+  } as unknown as OmniFocusTask;
+
+  it('keeps noteTruncated when note is among the projected fields', () => {
+    const out = projectFields([truncatedTask], ['id', 'name', 'note']) as Array<Record<string, unknown>>;
+    expect(out[0].noteTruncated).toBe(true);
+  });
+
+  it('drops noteTruncated when note is NOT projected (marker rides the note)', () => {
+    const out = projectFields([truncatedTask], ['id', 'name']) as Array<Record<string, unknown>>;
+    expect(out[0]).not.toHaveProperty('noteTruncated');
+    expect(out[0]).not.toHaveProperty('note');
+  });
+
+  it('does not invent the marker for full notes', () => {
+    const full = { ...truncatedTask, note: 'short' } as Record<string, unknown>;
+    delete full.noteTruncated;
+    const out = projectFields([full as unknown as OmniFocusTask], ['id', 'note']) as Array<Record<string, unknown>>;
+    expect(out[0]).not.toHaveProperty('noteTruncated');
+  });
+});
+
+describe('OMN-244: TaskRowSchema accepts the marker (strict widening)', () => {
+  it('accepts a truncated row carrying noteTruncated: true', () => {
+    const r = TaskRowSchema.safeParse({ id: 't1', note: 'x...', noteTruncated: true });
+    expect(r.success).toBe(true);
+  });
+
+  it('remains strict for unknown keys', () => {
+    const r = TaskRowSchema.safeParse({ id: 't1', bogusKey: 1 });
+    expect(r.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Task-side sibling of OMN-242/OMN-245 — mirrors the **merged** project pattern (#194's conditional-spread emission + #204's marker-riding projection), per the ticket's 6-point builder guidance.

## Changes (mapped to the guidance)

1. **Truncation wiring** — audited, already correct: the task path threads `noteTruncateLength` through the shared `resolveNoteTruncateLength` (#204's helper). No new ternary.
2. **Emission**: `generateFieldProjection`'s `note` case emits `...(() => {…truncated ? { note, noteTruncated: true } : { note }})()` — byte-identical rows when truncation doesn't fire.
3. **Schema**: `TaskRowSchema` widened explicitly with `noteTruncated: z.boolean().optional()`; the projection-parity test now allows exactly `{noteTruncated}` as the task side's piggyback extra (same shape as the project assertion's OMN-242 entry). `OmniFocusTask` gains the optional member.
4. **Post-hoc projection**: `projectFields` (task-query-pipeline.ts) carries the marker whenever `note` is projected and drops it when it isn't — the exact class #204's live-verify caught on the project side.
5. **Cache audit**: task list reads are **uncached** (only projects/tags/folders have cache get/set), so there is no cache key to vary — finding documented here rather than a speculative change.
6. **Tool description**: 'projects only' wording now reads 'applies to tasks and projects'.

## Testing

- New `omn-244-task-note-truncation.test.ts`: emission with/without `details`, marker riding through post-hoc projection (kept/dropped/not-invented), strict-schema widening + strictness retained.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3722/3722 ✅ · `npm run lint` ✅.
- Suggested gate per ticket: **/code-review high** (codegen + response shape). Live-verify mirror of #204's: a task with a >200-char note returns 203 chars + `noteTruncated:true` on prod after deploy.

Closes OMN-244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)