### PR TITLE
fix(OMN-248): remove-mode tag assignment warns loudly on unresolvable names

### DIFF
--- a/src/contracts/ast/mutation/emitter.ts
+++ b/src/contracts/ast/mutation/emitter.ts
@@ -225,14 +225,19 @@ function emitAssignTags(node: AssignTagsNode): string {
   if (mode === 'remove') {
     // resolve-only: parseTagPath + resolveTagByPath for path names (shared single-source
     // helpers — parseTagPath keeps its empty-segment validation), flattenedTags.find for
-    // leaf names. Missing tags are silently skipped (legacy update builder semantics).
+    // leaf names. OMN-248: an unresolvable name used to be silently skipped (legacy
+    // update builder semantics) — success with warnings: [] while nothing was removed.
+    // Same fail-loud pattern as OMN-136: record a labeled warning naming the tag.
+    // (add/replace have no analogous case: their loop CREATES missing tags.)
+    const missingPrefix = JSON.stringify((node.label ?? 'tags') + ': tag not found — not removed: ');
+    const missingWarning = `_warnings.push(${missingPrefix} + _tagName);`;
     loop = [
       `for (const _tagName of ${tags}) {`,
       '  var _segs = parseTagPath(_tagName);',
       '  var _tag;',
       '  if (_segs) { _tag = resolveTagByPath(_segs); }',
       '  else { _tag = flattenedTags.find(t => t.name === _tagName); }',
-      `  if (_tag) { ${target}.removeTag(_tag); ${node.bind}.push(_tag.name); }`,
+      `  if (_tag) { ${target}.removeTag(_tag); ${node.bind}.push(_tag.name); } else { ${missingWarning} }`,
       '}',
     ].join('\n');
   } else {

--- a/tests/unit/contracts/ast/mutation/update-substrate.test.ts
+++ b/tests/unit/contracts/ast/mutation/update-substrate.test.ts
@@ -174,6 +174,11 @@ describe('assignTags modes', () => {
     expect(emitted).toContain('removeTag');
   });
 
+  it('remove mode warns loudly on an unresolvable tag name (OMN-248, the OMN-136 fail-loud pattern)', () => {
+    const emitted = emitStmt(assignTags(ref('task'), json(['a']), 'removed', true, 'tags', 'remove'));
+    expect(emitted).toContain('else { _warnings.push("tags: tag not found — not removed: " + _tagName); }');
+  });
+
   it('validator rejects an unknown mode', () => {
     const node = assignTags(ref('task'), json(['a']), 'b');
     (node as unknown as { mode: unknown }).mode = 'merge';

--- a/tests/unit/contracts/ast/mutation/update-task.test.ts
+++ b/tests/unit/contracts/ast/mutation/update-task.test.ts
@@ -396,6 +396,38 @@ describe('emitted update-task program executes (vm)', () => {
     expect(sets).toContain('name');
   });
 
+  // OMN-248: remove mode used to drop unresolvable tag names with zero signal —
+  // success with warnings: [] while nothing was removed (the same silent-skip
+  // shape OMN-136 eliminated in readModifyReassign).
+  it('vm: remove mode with an unresolvable tag name records a labeled warning, update still succeeds', () => {
+    const { task, calls } = makeRecordingTask();
+    const program = emitProgram(buildUpdateTaskProgram({ taskId: 't1', changes: { removeTags: ['no-such-tag'] } }));
+    const sandbox: Record<string, unknown> = {
+      Task: { byIdentifier: () => task },
+      flattenedTags: [], // nothing resolves
+      tags: [],
+    };
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+    expectMatchesSchema(TaskWriteResultSchema, parsed);
+    expect(parsed.updated).toBe(true);
+    expect(parsed.warnings).toEqual(['tags: tag not found — not removed: no-such-tag']);
+    expect(calls).not.toContain('removeTag');
+  });
+
+  it('vm: remove mode with a resolvable tag removes it warning-free (happy path unchanged)', () => {
+    const { task, calls } = makeRecordingTask();
+    const existingTag = { name: 'real-tag' };
+    const program = emitProgram(buildUpdateTaskProgram({ taskId: 't1', changes: { removeTags: ['real-tag'] } }));
+    const sandbox: Record<string, unknown> = {
+      Task: { byIdentifier: () => task },
+      flattenedTags: [existingTag],
+      tags: [existingTag],
+    };
+    const parsed = JSON.parse(vm.runInNewContext(program, sandbox) as string);
+    expect(parsed.warnings).toEqual([]);
+    expect(calls).toContain('removeTag');
+  });
+
   it('vm: replace mode calls clearTags before addTag', () => {
     const { task, calls } = makeRecordingTask();
     const program = emitProgram(buildUpdateTaskProgram({ taskId: 't1', changes: { tags: ['__test-a'] } }));


### PR DESCRIPTION
## What

Closes the sibling silent-skip your #202 review found: `emitAssignTags` 'remove' mode dropped unresolvable tag names with zero signal — success, `warnings: []`, nothing removed. The loop's `else` now records a labeled OMN-137 warning naming the tag: `tags: tag not found — not removed: <name>`. Same fail-loud pattern as OMN-136/#202, one function above in the same file.

## Ticket's audit question answered

`add`/`replace` modes have **no analogous case**: their loop creates missing tags (`resolveOrCreateTagByPath` / `new Tag`), so an unresolvable name cannot occur there. `parseTagPath`'s empty-segment throw is already caught by the bestEffort wrap (labeled warning). Noted in the code comment.

## Testing

- TDD: emission pin (the exact else-warning line) + two vm-execution proofs — missing name → warning present, update still succeeds, `removeTag` never called; resolvable name → removed warning-free.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3751/3751 ✅ · `npm run lint` ✅.
- Live-verify (optional, mirrors #202's): update a real sandbox task with `removeTags: ['no-such-tag']` → response `warnings` names the tag.

Closes OMN-248. Built off fresh main (`c8b7a0f8`), merge-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)