### PR TITLE
refactor(OMN-249): one shared review-date arithmetic body behind two thin adapters

### DIFF
--- a/src/contracts/ast/mutation/snippets.ts
+++ b/src/contracts/ast/mutation/snippets.ts
@@ -145,19 +145,13 @@ function resolveProjectFlexible(target) {
   return null;
 }`;
 
-// Review-interval arithmetic, lifted VERBATIM from the legacy
-// mark-project-reviewed.ts template (OMN-106). Unit names are the canonical
-// OmniJS plurals (ReviewInterval.unit.name); unknown units fall back to weekly,
-// matching legacy behavior byte-for-byte.
-const calculateNextReviewDate = `
-function calculateNextReviewDate(reviewInterval, fromDate) {
-  if (!reviewInterval) {
-    return null;
-  }
-  var date = new Date(fromDate);
-  var unitName = reviewInterval.unit ? reviewInterval.unit.name : 'weeks';
-  var steps = reviewInterval.steps || 1;
-  switch (unitName) {
+// OMN-249: ONE review-date arithmetic body shared by both entry points below —
+// a future date-math fix (month-end clamping, leap years) lands once. Expects a
+// NORMALIZED plural unit (see normalizeReviewUnit); unknown falls back to
+// weekly (the legacy default both templates carried).
+const advanceDateByReviewUnit = `
+function advanceDateByReviewUnit(date, unit, steps) {
+  switch (unit) {
     case 'days':
       date.setDate(date.getDate() + steps);
       break;
@@ -174,6 +168,19 @@ function calculateNextReviewDate(reviewInterval, fromDate) {
       date.setDate(date.getDate() + (steps * 7));
   }
   return date;
+}`;
+
+// mark_reviewed entry point (OMN-106): thin adapter over the shared body,
+// reading the TYPED OmniJS instance dialect (reviewInterval.unit.name).
+// Wire behavior pinned by the mark-reviewed vm goldens + the OMN-249 parity
+// tests.
+const calculateNextReviewDate = `
+function calculateNextReviewDate(reviewInterval, fromDate) {
+  if (!reviewInterval) {
+    return null;
+  }
+  var unitName = reviewInterval.unit ? reviewInterval.unit.name : 'weeks';
+  return advanceDateByReviewUnit(new Date(fromDate), normalizeReviewUnit(unitName), reviewInterval.steps || 1);
 }`;
 
 // The mark-reviewed mutation body (OMN-106): sets lastReviewDate, optionally
@@ -221,36 +228,14 @@ function normalizeReviewUnit(unitString) {
   return unitMap[unitString.toLowerCase()] || 'weeks';
 }`;
 
-// Next-review arithmetic over the RAW spec object (unit may be singular —
-// legacy deliberately switches on the unnormalized unit; renamed from the
-// template's calculateNextReviewDate to avoid colliding with the
-// mark-reviewed snippet, whose signature reads the typed .unit.name).
+// set_schedule entry point (OMN-106 PR-2): thin adapter over the shared body,
+// reading the RAW spec dialect (unit may be singular; missing base date means
+// compute from NOW). Wire behavior pinned by the set-review-schedule vm
+// goldens + the OMN-249 parity tests.
 const calculateNextReviewFromSpec = `
 function calculateNextReviewFromSpec(interval, baseDate) {
   var date = baseDate ? new Date(baseDate) : new Date();
-  var unit = interval.unit || 'week';
-  var steps = interval.steps || 1;
-  switch (unit) {
-    case 'day':
-    case 'days':
-      date.setDate(date.getDate() + steps);
-      break;
-    case 'week':
-    case 'weeks':
-      date.setDate(date.getDate() + (steps * 7));
-      break;
-    case 'month':
-    case 'months':
-      date.setMonth(date.getMonth() + steps);
-      break;
-    case 'year':
-    case 'years':
-      date.setFullYear(date.getFullYear() + steps);
-      break;
-    default:
-      date.setDate(date.getDate() + (steps * 7));
-  }
-  return date;
+  return advanceDateByReviewUnit(date, normalizeReviewUnit(interval.unit || 'week'), interval.steps || 1);
 }`;
 
 // The per-project set-review-schedule body (OMN-106 PR-2), lifted from the
@@ -331,12 +316,20 @@ export const SNIPPETS: Record<string, Snippet> = {
   // segment instead of creating. Used by the assignTags 'remove' mode (OMN-128 slice 4).
   resolveTagByPath: { source: resolveTagByPath, deps: ['parseTagPath'] },
   resolveProjectFlexible: { source: resolveProjectFlexible, deps: [] },
-  // OMN-106: review-interval arithmetic + the mark-reviewed mutation body.
-  calculateNextReviewDate: { source: calculateNextReviewDate, deps: [] },
+  // OMN-249: the ONE shared review-date arithmetic body.
+  advanceDateByReviewUnit: { source: advanceDateByReviewUnit, deps: [] },
+  // OMN-106: review-interval entry points (thin adapters) + the mark-reviewed mutation body.
+  calculateNextReviewDate: {
+    source: calculateNextReviewDate,
+    deps: ['normalizeReviewUnit', 'advanceDateByReviewUnit'],
+  },
   applyMarkReviewed: { source: applyMarkReviewed, deps: ['calculateNextReviewDate'] },
   // OMN-106 PR-2: set-review-schedule batch body + its helpers.
   normalizeReviewUnit: { source: normalizeReviewUnit, deps: [] },
-  calculateNextReviewFromSpec: { source: calculateNextReviewFromSpec, deps: [] },
+  calculateNextReviewFromSpec: {
+    source: calculateNextReviewFromSpec,
+    deps: ['normalizeReviewUnit', 'advanceDateByReviewUnit'],
+  },
   applySetReviewSchedule: {
     source: applySetReviewSchedule,
     deps: ['normalizeReviewUnit', 'calculateNextReviewFromSpec'],

--- a/tests/unit/contracts/ast/mutation/create-project.test.ts
+++ b/tests/unit/contracts/ast/mutation/create-project.test.ts
@@ -138,6 +138,37 @@ describe('emitted create-project program executes (vm)', () => {
     };
   }
 
+  // OMN-249 (coverage gap from the OMN-106 review): the reviewInterval branch
+  // was only string-asserted — execute it, both instance states, the way
+  // update-project.test.ts does post-OMN-136.
+  it('vm: create with reviewInterval on a stub WITH a default instance mutates it warning-free', () => {
+    const sandbox = makeSandbox();
+    (sandbox.Project as unknown as { prototype: Record<string, unknown> }).prototype.reviewInterval = undefined;
+    const withInstance = function (this: Record<string, unknown>, name: string) {
+      (sandbox.Project as unknown as (this: Record<string, unknown>, n: string) => void).call(this, name);
+      this.reviewInterval = { unit: 'weeks', steps: 1 };
+    };
+    const parsed = JSON.parse(
+      vm.runInNewContext(emitProgram(buildCreateProjectProgram({ name: 'P', reviewInterval: 14 })), {
+        ...sandbox,
+        Project: withInstance,
+      }) as string,
+    );
+    expect(parsed.warnings).toEqual([]);
+    expect(parsed.created).toBe(true);
+  });
+
+  it('vm: create with reviewInterval on a stub with NO instance records the OMN-136 warning', () => {
+    const sandbox = makeSandbox(); // ctor sets no reviewInterval → null-instance path
+    const parsed = JSON.parse(
+      vm.runInNewContext(emitProgram(buildCreateProjectProgram({ name: 'P', reviewInterval: 14 })), sandbox) as string,
+    );
+    expect(parsed.created).toBe(true);
+    expect(parsed.warnings).toEqual([
+      'reviewInterval: no existing typed instance to modify — OmniJS cannot construct one (OMN-41/OMN-58); value not set',
+    ]);
+  });
+
   it('vm: minimal create returns a ProjectWriteResultSchema-valid success envelope', () => {
     const program = emitProgram(buildCreateProjectProgram({ name: 'My Project' }));
     const sandbox = makeSandbox();

--- a/tests/unit/contracts/ast/mutation/review-date-snippets.test.ts
+++ b/tests/unit/contracts/ast/mutation/review-date-snippets.test.ts
@@ -1,0 +1,86 @@
+// tests/unit/contracts/ast/mutation/review-date-snippets.test.ts
+// OMN-249 — the two next-review-date snippets (mark_reviewed's typed-instance
+// reader and set_schedule's raw-spec reader) share ONE arithmetic body. A
+// future date-math fix (month-end clamping, leap years) lands once; these
+// parity tests fail if the paths ever diverge again.
+import vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import { collectSnippets } from '../../../../../src/contracts/ast/mutation/snippets.js';
+import {
+  buildMarkProjectReviewedProgram,
+  buildSetReviewScheduleProgram,
+  emitProgram,
+} from '../../../../../src/contracts/ast/mutation/index.js';
+
+/** Load both adapters (and their deps) into one vm context. */
+function loadSnippets(): Record<string, (...args: unknown[]) => unknown> {
+  const src = collectSnippets(['calculateNextReviewDate', 'calculateNextReviewFromSpec']);
+  const ctx: Record<string, unknown> = {};
+  vm.runInNewContext(
+    `${src}\nthis.calculateNextReviewDate = calculateNextReviewDate;\nthis.calculateNextReviewFromSpec = calculateNextReviewFromSpec;`,
+    ctx,
+  );
+  return ctx as Record<string, (...args: unknown[]) => unknown>;
+}
+
+const BASE = '2026-07-01T12:00:00.000Z';
+
+describe('OMN-249 — next-review-date path parity (typed instance vs raw spec)', () => {
+  const CASES: Array<{ typedUnit: string; specUnit: string; steps: number; expected: string }> = [
+    { typedUnit: 'days', specUnit: 'day', steps: 10, expected: '2026-07-11T12:00:00.000Z' },
+    { typedUnit: 'weeks', specUnit: 'week', steps: 3, expected: '2026-07-22T12:00:00.000Z' },
+    { typedUnit: 'months', specUnit: 'month', steps: 2, expected: '2026-09-01T12:00:00.000Z' },
+    { typedUnit: 'years', specUnit: 'year', steps: 1, expected: '2027-07-01T12:00:00.000Z' },
+  ];
+
+  for (const c of CASES) {
+    it(`${c.typedUnit}/${c.steps}: both paths produce the same date`, () => {
+      const fns = loadSnippets();
+      const viaTyped = fns.calculateNextReviewDate({ unit: { name: c.typedUnit }, steps: c.steps }, BASE) as Date;
+      const viaSpec = fns.calculateNextReviewFromSpec({ unit: c.specUnit, steps: c.steps }, BASE) as Date;
+      expect(viaTyped.toISOString()).toBe(c.expected);
+      expect(viaSpec.toISOString()).toBe(c.expected);
+    });
+  }
+
+  it('unknown units fall back to weekly on BOTH paths (legacy default)', () => {
+    const fns = loadSnippets();
+    const viaTyped = fns.calculateNextReviewDate({ unit: { name: 'fortnights' }, steps: 2 }, BASE) as Date;
+    const viaSpec = fns.calculateNextReviewFromSpec({ unit: 'fortnights', steps: 2 }, BASE) as Date;
+    expect(viaTyped.toISOString()).toBe('2026-07-15T12:00:00.000Z');
+    expect(viaSpec.toISOString()).toBe(viaTyped.toISOString());
+  });
+
+  it('null typed interval still returns null (mark_reviewed adapter guard)', () => {
+    const fns = loadSnippets();
+    expect(fns.calculateNextReviewDate(null, BASE)).toBeNull();
+  });
+
+  it('spec path without a base date still computes from now (set_schedule adapter guard)', () => {
+    const fns = loadSnippets();
+    const before = Date.now();
+    const d = fns.calculateNextReviewFromSpec({ unit: 'day', steps: 1 }, null) as Date;
+    expect(d.getTime()).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000 - 5000);
+  });
+});
+
+describe('OMN-249 — ONE shared arithmetic body', () => {
+  it('both emitted programs route through the shared advanceDateByReviewUnit snippet', () => {
+    const markReviewed = emitProgram(
+      buildMarkProjectReviewedProgram({ projectId: 'p1', reviewDate: BASE, updateNextReviewDate: true }),
+    );
+    const setSchedule = emitProgram(
+      buildSetReviewScheduleProgram({
+        projectIds: ['p1'],
+        reviewInterval: { unit: 'week', steps: 1 },
+        nextReviewDate: null,
+      }),
+    );
+    for (const program of [markReviewed, setSchedule]) {
+      expect(program).toContain('function advanceDateByReviewUnit(');
+    }
+    // The duplicated switch is gone: exactly one arithmetic body per program.
+    expect(markReviewed.match(/setFullYear\(/g)).toHaveLength(1);
+    expect(setSchedule.match(/setFullYear\(/g)).toHaveLength(1);
+  });
+});

--- a/tests/unit/contracts/ast/mutation/review-date-snippets.test.ts
+++ b/tests/unit/contracts/ast/mutation/review-date-snippets.test.ts
@@ -65,7 +65,27 @@ describe('OMN-249 — next-review-date path parity (typed instance vs raw spec)'
 });
 
 describe('OMN-249 — ONE shared arithmetic body', () => {
-  it('both emitted programs route through the shared advanceDateByReviewUnit snippet', () => {
+  /**
+   * Extract the full emitted text of a named function via brace counting.
+   * Containment/occurrence pins alone can't catch a variant arithmetic block
+   * reintroduced at one call site (gate finding, 2026-07-07) — only comparing
+   * the emitted bodies byte-for-byte proves both programs carry the SAME math.
+   */
+  function extractFunction(program: string, name: string): string {
+    const start = program.indexOf(`function ${name}(`);
+    expect(start).toBeGreaterThan(-1);
+    let i = program.indexOf('{', start);
+    let depth = 0;
+    do {
+      const ch = program[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+      i++;
+    } while (depth > 0 && i < program.length);
+    return program.slice(start, i);
+  }
+
+  it('both emitted programs carry a byte-identical advanceDateByReviewUnit body, exactly once each', () => {
     const markReviewed = emitProgram(
       buildMarkProjectReviewedProgram({ projectId: 'p1', reviewDate: BASE, updateNextReviewDate: true }),
     );
@@ -76,11 +96,22 @@ describe('OMN-249 — ONE shared arithmetic body', () => {
         nextReviewDate: null,
       }),
     );
+
     for (const program of [markReviewed, setSchedule]) {
-      expect(program).toContain('function advanceDateByReviewUnit(');
+      // Exactly one definition per program — no shadow copy anywhere else.
+      const first = program.indexOf('function advanceDateByReviewUnit(');
+      expect(first).toBeGreaterThan(-1);
+      expect(program.indexOf('function advanceDateByReviewUnit(', first + 1)).toBe(-1);
+      // No stray date arithmetic outside the shared body: every setFullYear/
+      // setMonth/setDate mutation lives inside the extracted function.
+      const body = extractFunction(program, 'advanceDateByReviewUnit');
+      const outside = program.replace(body, '');
+      expect(outside).not.toMatch(/set(?:FullYear|Month|Date|Hours)\(/);
     }
-    // The duplicated switch is gone: exactly one arithmetic body per program.
-    expect(markReviewed.match(/setFullYear\(/g)).toHaveLength(1);
-    expect(setSchedule.match(/setFullYear\(/g)).toHaveLength(1);
+
+    // The load-bearing pin: the two call sites emit the SAME arithmetic.
+    expect(extractFunction(markReviewed, 'advanceDateByReviewUnit')).toBe(
+      extractFunction(setSchedule, 'advanceDateByReviewUnit'),
+    );
   });
 });


### PR DESCRIPTION
## What

Unifies the two near-identical next-review-date switches the OMN-106 stack left in `snippets.ts`, per the ticket: `advanceDateByReviewUnit` holds the ONE arithmetic body (normalized plural units, weekly fallback); `calculateNextReviewDate` (typed `unit.name` dialect, null-interval guard) and `calculateNextReviewFromSpec` (raw spec dialect, from-NOW default) become thin adapters. `normalizeReviewUnit` — already in the file — does the unit normalization for both.

## Behavior pinned three ways

1. The existing mark-reviewed and set-review-schedule **vm goldens pass unchanged** (exact envelope dates).
2. New **parity tests**: both paths produce identical dates for equivalent inputs across all four units + the unknown-unit weekly fallback — these fail if the paths ever diverge again.
3. An **emission pin**: each emitted program contains exactly one arithmetic body.

## Also included (ticket's Include section)

The create-project vm coverage gap from the OMN-106 review: `buildCreateProjectProgram`'s reviewInterval branch now has vm-execution tests for both instance states (default instance → mutated warning-free; null instance → the OMN-136 warning), matching update-project's post-OMN-136 coverage.

## One microscopic deliberate delta

Miscased units (e.g. `'Months'`) previously fell to the weekly default on the typed path; they now normalize via `toLowerCase`. Unreachable from real inputs — OmniJS enum names and the zod unit enum are both lowercase — flagged rather than hidden.

## Testing

`npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3758/3758 ✅ · `npm run lint` ✅. Built off fresh main (`c8b7a0f8`), merge-independent.

Closes OMN-249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)