### PR TITLE
fix(OMN-250): reconcile productivity_stats period vocabulary; unknown periods fail loud

### DIFF
--- a/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
+++ b/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
@@ -33,8 +33,15 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
       const now = new Date();
       const periodStart = new Date();
 
+      // OMN-250 (OMN-148 drift D4+D23): the switch matches the Zod enum
+      // (day|week|month) EXACTLY. 'day' = since midnight today (the old
+      // unreachable 'today' branch's semantics); the enum-unreachable
+      // today/quarter/year branches are deleted; an unknown period fails
+      // LOUD via the error envelope instead of silently producing a
+      // zero-length period (whose dailyAverage division emitted NaN → JSON
+      // null → strict schema rejection).
       switch(options.period) {
-        case 'today':
+        case 'day':
           periodStart.setHours(0, 0, 0, 0);
           break;
         case 'week':
@@ -45,14 +52,8 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
           periodStart.setMonth(now.getMonth() - 1);
           periodStart.setHours(0, 0, 0, 0);
           break;
-        case 'quarter':
-          periodStart.setMonth(now.getMonth() - 3);
-          periodStart.setHours(0, 0, 0, 0);
-          break;
-        case 'year':
-          periodStart.setFullYear(now.getFullYear() - 1);
-          periodStart.setHours(0, 0, 0, 0);
-          break;
+        default:
+          throw new Error('Unknown period: ' + options.period);
       }
 
       const periodStartTime = periodStart.getTime();

--- a/tests/unit/omnifocus/scripts/analytics/productivity-period.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/productivity-period.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/omnifocus/scripts/analytics/productivity-period.test.ts
+// OMN-250 (OMN-148 drift D4+D23) — the productivity_stats period vocabulary is
+// reconciled: every value the Zod enum can send has a switch case, and a value
+// with no case fails LOUD (error envelope), never NaN→null→schema-rejection.
+import vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import { PRODUCTIVITY_STATS_SCRIPT_V3 } from '../../../../../src/omnifocus/scripts/analytics/productivity-stats-v3.js';
+import { PRODUCTIVITY_STATS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
+import { AnalyzeSchema } from '../../../../../src/tools/unified/schemas/analyze-schema.js';
+
+/** Execute the two-layer JXA→OmniJS script against an empty fake database. */
+function runScript(options: Record<string, unknown>): unknown {
+  const script = PRODUCTIVITY_STATS_SCRIPT_V3.replace('{{options}}', JSON.stringify(options));
+  const inner = {
+    flattenedTasks: [],
+    flattenedProjects: [],
+    flattenedTags: [],
+    Task: { Status: { Blocked: 'blocked' } },
+    Project: { Status: { Active: 'active' } },
+    JSON,
+  };
+  const outer = {
+    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
+    JSON,
+  };
+  return JSON.parse(vm.runInNewContext(script, outer) as string);
+}
+
+/** Mirror the script's daysInPeriod arithmetic: ceil((now − midnight(now − backDays))/86400000).
+ * The result is backDays+1 for most of the day (the start is midnight-anchored,
+ * `now` isn't) — pinned as CURRENT behavior, matching the spec draft §3.2. */
+function expectedDaysInPeriod(backDays: number): number {
+  const now = new Date();
+  const start = new Date();
+  start.setDate(now.getDate() - backDays);
+  start.setHours(0, 0, 0, 0);
+  return Math.ceil((now.getTime() - start.getTime()) / 86400000);
+}
+
+describe('OMN-250 — productivity_stats period vocabulary', () => {
+  it("period 'day' (a legal Zod value) produces a VALID envelope with midnight-today semantics", () => {
+    const parsed = runScript({ period: 'day', includeProjectStats: false, includeTagStats: false }) as {
+      ok: boolean;
+      data: { summary: { daysInPeriod: number; dailyAverage: number } };
+    };
+    expect(parsed.ok).toBe(true);
+    // Pre-fix: 'day' matched no case → daysInPeriod 0 → dailyAverage NaN →
+    // JSON null → the strict envelope schema REJECTED the response.
+    expect(PRODUCTIVITY_STATS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    expect(parsed.data.summary.daysInPeriod).toBe(expectedDaysInPeriod(0)); // 1, except exactly at midnight
+    expect(parsed.data.summary.dailyAverage).toBe(0);
+  });
+
+  it("period 'week' unchanged: midnight-anchored 7-day lookback, schema-valid (regression pin)", () => {
+    const parsed = runScript({ period: 'week', includeProjectStats: false, includeTagStats: false }) as {
+      ok: boolean;
+      data: { summary: { daysInPeriod: number } };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(PRODUCTIVITY_STATS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    // NOTE: 8 for most of the day (midnight-anchored start + ceil), not 7 —
+    // pinned current behavior, surfaced red-first while writing this test.
+    expect(parsed.data.summary.daysInPeriod).toBe(expectedDaysInPeriod(7));
+  });
+
+  it("period 'month' unchanged: calendar-month lookback, schema-valid (regression pin)", () => {
+    const parsed = runScript({ period: 'month', includeProjectStats: false, includeTagStats: false }) as {
+      ok: boolean;
+      data: { summary: { daysInPeriod: number } };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data.summary.daysInPeriod).toBeGreaterThanOrEqual(28);
+    expect(parsed.data.summary.daysInPeriod).toBeLessThanOrEqual(31);
+  });
+
+  it('an unknown period fails LOUD with the error envelope (never a silent no-match)', () => {
+    // 'quarter' was one of three switch branches the Zod enum could never send
+    // (D23) — post-reconciliation the switch matches the enum exactly and
+    // anything else is a loud error, guarding future vocabulary drift.
+    const parsed = runScript({ period: 'quarter', includeProjectStats: false, includeTagStats: false }) as {
+      ok: boolean;
+      error?: { message: string };
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.message).toContain('Unknown period');
+    expect(parsed.error?.message).toContain('quarter');
+  });
+
+  it('the Zod boundary still accepts exactly day|week|month (dual-schema pin)', () => {
+    const base = (groupBy: string) => ({
+      analysis: { type: 'productivity_stats', params: { groupBy } },
+    });
+    expect(AnalyzeSchema.safeParse(base('day')).success).toBe(true);
+    expect(AnalyzeSchema.safeParse(base('week')).success).toBe(true);
+    expect(AnalyzeSchema.safeParse(base('month')).success).toBe(true);
+    expect(AnalyzeSchema.safeParse(base('quarter')).success).toBe(false);
+    expect(AnalyzeSchema.safeParse(base('today')).success).toBe(false);
+  });
+});

--- a/tests/unit/omnifocus/scripts/analytics/productivity-period.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/productivity-period.test.ts
@@ -2,28 +2,15 @@
 // OMN-250 (OMN-148 drift D4+D23) — the productivity_stats period vocabulary is
 // reconciled: every value the Zod enum can send has a switch case, and a value
 // with no case fails LOUD (error envelope), never NaN→null→schema-rejection.
-import vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import { PRODUCTIVITY_STATS_SCRIPT_V3 } from '../../../../../src/omnifocus/scripts/analytics/productivity-stats-v3.js';
 import { PRODUCTIVITY_STATS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
 import { AnalyzeSchema } from '../../../../../src/tools/unified/schemas/analyze-schema.js';
+import { runAnalyticsScript } from './run-analytics-script.js';
 
 /** Execute the two-layer JXA→OmniJS script against an empty fake database. */
 function runScript(options: Record<string, unknown>): unknown {
-  const script = PRODUCTIVITY_STATS_SCRIPT_V3.replace('{{options}}', JSON.stringify(options));
-  const inner = {
-    flattenedTasks: [],
-    flattenedProjects: [],
-    flattenedTags: [],
-    Task: { Status: { Blocked: 'blocked' } },
-    Project: { Status: { Active: 'active' } },
-    JSON,
-  };
-  const outer = {
-    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
-    JSON,
-  };
-  return JSON.parse(vm.runInNewContext(script, outer) as string);
+  return runAnalyticsScript(PRODUCTIVITY_STATS_SCRIPT_V3, options);
 }
 
 /** Mirror the script's daysInPeriod arithmetic: ceil((now − midnight(now − backDays))/86400000).

--- a/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
+++ b/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
@@ -1,0 +1,36 @@
+// tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
+// Shared harness for the two-layer JXA→OmniJS analytics scripts: the outer JXA
+// layer calls Application().evaluateJavascript(src), which we replay in a second
+// vm context holding the fake OmniJS globals (flattenedTasks, Task.Status, …).
+// Keep this file BYTE-IDENTICAL across PR branches that add it — identical
+// add/add resolves cleanly at merge time.
+import vm from 'node:vm';
+
+export interface FakeDatabase {
+  flattenedTasks?: unknown[];
+  flattenedProjects?: unknown[];
+  flattenedTags?: unknown[];
+}
+
+/** Execute a `{{options}}`-templated analytics script against a fake database
+ * and parse its JSON envelope. */
+export function runAnalyticsScript(
+  scriptTemplate: string,
+  options: Record<string, unknown>,
+  db: FakeDatabase = {},
+): unknown {
+  const script = scriptTemplate.replace('{{options}}', JSON.stringify(options));
+  const inner = {
+    flattenedTasks: db.flattenedTasks ?? [],
+    flattenedProjects: db.flattenedProjects ?? [],
+    flattenedTags: db.flattenedTags ?? [],
+    Task: { Status: { Blocked: 'blocked', Dropped: 'dropped' } },
+    Project: { Status: { Active: 'active' } },
+    JSON,
+  };
+  const outer = {
+    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
+    JSON,
+  };
+  return JSON.parse(vm.runInNewContext(script, outer) as string);
+}

--- a/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
+++ b/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
@@ -24,7 +24,7 @@ export function runAnalyticsScript(
     flattenedTasks: db.flattenedTasks ?? [],
     flattenedProjects: db.flattenedProjects ?? [],
     flattenedTags: db.flattenedTags ?? [],
-    Task: { Status: { Blocked: 'blocked', Dropped: 'dropped' } },
+    Task: { Status: { Blocked: 'blocked', Completed: 'completed', Dropped: 'dropped' } },
     Project: { Status: { Active: 'active' } },
     JSON,
   };


### PR DESCRIPTION
## What

First of the **OMN-148 pre-capture fix wave** (Kip's 2026-07-07 spec-review amendment): drift **D4+D23** from the analytics spec draft.

The period switch (`productivity-stats-v3.ts`) and the Zod enum (`analyze-schema.ts`) drifted in **both directions**: `groupBy:'day'` — legal, advertised — matched no switch case → `daysInPeriod` 0 → `dailyAverage` NaN → JSON `null` → **strict envelope rejection at runtime** (a live crash on legal input), while the script's `today`/`quarter`/`year` branches were unreachable through the enum.

## Fix

The switch now matches the enum **exactly**:

| period | semantics |
|--------|-----------|
| `day` | since midnight today (the old unreachable `today` branch's semantics) |
| `week` / `month` | unchanged |
| anything else | `throw` → the existing `{ok:false, error}` envelope (`Unknown period: X`) — future vocabulary drift fails LOUD instead of emitting NaN |

No Zod/inputSchema change (the enum stays `day|week|month`; quarter/year exposure would be a capability decision, not a drift fix — deliberately out of scope).

## Testing

- Red-first via a **two-layer vm harness executing the real JXA→OmniJS script** against an empty fake DB (first vm coverage for an analytics script).
- Also surfaced+pinned red-first: `week`'s `daysInPeriod` is **8** for most of the day (midnight-anchored start + ceil), not the intuitive 7 — the test mirrors the script's arithmetic instead of assuming.
- Dual-schema pin: Zod accepts exactly day|week|month, rejects quarter/today.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3781/3781 ✅ · `npm run lint` ✅.
- Live-verify (optional): `omnifocus_analyze {analysis:{type:'productivity_stats', params:{groupBy:'day'}}}` on prod returns a valid response instead of a schema-rejection error.

Closes OMN-250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)