### PR TITLE
fix(OMN-251): taskAge reads the real OmniJS date properties (added/modified)

### DIFF
--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -205,8 +205,12 @@ export const WORKFLOW_ANALYSIS_V3 = `
               // Get dates
               const dueDate = task.dueDate;
               const deferDate = task.deferDate;
-              const creationDate = task.creationDate;
-              const modificationDate = task.modificationDate;
+              // OMN-251 (OMN-148 drift D17): added/modified are the OmniJS
+              // property names — the previous reads (task.creationDate /
+              // task.modificationDate, JXA names) were undefined here, so every
+              // taskAge was 0 and the avgAge>120 health penalty never fired.
+              const creationDate = task.added;
+              const modificationDate = task.modified;
 
               // Calculate overdue days
               let overdueDays = 0;

--- a/tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
@@ -4,10 +4,10 @@
 // `task.creationDate`/`task.modificationDate` (JXA names, undefined in OmniJS),
 // so every taskAge was 0 and the avgAge>120 project-health penalty never fired
 // — the OMN-142 silent-metric-death class.
-import vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import { WORKFLOW_ANALYSIS_V3 } from '../../../../../src/omnifocus/scripts/analytics/workflow-analysis-v3.js';
 import { WORKFLOW_ANALYSIS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
+import { runAnalyticsScript } from './run-analytics-script.js';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -58,8 +58,7 @@ function runScript(tasks: FakeTask[]): {
     maxInsights: 15,
     includeRawData: false,
   };
-  const script = WORKFLOW_ANALYSIS_V3.replace('{{options}}', JSON.stringify(options));
-  const inner = {
+  return runAnalyticsScript(WORKFLOW_ANALYSIS_V3, options, {
     flattenedTasks: tasks,
     flattenedProjects: [
       {
@@ -67,14 +66,7 @@ function runScript(tasks: FakeTask[]): {
         rootTask: { numberOfTasks: tasks.length, numberOfAvailableTasks: tasks.length, numberOfCompletedTasks: 0 },
       },
     ],
-    Task: { Status: { Blocked: 'blocked', Available: 'available' } },
-    JSON,
-  };
-  const outer = {
-    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
-    JSON,
-  };
-  return JSON.parse(vm.runInNewContext(script, outer) as string) as ReturnType<typeof runScript>;
+  }) as ReturnType<typeof runScript>;
 }
 
 describe('OMN-251 — taskAge reads the real OmniJS date properties', () => {

--- a/tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
+// OMN-251 (OMN-148 drift D17) — workflow_analysis's taskAge must read the real
+// OmniJS date properties (`added`/`modified`). The script previously read
+// `task.creationDate`/`task.modificationDate` (JXA names, undefined in OmniJS),
+// so every taskAge was 0 and the avgAge>120 project-health penalty never fired
+// — the OMN-142 silent-metric-death class.
+import vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import { WORKFLOW_ANALYSIS_V3 } from '../../../../../src/omnifocus/scripts/analytics/workflow-analysis-v3.js';
+import { WORKFLOW_ANALYSIS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface FakeTask {
+  completed: boolean;
+  numberOfTasks: number;
+  flagged: boolean;
+  taskStatus: string;
+  dueDate: Date | null;
+  deferDate: Date | null;
+  added: Date | null;
+  modified: Date | null;
+  estimatedMinutes: number;
+  inInbox: boolean;
+  containingProject: { name: string } | null;
+  tags: Array<{ name: string }>;
+  name: string;
+  id: { primaryKey: string };
+}
+
+function makeLeafTask(overrides: Partial<FakeTask>): FakeTask {
+  return {
+    completed: false,
+    numberOfTasks: 0,
+    flagged: false,
+    taskStatus: 'available',
+    dueDate: null,
+    deferDate: null,
+    added: null,
+    modified: null,
+    estimatedMinutes: 0,
+    inInbox: false,
+    containingProject: { name: 'Aged Project' },
+    tags: [],
+    name: 'Fixture task',
+    id: { primaryKey: 't1' },
+    ...overrides,
+  };
+}
+
+function runScript(tasks: FakeTask[]): {
+  ok: boolean;
+  data: { patterns: { workloadDistribution: { byProject: Record<string, { healthScore: number }> } } };
+} {
+  const options = {
+    analysisDepth: 'full',
+    focusAreas: ['productivity', 'workload', 'bottlenecks'],
+    maxInsights: 15,
+    includeRawData: false,
+  };
+  const script = WORKFLOW_ANALYSIS_V3.replace('{{options}}', JSON.stringify(options));
+  const inner = {
+    flattenedTasks: tasks,
+    flattenedProjects: [
+      {
+        name: 'Aged Project',
+        rootTask: { numberOfTasks: tasks.length, numberOfAvailableTasks: tasks.length, numberOfCompletedTasks: 0 },
+      },
+    ],
+    Task: { Status: { Blocked: 'blocked', Available: 'available' } },
+    JSON,
+  };
+  const outer = {
+    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
+    JSON,
+  };
+  return JSON.parse(vm.runInNewContext(script, outer) as string) as ReturnType<typeof runScript>;
+}
+
+describe('OMN-251 — taskAge reads the real OmniJS date properties', () => {
+  it('a 200-day-old task (via `added`) finally triggers the avgAge>120 health penalty', () => {
+    const parsed = runScript([makeLeafTask({ added: new Date(Date.now() - 200 * DAY) })]);
+    expect(parsed.ok).toBe(true);
+    expect(WORKFLOW_ANALYSIS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    // Otherwise-healthy project: 100 minus ONLY the stale-age penalty (15).
+    // Pre-fix the read was undefined → taskAge 0 → healthScore stayed 100.
+    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].healthScore).toBe(85);
+  });
+
+  it('falls back to `modified` when `added` is absent (the || fallback, real names)', () => {
+    const parsed = runScript([makeLeafTask({ modified: new Date(Date.now() - 200 * DAY) })]);
+    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].healthScore).toBe(85);
+  });
+
+  it('a fresh task keeps the project unpenalized (no age → no penalty)', () => {
+    const parsed = runScript([makeLeafTask({ added: new Date(Date.now() - 3 * DAY) })]);
+    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].healthScore).toBe(100);
+  });
+});


### PR DESCRIPTION
## What

**OMN-148 pre-capture fix wave, drift D17 (HIGH)** — the OMN-142 silent-metric-death class. `workflow-analysis-v3.ts`'s bridge code read `task.creationDate`/`task.modificationDate` — JXA names that don't exist in OmniJS (app-exported typings `OmniFocus-4.8.11-d.ts` have only `added`/`modified`; the sibling velocity script already used `modified` correctly). Both reads were `undefined` → every `taskAge` = 0 → per-project `avgAge` = 0 → **the `avgAge>120` health penalty has never fired since the script was written**. No error, no warning — the formula just quietly lost a term.

## Fix

One substitution at the read site: `task.added` with `task.modified` fallback (same `||` shape as before). Materially changes `healthScore` for projects holding stale tasks — its own PR per the wave's one-variable rule.

## Testing

- Red-first via the analytics vm harness (introduced in #209): a 200-day-old task drops its otherwise-healthy project from healthScore **100 → 85** (the penalty firing for the first time); the `modified` fallback pinned; a fresh task stays at 100. Envelope schema-validated.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3779/3779 ✅ · `npm run lint` ✅.
- In-flight gotcha worth a reviewer's smile: the fix comment initially contained backticks *inside the script template literal*, truncating it — the nested-template hazard striking documentation. Comment de-backticked.

Merge-independent of #209 (different script). Spec-draft note for ratification: §6.2/§8 D17 flip to RESOLVED on merge; goldens will pin nonzero ages.

Closes OMN-251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)