### PR TITLE
fix(OMN-252): read the script's 'completed' key so the most-productive finding can fire

### DIFF
--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -523,6 +523,7 @@ SCOPE FILTERING:
     overview: {
       totalTasks: number;
       completedTasks: number;
+      availableTasks: number;
       completionRate: number;
       activeProjects: number;
       overdueCount: number;
@@ -534,6 +535,7 @@ SCOPE FILTERING:
     interface ScriptOverview {
       totalTasks?: number;
       completedTasks?: number;
+      availableTasks?: number;
       completionRate?: number;
       activeProjects?: number;
       overdueCount?: number;
@@ -555,7 +557,14 @@ SCOPE FILTERING:
       actualData = result;
     }
 
-    const empty = { totalTasks: 0, completedTasks: 0, completionRate: 0, activeProjects: 0, overdueCount: 0 };
+    const empty = {
+      totalTasks: 0,
+      completedTasks: 0,
+      availableTasks: 0,
+      completionRate: 0,
+      activeProjects: 0,
+      overdueCount: 0,
+    };
     if (!actualData || typeof actualData !== 'object' || !('summary' in actualData)) {
       return { overview: empty, projectStatsArray: [], tagStatsArray: {}, insights: [] };
     }
@@ -566,6 +575,10 @@ SCOPE FILTERING:
       overview: {
         totalTasks: summary.totalTasks || 0,
         completedTasks: summary.completedTasks || 0,
+        // OMN-254 surfacing (/code-review of #209/#211/#213): the script's
+        // terminal-state-corrected available count was computed but never
+        // copied into the response.
+        availableTasks: summary.availableTasks || 0,
         completionRate: summary.completionRate || 0,
         activeProjects: summary.activeProjects || 0,
         overdueCount: summary.overdueCount || 0,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -476,8 +476,11 @@ SCOPE FILTERING:
             ? projectStatsArray
             : Object.entries(projectStatsArray || {}).map(([name, data]) => ({
                 name,
+                // OMN-252 (OMN-148 drift D8): the script's map emits `completed`;
+                // this reshape read `completedCount` — always 0, so the "Most
+                // productive project" finding could never fire.
                 completedCount:
-                  data && typeof data === 'object' && 'completedCount' in data ? Number(data.completedCount) || 0 : 0,
+                  data && typeof data === 'object' && 'completed' in data ? Number(data.completed) || 0 : 0,
                 ...(data && typeof data === 'object' ? (data as Record<string, unknown>) : {}),
               })),
           tagStats: tagStatsArray,

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -225,6 +225,32 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(res.data.stats.overview.activeProjects).toBe(12);
     });
 
+    it('includes availableTasks in response when script returns it (OMN-254 surfacing)', async () => {
+      // /code-review of PRs #209/#211/#213: the script computes the
+      // terminal-state-corrected summary.availableTasks, but the overview
+      // reshape silently dropped it — the fixed count never reached the client.
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue({
+        summary: {
+          totalTasks: 100,
+          completedTasks: 80,
+          availableTasks: 15,
+          completionRate: 0.8,
+          activeProjects: 5,
+          overdueCount: 5,
+        },
+        insights: [],
+      });
+
+      const res: any = await tool.execute({
+        analysis: { type: 'productivity_stats' },
+      });
+
+      expect(res.success).toBe(true);
+      expect(res.data.stats.overview.availableTasks).toBe(15);
+    });
+
     it('does not produce contradictory recommendations', async () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -110,6 +110,38 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(Array.isArray(res.summary.key_findings)).toBe(true);
     });
 
+    it('surfaces the most productive project from the script map (OMN-252)', async () => {
+      // OMN-148 drift D8: the map→array reshape read `completedCount`, but the
+      // script emits `completed` — every row got completedCount: 0 and the
+      // "Most productive project" finding could never fire.
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue({
+        summary: {
+          totalTasks: 50,
+          completedTasks: 9,
+          completionRate: 0.18,
+          activeProjects: 2,
+          overdueCount: 0,
+        },
+        projectStats: {
+          Alpha: { total: 10, completed: 7, available: 2, completionRate: '70.0', status: 'active' },
+          Beta: { total: 10, completed: 2, available: 5, completionRate: '20.0', status: 'active' },
+        },
+        tagStats: {},
+        insights: [],
+      });
+
+      const res: any = await tool.execute({
+        analysis: { type: 'productivity_stats', params: { groupBy: 'week' } },
+      });
+
+      expect(res.success).toBe(true);
+      const alpha = res.data.stats.projectStats.find((p: { name: string }) => p.name === 'Alpha');
+      expect(alpha.completedCount).toBe(7);
+      expect(res.summary.key_findings).toContain('Most productive project: Alpha (7 completed)');
+    });
+
     it('caches results after execution', async () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');


### PR DESCRIPTION
## What

**OMN-148 pre-capture fix wave, drift D8.** The productivity_stats map→array reshape (`executeProductivityStats`) looked up `completedCount`, but the script's `projectStats` map emits `completed` — every reshaped row carried `completedCount: 0`, so the `Most productive project: <name> (N completed)` key finding could never fire.

## Fix

One key rename in the reshape (`'completed' in data → Number(data.completed)`). The spread after it still carries the raw `completed` field, so rows now hold both — byte-compat with the previous shape plus a now-correct `completedCount`.

## Testing

- Red-first tool-layer test (mocked `executeJson`, the file's standard pattern): a two-project fixture pins `completedCount: 7` on the winner AND the exact finding string in `summary.key_findings` — pre-fix: 0 and absent.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3777/3777 ✅ · `npm run lint` ✅.

Merge-independent of #209/#210 (tool layer, different region). Spec §3.4/§8 D8 → RESOLVED on merge.

Closes OMN-252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)