### PR TITLE
fix(OMN-254): dropped tasks excluded from productivity availableTasks/overdueCount

### DIFF
--- a/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
+++ b/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
@@ -100,19 +100,27 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
                   }
                 }
               } else {
-                // Check if available (not blocked, not deferred)
-                const blocked = task.taskStatus === Task.Status.Blocked;
-                const deferDate = task.deferDate;
-                const isDeferred = deferDate && deferDate.getTime() > nowTime;
+                // OMN-254 (OMN-148 drift D5): effective status (the OMN-187
+                // predicate) — a DROPPED task, or a task inside a dropped/
+                // completed project, is terminal and belongs in neither the
+                // available nor the overdue population. totalTasks stays the
+                // whole-DB census; completedTasks stays task.completed.
+                const status = task.taskStatus;
+                if (status !== Task.Status.Dropped) {
+                  // Check if available (not blocked, not deferred)
+                  const blocked = status === Task.Status.Blocked;
+                  const deferDate = task.deferDate;
+                  const isDeferred = deferDate && deferDate.getTime() > nowTime;
 
-                if (!blocked && !isDeferred) {
-                  totalAvailable++;
-                }
+                  if (!blocked && !isDeferred) {
+                    totalAvailable++;
+                  }
 
-                // Check if overdue (has due date in the past)
-                const dueDate = task.dueDate;
-                if (dueDate && dueDate.getTime() < nowTime) {
-                  overdueCount++;
+                  // Check if overdue (has due date in the past)
+                  const dueDate = task.dueDate;
+                  if (dueDate && dueDate.getTime() < nowTime) {
+                    overdueCount++;
+                  }
                 }
               }
             } catch (e) {

--- a/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
+++ b/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
@@ -18,7 +18,7 @@
  * Pattern based on: task-velocity.ts, list-tags.ts
  */
 
-import { ROUND1_HELPER } from '../shared/helpers.js';
+import { ROUND1_HELPER, TERMINAL_STATUS_HELPER } from '../shared/helpers.js';
 
 export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
   (() => {
@@ -66,6 +66,7 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
       // Build comprehensive OmniJS script for ALL statistics in one bridge call
       const statsScript = \`
         (() => {
+          ${TERMINAL_STATUS_HELPER}
           const periodStartTime = \${periodStartTime};
           const nowTime = \${nowTime};
           const includeProjectStats = \${includeProjectStats};
@@ -106,7 +107,7 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
                 // available nor the overdue population. totalTasks stays the
                 // whole-DB census; completedTasks stays task.completed.
                 const status = task.taskStatus;
-                if (status !== Task.Status.Dropped) {
+                if (!isTerminalStatus(status)) {
                   // Check if available (not blocked, not deferred)
                   const blocked = status === Task.Status.Blocked;
                   const deferDate = task.deferDate;

--- a/src/omnifocus/scripts/shared/helpers.ts
+++ b/src/omnifocus/scripts/shared/helpers.ts
@@ -188,6 +188,20 @@ export function round1(n: number): number {
 }
 
 /**
+ * OmniJS-only helper (references `task.taskStatus` / `Task.Status`, which exist
+ * only inside evaluateJavascript) — inject into the INNER OmniJS script via
+ * template-literal interpolation.
+ *
+ * Defines `isTerminalStatus(status)` — the OMN-187 effective-status predicate.
+ * A task is terminal when its effective status is Dropped OR Completed; the
+ * Completed half covers tasks whose own `completed` flag is false but whose
+ * containing project is dropped/completed. Both halves are required — keeping
+ * one definition here means a terminal-state change is one edit (OMN-254).
+ */
+export const TERMINAL_STATUS_HELPER =
+  'function isTerminalStatus(status) { return status === Task.Status.Dropped || status === Task.Status.Completed; }';
+
+/**
  * Helper to extract project validation
  */
 export const PROJECT_VALIDATION = `

--- a/tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
@@ -56,6 +56,20 @@ describe('OMN-254 — three terminal states in productivity populations', () => 
     expect(parsed.data.summary.overdueCount).toBe(0);
   });
 
+  it('a task in a COMPLETED project (own .completed false, effective status Completed) counts in NEITHER population', () => {
+    // /code-review of this PR: the guard excluded only Dropped, but the OMN-187
+    // effective-status predicate is two-sided — a live task inside a completed
+    // project resolves to taskStatus Completed and is just as terminal.
+    const parsed = runScript([
+      task({}), // genuinely available
+      task({ taskStatus: 'completed', dueDate: new Date(Date.now() - 5 * DAY) }), // in a completed project, past-due
+    ]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data.summary.completedTasks).toBe(0); // own .completed stays false
+    expect(parsed.data.summary.availableTasks).toBe(1);
+    expect(parsed.data.summary.overdueCount).toBe(0);
+  });
+
   it('an ACTIVE past-due task still counts overdue; blocked/deferred still excluded from available', () => {
     const parsed = runScript([
       task({ dueDate: new Date(Date.now() - 2 * DAY) }), // active + overdue

--- a/tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
@@ -1,0 +1,79 @@
+// tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
+// OMN-254 (OMN-148 drift D5) — productivity_stats availableTasks/overdueCount
+// must exclude DROPPED tasks (effective status, the OMN-187 predicate).
+// Pre-fix the loop filtered only on task.completed, so dropped tasks — and
+// tasks inside dropped/completed projects — counted as "available" and
+// "overdue": the three-terminal-states violation.
+import vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import { PRODUCTIVITY_STATS_SCRIPT_V3 } from '../../../../../src/omnifocus/scripts/analytics/productivity-stats-v3.js';
+import { PRODUCTIVITY_STATS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface FakeTask {
+  completed: boolean;
+  taskStatus: string;
+  dueDate: Date | null;
+  deferDate: Date | null;
+  completionDate: Date | null;
+}
+
+function task(overrides: Partial<FakeTask>): FakeTask {
+  return {
+    completed: false,
+    taskStatus: 'available',
+    dueDate: null,
+    deferDate: null,
+    completionDate: null,
+    ...overrides,
+  };
+}
+
+function runScript(tasks: FakeTask[]): {
+  ok: boolean;
+  data: { summary: { totalTasks: number; completedTasks: number; availableTasks: number; overdueCount: number } };
+} {
+  const options = { period: 'week', includeProjectStats: false, includeTagStats: false };
+  const script = PRODUCTIVITY_STATS_SCRIPT_V3.replace('{{options}}', JSON.stringify(options));
+  const inner = {
+    flattenedTasks: tasks,
+    flattenedProjects: [],
+    flattenedTags: [],
+    Task: { Status: { Blocked: 'blocked', Dropped: 'dropped' } },
+    Project: { Status: { Active: 'active' } },
+    JSON,
+  };
+  const outer = {
+    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
+    JSON,
+  };
+  return JSON.parse(vm.runInNewContext(script, outer) as string) as ReturnType<typeof runScript>;
+}
+
+describe('OMN-254 — three terminal states in productivity populations', () => {
+  it('a dropped task (even overdue) counts in NEITHER availableTasks NOR overdueCount', () => {
+    const parsed = runScript([
+      task({}), // genuinely available
+      task({ taskStatus: 'dropped', dueDate: new Date(Date.now() - 5 * DAY) }), // dropped AND past-due
+      task({ completed: true, completionDate: new Date() }),
+    ]);
+    expect(parsed.ok).toBe(true);
+    expect(PRODUCTIVITY_STATS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    expect(parsed.data.summary.totalTasks).toBe(3); // whole-DB census unchanged
+    expect(parsed.data.summary.completedTasks).toBe(1);
+    // Pre-fix: available 2 (dropped counted), overdue 1 (dropped past-due counted).
+    expect(parsed.data.summary.availableTasks).toBe(1);
+    expect(parsed.data.summary.overdueCount).toBe(0);
+  });
+
+  it('an ACTIVE past-due task still counts overdue; blocked/deferred still excluded from available', () => {
+    const parsed = runScript([
+      task({ dueDate: new Date(Date.now() - 2 * DAY) }), // active + overdue
+      task({ taskStatus: 'blocked' }),
+      task({ deferDate: new Date(Date.now() + 5 * DAY) }), // future-deferred
+    ]);
+    expect(parsed.data.summary.overdueCount).toBe(1);
+    expect(parsed.data.summary.availableTasks).toBe(1);
+  });
+});

--- a/tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/productivity-terminal-states.test.ts
@@ -4,10 +4,10 @@
 // Pre-fix the loop filtered only on task.completed, so dropped tasks — and
 // tasks inside dropped/completed projects — counted as "available" and
 // "overdue": the three-terminal-states violation.
-import vm from 'node:vm';
 import { describe, it, expect } from 'vitest';
 import { PRODUCTIVITY_STATS_SCRIPT_V3 } from '../../../../../src/omnifocus/scripts/analytics/productivity-stats-v3.js';
 import { PRODUCTIVITY_STATS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
+import { runAnalyticsScript } from './run-analytics-script.js';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -35,20 +35,9 @@ function runScript(tasks: FakeTask[]): {
   data: { summary: { totalTasks: number; completedTasks: number; availableTasks: number; overdueCount: number } };
 } {
   const options = { period: 'week', includeProjectStats: false, includeTagStats: false };
-  const script = PRODUCTIVITY_STATS_SCRIPT_V3.replace('{{options}}', JSON.stringify(options));
-  const inner = {
+  return runAnalyticsScript(PRODUCTIVITY_STATS_SCRIPT_V3, options, {
     flattenedTasks: tasks,
-    flattenedProjects: [],
-    flattenedTags: [],
-    Task: { Status: { Blocked: 'blocked', Dropped: 'dropped' } },
-    Project: { Status: { Active: 'active' } },
-    JSON,
-  };
-  const outer = {
-    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
-    JSON,
-  };
-  return JSON.parse(vm.runInNewContext(script, outer) as string) as ReturnType<typeof runScript>;
+  }) as ReturnType<typeof runScript>;
 }
 
 describe('OMN-254 — three terminal states in productivity populations', () => {

--- a/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
+++ b/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
@@ -1,0 +1,36 @@
+// tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
+// Shared harness for the two-layer JXA→OmniJS analytics scripts: the outer JXA
+// layer calls Application().evaluateJavascript(src), which we replay in a second
+// vm context holding the fake OmniJS globals (flattenedTasks, Task.Status, …).
+// Keep this file BYTE-IDENTICAL across PR branches that add it — identical
+// add/add resolves cleanly at merge time.
+import vm from 'node:vm';
+
+export interface FakeDatabase {
+  flattenedTasks?: unknown[];
+  flattenedProjects?: unknown[];
+  flattenedTags?: unknown[];
+}
+
+/** Execute a `{{options}}`-templated analytics script against a fake database
+ * and parse its JSON envelope. */
+export function runAnalyticsScript(
+  scriptTemplate: string,
+  options: Record<string, unknown>,
+  db: FakeDatabase = {},
+): unknown {
+  const script = scriptTemplate.replace('{{options}}', JSON.stringify(options));
+  const inner = {
+    flattenedTasks: db.flattenedTasks ?? [],
+    flattenedProjects: db.flattenedProjects ?? [],
+    flattenedTags: db.flattenedTags ?? [],
+    Task: { Status: { Blocked: 'blocked', Dropped: 'dropped' } },
+    Project: { Status: { Active: 'active' } },
+    JSON,
+  };
+  const outer = {
+    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
+    JSON,
+  };
+  return JSON.parse(vm.runInNewContext(script, outer) as string);
+}

--- a/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
+++ b/tests/unit/omnifocus/scripts/analytics/run-analytics-script.ts
@@ -24,7 +24,7 @@ export function runAnalyticsScript(
     flattenedTasks: db.flattenedTasks ?? [],
     flattenedProjects: db.flattenedProjects ?? [],
     flattenedTags: db.flattenedTags ?? [],
-    Task: { Status: { Blocked: 'blocked', Dropped: 'dropped' } },
+    Task: { Status: { Blocked: 'blocked', Completed: 'completed', Dropped: 'dropped' } },
     Project: { Status: { Active: 'active' } },
     JSON,
   };


### PR DESCRIPTION
## What

**OMN-148 pre-capture fix wave, drift D5** — the last of the five wave tickets. `productivity-stats-v3.ts` filtered its incomplete-task branch only on `task.completed`, so **dropped** tasks (and tasks inside dropped/completed projects — effective status is terminal) counted toward `availableTasks` and `overdueCount`. The three-terminal-states violation; `overdue_analysis` already got this right via its OMN-187 `isActive` predicate.

## Fix

The same effective-status rule at the same seam: the else-branch's available/overdue counting is gated on `taskStatus !== Task.Status.Dropped` (using `taskStatus`, so project-level terminality is inherited). **Deliberately scoped per the ticket**: `totalTasks` stays the whole-DB census, `completedTasks` stays `task.completed`, and the D11 root-row population question — a separate design decision — is untouched.

## Testing

- Red-first via the analytics vm harness: a dropped past-due task counted as both available AND overdue pre-fix; post-fix neither, with `totalTasks`/`completedTasks` pinned unchanged. Active-overdue, blocked, and future-deferred behavior pinned as-is.
- `npm run build` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3778/3778 ✅ · `npm run lint` ✅.
- Note for goldens: `availableTasks`/`overdueCount` SHIFT on databases holding dropped tasks (the point); spec §3.2/§8 D5 → RESOLVED on merge.

Merge-independent of #209–#212 (same file as #209 but disjoint regions — the period switch vs the task loop; trivial rebase if #209 lands first).

Closes OMN-254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)