### PR TITLE
draft(OMN-280): KMM golden-database seed script (coverage-matrix fixtures + PROVENANCE.md)

### DIFF
--- a/scripts/kmm/install-kmm-server.sh
+++ b/scripts/kmm/install-kmm-server.sh
@@ -141,7 +141,11 @@ for _ in $(seq 1 10); do
   launchctl print "$GUI/$LABEL" >/dev/null 2>&1 || break
   sleep 0.5
 done
-launchctl bootstrap "$GUI" "$PLIST_DEST" || { sleep 1; launchctl bootstrap "$GUI" "$PLIST_DEST"; }
+launchctl bootstrap "$GUI" "$PLIST_DEST" || {
+  sleep 1
+  launchctl bootstrap "$GUI" "$PLIST_DEST" \
+    || die "launchctl bootstrap failed twice for $LABEL — launchd may still be tearing down the old job. Check: launchctl print $GUI/$LABEL ; then re-run this installer."
+}
 log "Loaded job $LABEL (RunAtLoad + KeepAlive)."
 
 # --- Optional verification ---------------------------------------------------

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -83,11 +83,12 @@ function buildOmniJsPayload(): string {
   // the first and corrupt whatever golden snapshot gets frozen from it.
   // FLATTENED collections, not top-level ones: a FIXTURE folder/tag nested
   // under a non-fixture parent would be invisible to folders/tags. Deleting
-  // a parent cascades to children already in the slice, so each delete is
+  // a parent cascades to children already in the snapshot, so each delete is
   // try/caught (a dead reference just means the cascade got there first).
-  // Slice first: deleting while iterating a live collection is undefined.
+  // filter() itself returns a fresh array, so iteration never walks the
+  // live collection while deleting — no extra slice() copy needed.
   function sweepFixtures(collection) {
-    collection.slice().filter(isFixture).forEach(function (obj) {
+    collection.filter(isFixture).forEach(function (obj) {
       try {
         deleteObject(obj);
       } catch (e) {
@@ -110,11 +111,11 @@ function buildOmniJsPayload(): string {
   // partial cascade can't hide — creating a fresh tree would produce
   // exactly the duplicate-fixture corruption the sweep exists to prevent;
   // fail loud instead (the throw propagates out of evaluateJavascript).
-  var leftovers = flattenedFolders.slice().filter(isFixture).length +
-    flattenedProjects.slice().filter(isFixture).length +
-    flattenedTags.slice().filter(isFixture).length +
-    flattenedTasks.slice().filter(isFixture).length +
-    inbox.slice().filter(isFixture).length;
+  var leftovers = flattenedFolders.filter(isFixture).length +
+    flattenedProjects.filter(isFixture).length +
+    flattenedTags.filter(isFixture).length +
+    flattenedTasks.filter(isFixture).length +
+    inbox.filter(isFixture).length;
   if (leftovers > 0) {
     throw new Error('idempotency sweep left ' + leftovers + ' FIXTURE item(s) behind — refusing to seed a second fixture tree alongside them.');
   }
@@ -323,7 +324,13 @@ function buildOmniJsPayload(): string {
     var customPerspective =
       Perspective.Custom.byName(fixtureName('Custom Perspective')) ||
       new Perspective.Custom(fixtureName('Custom Perspective'));
-    customPerspective.archivedFilterRules = [Perspective.FilterRule.Flagged];
+    // Plain-object rule format per Omni Automation's documented filter-rule
+    // dictionaries — archivedFilterRules is typed as bare Object in
+    // OmniFocus.d.ts, and the Perspective namespace declares NO filter-rule
+    // enum (referencing one throws, silently failing this block on every
+    // run while the warning below misdirects to licensing). Still
+    // best-effort: the exact rule-dictionary shape is a live-run hypothesis.
+    customPerspective.archivedFilterRules = [{ actionStatus: 'flagged' }];
     perspectiveCreated = true;
   } catch (e) {
     perspectiveCreated = false;

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -95,17 +95,25 @@ function buildOmniJsPayload(): string {
       }
     });
   }
+  // Projects and tasks are swept too, not just left to folder cascades: a
+  // cascade that failed partway on a prior run can leave orphaned FIXTURE
+  // projects/tasks whose parent folder no longer exists.
   sweepFixtures(flattenedFolders);
+  sweepFixtures(flattenedProjects);
   sweepFixtures(flattenedTags);
+  sweepFixtures(flattenedTasks);
   sweepFixtures(inbox);
   // Post-sweep verification: the per-delete try/catch above tolerates
   // cascade-dead references, but that must not hide a delete that failed
   // for a REAL reason (mid-sync, locked item). If anything FIXTURE-prefixed
-  // survived the sweep, creating a fresh tree would produce exactly the
-  // duplicate-fixture corruption the sweep exists to prevent — fail loud
-  // instead (the throw propagates out of evaluateJavascript to the caller).
+  // survived the sweep — in ANY flattened collection, so orphans of a
+  // partial cascade can't hide — creating a fresh tree would produce
+  // exactly the duplicate-fixture corruption the sweep exists to prevent;
+  // fail loud instead (the throw propagates out of evaluateJavascript).
   var leftovers = flattenedFolders.slice().filter(isFixture).length +
+    flattenedProjects.slice().filter(isFixture).length +
     flattenedTags.slice().filter(isFixture).length +
+    flattenedTasks.slice().filter(isFixture).length +
     inbox.slice().filter(isFixture).length;
   if (leftovers > 0) {
     throw new Error('idempotency sweep left ' + leftovers + ' FIXTURE item(s) behind — refusing to seed a second fixture tree alongside them.');

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env npx tsx
+/**
+ * KMM golden-database seeder (OMN-235 Phase 1, Deliverable 3).
+ *
+ * Runs ON KMM against whatever OmniFocus document is currently open. Creates a
+ * `Fixtures` top-level folder containing labeled `FIXTURE:`-prefixed data covering the
+ * coverage matrix in docs/superpowers/specs/2026-07-02-kmm-test-ground-design.md, then
+ * reads the resulting entity counts back and writes them to PROVENANCE.md.
+ *
+ * All dates are computed relative to the moment this script runs (never hardcoded), so
+ * the golden DB stays "overdue 12 days" etc. no matter when it's re-seeded.
+ *
+ * Usage: npx tsx scripts/kmm/seed-golden-database.ts [--out ~/of-golden]
+ *
+ * NOT YET LIVE-VERIFIED — this must run against real OmniFocus on KMM before the
+ * database is frozen. Treat every OmniJS API call below as a hypothesis until an
+ * actual run confirms it (perspective creation in particular is best-effort).
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { mkdir, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv: string[]): { outDir: string } {
+  const outIndex = argv.indexOf('--out');
+  const outDir = outIndex !== -1 && argv[outIndex + 1] ? argv[outIndex + 1] : join(homedir(), 'of-golden');
+  return { outDir };
+}
+
+/**
+ * The seeding logic runs as OmniJS (property access, not method calls) because it
+ * creates folders/projects/tags and assigns tags+parents — all bridge-only operations
+ * per this repo's JXA-vs-OmniJS split (CLAUDE.md "Tag Operations").
+ *
+ * JXA drives `evaluateJavascript` from the outside so the whole payload is one
+ * osascript invocation.
+ */
+function buildOmniJsPayload(): string {
+  return `
+(function () {
+  var now = new Date();
+  function daysFromNow(n) {
+    var d = new Date(now.getTime());
+    d.setDate(d.getDate() + n);
+    return d;
+  }
+  function fixtureName(label) {
+    return 'FIXTURE: ' + label;
+  }
+
+  var root = new Folder(fixtureName('Fixtures'), Folder.ending.None, library.beginning);
+  var nested1 = new Folder(fixtureName('Nested L1'), Folder.ending.None, root);
+  var nested2 = new Folder(fixtureName('Nested L2'), Folder.ending.None, nested1);
+  var droppedFolder = new Folder(fixtureName('Dropped Folder'), Folder.ending.None, root);
+  droppedFolder.status = Folder.Status.Dropped;
+
+  // ---- Tags ------------------------------------------------------------
+  var tagSingle = new Tag(fixtureName('tag-single'));
+  var tagMultiA = new Tag(fixtureName('tag-multi-a'));
+  var tagMultiB = new Tag(fixtureName('tag-multi-b'));
+  var tagParent = new Tag(fixtureName('tag-parent'));
+  var tagChild = new Tag(fixtureName('tag-child'), tagParent);
+  var tagOnHold = new Tag(fixtureName('tag-on-hold'));
+  tagOnHold.status = Tag.Status.OnHold;
+  var tagDropped = new Tag(fixtureName('tag-dropped'));
+  tagDropped.status = Tag.Status.Dropped;
+  var tagUnused = new Tag(fixtureName('tag-zero-tasks'));
+
+  // ---- Projects: types x statuses x features ----------------------------
+  var pParallel = new Project(fixtureName('Parallel Project'), root);
+  pParallel.sequential = false;
+
+  var pSequential = new Project(fixtureName('Sequential Project'), root);
+  pSequential.sequential = true;
+
+  var pSingleAction = new Project(fixtureName('Single Action List'), root);
+  pSingleAction.singletonActionHolder = true;
+
+  var pOnHold = new Project(fixtureName('On Hold Project'), root);
+  pOnHold.status = Project.Status.OnHold;
+
+  var pCompleted = new Project(fixtureName('Completed Project'), root);
+  var completedTask = new Task(fixtureName('completed project seed task'), pCompleted);
+  completedTask.markComplete();
+  pCompleted.status = Project.Status.Done;
+
+  var pDropped = new Project(fixtureName('Dropped Project'), root);
+  pDropped.status = Project.Status.Dropped;
+
+  var pReview = new Project(fixtureName('Review Interval Project'), root);
+  pReview.reviewInterval = { unit: 'week', steps: 1 };
+  pReview.nextReviewDate = daysFromNow(3);
+
+  var pDeferDue = new Project(fixtureName('Defer+Due Project'), root);
+  pDeferDue.deferDate = daysFromNow(-2);
+  pDeferDue.dueDate = daysFromNow(10);
+
+  var pCompleteWithLast = new Project(fixtureName('Complete-With-Last-Action Project'), root);
+  pCompleteWithLast.completedByChildren = true;
+
+  var pRepeating = new Project(fixtureName('Repeating Project'), root);
+  pRepeating.repetitionRule = new Task.RepetitionRule('FREQ=WEEKLY', Task.RepetitionMethod.Fixed);
+
+  var pEmpty = new Project(fixtureName('Empty Project'), root);
+
+  var pPerf = new Project(fixtureName('Perf 100+ Tasks Project'), root);
+  for (var i = 0; i < 105; i++) {
+    new Task(fixtureName('perf task ' + i), pPerf);
+  }
+
+  // Duplicate project names (OF allows this; known trap).
+  new Project(fixtureName('Duplicate Name'), root);
+  new Project(fixtureName('Duplicate Name'), root);
+
+  // ---- Task locations: inbox / root / nested action groups --------------
+  new Task(fixtureName('inbox task'), inbox);
+
+  var rootTask = new Task(fixtureName('root-level task'), pParallel);
+
+  var groupL1 = new Task(fixtureName('action group L1'), pParallel);
+  groupL1.sequential = true;
+  var groupL2 = new Task(fixtureName('action group L2 (nested)'), groupL1);
+  new Task(fixtureName('nested task under group L2'), groupL2);
+
+  // sequential group inside parallel project
+  var seqGroupInParallel = new Task(fixtureName('sequential group in parallel project'), pParallel);
+  seqGroupInParallel.sequential = true;
+  new Task(fixtureName('seq-in-parallel child 1'), seqGroupInParallel);
+  new Task(fixtureName('seq-in-parallel child 2'), seqGroupInParallel);
+
+  // parallel group inside sequential project
+  var parGroupInSequential = new Task(fixtureName('parallel group in sequential project'), pSequential);
+  parGroupInSequential.sequential = false;
+  new Task(fixtureName('par-in-sequential child 1'), parGroupInSequential);
+  new Task(fixtureName('par-in-sequential child 2'), parGroupInSequential);
+
+  // ---- Task states --------------------------------------------------------
+  new Task(fixtureName('available task'), pParallel);
+
+  var blockedChain = new Task(fixtureName('blocked-by-sequence chain'), pSequential);
+  blockedChain.sequential = true;
+  var blockerFirst = new Task(fixtureName('blocker: do this first'), blockedChain);
+  var blockedSecond = new Task(fixtureName('blocked: waits on first'), blockedChain);
+
+  var deferredTask = new Task(fixtureName('deferred (future)'), pParallel);
+  deferredTask.deferDate = daysFromNow(14);
+
+  var dueSoonTask = new Task(fixtureName('due soon'), pParallel);
+  dueSoonTask.dueDate = daysFromNow(2);
+
+  // Overdue spread: 1d / 3d / 12d / 45d, across >=3 projects, one clear bottleneck.
+  var overdue1 = new Task(fixtureName('overdue 1d'), pParallel);
+  overdue1.dueDate = daysFromNow(-1);
+  var overdue3 = new Task(fixtureName('overdue 3d'), pSequential);
+  overdue3.dueDate = daysFromNow(-3);
+  var overdue12 = new Task(fixtureName('overdue 12d'), pDeferDue);
+  overdue12.dueDate = daysFromNow(-12);
+  var bottleneckProject = new Project(fixtureName('Overdue Bottleneck Project'), root);
+  var overdue45 = new Task(fixtureName('overdue 45d (bottleneck)'), bottleneckProject);
+  overdue45.dueDate = daysFromNow(-45);
+
+  var flaggedTask = new Task(fixtureName('flagged task'), pParallel);
+  flaggedTask.flagged = true;
+
+  var completedStandaloneTask = new Task(fixtureName('completed standalone task'), pParallel);
+  completedStandaloneTask.markComplete();
+
+  var droppedStandaloneTask = new Task(fixtureName('dropped standalone task'), pParallel);
+  droppedStandaloneTask.drop();
+
+  // ---- Task features --------------------------------------------------
+  var repFixed = new Task(fixtureName('repeats fixed weekly'), pParallel);
+  repFixed.repetitionRule = new Task.RepetitionRule('FREQ=WEEKLY', Task.RepetitionMethod.Fixed);
+  repFixed.dueDate = daysFromNow(7);
+
+  var repDeferAnother = new Task(fixtureName('repeats defer-another'), pParallel);
+  repDeferAnother.repetitionRule = new Task.RepetitionRule('FREQ=DAILY', Task.RepetitionMethod.DeferUntilDate);
+  repDeferAnother.deferDate = daysFromNow(1);
+
+  var repDueAgain = new Task(fixtureName('repeats due-again'), pParallel);
+  repDueAgain.repetitionRule = new Task.RepetitionRule('FREQ=MONTHLY', Task.RepetitionMethod.DueDate);
+  repDueAgain.dueDate = daysFromNow(30);
+
+  var estimatedTask = new Task(fixtureName('has estimated duration'), pParallel);
+  estimatedTask.estimatedMinutes = 45;
+
+  var plainNoteTask = new Task(fixtureName('plain note'), pParallel);
+  plainNoteTask.note = 'Plain fixture note, no links.';
+
+  var urlNoteTask = new Task(fixtureName('note with URL'), pParallel);
+  urlNoteTask.note = 'See https://example.com/fixture for context.';
+
+  var plannedTask = new Task(fixtureName('planned date'), pParallel);
+  plannedTask.plannedDate = daysFromNow(5);
+
+  new Task(fixtureName('no dates at all'), pParallel);
+
+  // ---- Tag assignments (bridge-only per this repo's addTag() convention) --
+  var untaggedTask = new Task(fixtureName('untagged task'), pParallel);
+  var singleTagTask = new Task(fixtureName('single-tag task'), pParallel);
+  singleTagTask.addTag(tagSingle);
+  var multiTagTask = new Task(fixtureName('multi-tag task'), pParallel);
+  multiTagTask.addTag(tagMultiA);
+  multiTagTask.addTag(tagMultiB);
+  var nestedTagTask = new Task(fixtureName('nested-tag task'), pParallel);
+  nestedTagTask.addTag(tagChild);
+  var onHoldTagTask = new Task(fixtureName('on-hold-tag task'), pParallel);
+  onHoldTagTask.addTag(tagOnHold);
+  var droppedTagTask = new Task(fixtureName('dropped-tag task'), pParallel);
+  droppedTagTask.addTag(tagDropped);
+
+  // ---- Name edge cases ------------------------------------------------
+  new Task(fixtureName('unicode/emoji name ✅ 日本語 🚀'), pParallel);
+  new Task(fixtureName('name with "quotes" and \\\\backslashes\\\\'), pParallel);
+  new Task(
+    fixtureName(
+      'a very long task name that goes on and on and on to make sure truncation and rendering code paths ' +
+        'get exercised against something realistically oversized rather than a short sample string',
+    ),
+    pParallel,
+  );
+
+  // ---- Custom perspective (best-effort; requires Pro; verify on KMM) ---
+  var perspectiveCreated = false;
+  try {
+    var customPerspective = new Perspective.Custom(fixtureName('Custom Perspective'));
+    customPerspective.archivedFilterRules = [Perspective.FilterRule.Flagged];
+    perspectiveCreated = true;
+  } catch (e) {
+    perspectiveCreated = false;
+  }
+
+  // ---- Seed-timestamp marker task (conformance suite reset-window precondition) ---
+  var marker = new Task(fixtureName('seed-timestamp'), root);
+  marker.note = now.toISOString();
+
+  // ---- Count-verify -----------------------------------------------------
+  var allTasks = flattenedTasks;
+  var allProjects = flattenedProjects;
+  var allTags = flattenedTags;
+  var allFolders = flattenedFolders;
+
+  var counts = {
+    tasks: allTasks.length,
+    projects: allProjects.length,
+    tags: allTags.length,
+    folders: allFolders.length,
+    tasks_completed: allTasks.filter(function (t) { return t.completed; }).length,
+    tasks_dropped: allTasks.filter(function (t) { return t.dropped; }).length,
+    projects_dropped: allProjects.filter(function (p) { return p.status === Project.Status.Dropped; }).length,
+    projects_done: allProjects.filter(function (p) { return p.status === Project.Status.Done; }).length,
+    seed_timestamp: now.toISOString(),
+    perspective_created: perspectiveCreated,
+  };
+
+  return JSON.stringify(counts);
+})();
+`;
+}
+
+interface SeedCounts {
+  tasks: number;
+  projects: number;
+  tags: number;
+  folders: number;
+  tasks_completed: number;
+  tasks_dropped: number;
+  projects_dropped: number;
+  projects_done: number;
+  seed_timestamp: string;
+  perspective_created: boolean;
+}
+
+async function runOmniJs(omniJsPayload: string): Promise<string> {
+  const jxa = `
+    var of = Application('OmniFocus');
+    of.includeStandardAdditions = true;
+    var result = of.evaluateJavascript(${JSON.stringify(omniJsPayload)});
+    result;
+  `;
+  const { stdout } = await execFileAsync('osascript', ['-l', 'JavaScript', '-e', jxa]);
+  return stdout.trim();
+}
+
+function renderProvenance(counts: SeedCounts): string {
+  return `# KMM Golden Database Provenance
+
+Generated by \`scripts/kmm/seed-golden-database.ts\`. Do not hand-edit — regenerate by re-seeding.
+
+Export date: ${counts.seed_timestamp}
+Custom perspective created: ${counts.perspective_created}
+
+## Counts
+
+tasks: ${counts.tasks}
+projects: ${counts.projects}
+tags: ${counts.tags}
+folders: ${counts.folders}
+tasks_completed: ${counts.tasks_completed}
+tasks_dropped: ${counts.tasks_dropped}
+projects_dropped: ${counts.projects_dropped}
+projects_done: ${counts.projects_done}
+
+## Notes
+
+- These counts are the OmniFocus \`flattenedTasks\` / \`flattenedProjects\` / \`flattenedTags\` / \`flattenedFolders\`
+  totals across the WHOLE document, not just the \`Fixtures\` folder — the golden DB is Kip's old real database
+  plus these fixtures layered on top, so counts include both.
+- \`scripts/kmm/of-db-reset.sh\` diffs its post-restore counts against this file and fails loudly on mismatch.
+- Re-run the coverage-matrix audit (spec §2) before trusting a freshly regenerated golden snapshot; this script
+  does not itself verify coverage, only entity counts.
+`;
+}
+
+async function main(): Promise<void> {
+  const { outDir } = parseArgs(process.argv.slice(2));
+  console.log(`Seeding golden database fixtures (OmniFocus must already be running with the target document open)...`);
+
+  const rawResult = await runOmniJs(buildOmniJsPayload());
+  let counts: SeedCounts;
+  try {
+    counts = JSON.parse(rawResult) as SeedCounts;
+  } catch (err) {
+    throw new Error(`Seed script did not return valid JSON. Raw osascript output:\n${rawResult}\n\n${String(err)}`);
+  }
+
+  await mkdir(outDir, { recursive: true });
+  const provenancePath = join(outDir, 'PROVENANCE.md');
+  await writeFile(provenancePath, renderProvenance(counts), 'utf8');
+
+  console.log(`Seeding complete. Counts:`, counts);
+  console.log(`Wrote ${provenancePath}`);
+  if (!counts.perspective_created) {
+    console.warn(
+      'WARNING: custom perspective creation failed (Perspective.Custom API not available or not licensed for ' +
+        'Pro?). Coverage-matrix row "Perspectives" is not satisfied — investigate before freezing.',
+    );
+  }
+  console.log(
+    'Next: run the coverage-matrix audit by hand against docs/superpowers/specs/2026-07-02-kmm-test-ground-design.md §2, ' +
+      'then zip the document into the golden snapshot (see spec §2 "Freeze").',
+  );
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exitCode = 1;
+});

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -246,8 +246,12 @@ function buildOmniJsPayload(): string {
   var completedStandaloneTask = new Task(fixtureName('completed standalone task'), pParallel);
   completedStandaloneTask.markComplete();
 
+  // drop() requires (allOccurrences, dateDropped) per OmniFocus.d.ts — the
+  // production mutation code (src/contracts/ast/mutation/defs.ts) always
+  // calls it with both; there is no documented no-arg fallback like
+  // markComplete()'s.
   var droppedStandaloneTask = new Task(fixtureName('dropped standalone task'), pParallel);
-  droppedStandaloneTask.drop();
+  droppedStandaloneTask.drop(true, now);
 
   // ---- Task features --------------------------------------------------
   var repFixed = new Task(fixtureName('repeats fixed weekly'), pParallel);

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -111,6 +111,11 @@ function buildOmniJsPayload(): string {
   // partial cascade can't hide — creating a fresh tree would produce
   // exactly the duplicate-fixture corruption the sweep exists to prevent;
   // fail loud instead (the throw propagates out of evaluateJavascript).
+  // This re-scan is a DELIBERATE extra traversal, not a redundant one: the
+  // sweep, this verification, and the final count block each read a
+  // DIFFERENT database state (pre-sweep, post-sweep, post-create) — merging
+  // them would verify intentions instead of effects. The cost is bounded by
+  // the whole-DB traversal floor; raise OF_SEED_TIMEOUT_MS on a huge DB.
   var leftovers = flattenedFolders.filter(isFixture).length +
     flattenedProjects.filter(isFixture).length +
     flattenedTags.filter(isFixture).length +
@@ -320,6 +325,7 @@ function buildOmniJsPayload(): string {
   // prior run's copy (no documented delete API exists to sweep it), so
   // re-seeding never duplicates the perspective.
   var perspectiveCreated = false;
+  var perspectiveError = null;
   try {
     var customPerspective =
       Perspective.Custom.byName(fixtureName('Custom Perspective')) ||
@@ -334,6 +340,10 @@ function buildOmniJsPayload(): string {
     perspectiveCreated = true;
   } catch (e) {
     perspectiveCreated = false;
+    // Preserve the REAL error: a malformed rule shape or typo'd property is
+    // a fixable code bug, and reporting it as a licensing question would
+    // burn a live debug cycle chasing the wrong cause.
+    perspectiveError = String(e);
   }
 
   // ---- Seed-timestamp marker task (conformance suite reset-window precondition) ---
@@ -375,6 +385,7 @@ function buildOmniJsPayload(): string {
     projects_done: projectTotals.done,
     seed_timestamp: now.toISOString(),
     perspective_created: perspectiveCreated,
+    perspective_error: perspectiveError,
   };
 
   return JSON.stringify(counts);
@@ -393,6 +404,7 @@ interface SeedCounts {
   projects_done: number;
   seed_timestamp: string;
   perspective_created: boolean;
+  perspective_error: string | null;
 }
 
 async function runOmniJs(omniJsPayload: string): Promise<string> {
@@ -426,7 +438,7 @@ async function runOmniJs(omniJsPayload: string): Promise<string> {
       if (signal) {
         reject(
           new Error(
-            `osascript killed by ${signal} after ${timeoutMs}ms — is OmniFocus blocked by a modal dialog? (OF_SEED_TIMEOUT_MS overrides the bound)`,
+            `osascript killed by ${signal} after ${timeoutMs}ms. Either OmniFocus is wedged (modal dialog) or the seed is legitimately slow on a large database — NOTE: killing osascript does NOT stop an in-flight evaluateJavascript inside OmniFocus, so the mutation may still be running server-side. Wait for OmniFocus to settle before re-running (an immediate re-run races it; a later one may hit the leftover-sweep guard). Raise OF_SEED_TIMEOUT_MS if the run was merely slow.`,
           ),
         );
       } else if (code !== 0) {
@@ -505,8 +517,10 @@ async function main(): Promise<void> {
   console.log(`Wrote ${provenancePath}`);
   if (!counts.perspective_created) {
     console.warn(
-      'WARNING: custom perspective creation failed (Perspective.Custom API not available or not licensed for ' +
-        'Pro?). Coverage-matrix row "Perspectives" is not satisfied — investigate before freezing.',
+      `WARNING: custom perspective creation failed. Actual error: ${counts.perspective_error ?? '(none captured)'}\n` +
+        'If this reads as a missing API/licensing error, Perspective.Custom may need Pro; otherwise it is a code ' +
+        'bug (e.g. rule-dictionary shape) — fix it rather than chasing licensing. Coverage-matrix row ' +
+        '"Perspectives" is not satisfied — investigate before freezing.',
     );
   }
   console.log(

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -28,15 +28,26 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { isRunDirectly } from '../lib/run-directly.js';
 
-const SEED_TIMEOUT_MS = Number(process.env.OF_SEED_TIMEOUT_MS ?? 180_000);
+// Validated lazily (not at module scope) so importing the module for tests
+// never throws on a stray env var; a bad value fails loud with the actual
+// cause instead of spawn() rejecting NaN as an opaque ERR_OUT_OF_RANGE.
+function resolveSeedTimeoutMs(raw: string | undefined = process.env.OF_SEED_TIMEOUT_MS): number {
+  if (raw === undefined || raw === '') return 180_000;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`OF_SEED_TIMEOUT_MS must be a positive number of milliseconds, got: '${raw}'`);
+  }
+  return n;
+}
 
 function parseArgs(argv: string[]): { outDir: string } {
   const outIndex = argv.indexOf('--out');
-  if (outIndex !== -1 && !argv[outIndex + 1]) {
-    // Fail loud, not fall back: silently writing PROVENANCE.md to the
-    // default location on a value-less --out means of-db-reset.sh later
-    // reads the wrong (or stale) file from the unintended directory.
-    throw new Error('--out requires a directory argument (e.g. --out ~/of-golden)');
+  // Fail loud, not fall back: silently writing PROVENANCE.md to the default
+  // location on a value-less --out (or mkdir-ing a directory literally named
+  // '--verbose' when the value is another flag) means of-db-reset.sh later
+  // reads the wrong (or stale) file from an unintended directory.
+  if (outIndex !== -1 && (!argv[outIndex + 1] || argv[outIndex + 1].startsWith('-'))) {
+    throw new Error(`--out requires a directory argument (e.g. --out ~/of-golden), got: '${argv[outIndex + 1] ?? ''}'`);
   }
   const outDir = outIndex !== -1 ? argv[outIndex + 1] : join(homedir(), 'of-golden');
   return { outDir };
@@ -87,6 +98,18 @@ function buildOmniJsPayload(): string {
   sweepFixtures(flattenedFolders);
   sweepFixtures(flattenedTags);
   sweepFixtures(inbox);
+  // Post-sweep verification: the per-delete try/catch above tolerates
+  // cascade-dead references, but that must not hide a delete that failed
+  // for a REAL reason (mid-sync, locked item). If anything FIXTURE-prefixed
+  // survived the sweep, creating a fresh tree would produce exactly the
+  // duplicate-fixture corruption the sweep exists to prevent — fail loud
+  // instead (the throw propagates out of evaluateJavascript to the caller).
+  var leftovers = flattenedFolders.slice().filter(isFixture).length +
+    flattenedTags.slice().filter(isFixture).length +
+    inbox.slice().filter(isFixture).length;
+  if (leftovers > 0) {
+    throw new Error('idempotency sweep left ' + leftovers + ' FIXTURE item(s) behind — refusing to seed a second fixture tree alongside them.');
+  }
   // The custom perspective is handled by reuse-not-recreate below (there is
   // no documented Perspective delete API to sweep with).
 
@@ -345,7 +368,8 @@ async function runOmniJs(omniJsPayload: string): Promise<string> {
   // on the MCP server's src/ runtime — the same no-server-dependency rule
   // its sibling of-db-reset.sh states in its header.
   return new Promise<string>((resolve, reject) => {
-    const proc = spawn('osascript', ['-l', 'JavaScript'], { timeout: SEED_TIMEOUT_MS });
+    const timeoutMs = resolveSeedTimeoutMs();
+    const proc = spawn('osascript', ['-l', 'JavaScript'], { timeout: timeoutMs });
     let stdout = '';
     let stderr = '';
     proc.stdout.on('data', (data: Buffer) => {
@@ -359,7 +383,7 @@ async function runOmniJs(omniJsPayload: string): Promise<string> {
       if (signal) {
         reject(
           new Error(
-            `osascript killed by ${signal} after ${SEED_TIMEOUT_MS}ms — is OmniFocus blocked by a modal dialog? (OF_SEED_TIMEOUT_MS overrides the bound)`,
+            `osascript killed by ${signal} after ${timeoutMs}ms — is OmniFocus blocked by a modal dialog? (OF_SEED_TIMEOUT_MS overrides the bound)`,
           ),
         );
       } else if (code !== 0) {
@@ -449,4 +473,4 @@ if (isRunDirectly(import.meta.url)) {
 }
 
 // Exported for unit tests (the run-guard above makes importing side-effect-free).
-export { parseArgs, buildOmniJsPayload, renderProvenance, type SeedCounts };
+export { parseArgs, buildOmniJsPayload, renderProvenance, resolveSeedTimeoutMs, type SeedCounts };

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -167,7 +167,16 @@ function buildOmniJsPayload(): string {
   pDropped.status = Project.Status.Dropped;
 
   var pReview = new Project(fixtureName('Review Interval Project'), root);
-  pReview.reviewInterval = { unit: 'week', steps: 1 };
+  // Read-modify-reassign, never a plain object literal: OmniJS cannot
+  // construct the typed Project.ReviewInterval, and assigning a literal
+  // silently no-ops (OMN-41/OMN-58 — see mutation/emitter.ts
+  // readModifyReassign). reviewInterval is non-nullable on a fresh project
+  // (OMN-273), so the typed instance exists to modify. Units are PLURAL
+  // ('weeks'), matching defs.ts reviewIntervalUnit().
+  var reviewRmr = pReview.reviewInterval;
+  reviewRmr.unit = 'weeks';
+  reviewRmr.steps = 1;
+  pReview.reviewInterval = reviewRmr;
   pReview.nextReviewDate = daysFromNow(3);
 
   var pDeferDue = new Project(fixtureName('Defer+Due Project'), root);

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -333,15 +333,30 @@ function buildOmniJsPayload(): string {
   var allTags = flattenedTags;
   var allFolders = flattenedFolders;
 
+  // One pass per collection, not one filter() per counter: these totals
+  // cover the WHOLE document (the real database plus fixtures), inside a
+  // timeout-bounded evaluateJavascript call — avoid re-traversing a large
+  // flattenedTasks twice and flattenedProjects twice.
+  var taskTotals = allTasks.reduce(function (acc, t) {
+    if (t.completed) { acc.completed += 1; }
+    if (t.dropped) { acc.dropped += 1; }
+    return acc;
+  }, { completed: 0, dropped: 0 });
+  var projectTotals = allProjects.reduce(function (acc, p) {
+    if (p.status === Project.Status.Dropped) { acc.dropped += 1; }
+    if (p.status === Project.Status.Done) { acc.done += 1; }
+    return acc;
+  }, { dropped: 0, done: 0 });
+
   var counts = {
     tasks: allTasks.length,
     projects: allProjects.length,
     tags: allTags.length,
     folders: allFolders.length,
-    tasks_completed: allTasks.filter(function (t) { return t.completed; }).length,
-    tasks_dropped: allTasks.filter(function (t) { return t.dropped; }).length,
-    projects_dropped: allProjects.filter(function (p) { return p.status === Project.Status.Dropped; }).length,
-    projects_done: allProjects.filter(function (p) { return p.status === Project.Status.Done; }).length,
+    tasks_completed: taskTotals.completed,
+    tasks_dropped: taskTotals.dropped,
+    projects_dropped: projectTotals.dropped,
+    projects_done: projectTotals.done,
     seed_timestamp: now.toISOString(),
     perspective_created: perspectiveCreated,
   };

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -8,21 +8,27 @@
  * reads the resulting entity counts back and writes them to PROVENANCE.md.
  *
  * All dates are computed relative to the moment this script runs (never hardcoded), so
- * the golden DB stays "overdue 12 days" etc. no matter when it's re-seeded.
+ * the golden DB stays "overdue 12 days" etc. no matter when it's re-seeded. Re-seeding
+ * is IDEMPOTENT: the payload first deletes any prior `FIXTURE:`-prefixed folders, tags,
+ * and inbox tasks, so a re-run refreshes the fixture tree instead of duplicating it.
  *
  * Usage: npx tsx scripts/kmm/seed-golden-database.ts [--out ~/of-golden]
+ *
+ * Env: OF_SEED_TIMEOUT_MS bounds the osascript run (default 180000) — a wedged
+ * OmniFocus (modal dialog) otherwise hangs the seeder forever (known failure mode,
+ * see CLAUDE.md "Script timeouts").
  *
  * NOT YET LIVE-VERIFIED — this must run against real OmniFocus on KMM before the
  * database is frozen. Treat every OmniJS API call below as a hypothesis until an
  * actual run confirms it (perspective creation in particular is best-effort).
  */
-import { execFile } from 'child_process';
-import { promisify } from 'util';
+import { spawn } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
+import { isRunDirectly } from '../lib/run-directly.js';
 
-const execFileAsync = promisify(execFile);
+const SEED_TIMEOUT_MS = Number(process.env.OF_SEED_TIMEOUT_MS ?? 180_000);
 
 function parseArgs(argv: string[]): { outDir: string } {
   const outIndex = argv.indexOf('--out');
@@ -50,24 +56,44 @@ function buildOmniJsPayload(): string {
   function fixtureName(label) {
     return 'FIXTURE: ' + label;
   }
+  function isFixture(obj) {
+    return obj.name.indexOf('FIXTURE: ') === 0;
+  }
 
-  var root = new Folder(fixtureName('Fixtures'), Folder.ending.None, library.beginning);
-  var nested1 = new Folder(fixtureName('Nested L1'), Folder.ending.None, root);
-  var nested2 = new Folder(fixtureName('Nested L2'), Folder.ending.None, nested1);
-  var droppedFolder = new Folder(fixtureName('Dropped Folder'), Folder.ending.None, root);
+  // ---- Idempotency: remove any prior FIXTURE: data before re-seeding -----
+  // The header advertises re-running this script to refresh relative dates;
+  // without this sweep a re-run would create a SECOND fixture tree alongside
+  // the first and corrupt whatever golden snapshot gets frozen from it.
+  // Deleting a folder cascades to its contained projects/tasks; tags and
+  // inbox tasks live outside the folder tree and are swept separately.
+  // Slice first: deleting while iterating a live collection is undefined.
+  folders.slice().filter(isFixture).forEach(function (f) { deleteObject(f); });
+  tags.slice().filter(isFixture).forEach(function (t) { deleteObject(t); });
+  inbox.slice().filter(isFixture).forEach(function (t) { deleteObject(t); });
+
+  // Folder/Project constructors take (name, position) — position is a parent
+  // Folder or a Folder.ChildInsertionLocation like library.beginning
+  // (src/omnifocus/api/OmniFocus.d.ts). The Folder CLASS has no insertion-
+  // location statics — beginning/ending exist only on instances/library.
+  var root = new Folder(fixtureName('Fixtures'), library.beginning);
+  var nested1 = new Folder(fixtureName('Nested L1'), root);
+  var nested2 = new Folder(fixtureName('Nested L2'), nested1);
+  var droppedFolder = new Folder(fixtureName('Dropped Folder'), root);
   droppedFolder.status = Folder.Status.Dropped;
 
   // ---- Tags ------------------------------------------------------------
-  var tagSingle = new Tag(fixtureName('tag-single'));
-  var tagMultiA = new Tag(fixtureName('tag-multi-a'));
-  var tagMultiB = new Tag(fixtureName('tag-multi-b'));
-  var tagParent = new Tag(fixtureName('tag-parent'));
+  // Tag constructor is (name, position: Tag | Tag.ChildInsertionLocation |
+  // null) — null = top level, explicit per the typedef's required arity.
+  var tagSingle = new Tag(fixtureName('tag-single'), null);
+  var tagMultiA = new Tag(fixtureName('tag-multi-a'), null);
+  var tagMultiB = new Tag(fixtureName('tag-multi-b'), null);
+  var tagParent = new Tag(fixtureName('tag-parent'), null);
   var tagChild = new Tag(fixtureName('tag-child'), tagParent);
-  var tagOnHold = new Tag(fixtureName('tag-on-hold'));
+  var tagOnHold = new Tag(fixtureName('tag-on-hold'), null);
   tagOnHold.status = Tag.Status.OnHold;
-  var tagDropped = new Tag(fixtureName('tag-dropped'));
+  var tagDropped = new Tag(fixtureName('tag-dropped'), null);
   tagDropped.status = Tag.Status.Dropped;
-  var tagUnused = new Tag(fixtureName('tag-zero-tasks'));
+  var tagUnused = new Tag(fixtureName('tag-zero-tasks'), null);
 
   // ---- Projects: types x statuses x features ----------------------------
   var pParallel = new Project(fixtureName('Parallel Project'), root);
@@ -116,7 +142,9 @@ function buildOmniJsPayload(): string {
   new Project(fixtureName('Duplicate Name'), root);
 
   // ---- Task locations: inbox / root / nested action groups --------------
-  new Task(fixtureName('inbox task'), inbox);
+  // Task positions are Project | Task | Task.ChildInsertionLocation — the
+  // Inbox collection itself is not one, but inbox.ending is.
+  new Task(fixtureName('inbox task'), inbox.ending);
 
   var rootTask = new Task(fixtureName('root-level task'), pParallel);
 
@@ -234,7 +262,10 @@ function buildOmniJsPayload(): string {
   }
 
   // ---- Seed-timestamp marker task (conformance suite reset-window precondition) ---
-  var marker = new Task(fixtureName('seed-timestamp'), root);
+  // Tasks cannot live directly in a Folder — the marker gets its own tiny
+  // project so the conformance suite has a stable, named home to read it from.
+  var pMeta = new Project(fixtureName('Seed Meta'), root);
+  var marker = new Task(fixtureName('seed-timestamp'), pMeta);
   marker.note = now.toISOString();
 
   // ---- Count-verify -----------------------------------------------------
@@ -281,8 +312,37 @@ async function runOmniJs(omniJsPayload: string): Promise<string> {
     var result = of.evaluateJavascript(${JSON.stringify(omniJsPayload)});
     result;
   `;
-  const { stdout } = await execFileAsync('osascript', ['-l', 'JavaScript', '-e', jxa]);
-  return stdout.trim();
+  // stdin piping + a hard timeout, mirroring production OmniAutomation.ts:
+  // a ~300-line JSON-escaped payload in a single `-e` argv element invites
+  // argv-length/escaping edge cases stdin avoids, and a wedged OmniFocus
+  // (modal dialog) would otherwise hang the seeder with no diagnostic.
+  return new Promise<string>((resolve, reject) => {
+    const proc = spawn('osascript', ['-l', 'JavaScript'], { timeout: SEED_TIMEOUT_MS });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code, signal) => {
+      if (signal) {
+        reject(
+          new Error(
+            `osascript killed by ${signal} after ${SEED_TIMEOUT_MS}ms — is OmniFocus blocked by a modal dialog? (OF_SEED_TIMEOUT_MS overrides the bound)`,
+          ),
+        );
+      } else if (code !== 0) {
+        reject(new Error(`osascript exited ${code}: ${stderr.trim()}`));
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+    proc.stdin.write(jxa);
+    proc.stdin.end();
+  });
 }
 
 function renderProvenance(counts: SeedCounts): string {
@@ -345,7 +405,16 @@ async function main(): Promise<void> {
   );
 }
 
-main().catch((err) => {
-  console.error('Seeding failed:', err);
-  process.exitCode = 1;
-});
+// Run-guard (scripts/lib/run-directly.ts pattern, same as verify-deploy.ts):
+// without it, merely IMPORTING this module — e.g. a unit test exercising
+// parseArgs/renderProvenance — would fire real OmniFocus mutations against
+// whatever database happens to be open.
+if (isRunDirectly(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Seeding failed:', err);
+    process.exitCode = 1;
+  });
+}
+
+// Exported for unit tests (the run-guard above makes importing side-effect-free).
+export { parseArgs, buildOmniJsPayload, renderProvenance, type SeedCounts };

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -32,7 +32,13 @@ const SEED_TIMEOUT_MS = Number(process.env.OF_SEED_TIMEOUT_MS ?? 180_000);
 
 function parseArgs(argv: string[]): { outDir: string } {
   const outIndex = argv.indexOf('--out');
-  const outDir = outIndex !== -1 && argv[outIndex + 1] ? argv[outIndex + 1] : join(homedir(), 'of-golden');
+  if (outIndex !== -1 && !argv[outIndex + 1]) {
+    // Fail loud, not fall back: silently writing PROVENANCE.md to the
+    // default location on a value-less --out means of-db-reset.sh later
+    // reads the wrong (or stale) file from the unintended directory.
+    throw new Error('--out requires a directory argument (e.g. --out ~/of-golden)');
+  }
+  const outDir = outIndex !== -1 ? argv[outIndex + 1] : join(homedir(), 'of-golden');
   return { outDir };
 }
 
@@ -334,6 +340,10 @@ async function runOmniJs(omniJsPayload: string): Promise<string> {
   // a ~300-line JSON-escaped payload in a single `-e` argv element invites
   // argv-length/escaping edge cases stdin avoids, and a wedged OmniFocus
   // (modal dialog) would otherwise hang the seeder with no diagnostic.
+  // Deliberately MIRRORS (not imports) OmniAutomation.ts's runner: this is
+  // a standalone ops script (npx tsx, no build step) that must not depend
+  // on the MCP server's src/ runtime — the same no-server-dependency rule
+  // its sibling of-db-reset.sh states in its header.
   return new Promise<string>((resolve, reject) => {
     const proc = spawn('osascript', ['-l', 'JavaScript'], { timeout: SEED_TIMEOUT_MS });
     let stdout = '';

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -64,12 +64,25 @@ function buildOmniJsPayload(): string {
   // The header advertises re-running this script to refresh relative dates;
   // without this sweep a re-run would create a SECOND fixture tree alongside
   // the first and corrupt whatever golden snapshot gets frozen from it.
-  // Deleting a folder cascades to its contained projects/tasks; tags and
-  // inbox tasks live outside the folder tree and are swept separately.
+  // FLATTENED collections, not top-level ones: a FIXTURE folder/tag nested
+  // under a non-fixture parent would be invisible to folders/tags. Deleting
+  // a parent cascades to children already in the slice, so each delete is
+  // try/caught (a dead reference just means the cascade got there first).
   // Slice first: deleting while iterating a live collection is undefined.
-  folders.slice().filter(isFixture).forEach(function (f) { deleteObject(f); });
-  tags.slice().filter(isFixture).forEach(function (t) { deleteObject(t); });
-  inbox.slice().filter(isFixture).forEach(function (t) { deleteObject(t); });
+  function sweepFixtures(collection) {
+    collection.slice().filter(isFixture).forEach(function (obj) {
+      try {
+        deleteObject(obj);
+      } catch (e) {
+        // already removed via a parent's cascade delete
+      }
+    });
+  }
+  sweepFixtures(flattenedFolders);
+  sweepFixtures(flattenedTags);
+  sweepFixtures(inbox);
+  // The custom perspective is handled by reuse-not-recreate below (there is
+  // no documented Perspective delete API to sweep with).
 
   // Folder/Project constructors take (name, position) — position is a parent
   // Folder or a Folder.ChildInsertionLocation like library.beginning
@@ -252,9 +265,14 @@ function buildOmniJsPayload(): string {
   );
 
   // ---- Custom perspective (best-effort; requires Pro; verify on KMM) ---
+  // Reuse-not-recreate for idempotency: Perspective.Custom.byName finds a
+  // prior run's copy (no documented delete API exists to sweep it), so
+  // re-seeding never duplicates the perspective.
   var perspectiveCreated = false;
   try {
-    var customPerspective = new Perspective.Custom(fixtureName('Custom Perspective'));
+    var customPerspective =
+      Perspective.Custom.byName(fixtureName('Custom Perspective')) ||
+      new Perspective.Custom(fixtureName('Custom Perspective'));
     customPerspective.archivedFilterRules = [Perspective.FilterRule.Flagged];
     perspectiveCreated = true;
   } catch (e) {
@@ -379,6 +397,11 @@ async function main(): Promise<void> {
   const { outDir } = parseArgs(process.argv.slice(2));
   console.log(`Seeding golden database fixtures (OmniFocus must already be running with the target document open)...`);
 
+  // Fail fast on a bad --out BEFORE the live OmniFocus mutation: if this
+  // mkdir ran after runOmniJs, a typo'd path would throw only after the
+  // expensive live seed, losing PROVENANCE.md and forcing a full re-seed.
+  await mkdir(outDir, { recursive: true });
+
   const rawResult = await runOmniJs(buildOmniJsPayload());
   let counts: SeedCounts;
   try {
@@ -387,7 +410,6 @@ async function main(): Promise<void> {
     throw new Error(`Seed script did not return valid JSON. Raw osascript output:\n${rawResult}\n\n${String(err)}`);
   }
 
-  await mkdir(outDir, { recursive: true });
   const provenancePath = join(outDir, 'PROVENANCE.md');
   await writeFile(provenancePath, renderProvenance(counts), 'utf8');
 

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -404,6 +404,17 @@ async function runOmniJs(omniJsPayload: string): Promise<string> {
         resolve(stdout.trim());
       }
     });
+    // Without this, a write to an already-closed pipe (osascript exiting
+    // instantly on a TCC/Automation prompt, or the timeout firing between
+    // spawn and write) emits an unhandled 'error' (EPIPE) that crashes the
+    // seeder with a raw stack trace instead of the diagnostics above.
+    proc.stdin.on('error', (err: Error) => {
+      reject(
+        new Error(
+          `failed to write the payload to osascript stdin — did it exit immediately (TCC/Automation prompt)? ${String(err)}`,
+        ),
+      );
+    });
     proc.stdin.write(jxa);
     proc.stdin.end();
   });

--- a/scripts/kmm/seed-golden-database.ts
+++ b/scripts/kmm/seed-golden-database.ts
@@ -14,6 +14,12 @@
  *
  * Usage: npx tsx scripts/kmm/seed-golden-database.ts [--out ~/of-golden]
  *
+ * IMPORTANT: --out must be the SAME directory of-db-reset.sh is given as
+ * OF_GOLDEN_DIR (both default-align on ~/of-golden, but of-db-reset.sh has
+ * no default — it requires the env var). A mismatch makes the reset verify
+ * counts against a missing or STALE PROVENANCE.md, silently defeating the
+ * verification the two scripts provide together.
+ *
  * Env: OF_SEED_TIMEOUT_MS bounds the osascript run (default 180000) — a wedged
  * OmniFocus (modal dialog) otherwise hangs the seeder forever (known failure mode,
  * see CLAUDE.md "Script timeouts").
@@ -46,8 +52,13 @@ function parseArgs(argv: string[]): { outDir: string } {
   // location on a value-less --out (or mkdir-ing a directory literally named
   // '--verbose' when the value is another flag) means of-db-reset.sh later
   // reads the wrong (or stale) file from an unintended directory.
+  // The dash check intentionally also rejects a real directory whose name
+  // starts with '-' — reach one as './-name' or an absolute path (both
+  // pass); silently mkdir-ing a flag typo is the worse failure.
   if (outIndex !== -1 && (!argv[outIndex + 1] || argv[outIndex + 1].startsWith('-'))) {
-    throw new Error(`--out requires a directory argument (e.g. --out ~/of-golden), got: '${argv[outIndex + 1] ?? ''}'`);
+    throw new Error(
+      `--out requires a directory argument (e.g. --out ~/of-golden), got: '${argv[outIndex + 1] ?? ''}'. For a directory name starting with '-', use ./ or an absolute path.`,
+    );
   }
   const outDir = outIndex !== -1 ? argv[outIndex + 1] : join(homedir(), 'of-golden');
   return { outDir };
@@ -74,7 +85,10 @@ function buildOmniJsPayload(): string {
     return 'FIXTURE: ' + label;
   }
   function isFixture(obj) {
-    return obj.name.indexOf('FIXTURE: ') === 0;
+    // typeof guard: this predicate runs over every REAL object in the
+    // document during the sweep, and an odd item with a null/undefined
+    // name must read as "not a fixture", not crash the whole run.
+    return typeof obj.name === 'string' && obj.name.indexOf('FIXTURE: ') === 0;
   }
 
   // ---- Idempotency: remove any prior FIXTURE: data before re-seeding -----

--- a/tests/unit/scripts/bash-harness.ts
+++ b/tests/unit/scripts/bash-harness.ts
@@ -16,23 +16,26 @@ export interface BashResult {
   stderr: string;
 }
 
-/** Runs `source <script>; <call>` in a fresh bash subprocess with a
- * controlled environment (default vars stripped unless provided). Sourcing
- * relies on the scripts' sourcing guard (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`)
- * to skip `main` — only the function/variable definitions load. */
-export function sourceAndRun(script: string, call: string, env: Record<string, string> = {}): BashResult {
-  const result = spawnSync('bash', ['-c', `source "$1"; ${call}`, 'bash', script], {
+// The ONE place the controlled environment and result shape are defined —
+// both public helpers delegate here, so an env-contract change (adding
+// LANG, stripping TZ, ...) cannot silently apply to one and not the other.
+function runBash(bashArgs: string[], env: Record<string, string>): BashResult {
+  const result = spawnSync('bash', bashArgs, {
     env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
     encoding: 'utf8',
   });
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
 
+/** Runs `source <script>; <call>` in a fresh bash subprocess with a
+ * controlled environment (default vars stripped unless provided). Sourcing
+ * relies on the scripts' sourcing guard (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`)
+ * to skip `main` — only the function/variable definitions load. */
+export function sourceAndRun(script: string, call: string, env: Record<string, string> = {}): BashResult {
+  return runBash(['-c', `source "$1"; ${call}`, 'bash', script], env);
+}
+
 /** Executes a script (not sourced — main runs) with a controlled environment. */
 export function spawnScript(script: string, args: string[], env: Record<string, string>): BashResult {
-  const result = spawnSync('bash', [script, ...args], {
-    env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
-    encoding: 'utf8',
-  });
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+  return runBash([script, ...args], env);
 }

--- a/tests/unit/scripts/bash-harness.ts
+++ b/tests/unit/scripts/bash-harness.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared bash test harness for scripts/ suites (kmm-scripts.test.ts,
+ * seed-golden-database.test.ts). One canonical way to source a script and
+ * call a function inside it — if the scripts' sourcing contract changes
+ * (sourcing guard, PATH/HOME requirements), there is exactly one call shape
+ * to update.
+ */
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+export const REPO_ROOT = join(__dirname, '../../..');
+
+export interface BashResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Runs `source <script>; <call>` in a fresh bash subprocess with a
+ * controlled environment (default vars stripped unless provided). Sourcing
+ * relies on the scripts' sourcing guard (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`)
+ * to skip `main` — only the function/variable definitions load. */
+export function sourceAndRun(script: string, call: string, env: Record<string, string> = {}): BashResult {
+  const result = spawnSync('bash', ['-c', `source "$1"; ${call}`, 'bash', script], {
+    env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
+    encoding: 'utf8',
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+/** Executes a script (not sourced — main runs) with a controlled environment. */
+export function spawnScript(script: string, args: string[], env: Record<string, string>): BashResult {
+  const result = spawnSync('bash', [script, ...args], {
+    env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
+    encoding: 'utf8',
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}

--- a/tests/unit/scripts/kmm-scripts.test.ts
+++ b/tests/unit/scripts/kmm-scripts.test.ts
@@ -7,7 +7,7 @@
  * or a real KMM machine, per the ticket's own acceptance criteria.
  */
 import { describe, it, expect } from 'vitest';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -294,11 +294,9 @@ describe('scripts/kmm — PATH-symlink invocation (SCRIPT_DIR symlink resolution
     try {
       const link = join(dir, 'linked-script');
       symlinkSync(script, link);
-      const result = spawnSync('bash', [link], {
-        env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
-        encoding: 'utf8',
-      });
-      return { status: result.status, stderr: result.stderr };
+      // Delegates to the shared harness so the symlink tests run under the
+      // exact same controlled environment as every other scripts test.
+      return spawnScript(link, [], env);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/scripts/kmm-scripts.test.ts
+++ b/tests/unit/scripts/kmm-scripts.test.ts
@@ -11,8 +11,8 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { REPO_ROOT, sourceAndRun, spawnScript } from './bash-harness.js';
 
-const REPO_ROOT = join(__dirname, '../../..');
 // Placeholder paths used only as fake env-var VALUES in these tests (never
 // actually written to) — computed rather than literal so no hardcoded
 // world-writable-directory string appears in source (sonarjs/publicly-writable-directories).
@@ -30,22 +30,6 @@ function bashSyntaxOk(script: string): boolean {
   } catch {
     return false;
   }
-}
-
-/** Runs `source <script>; <call>` in a fresh bash subprocess with a
- * controlled environment (default vars stripped unless provided). Sourcing
- * relies on the scripts' sourcing guard (`[[ "${BASH_SOURCE[0]}" == "${0}" ]]`)
- * to skip `main` — only the function/variable definitions load. */
-function sourceAndRun(
-  script: string,
-  call: string,
-  env: Record<string, string> = {},
-): { status: number | null; stdout: string; stderr: string } {
-  const result = spawnSync('bash', ['-c', `source "$1"; ${call}`, 'bash', script], {
-    env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
-    encoding: 'utf8',
-  });
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
 
 describe('scripts/kmm — syntax', () => {
@@ -579,15 +563,3 @@ describe('of-kmm-redeploy — env validation', () => {
     }
   });
 });
-
-function spawnScript(
-  script: string,
-  args: string[],
-  env: Record<string, string>,
-): { status: number | null; stdout: string; stderr: string } {
-  const result = spawnSync('bash', [script, ...args], {
-    env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...env },
-    encoding: 'utf8',
-  });
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
-}

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -1,0 +1,133 @@
+/**
+ * OMN-280 — unit coverage for the KMM golden-database seeder (PR #216).
+ * Live behavioral verification (actually seeding OmniFocus) is deferred to
+ * OMN-280's on-machine sitting; this suite covers what's testable without
+ * OmniFocus: pure functions, payload pins for the OmniJS API-shape bugs the
+ * /code-review gate confirmed, and the PROVENANCE.md contract shared with
+ * scripts/kmm/of-db-reset.sh.
+ *
+ * Importing the module at all is itself a regression test: without the
+ * isRunDirectly guard, this import would shell out to osascript and mutate
+ * a real OmniFocus database.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseArgs,
+  buildOmniJsPayload,
+  renderProvenance,
+  type SeedCounts,
+} from '../../../scripts/kmm/seed-golden-database.js';
+
+const REPO_ROOT = join(__dirname, '../../..');
+const OF_DB_RESET = join(REPO_ROOT, 'scripts/kmm/of-db-reset.sh');
+
+const SAMPLE_COUNTS: SeedCounts = {
+  tasks: 152,
+  projects: 21,
+  tags: 9,
+  folders: 4,
+  tasks_completed: 3,
+  tasks_dropped: 1,
+  projects_dropped: 1,
+  projects_done: 1,
+  seed_timestamp: '2026-07-21T12:00:00.000Z',
+  perspective_created: false,
+};
+
+describe('parseArgs', () => {
+  it('defaults --out to ~/of-golden', () => {
+    expect(parseArgs([]).outDir).toBe(join(homedir(), 'of-golden'));
+  });
+
+  it('honors --out override', () => {
+    // Computed rather than literal so no hardcoded world-writable-directory
+    // string appears in source (sonarjs/publicly-writable-directories).
+    const customOut = join(tmpdir(), 'custom-golden');
+    expect(parseArgs(['--out', customOut]).outDir).toBe(customOut);
+  });
+});
+
+describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
+  const payload = buildOmniJsPayload();
+
+  it('is syntactically valid JavaScript', () => {
+    // new Function() parses without executing — OmniFocus globals stay
+    // unresolved, but a syntax error (the class of bug that burns a live
+    // KMM sitting instantly) throws here.
+    expect(() => new Function(payload)).not.toThrow();
+  });
+
+  it('never references the nonexistent Folder.ending static', () => {
+    expect(payload).not.toContain('Folder.ending');
+  });
+
+  it('creates the fixture root at library.beginning with two-arg Folder constructors', () => {
+    expect(payload).toContain("new Folder(fixtureName('Fixtures'), library.beginning)");
+    expect(payload).toContain("new Folder(fixtureName('Nested L1'), root)");
+  });
+
+  it('never positions a Task in a Folder (marker lives in the Seed Meta project)', () => {
+    expect(payload).not.toMatch(/new Task\([^)]*,\s*root\)/);
+    expect(payload).toContain("new Project(fixtureName('Seed Meta'), root)");
+    expect(payload).toContain("new Task(fixtureName('seed-timestamp'), pMeta)");
+  });
+
+  it('positions the inbox task at inbox.ending, not the Inbox collection itself', () => {
+    expect(payload).toContain('inbox.ending');
+    expect(payload).not.toMatch(/new Task\([^)]*,\s*inbox\)/);
+  });
+
+  it('sweeps prior FIXTURE: folders, tags, and inbox tasks before creating anything (idempotent re-seed)', () => {
+    for (const sweep of [
+      'folders.slice().filter(isFixture)',
+      'tags.slice().filter(isFixture)',
+      'inbox.slice().filter(isFixture)',
+    ]) {
+      expect(payload).toContain(sweep);
+    }
+    // The sweep must run BEFORE the first fixture creation.
+    expect(payload.indexOf('deleteObject')).toBeLessThan(payload.indexOf('new Folder('));
+  });
+
+  it('contains the seed-timestamp marker and returns JSON counts', () => {
+    expect(payload).toContain("fixtureName('seed-timestamp')");
+    expect(payload).toContain('return JSON.stringify(counts)');
+  });
+});
+
+describe('renderProvenance — contract with of-db-reset.sh', () => {
+  it('renders the key: value count lines', () => {
+    const rendered = renderProvenance(SAMPLE_COUNTS);
+    expect(rendered).toContain('tasks: 152');
+    expect(rendered).toContain('projects: 21');
+  });
+
+  it("parses with the merged reset script's parse_provenance_count (cross-contract)", () => {
+    // The real seam: of-db-reset.sh diffs live counts against this exact
+    // file. Feed the rendered output through the actual bash parser rather
+    // than re-asserting the format in TypeScript.
+    const dir = mkdtempSync(join(tmpdir(), 'provenance-xcontract-'));
+    try {
+      writeFileSync(join(dir, 'PROVENANCE.md'), renderProvenance(SAMPLE_COUNTS));
+      const result = spawnSync(
+        'bash',
+        [
+          '-c',
+          `source "$1"; PROVENANCE="$2/PROVENANCE.md"; echo "$(parse_provenance_count tasks) $(parse_provenance_count projects)"`,
+          'bash',
+          OF_DB_RESET,
+          dir,
+        ],
+        { env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '' }, encoding: 'utf8' },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe('152 21');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -81,21 +81,36 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
     expect(payload).not.toMatch(/new Task\([^)]*,\s*inbox\)/);
   });
 
-  it('sweeps prior FIXTURE: folders, tags, and inbox tasks before creating anything (idempotent re-seed)', () => {
-    for (const sweep of [
-      'folders.slice().filter(isFixture)',
-      'tags.slice().filter(isFixture)',
-      'inbox.slice().filter(isFixture)',
-    ]) {
-      expect(payload).toContain(sweep);
+  it('sweeps prior FIXTURE: data from FLATTENED collections before creating anything (idempotent re-seed)', () => {
+    // Flattened, not top-level — a fixture nested under a non-fixture
+    // parent would be invisible to the top-level folders/tags collections.
+    for (const swept of ['sweepFixtures(flattenedFolders)', 'sweepFixtures(flattenedTags)', 'sweepFixtures(inbox)']) {
+      expect(payload).toContain(swept);
     }
     // The sweep must run BEFORE the first fixture creation.
     expect(payload.indexOf('deleteObject')).toBeLessThan(payload.indexOf('new Folder('));
   });
 
+  it('reuses an existing FIXTURE custom perspective instead of duplicating it on re-seed', () => {
+    expect(payload).toContain("Perspective.Custom.byName(fixtureName('Custom Perspective')) ||");
+  });
+
   it('contains the seed-timestamp marker and returns JSON counts', () => {
     expect(payload).toContain("fixtureName('seed-timestamp')");
     expect(payload).toContain('return JSON.stringify(counts)');
+  });
+});
+
+describe('main() ordering', () => {
+  it('creates the output directory BEFORE the live OmniFocus mutation', () => {
+    // A bad --out path must fail fast, not after the expensive live seed
+    // has already mutated the real document (losing PROVENANCE.md).
+    const src = readFileSync(join(REPO_ROOT, 'scripts/kmm/seed-golden-database.ts'), 'utf8');
+    const mkdirIndex = src.indexOf('await mkdir(outDir');
+    const seedIndex = src.indexOf('await runOmniJs(');
+    expect(mkdirIndex).toBeGreaterThan(-1);
+    expect(seedIndex).toBeGreaterThan(-1);
+    expect(mkdirIndex).toBeLessThan(seedIndex);
   });
 });
 

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -117,10 +117,7 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
       expect(payload).toContain(swept);
     }
     // The leftover verification must scan the same five collections.
-    for (const checked of [
-      'flattenedProjects.slice().filter(isFixture).length',
-      'flattenedTasks.slice().filter(isFixture).length',
-    ]) {
+    for (const checked of ['flattenedProjects.filter(isFixture).length', 'flattenedTasks.filter(isFixture).length']) {
       expect(payload).toContain(checked);
     }
     // The sweep must run BEFORE the first fixture creation.
@@ -129,6 +126,13 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
 
   it('reuses an existing FIXTURE custom perspective instead of duplicating it on re-seed', () => {
     expect(payload).toContain("Perspective.Custom.byName(fixtureName('Custom Perspective')) ||");
+  });
+
+  it('never references the nonexistent Perspective.FilterRule namespace', () => {
+    // archivedFilterRules is typed as bare Object; no FilterRule enum exists
+    // in OmniFocus.d.ts — referencing one throws inside the try/catch and
+    // silently fails the Perspectives coverage row on every run.
+    expect(payload).not.toContain('Perspective.FilterRule');
   });
 
   it('sets reviewInterval via read-modify-reassign with plural units, never an object literal', () => {

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -11,18 +11,18 @@
  * a real OmniFocus database.
  */
 import { describe, it, expect } from 'vitest';
-import { spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
+import { REPO_ROOT, sourceAndRun } from './bash-harness.js';
 import {
   parseArgs,
   buildOmniJsPayload,
   renderProvenance,
+  resolveSeedTimeoutMs,
   type SeedCounts,
 } from '../../../scripts/kmm/seed-golden-database.js';
 
-const REPO_ROOT = join(__dirname, '../../..');
 const OF_DB_RESET = join(REPO_ROOT, 'scripts/kmm/of-db-reset.sh');
 
 const SAMPLE_COUNTS: SeedCounts = {
@@ -45,6 +45,10 @@ describe('parseArgs', () => {
 
   it('throws loudly when --out has no value instead of silently defaulting', () => {
     expect(() => parseArgs(['--out'])).toThrow('--out requires a directory argument');
+  });
+
+  it('throws loudly when --out is followed by another flag instead of mkdir-ing a directory named like the flag', () => {
+    expect(() => parseArgs(['--out', '--verbose'])).toThrow('--out requires a directory argument');
   });
 
   it('honors --out override', () => {
@@ -145,21 +149,31 @@ describe('renderProvenance — contract with of-db-reset.sh', () => {
     const dir = mkdtempSync(join(tmpdir(), 'provenance-xcontract-'));
     try {
       writeFileSync(join(dir, 'PROVENANCE.md'), renderProvenance(SAMPLE_COUNTS));
-      const result = spawnSync(
-        'bash',
-        [
-          '-c',
-          `source "$1"; PROVENANCE="$2/PROVENANCE.md"; echo "$(parse_provenance_count tasks) $(parse_provenance_count projects)"`,
-          'bash',
-          OF_DB_RESET,
-          dir,
-        ],
-        { env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '' }, encoding: 'utf8' },
+      const result = sourceAndRun(
+        OF_DB_RESET,
+        `PROVENANCE="${dir}/PROVENANCE.md"; echo "$(parse_provenance_count tasks) $(parse_provenance_count projects)"`,
       );
       expect(result.status).toBe(0);
       expect(result.stdout.trim()).toBe('152 21');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveSeedTimeoutMs', () => {
+  it('defaults to 180000 when unset or empty', () => {
+    expect(resolveSeedTimeoutMs(undefined)).toBe(180_000);
+    expect(resolveSeedTimeoutMs('')).toBe(180_000);
+  });
+
+  it('honors a numeric override', () => {
+    expect(resolveSeedTimeoutMs('60000')).toBe(60_000);
+  });
+
+  it('throws loudly on a non-numeric or non-positive value instead of passing NaN to spawn', () => {
+    expect(() => resolveSeedTimeoutMs('abc')).toThrow('OF_SEED_TIMEOUT_MS must be a positive number');
+    expect(() => resolveSeedTimeoutMs('0')).toThrow('OF_SEED_TIMEOUT_MS must be a positive number');
+    expect(() => resolveSeedTimeoutMs('-5')).toThrow('OF_SEED_TIMEOUT_MS must be a positive number');
   });
 });

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -131,6 +131,13 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
     expect(payload).toContain("Perspective.Custom.byName(fixtureName('Custom Perspective')) ||");
   });
 
+  it('calls Task.drop() with both required arguments (allOccurrences, dateDropped)', () => {
+    // Zero-arg drop() has no documented fallback (unlike markComplete);
+    // production defs.ts always passes both.
+    expect(payload).toContain('.drop(true, now)');
+    expect(payload).not.toMatch(/\.drop\(\)/);
+  });
+
   it('contains the seed-timestamp marker and returns JSON counts', () => {
     expect(payload).toContain("fixtureName('seed-timestamp')");
     expect(payload).toContain('return JSON.stringify(counts)');

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -105,8 +105,23 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
   it('sweeps prior FIXTURE: data from FLATTENED collections before creating anything (idempotent re-seed)', () => {
     // Flattened, not top-level — a fixture nested under a non-fixture
     // parent would be invisible to the top-level folders/tags collections.
-    for (const swept of ['sweepFixtures(flattenedFolders)', 'sweepFixtures(flattenedTags)', 'sweepFixtures(inbox)']) {
+    // ALL flattened collections — a partial cascade failure can orphan
+    // FIXTURE projects/tasks whose parent folder is already gone.
+    for (const swept of [
+      'sweepFixtures(flattenedFolders)',
+      'sweepFixtures(flattenedProjects)',
+      'sweepFixtures(flattenedTags)',
+      'sweepFixtures(flattenedTasks)',
+      'sweepFixtures(inbox)',
+    ]) {
       expect(payload).toContain(swept);
+    }
+    // The leftover verification must scan the same five collections.
+    for (const checked of [
+      'flattenedProjects.slice().filter(isFixture).length',
+      'flattenedTasks.slice().filter(isFixture).length',
+    ]) {
+      expect(payload).toContain(checked);
     }
     // The sweep must run BEFORE the first fixture creation.
     expect(payload.indexOf('deleteObject')).toBeLessThan(payload.indexOf('new Folder('));

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -43,6 +43,10 @@ describe('parseArgs', () => {
     expect(parseArgs([]).outDir).toBe(join(homedir(), 'of-golden'));
   });
 
+  it('throws loudly when --out has no value instead of silently defaulting', () => {
+    expect(() => parseArgs(['--out'])).toThrow('--out requires a directory argument');
+  });
+
   it('honors --out override', () => {
     // Computed rather than literal so no hardcoded world-writable-directory
     // string appears in source (sonarjs/publicly-writable-directories).
@@ -70,15 +74,28 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
     expect(payload).toContain("new Folder(fixtureName('Nested L1'), root)");
   });
 
+  // [^\n]* not [^)]* — the first argument is always a fixtureName(...) call,
+  // whose closing paren would stop a [^)]* class before it ever reached the
+  // position argument, making the not.toMatch a permanent false negative.
+  const TASK_IN_FOLDER = /new Task\([^\n]*,\s*root\)/;
+  const TASK_IN_INBOX_COLLECTION = /new Task\([^\n]*,\s*inbox\)/;
+
+  it('the Task-position pin regexes actually match known-bad code (canary)', () => {
+    // Watched-it-fail guard: if these regexes cannot flag the exact bug
+    // they exist to catch, the pins below prove nothing.
+    expect("var marker = new Task(fixtureName('seed-timestamp'), root);").toMatch(TASK_IN_FOLDER);
+    expect("new Task(fixtureName('inbox task'), inbox);").toMatch(TASK_IN_INBOX_COLLECTION);
+  });
+
   it('never positions a Task in a Folder (marker lives in the Seed Meta project)', () => {
-    expect(payload).not.toMatch(/new Task\([^)]*,\s*root\)/);
+    expect(payload).not.toMatch(TASK_IN_FOLDER);
     expect(payload).toContain("new Project(fixtureName('Seed Meta'), root)");
     expect(payload).toContain("new Task(fixtureName('seed-timestamp'), pMeta)");
   });
 
   it('positions the inbox task at inbox.ending, not the Inbox collection itself', () => {
     expect(payload).toContain('inbox.ending');
-    expect(payload).not.toMatch(/new Task\([^)]*,\s*inbox\)/);
+    expect(payload).not.toMatch(TASK_IN_INBOX_COLLECTION);
   });
 
   it('sweeps prior FIXTURE: data from FLATTENED collections before creating anything (idempotent re-seed)', () => {

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -131,6 +131,16 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
     expect(payload).toContain("Perspective.Custom.byName(fixtureName('Custom Perspective')) ||");
   });
 
+  it('sets reviewInterval via read-modify-reassign with plural units, never an object literal', () => {
+    // A plain literal assignment silently no-ops in OmniJS (OMN-41/OMN-58);
+    // production lowers this via readModifyReassign, and units are plural
+    // per defs.ts reviewIntervalUnit().
+    expect(payload).not.toMatch(/reviewInterval\s*=\s*\{/);
+    expect(payload).toContain('var reviewRmr = pReview.reviewInterval;');
+    expect(payload).toContain("reviewRmr.unit = 'weeks';");
+    expect(payload).toContain('pReview.reviewInterval = reviewRmr;');
+  });
+
   it('calls Task.drop() with both required arguments (allOccurrences, dateDropped)', () => {
     // Zero-arg drop() has no documented fallback (unlike markComplete);
     // production defs.ts always passes both.

--- a/tests/unit/scripts/seed-golden-database.test.ts
+++ b/tests/unit/scripts/seed-golden-database.test.ts
@@ -36,6 +36,7 @@ const SAMPLE_COUNTS: SeedCounts = {
   projects_done: 1,
   seed_timestamp: '2026-07-21T12:00:00.000Z',
   perspective_created: false,
+  perspective_error: null,
 };
 
 describe('parseArgs', () => {
@@ -78,17 +79,22 @@ describe('buildOmniJsPayload — OmniJS API-shape pins (gate findings)', () => {
     expect(payload).toContain("new Folder(fixtureName('Nested L1'), root)");
   });
 
-  // [^\n]* not [^)]* — the first argument is always a fixtureName(...) call,
-  // whose closing paren would stop a [^)]* class before it ever reached the
-  // position argument, making the not.toMatch a permanent false negative.
-  const TASK_IN_FOLDER = /new Task\([^\n]*,\s*root\)/;
-  const TASK_IN_INBOX_COLLECTION = /new Task\([^\n]*,\s*inbox\)/;
+  // [^;]* not [^)]* (which stops at fixtureName()'s closing paren — a
+  // permanent false negative) and not [^\n]* (which misses multi-line
+  // new Task(...) calls, a formatting the payload already uses elsewhere).
+  // Statements end with ';' and fixtureName args contain none, so [^;]*
+  // spans exactly one call including line breaks.
+  const TASK_IN_FOLDER = /new Task\([^;]*,\s*root,?\s*\)/;
+  const TASK_IN_INBOX_COLLECTION = /new Task\([^;]*,\s*inbox,?\s*\)/;
 
   it('the Task-position pin regexes actually match known-bad code (canary)', () => {
     // Watched-it-fail guard: if these regexes cannot flag the exact bug
-    // they exist to catch, the pins below prove nothing.
+    // they exist to catch, the pins below prove nothing — in single-line
+    // AND multi-line formatting.
     expect("var marker = new Task(fixtureName('seed-timestamp'), root);").toMatch(TASK_IN_FOLDER);
+    expect("new Task(\n  fixtureName('a long name'),\n  root,\n);").toMatch(TASK_IN_FOLDER);
     expect("new Task(fixtureName('inbox task'), inbox);").toMatch(TASK_IN_INBOX_COLLECTION);
+    expect("new Task(\n  fixtureName('x'),\n  inbox,\n);").toMatch(TASK_IN_INBOX_COLLECTION);
   });
 
   it('never positions a Task in a Folder (marker lives in the Seed Meta project)', () => {


### PR DESCRIPTION
## Summary
- `scripts/kmm/seed-golden-database.ts` — seeds the coverage-matrix fixtures (project types/statuses/features, folder structure, task locations/states/features, tag taxonomy, name edge cases, seed-relative dates, seed-timestamp marker task) under a `FIXTURE:`-prefixed `Fixtures` folder, then writes `PROVENANCE.md` with entity counts.

Per `docs/superpowers/specs/2026-07-02-kmm-test-ground-design.md` §2. Supports OMN-280's golden-DB enrichment/freeze session; meets the OMN-148 skeleton's seeding requirements (seed-relative dates, discriminative analytics content, seed-timestamp marker task the conformance suite reads).

## Disposition history (2026-07-21)
Originally drafted under OMN-235 with its own `of-db-reset.sh`. Slimmed + rebased onto main after PR #238 (OMN-279) merged: the reset script here was **superseded** by #238's gate-hardened version (7-round /code-review), so it was dropped. The `PROVENANCE.md` this seeder renders (`tasks:`/`projects:` key-value lines) matches the parser contract #238's merged `of-db-reset.sh` defines.

## Not yet done / needs live verification on KMM
- The seeder has never run against real OmniFocus — this environment has none. Treat every OmniJS call as a hypothesis until a live run on KMM confirms it.
- Custom-perspective creation (`Perspective.Custom`) is wrapped in try/catch as best-effort; the script logs a warning if the API/license doesn't support it.
- Coverage-matrix audit (spec §2) and the golden-snapshot zip/freeze step are manual follow-ups in OMN-280, not automated here.

## Test plan (lives in OMN-280's sitting)
- [ ] Run `npx tsx scripts/kmm/seed-golden-database.ts` on KMM against a scratch document; confirm `PROVENANCE.md` counts look sane and the coverage matrix rows are all present
- [ ] Zip the seeded `.ofocus` into `~/of-golden/golden.ofocus.zip`
- [ ] Run `scripts/kmm/of-db-reset.sh` (from main), confirm restore + count-verify passes
- [ ] Make a destructive change, re-run reset, confirm it's reverted and counts still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzEN3X23TZxvzcDo7mvwus