### PR TITLE
fix(OMN-262): make integration-test RUN_ID genuinely process-scoped, not per-file

### DIFF
--- a/tests/integration/helpers/run-id.ts
+++ b/tests/integration/helpers/run-id.ts
@@ -62,11 +62,21 @@ import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
  *
  * Format: `<base36(Date.now())>-<6 hex chars>`.
  */
+// Exported (not inlined) so run-id.test.ts's globalThis-clearing helper —
+// which simulates a genuinely separate process, since vi.resetModules()
+// alone no longer changes RUN_ID — imports the real key instead of
+// duplicating the string, which would otherwise be free to drift out of
+// sync with this one and silently clear the wrong slot.
+export const RUN_ID_GLOBAL_KEY = Symbol.for('omnifocus-mcp:integration-test-run-id');
+
 function getOrCreateRunId(): string {
-  const key = Symbol.for('omnifocus-mcp:integration-test-run-id');
-  const store = globalThis as unknown as Record<symbol, string>;
-  store[key] ??= `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`;
-  return store[key];
+  // `| undefined` keeps the `??=` guard's necessity visible to the type
+  // system — a plain `string` type would let a future refactor "simplify"
+  // this into a bare read that compiles fine but returns undefined on a
+  // fresh process.
+  const store = globalThis as unknown as Record<symbol, string | undefined>;
+  store[RUN_ID_GLOBAL_KEY] ??= `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`;
+  return store[RUN_ID_GLOBAL_KEY];
 }
 
 export const RUN_ID: string = getOrCreateRunId();

--- a/tests/integration/helpers/run-id.ts
+++ b/tests/integration/helpers/run-id.ts
@@ -9,8 +9,8 @@
  *  3. The generic-prefix sweep (`__TEST__`/`__test-`) remains the safety net
  *     for prior-run residue from crashed runs that predate this contract.
  *
- * The id is generated once per process and is process-scoped — every test
- * file in the same vitest run sees the same `RUN_ID`. Generation:
+ * The id is process-scoped — every test file in the same vitest run must see
+ * the same `RUN_ID`. Generation:
  *
  *   `<base36 millis>-<6 hex bytes>`
  *
@@ -38,11 +38,38 @@ import { randomBytes } from 'crypto';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
 
 /**
- * Process-scoped run identifier. Generated once at module load.
+ * Process-scoped run identifier, cached on `globalThis` rather than a plain
+ * module-level `const`. Vitest's default `isolate: true` resets every test
+ * file's ES-module top-level bindings to a fresh instance — even under
+ * `pool:'forks', poolOptions.forks.singleFork:true` (one OS process, but one
+ * module registry per file) — so a plain `const` here silently re-generates
+ * a NEW id per file, contradicting the "every file sees the same RUN_ID"
+ * contract above. That drift was invisible as long as each file also got its
+ * own fresh `MCPTestClient`/MCP server; it stopped being invisible once a
+ * long-lived client became genuinely shared across files (OMN-261), whose
+ * `createTestTask()`/`createTestProject()` closures capture the RUN_ID of
+ * whichever file happened to instantiate the client first. A later file
+ * passing an already-prefixed name (built from ITS OWN `runScopedName()`,
+ * i.e. a different RUN_ID) into that stale closure fails the
+ * `name.startsWith(RUN_NAME_PREFIX)` fast path and falls through to
+ * re-prefixing, corrupting the name into a DOUBLE run-id prefix — this is
+ * exactly what made the OMN-126 empty-string-project dedup test intermittently
+ * fail (OMN-262): the dedup CODE was never wrong, the fixture name just no
+ * longer matched what the test asserted against. `globalThis` is the one
+ * thing per-file isolation does not reset, so caching here — rather than
+ * importing a shared helper module, to keep this fix independent of any
+ * unmerged shared-client work — makes RUN_ID genuinely process-scoped again.
  *
  * Format: `<base36(Date.now())>-<6 hex chars>`.
  */
-export const RUN_ID: string = `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`;
+function getOrCreateRunId(): string {
+  const key = Symbol.for('omnifocus-mcp:integration-test-run-id');
+  const store = globalThis as unknown as Record<symbol, string>;
+  store[key] ??= `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`;
+  return store[key];
+}
+
+export const RUN_ID: string = getOrCreateRunId();
 
 /**
  * Per-run inbox-task / project name prefix: `__TEST__-<runId>-`.

--- a/tests/unit/integration-helpers/run-id.test.ts
+++ b/tests/unit/integration-helpers/run-id.test.ts
@@ -19,10 +19,13 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { RUN_ID_GLOBAL_KEY } from '../../integration/helpers/run-id.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from '../../integration/helpers/sandbox-manager.js';
 
-const RUN_ID_GLOBAL_KEY = Symbol.for('omnifocus-mcp:integration-test-run-id');
-
+// Imported (not duplicated as a string literal) so this can never drift out
+// of sync with the real key run-id.ts caches RUN_ID under — Symbol.for(key)
+// is idempotent from the global symbol registry, so this stays valid even
+// after vi.resetModules() re-evaluates run-id.ts's module bindings.
 function clearGlobalRunId(): void {
   delete (globalThis as unknown as Record<symbol, unknown>)[RUN_ID_GLOBAL_KEY];
 }

--- a/tests/unit/integration-helpers/run-id.test.ts
+++ b/tests/unit/integration-helpers/run-id.test.ts
@@ -2,30 +2,50 @@
  * OMN-84 — per-runId fixture-name uniqueness regression.
  *
  * The whole point of `RUN_ID` and `runScopedName` / `runScopedTag` is that
- * two integration-test processes (or two re-runs of the same process)
- * cannot collide on a fixture name even if they happen to produce
- * overlapping suffixes (`Completed_1`, `TestBatch_Simple`, `RT_renamed`,
- * etc.). The runId is the discriminator.
+ * two integration-test processes cannot collide on a fixture name even if
+ * they happen to produce overlapping suffixes (`Completed_1`,
+ * `TestBatch_Simple`, `RT_renamed`, etc.). The runId is the discriminator.
  *
- * These tests simulate distinct runs by importing the runId module fresh
- * via `vi.resetModules()` and asserting that names produced in run A do
- * NOT collide with names produced in run B for the same suffix. The
- * generic-prefix safety net (OMN-83 contract) is also verified — runId
- * scoping must NOT break the underlying `__TEST__` / `__test-` startsWith
- * contract that drives the cross-run sweep.
+ * Uniqueness must hold ACROSS OS processes (RUN_ID collide check) while
+ * STABILITY must hold WITHIN one process, even across vitest's per-file
+ * module reloads (OMN-262 — see run-id.ts's `getOrCreateRunId` doc comment).
+ * `vi.resetModules()` alone simulates the latter (same process, same
+ * `globalThis`, fresh ES-module bindings — exactly what vitest does between
+ * test files); it can no longer be used to simulate "a different run", since
+ * that's precisely the drift OMN-262 closed. `loadRunIdModuleAsNewRun()`
+ * below additionally clears the `globalThis` slot RUN_ID is cached under, to
+ * accurately simulate a genuinely separate process.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from '../../integration/helpers/sandbox-manager.js';
 
-// Reset the runId module before each test so each block sees a fresh RUN_ID.
+const RUN_ID_GLOBAL_KEY = Symbol.for('omnifocus-mcp:integration-test-run-id');
+
+function clearGlobalRunId(): void {
+  delete (globalThis as unknown as Record<symbol, unknown>)[RUN_ID_GLOBAL_KEY];
+}
+
+// Reset the runId module before each test so each block starts clean.
 beforeEach(() => {
   vi.resetModules();
+  clearGlobalRunId();
 });
 
 async function loadRunIdModule() {
-  // Dynamic import after resetModules() → fresh RUN_ID per call.
+  // Dynamic import after resetModules() → fresh ES-module bindings, but
+  // RUN_ID itself is cached on globalThis (OMN-262), so this alone does NOT
+  // change RUN_ID within the same process — matching real vitest per-file
+  // module isolation under a shared, long-lived MCP client (OMN-261).
+  return await import('../../integration/helpers/run-id.js');
+}
+
+// Simulates a genuinely different integration-test PROCESS: clears both the
+// module cache and the globalThis slot RUN_ID is cached under.
+async function loadRunIdModuleAsNewRun() {
+  vi.resetModules();
+  clearGlobalRunId();
   return await import('../../integration/helpers/run-id.js');
 }
 
@@ -43,6 +63,20 @@ describe('RUN_ID format (OMN-84)', () => {
 
   it('is stable within a process load (same import returns same id)', async () => {
     const a = await loadRunIdModule();
+    const b = await import('../../integration/helpers/run-id.js');
+    expect(b.RUN_ID).toBe(a.RUN_ID);
+  });
+
+  it('OMN-262: is stable across a simulated per-file module reload within the same process', async () => {
+    // vitest's default per-file isolation resets ES-module top-level bindings
+    // between test files even under a single forked OS process
+    // (pool:'forks', singleFork:true) — vi.resetModules() alone reproduces
+    // that. Before OMN-262, RUN_ID was a plain module-level const, so this
+    // reload silently produced a DIFFERENT id, which corrupted fixture names
+    // once a long-lived MCPTestClient became genuinely shared across files
+    // (OMN-261) — see run-id.ts's getOrCreateRunId doc comment.
+    const a = await loadRunIdModule();
+    vi.resetModules();
     const b = await import('../../integration/helpers/run-id.js');
     expect(b.RUN_ID).toBe(a.RUN_ID);
   });
@@ -120,13 +154,13 @@ describe('isCurrentRunName / isCurrentRunTagName (OMN-84)', () => {
 });
 
 describe('Two simulated runs do not collide on overlapping suffixes (OMN-84 acceptance)', () => {
-  // The canonical OMN-84 acceptance test: two simulated runs (different RUN_IDs)
-  // produce the same suffix; their names must NOT collide.
+  // The canonical OMN-84 acceptance test: two simulated runs (different RUN_IDs,
+  // i.e. different processes — see loadRunIdModuleAsNewRun) produce the same
+  // suffix; their names must NOT collide.
 
   it('two distinct runs produce different RUN_IDs', async () => {
     const runA = await loadRunIdModule();
-    vi.resetModules();
-    const runB = await import('../../integration/helpers/run-id.js');
+    const runB = await loadRunIdModuleAsNewRun();
     // RUN_IDs include `Date.now().toString(36)` plus 6 hex chars of randomness
     // → vanishingly unlikely to collide even at sub-ms intervals.
     expect(runB.RUN_ID).not.toBe(runA.RUN_ID);
@@ -135,8 +169,7 @@ describe('Two simulated runs do not collide on overlapping suffixes (OMN-84 acce
   it('two runs produce non-colliding task names for the same suffix', async () => {
     const runA = await loadRunIdModule();
     const nameA = runA.runScopedName('Completed_1');
-    vi.resetModules();
-    const runB = await import('../../integration/helpers/run-id.js');
+    const runB = await loadRunIdModuleAsNewRun();
     const nameB = runB.runScopedName('Completed_1');
     expect(nameA).not.toBe(nameB);
     // Each is still attributable to its own run.
@@ -150,8 +183,7 @@ describe('Two simulated runs do not collide on overlapping suffixes (OMN-84 acce
   it('two runs produce non-colliding tag names for the same suffix', async () => {
     const runA = await loadRunIdModule();
     const tagA = runA.runScopedTag('rt');
-    vi.resetModules();
-    const runB = await import('../../integration/helpers/run-id.js');
+    const runB = await loadRunIdModuleAsNewRun();
     const tagB = runB.runScopedTag('rt');
     expect(tagA).not.toBe(tagB);
     expect(runA.isCurrentRunTagName(tagA)).toBe(true);
@@ -170,8 +202,7 @@ describe('Two simulated runs do not collide on overlapping suffixes (OMN-84 acce
     expect(nameA.startsWith(TEST_INBOX_PREFIX)).toBe(true);
     expect(tagA.startsWith(TEST_TAG_PREFIX)).toBe(true);
 
-    vi.resetModules();
-    const runB = await import('../../integration/helpers/run-id.js');
+    const runB = await loadRunIdModuleAsNewRun();
     const nameB = runB.runScopedName('SomeTask');
     const tagB = runB.runScopedTag('some-tag');
     expect(nameB.startsWith(TEST_INBOX_PREFIX)).toBe(true);


### PR DESCRIPTION
## Summary

- Root-causes the intermittent `omn-126-dedup-scope.test.ts` failure Kip hit while supervising OMN-261's verification run (`empty-string project dedups against the inbox` — `expected null to be truthy`).
- **This is a test-infrastructure bug, not a production correctness bug.** The dedup logic in `OmniFocusAnalyzeTool.ts` was never wrong; a test fixture-naming helper was.

## Root cause

`tests/integration/helpers/run-id.ts` generated `RUN_ID` as a plain module-level `const`. Its own doc comment claims "every test file in the same vitest run sees the same `RUN_ID`," but vitest's default per-file module isolation resets ES-module top-level bindings *between files*, even under `pool:'forks', poolOptions.forks.singleFork:true` (one OS process, many module registries). So `RUN_ID` was silently re-generated per file — invisible as long as each file also spawned its own `MCPTestClient`/MCP server (pre-OMN-261).

Once OMN-261 makes the `MCPTestClient` genuinely shared across files via `globalThis`, its `createTestTask()` method becomes a closure bound to whichever file's `run-id.ts` instance happened to initialize the client first. A *later* file (e.g. `omn-126-dedup-scope.test.ts`) that pre-builds a name via its own `runScopedName()` and passes it into `createTestTask()` hits a mismatched `name.startsWith(RUN_NAME_PREFIX)` check inside that stale closure, falls through to the re-prefixing branch, and gets a **double run-id prefix** baked into the persisted task name.

Confirmed via a temporary diagnostic trace against real OmniFocus: on a failing run, the created inbox task actually persisted as `__TEST__-mrh2hsbo-c5f075-mrh2n1u5-d0aa29-OMN126EmptyProjInbox` (two run-ids concatenated) instead of the expected `__TEST__-mrh2n1u5-d0aa29-OMN126EmptyProjInbox`. The dedup scoped read succeeded and returned the task with the correct `project: null` — it just had the wrong *name*, so the string match in `findDuplicateTask` legitimately failed.

This also explains why:
- Only this one test in the file fails — the other 3 describe-blocks build their names via a direct `omnifocus_write` batch call, not `createTestTask()`.
- It's intermittent — depends on which file happens to win the shared-client init race (vitest 3.2.4's default sequencer reorders files by a persisted pass/fail/duration cache, not filename).
- A standalone single-file run always passes — the file is trivially "first" when it's the only one running.
- It never showed up before OMN-261 — no other file's closure was ever in play.

## Fix

Cache `RUN_ID` on `globalThis` (`Symbol.for(...)`) instead of a plain module-level `const`, so it's stable for the process's lifetime regardless of which file touches it first — restoring the property the doc comment already claimed. Implemented inline (no dependency on OMN-261's unmerged `global-singleton.ts` helper), so this fix stands alone and unblocks OMN-261.

Also updates `run-id.test.ts`'s "two simulated runs" cases: they previously used a bare `vi.resetModules()` as a stand-in for "a different run," which is now the *wrong* proxy — that exact mechanism now correctly represents "same process, different file" (stable id), not "different run" (should differ). Those tests now also clear the new `globalThis` slot to simulate a genuinely separate process, and a new explicit regression test pins the fixed behavior directly.

## Verification

- All 21 `run-id.test.ts` tests pass; full unit suite (3807 tests / 167 files) passes; build is clean.
- Reproduced the original failure live against real OmniFocus by temporarily cherry-picking OMN-261's shared-client commits on top of a clean checkout (server genuinely shared across all 23 integration files, confirmed by a single "Starting shared MCP server" line) — failed 2 of 3 attempts pre-fix, with a diagnostic trace confirming the double-prefix mechanism above.
- With this fix + the same OMN-261 cherry-pick applied, ran the full `tests/integration` suite twice more, back to back — both fully green, including the previously-flaky test. OMN-261's cherry-pick was then dropped; this PR contains only the `run-id.ts`/`run-id.test.ts` changes.

## Test plan

- [x] `npm run build`
- [x] `npx vitest tests/unit --run` (3807 passed)
- [x] Full `tests/integration` suite, 2 consecutive clean runs under genuine cross-file MCP client sharing (verification-only, via a temporarily cherry-picked OMN-261)
- [ ] Kip's `/code-review`

## Follow-up

OMN-261 (share the MCP server across integration files) was explicitly blocked on this ticket and can resume once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)