### PR TITLE
fix(OMN-261): share the MCP server across integration files via globalThis

### DIFF
--- a/docs/superpowers/plans/2026-07-11-omn261-shared-server-globalthis.md
+++ b/docs/superpowers/plans/2026-07-11-omn261-shared-server-globalthis.md
@@ -1,0 +1,598 @@
+# OMN-261: Cross-file shared MCP server via globalThis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `tests/integration/helpers/shared-server.ts`'s "one MCP server per suite run" design actually work across
+test files, instead of silently re-spawning a fresh server (and idle Node process) for 13 of 17 `getSharedClient()` call
+sites.
+
+**Architecture:** Vitest's `forks` pool defaults to `isolate: true`, which resets every test file's ES-module top-level
+bindings to a fresh instance — independent of `singleFork: true`, which only controls OS-process count (one process,
+many fresh module registries). `globalThis` is the one thing per-file isolation does _not_ reset within a single OS
+process. Move `shared-server.ts`'s three pieces of mutable state (`sharedClient`, `initPromise`, `isFirstAccess`) off
+module-scope `let` bindings and onto a `globalThis`-keyed slot via a small new `global-singleton.ts` helper. Zero
+test-file edits — same invariant OMN-186 held to. Also add a real `process.once('beforeExit', ...)` graceful-shutdown
+hook inside `shared-server.ts`, since `setup-integration.ts`'s `globalTeardown` call to `shutdownSharedClient()` runs in
+a separate OS process from the worker fork and can never reach the real client (confirmed: the 2026-07-08 profiler
+logged that call at `1 call, 0s` — a real shutdown involving IPC round-trips to a live server cannot complete in 0ms).
+
+**Tech Stack:** TypeScript, Vitest 3.2.4, `@modelcontextprotocol/sdk` stdio transport (via `MCPTestClient`).
+
+---
+
+## Root cause (already confirmed — do not re-derive, just verify empirically in Task 1)
+
+17 total `getSharedClient()` calls across 13 files (`grep -rn "getSharedClient(" tests/integration --include="*.ts"`).
+Two files call it more than once: `omn-126-dedup-scope.test.ts` (4 calls) and `project-name-filter.test.ts` (2 calls).
+The 2026-07-11 profiler showed **13 inits / 4 reuses** — and `4 = (4-1) + (2-1)` exactly: every reuse is a _second call
+within the same file_. There is **zero cross-file reuse** today. `isolate` is not set anywhere in `vitest.config.ts`
+(confirmed via grep), so it's vitest's default (`true`) for the `forks` pool.
+
+## Rejected alternative: `isolate: false`
+
+Flipping `isolate: false` suite-wide would fix this file too, but changes module-reset semantics for **every**
+integration helper simultaneously — an unaudited blast radius (any other helper that assumes fresh per-file state would
+silently start sharing state too). The `globalThis`-keyed slot is a contained, one-file change with no config edits and
+no test-file edits. Do not implement `isolate: false` as part of this plan.
+
+---
+
+### Task 1: Regression-pinning test for the vitest isolation behavior itself
+
+**Files:**
+
+- Create: `tests/integration/_diagnostics/module-isolation-probe-a.test.ts`
+- Create: `tests/integration/_diagnostics/module-isolation-probe-b.test.ts`
+- Create: `tests/integration/_diagnostics/module-isolation-probe-z-verify.test.ts`
+
+This proves — empirically, against the _real_ integration-suite vitest config (`pool:'forks'`, `singleFork:true`), not a
+simulation — that module-scope state resets per file while `globalThis` does not. It's a permanent regression pin: if a
+future vitest upgrade or config change alters this behavior, this test fails loudly instead of silently reintroducing
+the per-file-respawn bug. Order-independent (doesn't assume file A runs before B).
+
+- [ ] **Step 1: Write the three probe files**
+
+`tests/integration/_diagnostics/module-isolation-probe-a.test.ts`:
+
+```typescript
+import { describe, it, beforeAll } from 'vitest';
+
+// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
+// for the `forks` pool) resets this file's own module-scope state, while
+// globalThis survives across files in the same singleFork process. See
+// module-isolation-probe-z-verify.test.ts for the assertions — this file and
+// -b.test.ts only record observations, since file execution order isn't
+// guaranteed by the vitest API.
+let moduleScopeCounter = 0;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __omn261ProbeCounter: number | undefined;
+  // eslint-disable-next-line no-var
+  var __omn261ProbeResults:
+    | Array<{ file: string; moduleScopeSeenBefore: number; globalThisSeenBefore: number }>
+    | undefined;
+}
+
+describe('module isolation probe (file a)', () => {
+  let moduleScopeSeenBefore = -1;
+  let globalThisSeenBefore = -1;
+
+  beforeAll(() => {
+    moduleScopeSeenBefore = moduleScopeCounter;
+    moduleScopeCounter++;
+    globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
+    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
+    globalThis.__omn261ProbeResults ??= [];
+    globalThis.__omn261ProbeResults.push({ file: 'a', moduleScopeSeenBefore, globalThisSeenBefore });
+  });
+
+  it('records its observation', () => {
+    // Assertion lives in the -z-verify file; this just needs to run.
+  });
+});
+```
+
+`tests/integration/_diagnostics/module-isolation-probe-b.test.ts` — identical to `-a.test.ts` except `file: 'b'` in the
+pushed result and the describe label says `(file b)`.
+
+`tests/integration/_diagnostics/module-isolation-probe-z-verify.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+// OMN-261: named `-z-` to sort after -a and -b in vitest's default file
+// discovery order. Verifies the CROSS-FILE behavior both probes recorded.
+describe('module isolation probe (verification)', () => {
+  it('module-scope state resets per file; globalThis state persists across files', () => {
+    const results = globalThis.__omn261ProbeResults ?? [];
+    expect(results).toHaveLength(2);
+
+    // Every file saw a FRESH module-scope counter (proves isolate:true resets
+    // top-level `let` bindings per file, even under singleFork:true).
+    for (const r of results) {
+      expect(r.moduleScopeSeenBefore).toBe(0);
+    }
+
+    // The two files' globalThis-seen-before values are {0, 1} in SOME order —
+    // proves one file saw the OTHER file's increment (globalThis persists
+    // across the per-file module reset).
+    const globalThisSeen = results.map((r) => r.globalThisSeenBefore).sort();
+    expect(globalThisSeen).toEqual([0, 1]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the three probe files together to confirm they pass**
+
+Run: `npm run build && npx vitest tests/integration/_diagnostics --run` Expected: 3 files, 3 tests, all PASS. If the
+verify assertions fail, STOP — the root-cause hypothesis is wrong and Task 2's fix premise is invalid; report back
+instead of proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/_diagnostics/
+git commit -m "test(OMN-261): pin vitest per-file module isolation vs globalThis persistence"
+```
+
+---
+
+### Task 2: `global-singleton.ts` helper + unit test (TDD)
+
+**Files:**
+
+- Create: `tests/integration/helpers/global-singleton.ts`
+- Create: `tests/unit/integration-helpers/global-singleton.test.ts`
+
+- [ ] **Step 1: Write the failing unit test**
+
+`tests/unit/integration-helpers/global-singleton.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('getGlobalSlot', () => {
+  const KEY = 'unit-test-probe';
+  const globalKey = Symbol.for(`omnifocus-mcp:${KEY}`);
+
+  beforeEach(() => {
+    delete (globalThis as unknown as Record<symbol, unknown>)[globalKey];
+  });
+
+  it('returns the same instance on repeated calls, ignoring the factory after first creation', async () => {
+    const { getGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
+    const a = getGlobalSlot(KEY, () => ({ n: 0 }));
+    const b = getGlobalSlot(KEY, () => ({ n: 999 }));
+    expect(b).toBe(a);
+    expect(b.n).toBe(0);
+  });
+
+  it('survives a fresh module re-import (the mechanism vitest per-file isolation relies on)', async () => {
+    const mod1 = await import('../../integration/helpers/global-singleton.js');
+    const slot1 = mod1.getGlobalSlot(KEY, () => ({ n: 0 }));
+    slot1.n = 42;
+
+    vi.resetModules();
+    const mod2 = await import('../../integration/helpers/global-singleton.js');
+    const slot2 = mod2.getGlobalSlot(KEY, () => ({ n: 0 }));
+
+    expect(slot2.n).toBe(42);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest tests/unit/integration-helpers/global-singleton.test.ts --run` Expected: FAIL —
+`Cannot find module '../../integration/helpers/global-singleton.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+`tests/integration/helpers/global-singleton.ts`:
+
+```typescript
+/**
+ * Vitest's default `isolate: true` (the `forks` pool default) resets every
+ * test file's ES-module top-level bindings to a fresh instance, even under
+ * `pool:'forks', poolOptions.forks.singleFork:true` (one OS process, but one
+ * module registry per file). `globalThis` is the one thing that per-file
+ * isolation does NOT reset — same JS realm/object across files in the same
+ * fork. Use this to persist state across integration test files within a
+ * single suite run. See OMN-261.
+ */
+export function getGlobalSlot<T>(key: string, initial: () => T): T {
+  const globalKey = Symbol.for(`omnifocus-mcp:${key}`);
+  const store = globalThis as unknown as Record<symbol, T>;
+  if (store[globalKey] === undefined) {
+    store[globalKey] = initial();
+  }
+  return store[globalKey];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest tests/unit/integration-helpers/global-singleton.test.ts --run` Expected: PASS (both tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/helpers/global-singleton.ts tests/unit/integration-helpers/global-singleton.test.ts
+git commit -m "feat(OMN-261): add globalThis-backed singleton slot helper"
+```
+
+---
+
+### Task 3: Wire `shared-server.ts` onto the global slot + real graceful shutdown
+
+**Files:**
+
+- Modify: `tests/integration/helpers/shared-server.ts` (full file — state management section)
+- Modify: `tests/support/setup-integration.ts` (remove the dead cross-process shutdown call)
+
+- [ ] **Step 1: Replace module-scope state with the global slot**
+
+In `tests/integration/helpers/shared-server.ts`, replace:
+
+```typescript
+let sharedClient: MCPTestClient | null = null;
+let initPromise: Promise<MCPTestClient> | null = null;
+let isFirstAccess = true;
+```
+
+with:
+
+```typescript
+import { getGlobalSlot } from './global-singleton.js';
+
+interface SharedServerState {
+  client: MCPTestClient | null;
+  initPromise: Promise<MCPTestClient> | null;
+  isFirstAccess: boolean;
+  shutdownHookRegistered: boolean;
+}
+
+// OMN-261: module-scope `let` bindings reset on every test file under
+// vitest's default per-file isolation, even inside the single OS process
+// `singleFork:true` guarantees — defeating the "one server per run" design
+// this file's docstring already describes. globalThis survives the reset.
+function getState(): SharedServerState {
+  return getGlobalSlot<SharedServerState>('shared-server-state', () => ({
+    client: null,
+    initPromise: null,
+    isFirstAccess: true,
+    shutdownHookRegistered: false,
+  }));
+}
+```
+
+- [ ] **Step 2: Update `getSharedClient` / `getSharedClientImpl` to read/write the state object**
+
+Replace:
+
+```typescript
+export async function getSharedClient(): Promise<MCPTestClient> {
+  // OMN-186: first access pays server start + cache warm + OmniFocus warm;
+  // later per-file accesses pay a cache clear. Split ops so a profiled run
+  // (FIXTURE_PROFILE=1) can tell the one-time warm from the per-file cost.
+  const op = sharedClient || initPromise ? 'getSharedClient.reuse' : 'getSharedClient.init';
+  return profileFixture('beforeAll', op, getSharedClientImpl);
+}
+
+async function getSharedClientImpl(): Promise<MCPTestClient> {
+  if (sharedClient) {
+    // Clear cache between test file accesses to prevent pollution
+    if (!isFirstAccess) {
+      await sharedClient.clearCache();
+    }
+    isFirstAccess = false;
+    return sharedClient;
+  }
+
+  // Prevent race conditions if multiple tests start simultaneously
+  if (initPromise) {
+    return initPromise;
+  }
+
+  initPromise = (async () => {
+    console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
+    sharedClient = new MCPTestClient({ enableCacheWarming: true });
+    await sharedClient.startServer();
+    console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
+    await warmupOmniFocus(sharedClient);
+    console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
+    isFirstAccess = false; // First access complete
+    return sharedClient;
+  })();
+
+  return initPromise;
+}
+```
+
+with:
+
+```typescript
+export async function getSharedClient(): Promise<MCPTestClient> {
+  // OMN-186/OMN-261: first access pays server start + cache warm + OmniFocus
+  // warm; later accesses (now genuinely cross-file, via the global slot) pay
+  // a cache clear. Split ops so a profiled run (FIXTURE_PROFILE=1) can tell
+  // the one-time warm from the per-file cost.
+  const state = getState();
+  const op = state.client || state.initPromise ? 'getSharedClient.reuse' : 'getSharedClient.init';
+  return profileFixture('beforeAll', op, getSharedClientImpl);
+}
+
+async function getSharedClientImpl(): Promise<MCPTestClient> {
+  const state = getState();
+
+  if (state.client) {
+    // Clear cache between test file accesses to prevent pollution
+    if (!state.isFirstAccess) {
+      await state.client.clearCache();
+    }
+    state.isFirstAccess = false;
+    return state.client;
+  }
+
+  // Prevent race conditions if multiple tests start simultaneously
+  if (state.initPromise) {
+    return state.initPromise;
+  }
+
+  state.initPromise = (async () => {
+    console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
+    const client = new MCPTestClient({ enableCacheWarming: true });
+    state.client = client;
+    await client.startServer();
+    console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
+    await warmupOmniFocus(client);
+    console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
+    state.isFirstAccess = false; // First access complete
+    registerShutdownHook();
+    return client;
+  })();
+
+  return state.initPromise;
+}
+
+// OMN-261: setup-integration.ts's globalTeardown runs in a separate OS
+// process from the worker fork that actually owns this client — its call to
+// shutdownSharedClient() can never reach `state.client` there (confirmed:
+// the 2026-07-08 profiler logged that call at 1 call/0s, impossible for a
+// real IPC-round-trip shutdown). Register a real in-process graceful
+// shutdown instead, once, the first time a client is created.
+function registerShutdownHook(): void {
+  const state = getState();
+  if (state.shutdownHookRegistered) return;
+  state.shutdownHookRegistered = true;
+  process.once('beforeExit', () => {
+    void shutdownSharedClient();
+  });
+}
+```
+
+- [ ] **Step 3: Update `shutdownSharedClient` and `getSharedClientSync` to read the state object**
+
+Replace:
+
+```typescript
+export async function shutdownSharedClient(): Promise<void> {
+  // OMN-186: end-of-run cost — profiled when FIXTURE_PROFILE=1
+  return profileFixture('globalTeardown', 'shutdownSharedClient', async () => {
+    if (sharedClient) {
+      console.log('🧹 Shutting down shared MCP server...');
+      await sharedClient.thoroughCleanup();
+      await sharedClient.stop();
+      sharedClient = null;
+      initPromise = null;
+      isFirstAccess = true; // Reset for next test run
+      console.log('✅ Shared MCP server shutdown complete');
+    }
+  });
+}
+
+export function getSharedClientSync(): MCPTestClient {
+  if (!sharedClient) {
+    throw new Error('Shared MCP client not initialized. Call getSharedClient() first.');
+  }
+  return sharedClient;
+}
+```
+
+with:
+
+```typescript
+export async function shutdownSharedClient(): Promise<void> {
+  // OMN-186/OMN-261: real end-of-run cost now (called from the beforeExit
+  // hook inside the actual worker-fork process) — profiled when
+  // FIXTURE_PROFILE=1.
+  return profileFixture('globalTeardown', 'shutdownSharedClient', async () => {
+    const state = getState();
+    if (state.client) {
+      console.log('🧹 Shutting down shared MCP server...');
+      await state.client.thoroughCleanup();
+      await state.client.stop();
+      state.client = null;
+      state.initPromise = null;
+      state.isFirstAccess = true; // Reset for next test run
+      console.log('✅ Shared MCP server shutdown complete');
+    }
+  });
+}
+
+export function getSharedClientSync(): MCPTestClient {
+  const state = getState();
+  if (!state.client) {
+    throw new Error('Shared MCP client not initialized. Call getSharedClient() first.');
+  }
+  return state.client;
+}
+```
+
+- [ ] **Step 4: Remove the dead cross-process shutdown call from `setup-integration.ts`**
+
+In `tests/support/setup-integration.ts`, remove the import:
+
+```typescript
+import { shutdownSharedClient } from '../integration/helpers/shared-server.js';
+```
+
+and remove from `teardown()`:
+
+```typescript
+// Shutdown shared client
+await shutdownSharedClient();
+```
+
+Replace with a one-line comment at the same spot explaining the removal:
+
+```typescript
+// OMN-261: shared-client shutdown no longer lives here — globalTeardown
+// runs in a separate OS process from the worker fork that owns the real
+// client, so this call could never reach it (confirmed dead at 1 call/0s
+// in the 2026-07-08 profile). shared-server.ts now registers its own
+// process.once('beforeExit', ...) hook inside the worker fork itself.
+```
+
+- [ ] **Step 5: Build and run the full unit suite**
+
+Run: `npm run build && npm run test:unit` Expected: build clean, all unit tests PASS (no regressions from the
+`shutdownSharedClient` signature/behavior change — check specifically for any unit test mocking
+`sharedClient`/`initPromise` as module exports rather than through the public functions, since those would now need to
+go through `getState()`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/integration/helpers/shared-server.ts tests/support/setup-integration.ts
+git commit -m "fix(OMN-261): share the MCP server across integration files via globalThis, add real beforeExit shutdown"
+```
+
+---
+
+### Task 4: Supervised full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Clear the stale fixture-profile log**
+
+Run: `rm -f tests/integration/fixture-profile.jsonl`
+
+- [ ] **Step 2: Snapshot any pre-existing dist/index.js processes**
+
+Run: `pgrep -fl 'dist/index.js' || echo "none running"` Record the output — this is the BEFORE snapshot for the orphan
+check in Step 5.
+
+- [ ] **Step 3: Build and run the full suite with profiling, in the background**
+
+Run (background, do not kill, ~15-20 min):
+
+```bash
+npm run build
+FIXTURE_PROFILE=1 npx vitest tests/integration --run --reporter=json --outputFile.json=/tmp/omn261-pertest.json
+```
+
+- [ ] **Step 4: Aggregate the fixture-profile log**
+
+```bash
+jq -s 'group_by(.op) | map({op: .[0].op, calls: length, total_s: ((map(.ms) | add) / 1000 | round), avg_s: ((map(.ms) | add) / length / 1000 * 100 | round) / 100})' tests/integration/fixture-profile.jsonl
+```
+
+Expected: `getSharedClient.init` calls drops from 13 to 1 (or very close — exactly 1 if file execution is strictly
+serial with no concurrent first-calls); `getSharedClient.reuse` calls rises to ~16. `shutdownSharedClient` (op, hook
+`globalTeardown`) should show a NON-ZERO duration now (real cleanup, not the old 0s no-op) — if it's still 0s, the
+`beforeExit` hook did not fire; investigate before declaring success (see [`superpowers:systematic-debugging`] rather
+than guessing).
+
+- [ ] **Step 5: Confirm zero orphaned server processes**
+
+Run: `pgrep -fl 'dist/index.js' || echo "none running"` Expected: matches (or is a subset of) the Step 2 BEFORE snapshot
+— no NEW lingering `dist/index.js` processes from this run. If there's a mismatch, this is a real regression (a spawned
+server outlived the run) — stop and report, do not proceed to Task 5.
+
+- [ ] **Step 6: Confirm test correctness**
+
+```bash
+jq '{numTotalTests, numPassedTests, numFailedTests, numPendingTests}' /tmp/omn261-pertest.json
+```
+
+Expected: `numFailedTests: 0`, same `numTotalTests`/`numPassedTests`/`numPendingTests` as the pre-change baseline (178
+passed / 0 failed / 22 pending, plus +3 for the new diagnostic probe files from Task 1 — expect 181 passed / 0 failed /
+22 pending, or note if the count differs and explain why before proceeding).
+
+- [ ] **Step 7: Check for the "No orphaned test data found" / zero fixture-leak signal**
+
+```bash
+grep -iE "fail|error|scanForFixtures|FIXTURE LEAK" <the run's stdout log> | grep -v "No orphaned test data found"
+```
+
+Expected: no output.
+
+---
+
+### Task 5: Document + close out
+
+**Files:**
+
+- Modify: `tests/integration/PERFORMANCE.md`
+
+- [ ] **Step 1: Add a new section to `PERFORMANCE.md`** documenting the design and the Task 4 verification numbers, in
+      the same style as the existing "Per-run fixture epoch (OMN-186 Phase 2)" section — include the before/after
+      `getSharedClient.init` call-count delta and the actual measured `getSharedClient.init` total-seconds delta from
+      Task 4's aggregation, plus a note that raw suite wall is still not the tracked metric (same caveat as OMN-186).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/integration/PERFORMANCE.md
+git commit -m "docs(OMN-261): document the shared-server globalThis fix + verification numbers"
+```
+
+- [ ] **Step 3: Push the branch and open a DRAFT PR — do not merge**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --repo kip-d/omnifocus-mcp --draft --title "fix(OMN-261): share the MCP server across integration files via globalThis" --body "$(cat <<'EOF'
+## Summary
+- Root cause: vitest's default `isolate:true` (forks pool) resets shared-server.ts's module-scope singleton on every test file, even under `singleFork:true` (one process, many fresh module registries) — so 13 of 17 `getSharedClient()` calls spawned a fresh MCP server instead of reusing one, and the file's own docstring's "one server per run" design never actually worked.
+- Fix: move the singleton state onto a `globalThis`-keyed slot (survives the per-file reset); add a real `process.once('beforeExit', ...)` graceful shutdown inside the worker-fork process, since `globalTeardown`'s call to `shutdownSharedClient()` runs in a separate OS process and could never reach the real client (confirmed dead at 1 call/0s in the 2026-07-08 profile).
+- Zero test-file edits — same invariant OMN-186 held to.
+- New permanent regression-pinning test (`tests/integration/_diagnostics/module-isolation-probe-*`) proves the vitest isolation behavior this fix depends on, against the real integration-suite config.
+
+## Test plan
+- [ ] `npm run test:unit` green
+- [ ] Supervised `FIXTURE_PROFILE=1` full-suite run: `getSharedClient.init` 13→1, zero orphaned `dist/index.js` processes, zero test regressions (see PERFORMANCE.md for numbers)
+- [ ] Kip's `/code-review` gate
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Post the same summary as a comment on OMN-261**, and leave the ticket state as-is (In Progress /
+      whatever it currently is) — do NOT mark it Done. Closing is gated on Kip's `/code-review` per this repo's review
+      protocol; that happens after this PR, not as part of this plan.
+
+---
+
+## Notes for the executing agent
+
+- **Do not merge this PR.** Repo norm: Kip runs `/code-review` before any merge. Stop after Task 5 Step 3.
+- **Do not skip Task 4's live verification** even though it's slow (~15-20 min) — it's the only thing that actually
+  proves the fix works, exactly like OMN-186's own VERIFY-DEBT. Run it via `run_in_background`, never kill it
+  (orphaned-worker hazard, OMN-143).
+- **Test independence** (OMN-261's own acceptance criterion) already relies on the _existing_ `clearCache()` call
+  between file accesses — `shared-server.ts`'s docstring already documented this as the cross-pollution guard, it just
+  never fired for 13 of 17 files because they never reached the reuse branch. This plan doesn't change that guard's
+  logic, only makes it actually execute for every file. Task 4 Step 6 (zero failures across the whole suite) is the
+  practical proof it still holds: any real cross-file pollution would surface as a downstream test failure once every
+  file is genuinely sharing one client.
+- If Task 1's probe assertions fail, or Task 4's `getSharedClient.init` count doesn't drop close to 1, **stop and
+  report** rather than adjusting the plan on your own — the root-cause premise would be wrong and needs
+  re-investigation, not a workaround.
+- If you find an existing unit test that mocks or imports `sharedClient`/`initPromise` as named exports directly (rather
+  than through `getSharedClient`/`getSharedClientSync`/`shutdownSharedClient`), it will break under this refactor since
+  those bindings no longer exist as module exports — that's expected; update the test to go through the public
+  functions, don't reintroduce the module-scope bindings to avoid touching it.

--- a/docs/superpowers/plans/2026-07-11-omn261-shared-server-globalthis.md
+++ b/docs/superpowers/plans/2026-07-11-omn261-shared-server-globalthis.md
@@ -42,93 +42,93 @@ no test-file edits. Do not implement `isolate: false` as part of this plan.
 
 **Files:**
 
-- Create: `tests/integration/_diagnostics/module-isolation-probe-a.test.ts`
-- Create: `tests/integration/_diagnostics/module-isolation-probe-b.test.ts`
-- Create: `tests/integration/_diagnostics/module-isolation-probe-z-verify.test.ts`
+- Create: `tests/integration/_diagnostics/module-isolation-probe-1.test.ts`
+- Create: `tests/integration/_diagnostics/module-isolation-probe-2.test.ts`
 
 This proves — empirically, against the _real_ integration-suite vitest config (`pool:'forks'`, `singleFork:true`), not a
 simulation — that module-scope state resets per file while `globalThis` does not. It's a permanent regression pin: if a
 future vitest upgrade or config change alters this behavior, this test fails loudly instead of silently reintroducing
-the per-file-respawn bug. Order-independent (doesn't assume file A runs before B).
+the per-file-respawn bug.
 
-- [ ] **Step 1: Write the three probe files**
+**Design note (revised 2026-07-11 after a real flake was caught during implementation):** the first draft of this task
+used a third `-z-verify` file whose name was chosen to sort after `-a`/`-b`, assuming vitest's default file-discovery
+order runs it last. That assumption is false in practice: vitest 3.2.4's default `BaseSequencer` persists a per-file
+pass/fail/duration cache (`node_modules/.vite/vitest/**/results.json`) and reorders files by it on every run after the
+first — independent of filename. Confirmed directly: cold cache → 3/3 pass in name order; any warm-cache rerun →
+deterministic failure with the verify file's `beforeAll` running before file B's. The fix below eliminates the ordering
+dependency entirely instead of working around the cache (`--no-cache` isn't viable for a permanent pin that runs as part
+of the normal `vitest tests/integration --run` invocation) or falling back to `vi.resetModules()` (that would duplicate
+Task 2's unit-level proof and lose the point of this task, which is proving the behavior against the _real_ multi-file
+suite execution, not a simulation within one file).
 
-`tests/integration/_diagnostics/module-isolation-probe-a.test.ts`:
+Two probe files, no separate verify file. Each does the SAME thing: assert its own module-scope state is fresh
+(order-independent — true for every file regardless of when it runs), then record a globalThis observation. Whichever
+file happens to run _last_ — tracked via a shared counter, not filename — does the aggregate cross-file assertion. This
+is correct no matter what vitest's sequencer decides, and self-checks: if two files ever ran with any lost-update race
+(they can't, under `singleFork:true`'s single OS process with synchronous same-tick increments, but the assertion would
+catch it if that ever changed), the aggregate values wouldn't come out as the expected `[0, 1]`.
 
-```typescript
-import { describe, it, beforeAll } from 'vitest';
+- [ ] **Step 1: Write the two probe files**
 
-// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
-// for the `forks` pool) resets this file's own module-scope state, while
-// globalThis survives across files in the same singleFork process. See
-// module-isolation-probe-z-verify.test.ts for the assertions — this file and
-// -b.test.ts only record observations, since file execution order isn't
-// guaranteed by the vitest API.
-let moduleScopeCounter = 0;
-
-declare global {
-  // eslint-disable-next-line no-var
-  var __omn261ProbeCounter: number | undefined;
-  // eslint-disable-next-line no-var
-  var __omn261ProbeResults:
-    | Array<{ file: string; moduleScopeSeenBefore: number; globalThisSeenBefore: number }>
-    | undefined;
-}
-
-describe('module isolation probe (file a)', () => {
-  let moduleScopeSeenBefore = -1;
-  let globalThisSeenBefore = -1;
-
-  beforeAll(() => {
-    moduleScopeSeenBefore = moduleScopeCounter;
-    moduleScopeCounter++;
-    globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
-    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
-    globalThis.__omn261ProbeResults ??= [];
-    globalThis.__omn261ProbeResults.push({ file: 'a', moduleScopeSeenBefore, globalThisSeenBefore });
-  });
-
-  it('records its observation', () => {
-    // Assertion lives in the -z-verify file; this just needs to run.
-  });
-});
-```
-
-`tests/integration/_diagnostics/module-isolation-probe-b.test.ts` — identical to `-a.test.ts` except `file: 'b'` in the
-pushed result and the describe label says `(file b)`.
-
-`tests/integration/_diagnostics/module-isolation-probe-z-verify.test.ts`:
+`tests/integration/_diagnostics/module-isolation-probe-1.test.ts`:
 
 ```typescript
 import { describe, it, expect } from 'vitest';
 
-// OMN-261: named `-z-` to sort after -a and -b in vitest's default file
-// discovery order. Verifies the CROSS-FILE behavior both probes recorded.
-describe('module isolation probe (verification)', () => {
-  it('module-scope state resets per file; globalThis state persists across files', () => {
-    const results = globalThis.__omn261ProbeResults ?? [];
-    expect(results).toHaveLength(2);
+// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
+// for the `forks` pool) resets this file's own module-scope state, while
+// globalThis survives across files in the same singleFork process.
+//
+// Order-independent by design: vitest's default sequencer reorders files by a
+// persisted pass/fail/duration cache, NOT file name, so this can't assume
+// "file 1 runs before file 2". Whichever of the TWO probe files happens to
+// run last does the aggregate assertion, tracked via a shared counter.
+const TOTAL_PROBE_FILES = 2;
 
-    // Every file saw a FRESH module-scope counter (proves isolate:true resets
-    // top-level `let` bindings per file, even under singleFork:true).
-    for (const r of results) {
-      expect(r.moduleScopeSeenBefore).toBe(0);
+let moduleScopeCounter = 0;
+
+declare global {
+  var __omn261ProbeCounter: number | undefined;
+  var __omn261ProbeSeenValues: number[] | undefined;
+  var __omn261ProbeFilesRun: number | undefined;
+}
+
+describe('module isolation probe (file 1)', () => {
+  it('sees fresh module-scope state; records a persistent globalThis observation', () => {
+    const moduleScopeSeenBefore = moduleScopeCounter;
+    moduleScopeCounter++;
+    // Order-independent: EVERY file starts with a fresh module-scope binding
+    // if isolate:true is in effect, regardless of which file runs first.
+    expect(moduleScopeSeenBefore).toBe(0);
+
+    const globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
+    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
+    globalThis.__omn261ProbeSeenValues ??= [];
+    globalThis.__omn261ProbeSeenValues.push(globalThisSeenBefore);
+
+    globalThis.__omn261ProbeFilesRun = (globalThis.__omn261ProbeFilesRun ?? 0) + 1;
+    if (globalThis.__omn261ProbeFilesRun === TOTAL_PROBE_FILES) {
+      // Whichever file happens to run last (by vitest's sequencer) verifies
+      // the aggregate: both files must have seen DIFFERENT globalThis values
+      // (0 and 1, in some order) — proof that globalThis persisted across
+      // the per-file module-scope reset.
+      const seen = [...globalThis.__omn261ProbeSeenValues].sort((x, y) => x - y);
+      expect(seen).toEqual([0, 1]);
     }
-
-    // The two files' globalThis-seen-before values are {0, 1} in SOME order —
-    // proves one file saw the OTHER file's increment (globalThis persists
-    // across the per-file module reset).
-    const globalThisSeen = results.map((r) => r.globalThisSeenBefore).sort();
-    expect(globalThisSeen).toEqual([0, 1]);
   });
 });
 ```
 
-- [ ] **Step 2: Run the three probe files together to confirm they pass**
+`tests/integration/_diagnostics/module-isolation-probe-2.test.ts` — byte-for-byte identical except the `describe` label
+reads `'module isolation probe (file 2)'`.
 
-Run: `npm run build && npx vitest tests/integration/_diagnostics --run` Expected: 3 files, 3 tests, all PASS. If the
-verify assertions fail, STOP — the root-cause hypothesis is wrong and Task 2's fix premise is invalid; report back
-instead of proceeding.
+- [ ] **Step 2: Run the two probe files together to confirm they pass, repeatedly (to rule out the cache-reordering
+      flake)**
+
+Run: `npm run build && npx vitest tests/integration/_diagnostics --run` three times in a row (warm cache on the 2nd/3rd
+runs — this is the condition that exposed the original flake). Expected: 2 files, 2 tests, all PASS, every time. If any
+run fails, STOP — the root-cause hypothesis is wrong and Task 2's fix premise is invalid; report back instead of
+proceeding.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/plans/2026-07-11-omn261-shared-server-globalthis.md
+++ b/docs/superpowers/plans/2026-07-11-omn261-shared-server-globalthis.md
@@ -472,6 +472,271 @@ git commit -m "fix(OMN-261): share the MCP server across integration files via g
 
 ---
 
+### Task 3b: Deterministic shutdown via a PID file (added after Task 4's first run exposed the `beforeExit` gap)
+
+**Why:** Task 4's first live run showed `getSharedClient.init`/`reuse` working exactly as designed (1 init, 16 reuses),
+but the `beforeExit` hook from Task 3 never fired — no shutdown log line, and one real orphaned `dist/index.js` process
+(PPID 1, reparented to launchd) appeared that wasn't in the before-snapshot. Investigation (read-only, all claims
+confirmed against actual source, not guessed):
+
+- `node_modules/tinypool/dist/index.js`'s `ProcessWorker.terminate()` tears down a `forks`-pool worker with an
+  **external** `this.process.kill()` (default SIGTERM) from tinypool's own pool process, falling back to SIGKILL after
+  1000ms if the worker hasn't died — NOT a `process.exit()` call from inside the worker.
+- `node_modules/vitest/dist/worker.js` only registers a `SIGTERM` handler inside the worker when Node's own profiling
+  flags (`--prof`, `--cpu-prof`, etc.) are present — unrelated to our own `FIXTURE_PROFILE=1` env var convention. Our
+  real runs set no such flags, so **no handler is registered for the incoming SIGTERM at all**, meaning Node's default
+  disposition (immediate termination, no more JS runs) applies. Neither `'exit'` nor `'beforeExit'` fires — this isn't a
+  "wrong event name" bug, the worker process gets **zero** JS-level teardown opportunity under real suite runs.
+- The orphaned MCP server (`dist/index.js`, a _grandchild_ of tinypool's pool process — child of the worker fork, not of
+  tinypool directly) is NOT killed when its immediate parent (the worker fork) dies; grandchildren reparent to `launchd`
+  (`PPID 1`) instead. It eventually exits on its own once the worker fork's death closes every fd it held, including the
+  stdin pipe into the server — the server's own `process.stdin.on('end'/'close', ...)` handler (`src/index.ts`, the same
+  convention CLAUDE.md documents) then calls `gracefulExit()` → `process.exit(0)`. That's why it eventually died with no
+  `🧹 Shutting down shared MCP server...` line: that string only exists in `shared-server.ts`, which never got to run.
+  The delay before that happens is OS pipe-teardown timing, not something in this repo's control.
+
+**Conclusion:** no hook registered _inside_ the worker fork process can be relied on for this. This repo already solves
+an equivalent problem — a PID recorded in a durable file, liveness-checked from a **different** process — for the
+OMN-143 integration lock (`tests/support/integration-guard.ts`'s `DEFAULT_LOCK_PATH`/`pidIsAlive`). Reuse that exact
+pattern instead of a new one: `globalTeardown` (which reliably runs once, in the orchestrator process, after the whole
+worker-fork phase ends — see Task 3's own rationale) reads a PID file written at spawn time and sends a prompt
+`SIGTERM`. This sidesteps the worker-teardown mechanism entirely; it doesn't matter whether tinypool SIGTERMs, SIGKILLs,
+or does anything else to the worker, because the kill now happens from a process that isn't the worker.
+
+Keep the existing `beforeExit` hook from Task 3 as harmless defense-in-depth (it costs nothing and might fire under some
+other invocation this repo doesn't currently exercise, e.g. a profiling run) — the PID-file mechanism below becomes the
+primary, guaranteed path.
+
+**Files:**
+
+- Modify: `tests/integration/helpers/mcp-test-client.ts` (expose the spawned child's PID)
+- Modify: `tests/integration/helpers/shared-server.ts` (record the PID at spawn; export the kill function)
+- Modify: `tests/support/setup-integration.ts` (call the kill function from both `setup()` and `teardown()`)
+- Create: `tests/unit/integration-helpers/shared-server-pid-file.test.ts`
+
+- [ ] **Step 1: Expose the child's PID from `MCPTestClient`**
+
+In `tests/integration/helpers/mcp-test-client.ts`, add this accessor near the top of the class (it already has a
+`transport` field — see the `private readonly transport: StdioJsonRpcTransport;` declaration):
+
+```typescript
+  /** PID of the spawned server child process, once `startServer()` has run. */
+  get pid(): number | undefined {
+    return this.transport.child.pid;
+  }
+```
+
+(`StdioJsonRpcTransport` already exposes `get child(): ChildProcess` for exactly this kind of use — see
+`tests/integration/helpers/stdio-jsonrpc-transport.ts`.)
+
+- [ ] **Step 2: Write the failing unit test for the PID-file kill function**
+
+`tests/unit/integration-helpers/shared-server-pid-file.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('killOrphanedSharedServer', () => {
+  let dir: string;
+  let pidFilePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'omn261-pidfile-'));
+    pidFilePath = join(dir, 'shared-server.pid');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('does nothing when no PID file exists', async () => {
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    expect(() =>
+      killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true,
+        kill: () => {
+          throw new Error('should not be called');
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('sends SIGTERM to a live PID and removes the file', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    const killed: Array<{ pid: number; signal: string }> = [];
+    killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: (pid) => pid === 4242,
+      kill: (pid, signal) => killed.push({ pid, signal }),
+    });
+
+    expect(killed).toEqual([{ pid: 4242, signal: 'SIGTERM' }]);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  it('removes the file but does not kill when the recorded PID is no longer alive', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => false,
+      kill: () => {
+        throw new Error('should not be called');
+      },
+    });
+
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest tests/unit/integration-helpers/shared-server-pid-file.test.ts --run` Expected: FAIL —
+`killOrphanedSharedServer` is not exported from `shared-server.ts` yet.
+
+- [ ] **Step 4: Implement PID recording + the kill function in `shared-server.ts`**
+
+Add near the top of `tests/integration/helpers/shared-server.ts` (alongside the existing imports):
+
+```typescript
+import { mkdirSync, writeFileSync, readFileSync, existsSync, unlinkSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pidIsAlive } from '../../support/integration-guard.js';
+
+// OMN-261: mirrors the OMN-143 lock's PID-in-a-file pattern (integration-guard.ts's
+// DEFAULT_LOCK_PATH/pidIsAlive) — see Task 3b's rationale for why no in-process
+// exit hook can be relied on to shut this down.
+const SHARED_SERVER_PID_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'shared-server.pid');
+
+function recordSharedServerPid(pid: number | undefined): void {
+  if (pid === undefined) return;
+  try {
+    mkdirSync(path.dirname(SHARED_SERVER_PID_PATH), { recursive: true });
+    writeFileSync(SHARED_SERVER_PID_PATH, String(pid), 'utf-8');
+  } catch {
+    // Best-effort — losing this only loses the deterministic-cleanup path,
+    // not correctness of the suite itself.
+  }
+}
+
+/**
+ * OMN-261: call from a DIFFERENT process than the one that spawned the
+ * server (e.g. globalTeardown) — see Task 3b for why no hook registered
+ * inside the vitest worker fork process can be relied on here.
+ */
+export function killOrphanedSharedServer(
+  opts: {
+    pidFilePath?: string;
+    isPidAlive?: (pid: number) => boolean;
+    kill?: (pid: number, signal: string) => void;
+  } = {},
+): void {
+  const pidFilePath = opts.pidFilePath ?? SHARED_SERVER_PID_PATH;
+  const isAlive = opts.isPidAlive ?? pidIsAlive;
+  const kill = opts.kill ?? ((pid, signal) => process.kill(pid, signal));
+
+  let raw: string;
+  try {
+    raw = readFileSync(pidFilePath, 'utf-8').trim();
+  } catch {
+    return; // no PID file — nothing to do
+  }
+  try {
+    unlinkSync(pidFilePath);
+  } catch {
+    /* already gone — fine, we still act on what we read */
+  }
+
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return;
+  if (!isAlive(pid)) return;
+  try {
+    kill(pid, 'SIGTERM');
+  } catch {
+    /* gone between the liveness check and the kill; harmless */
+  }
+}
+```
+
+Then, inside `getSharedClientImpl`'s init branch (from Task 3 Step 2), right after `await client.startServer();`, add:
+
+```typescript
+recordSharedServerPid(client.pid);
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest tests/unit/integration-helpers/shared-server-pid-file.test.ts --run` Expected: PASS (all three cases)
+
+- [ ] **Step 6: Wire the kill into `setup-integration.ts`**
+
+In `tests/support/setup-integration.ts`, add the import:
+
+```typescript
+import { killOrphanedSharedServer } from '../integration/helpers/shared-server.js';
+```
+
+Call it defensively in `setup()`, right before the existing `fullCleanup({ scope: 'full' })` prior-run orphan hunt (same
+"clean up whatever a crashed prior run left behind" spirit):
+
+```typescript
+// OMN-261: a crashed prior run may have left its shared server's PID file
+// behind with the process still alive (or, more likely, already dead) —
+// clear it before this run starts its own.
+killOrphanedSharedServer();
+```
+
+And replace the comment Task 3 Step 4 left in `teardown()`:
+
+```typescript
+// OMN-261: shared-client shutdown no longer lives here — globalTeardown
+// runs in a separate OS process from the worker fork that owns the real
+// client, so this call could never reach it (confirmed dead at 1 call/0s
+// in the 2026-07-08 profile). shared-server.ts now registers its own
+// process.once('beforeExit', ...) hook inside the worker fork itself.
+```
+
+with:
+
+```typescript
+// OMN-261: the beforeExit hook shared-server.ts registers inside the
+// worker fork is defense-in-depth only — investigation confirmed Vitest's
+// forks-pool teardown (an external SIGTERM/SIGKILL from tinypool, no
+// in-worker signal handler for non-profiling runs) gives the worker zero
+// JS-level teardown opportunity, so beforeExit realistically never fires.
+// This PID-file kill runs from THIS process instead, which always executes
+// regardless of how the worker fork itself was torn down.
+killOrphanedSharedServer();
+```
+
+- [ ] **Step 7: Build and run the full unit suite**
+
+Run: `npm run build && npm run test:unit` Expected: build clean, all unit tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/integration/helpers/mcp-test-client.ts tests/integration/helpers/shared-server.ts tests/support/setup-integration.ts tests/unit/integration-helpers/shared-server-pid-file.test.ts
+git commit -m "fix(OMN-261): deterministic shared-server shutdown via a PID file, not an in-worker exit hook"
+```
+
+**Do not re-run Task 4's full live verification yet** — OMN-261 is on hold pending OMN-262 (the dedup-cache regression
+Task 4's first run exposed). Stop after this commit and report back; Task 4 gets re-run once OMN-262 is resolved and
+this fix is already in place.
+
+---
+
 ### Task 4: Supervised full-suite verification
 
 **Files:** none (verification only)

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,10 +281,25 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
   // (a hung osascript/JXA call blocked on an OmniFocus dialog), the process
   // would never exit and become a permanent, unreapable orphan.
   const SIGNAL_EXIT_TIMEOUT_MS = 5000;
+  // OMN-261 review: forcing exit must not skip stdioServer.close() outright —
+  // this repo's own MCP-lifecycle rule (CLAUDE.md) requires closing before
+  // exit so any already-computed response gets flushed. Give close() a short,
+  // separately-bounded grace period rather than the unbounded wait
+  // gracefulExit gives it normally (that unbounded wait is exactly what
+  // we're forcing past here).
+  const FORCE_CLOSE_GRACE_MS = 1000;
   const gracefulExitOnSignal = (reason: string) => {
     const forceExitTimer = setTimeout(() => {
       logger.warn(`${reason}: pending operations did not drain within ${SIGNAL_EXIT_TIMEOUT_MS}ms, forcing exit`);
-      process.exit(1);
+      void stdioServer
+        .close()
+        .catch((error) => {
+          logger.warn('Server close failed during forced shutdown (continuing to exit):', error);
+        })
+        .finally(() => process.exit(1));
+      // Belt-and-suspenders: if close() itself hangs, don't let the forced
+      // exit become unbounded again.
+      setTimeout(() => process.exit(1), FORCE_CLOSE_GRACE_MS).unref();
     }, SIGNAL_EXIT_TIMEOUT_MS);
     forceExitTimer.unref();
     void gracefulExit(reason).finally(() => clearTimeout(forceExitTimer));

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,12 +273,29 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
   // disposition (immediate termination, no drain of pendingOperations) with
   // no application code running. Route both through the same gracefulExit
   // path the other triggers already use.
+  //
+  // Unlike the stdin/EPIPE triggers, a signal-driven exit must be bounded:
+  // a caller sending SIGTERM (e.g. killOrphanedSharedServer in the
+  // integration test harness) fires-and-forgets, with no fallback SIGKILL —
+  // if gracefulExit's unbounded await on pendingOperations never resolves
+  // (a hung osascript/JXA call blocked on an OmniFocus dialog), the process
+  // would never exit and become a permanent, unreapable orphan.
+  const SIGNAL_EXIT_TIMEOUT_MS = 5000;
+  const gracefulExitOnSignal = (reason: string) => {
+    const forceExitTimer = setTimeout(() => {
+      logger.warn(`${reason}: pending operations did not drain within ${SIGNAL_EXIT_TIMEOUT_MS}ms, forcing exit`);
+      process.exit(1);
+    }, SIGNAL_EXIT_TIMEOUT_MS);
+    forceExitTimer.unref();
+    void gracefulExit(reason).finally(() => clearTimeout(forceExitTimer));
+  };
+
   process.on('SIGTERM', () => {
-    gracefulExit('SIGTERM received');
+    gracefulExitOnSignal('SIGTERM received');
   });
 
   process.on('SIGINT', () => {
-    gracefulExit('SIGINT received');
+    gracefulExitOnSignal('SIGINT received');
   });
 
   await stdioServer.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,20 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
     }
   });
 
+  // OMN-261 review: stdio mode previously handled only stdin closure and
+  // EPIPE as exit triggers — an external SIGTERM (e.g. a test harness or
+  // process manager killing this process directly) hit Node's default
+  // disposition (immediate termination, no drain of pendingOperations) with
+  // no application code running. Route both through the same gracefulExit
+  // path the other triggers already use.
+  process.on('SIGTERM', () => {
+    gracefulExit('SIGTERM received');
+  });
+
+  process.on('SIGINT', () => {
+    gracefulExit('SIGINT received');
+  });
+
   await stdioServer.connect(transport);
   startupTimer.mark('ready');
   logger.info(startupTimer.summary('stdio'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,34 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
 
   const transport = new StdioServerTransport();
 
+  // OMN-261 review: a single guard so exactly ONE shutdown path commits to
+  // closing + exiting. Multiple triggers can now race — a signal-driven
+  // force-exit timer (below) and the un-cancellable gracefulExit drain it
+  // raced, repeated signals, or a signal arriving mid stdin-close — and
+  // without this each could independently reach stdioServer.close()/
+  // process.exit(): double-closing the transport and exiting with
+  // contradictory codes (a drain that blew its bounded deadline could still
+  // report 0). Whichever path reaches commitExit first wins; the rest no-op.
+  // The check+set is synchronous, so on JS's single thread there is no
+  // interleaving window between the guard and the claim.
+  let exitCommitted = false;
+  const commitExit = async (code: number) => {
+    if (exitCommitted) return;
+    exitCommitted = true;
+
+    // Close server connection cleanly, allowing transport to flush responses.
+    // Wrapped: on an EPIPE-triggered exit the pipe is already dead and the
+    // flush may itself throw — that must not prevent the exit.
+    logger.info('Closing server connection...');
+    try {
+      await stdioServer.close();
+    } catch (error) {
+      logger.warn('Server close failed during shutdown (continuing to exit):', error);
+    }
+
+    process.exit(code);
+  };
+
   // Handle stdin closure for proper MCP lifecycle compliance
   // Wait for pending operations before exiting
   const gracefulExit = async (reason: string) => {
@@ -221,18 +249,8 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
       }
     }
 
-    // Close server connection cleanly, allowing transport to flush responses.
-    // Wrapped: on an EPIPE-triggered exit the pipe is already dead and the
-    // flush may itself throw — that must not prevent the exit.
-    logger.info('Closing server connection...');
-    try {
-      await stdioServer.close();
-    } catch (error) {
-      logger.warn('Server close failed during shutdown (continuing to exit):', error);
-    }
-
     logger.info('Exiting gracefully per MCP specification');
-    process.exit(0);
+    await commitExit(0);
   };
 
   process.stdin.on('end', () => {
@@ -290,7 +308,16 @@ async function runStdioServer(cacheManager: CacheManager, startupGate: Promise<v
   const FORCE_CLOSE_GRACE_MS = 1000;
   const gracefulExitOnSignal = (reason: string) => {
     const forceExitTimer = setTimeout(() => {
+      // Claim the shared guard synchronously: if the drain's commitExit(0)
+      // already committed, don't also force — and if it hasn't, block it from
+      // committing 0 after we've decided to force 1.
+      if (exitCommitted) return;
+      exitCommitted = true;
       logger.warn(`${reason}: pending operations did not drain within ${SIGNAL_EXIT_TIMEOUT_MS}ms, forcing exit`);
+      // Deliberately NOT commitExit(): that awaits close() unboundedly, which
+      // is exactly the wait we're forcing past. Give close() its own bounded
+      // grace instead so CLAUDE.md's "close before exit" rule is still honored
+      // on a best-effort basis.
       void stdioServer
         .close()
         .catch((error) => {

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -132,6 +132,16 @@ Entries are `{file, hook, op, ms, at, failed?}`; `file` is `"(global)"` for glob
 off (default) is a pure pass-through — normal runs are untouched. This profile is the decision gate for OMN-186 Phase 2
 (per-run fixture epoch): proceed only if teardown-dominated.
 
+**Supervising a live run:** `--reporter=json` alone goes nearly silent on stdout — it buffers per-test output into the
+JSON file instead of streaming it, so a healthy multi-minute run and a genuinely hung one look identical from the
+outside (2026-07-12: this cost a false "it's hung" call and a near-kill of a live suite mid-OMN-261-verification). Stack
+a second reporter for a continuous liveness signal without losing the machine-readable output:
+
+```bash
+FIXTURE_PROFILE=1 npx vitest tests/integration --run --reporter=dot --reporter=json --outputFile.json=/tmp/pertest.json
+# `dot` is low-noise (one character per test); use `default` instead for per-test names if the extra log volume is fine
+```
+
 ### Per-run fixture epoch (OMN-186 Phase 2)
 
 The Phase-1 profile (2026-07-08, quiet host, 525 s wall) confirmed teardown dominance: `fullCleanup` was 109 s of the

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -150,3 +150,52 @@ make their own correctness assertion vacuous. The post-run `scanForFixtures` fai
 (`npm run test:cleanup -- --apply`) pass explicit full and never scope down. In profiler logs the scoped sweeps record
 op `fullCleanup.scoped`, so before/after aggregations can split the modes — expect the ~109 s baseline to drop by
 roughly 10/15 of the scoped sweeps' savings, not the full amount.
+
+## Cross-file shared server via globalThis (OMN-261)
+
+Before this fix, `shared-server.ts`'s module-scope `let sharedClient`/`initPromise`/`isFirstAccess` bindings reset on
+every test file under vitest's default per-file `isolate: true` (the `forks` pool default) — independent of
+`singleFork: true`, which only guarantees one OS process, not one module registry. So despite the file's own docstring
+describing "one server per run," 13 of the suite's 17 `getSharedClient()` call sites each spawned and warmed a brand-new
+MCP server + OmniFocus cache from scratch; the only reuse came from a second call within the same file
+(`4 = (4-1) + (2-1)`, the two files that call it twice). Root cause is confirmed by a permanent regression-pinning test
+(`tests/integration/_diagnostics/module-isolation-probe-*.test.ts`) that proves the isolation behavior against the real
+integration-suite vitest config, not a simulation.
+
+Fix: move the three pieces of state onto a `globalThis`-keyed slot (`tests/integration/helpers/global-singleton.ts`) —
+the one thing per-file module isolation does not reset within a single OS process. Zero test-file edits, same invariant
+OMN-186 held to.
+
+Shutdown is two-layered. A `process.once('beforeExit', ...)` hook inside the worker fork is defense-in-depth only —
+investigation found it realistically never fires under a real `vitest --run`, since tinypool's
+`ProcessWorker .terminate()` SIGTERMs the worker externally and no in-worker signal handler is registered outside Node's
+own profiling flags. The load-bearing mechanism is a PID-file kill (`killOrphanedSharedServer`, mirroring the OMN-143
+lock's PID-in-a-file pattern) called from `globalTeardown` — a different process than the one that spawned the server —
+plus defensively at the start of the next run, in case a crashed prior run left its server alive.
+
+**Call-count delta:**
+
+|                                      | `getSharedClient.init` | `getSharedClient.reuse` |
+| ------------------------------------ | ---------------------- | ----------------------- |
+| Before (2026-07-11 profile)          | 13                     | 4                       |
+| After (2026-07-12 profile, this fix) | 1                      | 16                      |
+
+**Total-seconds:** post-fix, the single init totaled ~11–12 s across two verification runs (11.22 s and 11.52 s),
+consistent with the file's documented ~13 s cache-warm cost. The pre-fix total-seconds for the 13 inits was never
+separately recorded — only the call count was profiled on 2026-07-11 — so there's no measured before/after total-seconds
+delta to report here; a same-cost-per-init extrapolation (13 × ~11.5 s ≈ 150 s) is a plausible estimate, not a measured
+figure, and is called out as such rather than presented as data.
+
+**Verification (2026-07-12, live suite against real OmniFocus, `FIXTURE_PROFILE=1`):**
+
+- 202 tests total, 0 failures, 22 pending, on a clean re-run. (An earlier same-day run hit 1 isolated failure in
+  `update-operations.test.ts`, fully explained by an OmniFocus app crash mid-run — an isolated re-run of just that file
+  passed 9/9 clean, and the subsequent full clean re-run passed 202/202.)
+- Zero orphaned `dist/index.js` processes: before/after `pgrep -fl 'dist/index.js'` snapshots were byte-identical across
+  every run.
+- `shutdownSharedClient` shows zero entries in `fixture-profile.jsonl` in every run — expected, per the
+  `beforeExit`-never-fires finding above. The PID-file path is invisible to this profiler (it runs from a different
+  process) but is confirmed working by the zero-orphan-process result.
+- As with OMN-186, raw suite wall is not the tracked metric here — this is a correctness/resource-leak fix (spawning 13
+  servers instead of 1 wasted OS processes and OmniFocus warm-up time, but the suite was already fixture-noise-dominated
+  per the TL;DR above, so wall-clock delta is not a reliable signal for this change either).

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -183,7 +183,7 @@ run, in case a crashed prior run left its server alive. An earlier design also r
 realistically never fires under a real `vitest --run` (tinypool's `ProcessWorker.terminate()` SIGTERMs the worker
 externally, no in-worker signal handler registered outside Node's own profiling flags) — it was removed as confirmed
 dead code (`/code-review high` finding, 2026-07-12). `shutdownSharedClient()`'s graceful, ID-based cleanup
-(`thoroughCleanup()`) is kept as a tested, reusable unit but currently has no automatic caller — tracked in OMN-263.
+(`thoroughCleanup()`) is kept as a tested, reusable unit but currently has no automatic caller — tracked in OMN-264.
 
 **Call-count delta:**
 

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -176,12 +176,14 @@ Fix: move the three pieces of state onto a `globalThis`-keyed slot (`tests/integ
 the one thing per-file module isolation does not reset within a single OS process. Zero test-file edits, same invariant
 OMN-186 held to.
 
-Shutdown is two-layered. A `process.once('beforeExit', ...)` hook inside the worker fork is defense-in-depth only —
-investigation found it realistically never fires under a real `vitest --run`, since tinypool's
-`ProcessWorker .terminate()` SIGTERMs the worker externally and no in-worker signal handler is registered outside Node's
-own profiling flags. The load-bearing mechanism is a PID-file kill (`killOrphanedSharedServer`, mirroring the OMN-143
-lock's PID-in-a-file pattern) called from `globalTeardown` — a different process than the one that spawned the server —
-plus defensively at the start of the next run, in case a crashed prior run left its server alive.
+Shutdown is a PID-file kill (`killOrphanedSharedServer`, mirroring the OMN-143 lock's PID-in-a-file pattern) called from
+`globalTeardown` — a different process than the one that spawned the server — plus defensively at the start of the next
+run, in case a crashed prior run left its server alive. An earlier design also registered a
+`process.once('beforeExit', ...)` hook inside the worker fork as a second layer, but investigation found it
+realistically never fires under a real `vitest --run` (tinypool's `ProcessWorker.terminate()` SIGTERMs the worker
+externally, no in-worker signal handler registered outside Node's own profiling flags) — it was removed as confirmed
+dead code (`/code-review high` finding, 2026-07-12). `shutdownSharedClient()`'s graceful, ID-based cleanup
+(`thoroughCleanup()`) is kept as a tested, reusable unit but currently has no automatic caller — tracked in OMN-263.
 
 **Call-count delta:**
 
@@ -203,9 +205,9 @@ figure, and is called out as such rather than presented as data.
   passed 9/9 clean, and the subsequent full clean re-run passed 202/202.)
 - Zero orphaned `dist/index.js` processes: before/after `pgrep -fl 'dist/index.js'` snapshots were byte-identical across
   every run.
-- `shutdownSharedClient` shows zero entries in `fixture-profile.jsonl` in every run — expected, per the
-  `beforeExit`-never-fires finding above. The PID-file path is invisible to this profiler (it runs from a different
-  process) but is confirmed working by the zero-orphan-process result.
+- `shutdownSharedClient` shows zero entries in `fixture-profile.jsonl` in every run — expected, since it currently has
+  no automatic caller (see above). The PID-file path is invisible to this profiler (it runs from a different process)
+  but is confirmed working by the zero-orphan-process result.
 - As with OMN-186, raw suite wall is not the tracked metric here — this is a correctness/resource-leak fix (spawning 13
   servers instead of 1 wasted OS processes and OmniFocus warm-up time, but the suite was already fixture-noise-dominated
   per the TL;DR above, so wall-clock delta is not a reliable signal for this change either).

--- a/tests/integration/_diagnostics/module-isolation-probe-1.test.ts
+++ b/tests/integration/_diagnostics/module-isolation-probe-1.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
+// for the `forks` pool) resets this file's own module-scope state, while
+// globalThis survives across files in the same singleFork process.
+//
+// Order-independent by design: vitest's default sequencer reorders files by a
+// persisted pass/fail/duration cache, NOT file name, so this can't assume
+// "file 1 runs before file 2". Whichever of the TWO probe files happens to
+// run last does the aggregate assertion, tracked via a shared counter.
+const TOTAL_PROBE_FILES = 2;
+
+let moduleScopeCounter = 0;
+
+declare global {
+  var __omn261ProbeCounter: number | undefined;
+  var __omn261ProbeSeenValues: number[] | undefined;
+  var __omn261ProbeFilesRun: number | undefined;
+}
+
+describe('module isolation probe (file 1)', () => {
+  it('sees fresh module-scope state; records a persistent globalThis observation', () => {
+    const moduleScopeSeenBefore = moduleScopeCounter;
+    moduleScopeCounter++;
+    // Order-independent: EVERY file starts with a fresh module-scope binding
+    // if isolate:true is in effect, regardless of which file runs first.
+    expect(moduleScopeSeenBefore).toBe(0);
+
+    const globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
+    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
+    globalThis.__omn261ProbeSeenValues ??= [];
+    globalThis.__omn261ProbeSeenValues.push(globalThisSeenBefore);
+
+    globalThis.__omn261ProbeFilesRun = (globalThis.__omn261ProbeFilesRun ?? 0) + 1;
+    if (globalThis.__omn261ProbeFilesRun === TOTAL_PROBE_FILES) {
+      // Whichever file happens to run last (by vitest's sequencer) verifies
+      // the aggregate: both files must have seen DIFFERENT globalThis values
+      // (0 and 1, in some order) — proof that globalThis persisted across
+      // the per-file module-scope reset.
+      const seen = [...globalThis.__omn261ProbeSeenValues].sort((x, y) => x - y);
+      expect(seen).toEqual([0, 1]);
+    }
+  });
+});

--- a/tests/integration/_diagnostics/module-isolation-probe-1.test.ts
+++ b/tests/integration/_diagnostics/module-isolation-probe-1.test.ts
@@ -1,44 +1,8 @@
-import { describe, it, expect } from 'vitest';
-
-// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
-// for the `forks` pool) resets this file's own module-scope state, while
-// globalThis survives across files in the same singleFork process.
-//
-// Order-independent by design: vitest's default sequencer reorders files by a
-// persisted pass/fail/duration cache, NOT file name, so this can't assume
-// "file 1 runs before file 2". Whichever of the TWO probe files happens to
-// run last does the aggregate assertion, tracked via a shared counter.
-const TOTAL_PROBE_FILES = 2;
-
-let moduleScopeCounter = 0;
-
-declare global {
-  var __omn261ProbeCounter: number | undefined;
-  var __omn261ProbeSeenValues: number[] | undefined;
-  var __omn261ProbeFilesRun: number | undefined;
-}
+import { describe, it } from 'vitest';
+import { runModuleIsolationProbe } from './module-isolation-probe.helper.js';
 
 describe('module isolation probe (file 1)', () => {
   it('sees fresh module-scope state; records a persistent globalThis observation', () => {
-    const moduleScopeSeenBefore = moduleScopeCounter;
-    moduleScopeCounter++;
-    // Order-independent: EVERY file starts with a fresh module-scope binding
-    // if isolate:true is in effect, regardless of which file runs first.
-    expect(moduleScopeSeenBefore).toBe(0);
-
-    const globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
-    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
-    globalThis.__omn261ProbeSeenValues ??= [];
-    globalThis.__omn261ProbeSeenValues.push(globalThisSeenBefore);
-
-    globalThis.__omn261ProbeFilesRun = (globalThis.__omn261ProbeFilesRun ?? 0) + 1;
-    if (globalThis.__omn261ProbeFilesRun === TOTAL_PROBE_FILES) {
-      // Whichever file happens to run last (by vitest's sequencer) verifies
-      // the aggregate: both files must have seen DIFFERENT globalThis values
-      // (0 and 1, in some order) — proof that globalThis persisted across
-      // the per-file module-scope reset.
-      const seen = [...globalThis.__omn261ProbeSeenValues].sort((x, y) => x - y);
-      expect(seen).toEqual([0, 1]);
-    }
+    runModuleIsolationProbe();
   });
 });

--- a/tests/integration/_diagnostics/module-isolation-probe-2.test.ts
+++ b/tests/integration/_diagnostics/module-isolation-probe-2.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
+// for the `forks` pool) resets this file's own module-scope state, while
+// globalThis survives across files in the same singleFork process.
+//
+// Order-independent by design: vitest's default sequencer reorders files by a
+// persisted pass/fail/duration cache, NOT file name, so this can't assume
+// "file 1 runs before file 2". Whichever of the TWO probe files happens to
+// run last does the aggregate assertion, tracked via a shared counter.
+const TOTAL_PROBE_FILES = 2;
+
+let moduleScopeCounter = 0;
+
+declare global {
+  var __omn261ProbeCounter: number | undefined;
+  var __omn261ProbeSeenValues: number[] | undefined;
+  var __omn261ProbeFilesRun: number | undefined;
+}
+
+describe('module isolation probe (file 2)', () => {
+  it('sees fresh module-scope state; records a persistent globalThis observation', () => {
+    const moduleScopeSeenBefore = moduleScopeCounter;
+    moduleScopeCounter++;
+    // Order-independent: EVERY file starts with a fresh module-scope binding
+    // if isolate:true is in effect, regardless of which file runs first.
+    expect(moduleScopeSeenBefore).toBe(0);
+
+    const globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
+    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
+    globalThis.__omn261ProbeSeenValues ??= [];
+    globalThis.__omn261ProbeSeenValues.push(globalThisSeenBefore);
+
+    globalThis.__omn261ProbeFilesRun = (globalThis.__omn261ProbeFilesRun ?? 0) + 1;
+    if (globalThis.__omn261ProbeFilesRun === TOTAL_PROBE_FILES) {
+      // Whichever file happens to run last (by vitest's sequencer) verifies
+      // the aggregate: both files must have seen DIFFERENT globalThis values
+      // (0 and 1, in some order) — proof that globalThis persisted across
+      // the per-file module-scope reset.
+      const seen = [...globalThis.__omn261ProbeSeenValues].sort((x, y) => x - y);
+      expect(seen).toEqual([0, 1]);
+    }
+  });
+});

--- a/tests/integration/_diagnostics/module-isolation-probe-2.test.ts
+++ b/tests/integration/_diagnostics/module-isolation-probe-2.test.ts
@@ -1,44 +1,8 @@
-import { describe, it, expect } from 'vitest';
-
-// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
-// for the `forks` pool) resets this file's own module-scope state, while
-// globalThis survives across files in the same singleFork process.
-//
-// Order-independent by design: vitest's default sequencer reorders files by a
-// persisted pass/fail/duration cache, NOT file name, so this can't assume
-// "file 1 runs before file 2". Whichever of the TWO probe files happens to
-// run last does the aggregate assertion, tracked via a shared counter.
-const TOTAL_PROBE_FILES = 2;
-
-let moduleScopeCounter = 0;
-
-declare global {
-  var __omn261ProbeCounter: number | undefined;
-  var __omn261ProbeSeenValues: number[] | undefined;
-  var __omn261ProbeFilesRun: number | undefined;
-}
+import { describe, it } from 'vitest';
+import { runModuleIsolationProbe } from './module-isolation-probe.helper.js';
 
 describe('module isolation probe (file 2)', () => {
   it('sees fresh module-scope state; records a persistent globalThis observation', () => {
-    const moduleScopeSeenBefore = moduleScopeCounter;
-    moduleScopeCounter++;
-    // Order-independent: EVERY file starts with a fresh module-scope binding
-    // if isolate:true is in effect, regardless of which file runs first.
-    expect(moduleScopeSeenBefore).toBe(0);
-
-    const globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
-    globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
-    globalThis.__omn261ProbeSeenValues ??= [];
-    globalThis.__omn261ProbeSeenValues.push(globalThisSeenBefore);
-
-    globalThis.__omn261ProbeFilesRun = (globalThis.__omn261ProbeFilesRun ?? 0) + 1;
-    if (globalThis.__omn261ProbeFilesRun === TOTAL_PROBE_FILES) {
-      // Whichever file happens to run last (by vitest's sequencer) verifies
-      // the aggregate: both files must have seen DIFFERENT globalThis values
-      // (0 and 1, in some order) — proof that globalThis persisted across
-      // the per-file module-scope reset.
-      const seen = [...globalThis.__omn261ProbeSeenValues].sort((x, y) => x - y);
-      expect(seen).toEqual([0, 1]);
-    }
+    runModuleIsolationProbe();
   });
 });

--- a/tests/integration/_diagnostics/module-isolation-probe.helper.ts
+++ b/tests/integration/_diagnostics/module-isolation-probe.helper.ts
@@ -1,0 +1,49 @@
+import { expect } from 'vitest';
+
+// OMN-261: proves vitest's per-file module isolation (default `isolate: true`
+// for the `forks` pool) resets this file's own module-scope state, while
+// globalThis survives across files in the same singleFork process.
+//
+// Order-independent by design: vitest's default sequencer reorders files by a
+// persisted pass/fail/duration cache, NOT file name, so this can't assume
+// "file 1 runs before file 2". Whichever of the TWO probe files happens to
+// run last does the aggregate assertion, tracked via a shared counter.
+//
+// Shared by both module-isolation-probe-*.test.ts files. This is safe
+// because isolate:true resets the WHOLE per-file import graph, not just the
+// top-level test file — shared-server.ts's own module-scope state needed the
+// same globalThis workaround for the identical reason (see its OMN-261
+// comment) — so `moduleScopeCounter` below still starts fresh for each probe
+// file exactly as if this logic were copy-pasted into each one directly.
+const TOTAL_PROBE_FILES = 2;
+
+let moduleScopeCounter = 0;
+
+declare global {
+  var __omn261ProbeCounter: number | undefined;
+  var __omn261ProbeSeenValues: number[] | undefined;
+  var __omn261ProbeFilesRun: number | undefined;
+}
+
+export function runModuleIsolationProbe(): void {
+  const moduleScopeSeenBefore = moduleScopeCounter;
+  moduleScopeCounter++;
+  // Order-independent: EVERY file starts with a fresh module-scope binding
+  // if isolate:true is in effect, regardless of which file runs first.
+  expect(moduleScopeSeenBefore).toBe(0);
+
+  const globalThisSeenBefore = globalThis.__omn261ProbeCounter ?? 0;
+  globalThis.__omn261ProbeCounter = globalThisSeenBefore + 1;
+  globalThis.__omn261ProbeSeenValues ??= [];
+  globalThis.__omn261ProbeSeenValues.push(globalThisSeenBefore);
+
+  globalThis.__omn261ProbeFilesRun = (globalThis.__omn261ProbeFilesRun ?? 0) + 1;
+  if (globalThis.__omn261ProbeFilesRun === TOTAL_PROBE_FILES) {
+    // Whichever file happens to run last (by vitest's sequencer) verifies
+    // the aggregate: both files must have seen DIFFERENT globalThis values
+    // (0 and 1, in some order) — proof that globalThis persisted across
+    // the per-file module-scope reset.
+    const seen = [...globalThis.__omn261ProbeSeenValues].sort((x, y) => x - y);
+    expect(seen).toEqual([0, 1]);
+  }
+}

--- a/tests/integration/helpers/fixture-profiler.ts
+++ b/tests/integration/helpers/fixture-profiler.ts
@@ -79,13 +79,20 @@ interface FixtureProfilerState {
   logDirEnsured: boolean;
 }
 
+// Exported so tests that clear this slot in beforeEach import the real key
+// rather than re-typing the literal (OMN-261 review — same drift-safety as
+// SHARED_SERVER_STATE_SLOT / RUN_ID_SLOT_KEY).
+export const FIXTURE_PROFILER_STATE_SLOT = 'fixture-profiler-state';
+
 // OMN-261 review: module-scope `let` bindings here had the SAME per-file
 // vitest isolation bug OMN-261 diagnosed and fixed for shared-server.ts's
 // state (isolate:true resets top-level bindings per file even under
 // singleFork:true) — converted to the same globalThis-keyed slot so "once
-// per run" is actually once per run, not once per file.
+// per run" is actually once per run, not once per file. The warn-once guard
+// is deliberately run-scoped: its job is a single "profile data is
+// incomplete, distrust this run's log" signal, not a per-file failure count.
 function getProfilerState(): FixtureProfilerState {
-  return getGlobalSlot<FixtureProfilerState>('fixture-profiler-state', () => ({
+  return getGlobalSlot<FixtureProfilerState>(FIXTURE_PROFILER_STATE_SLOT, () => ({
     warnedWriteFailure: false,
     logDirEnsured: false,
   }));

--- a/tests/integration/helpers/fixture-profiler.ts
+++ b/tests/integration/helpers/fixture-profiler.ts
@@ -29,6 +29,7 @@
 import { appendFileSync, mkdirSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import { performance } from 'perf_hooks';
+import { getGlobalSlot } from './global-singleton.js';
 
 /**
  * Where in the vitest lifecycle the profiled call runs (best-effort label).
@@ -70,25 +71,41 @@ function currentTestFile(): string {
   return '(global)';
 }
 
-let warnedWriteFailure = false;
-// Ensure the log directory once per run, not per profiled call — the profiler
-// measures fixture overhead, so it must not add a syscall to every event.
-let logDirEnsured = false;
+interface FixtureProfilerState {
+  warnedWriteFailure: boolean;
+  // Ensure the log directory once per run, not per profiled call — the
+  // profiler measures fixture overhead, so it must not add a syscall to
+  // every event.
+  logDirEnsured: boolean;
+}
+
+// OMN-261 review: module-scope `let` bindings here had the SAME per-file
+// vitest isolation bug OMN-261 diagnosed and fixed for shared-server.ts's
+// state (isolate:true resets top-level bindings per file even under
+// singleFork:true) — converted to the same globalThis-keyed slot so "once
+// per run" is actually once per run, not once per file.
+function getProfilerState(): FixtureProfilerState {
+  return getGlobalSlot<FixtureProfilerState>('fixture-profiler-state', () => ({
+    warnedWriteFailure: false,
+    logDirEnsured: false,
+  }));
+}
 
 function record(entry: Record<string, unknown>): void {
+  const state = getProfilerState();
   try {
     const path = logPath();
-    if (!logDirEnsured) {
+    if (!state.logDirEnsured) {
       mkdirSync(dirname(path), { recursive: true });
-      logDirEnsured = true;
+      state.logDirEnsured = true;
     }
     appendFileSync(path, `${JSON.stringify(entry)}\n`);
   } catch (err) {
     // Profiling must never fail the fixture call it wraps — but a profiled
     // run whose log can't be written must not finish looking successful
     // (the whole run exists to produce this file), so warn once.
-    if (!warnedWriteFailure) {
-      warnedWriteFailure = true;
+    if (!state.warnedWriteFailure) {
+      state.warnedWriteFailure = true;
       console.warn(`[fixture-profiler] failed to write ${logPath()}: ${String(err)} — profile data will be incomplete`);
     }
   }

--- a/tests/integration/helpers/global-singleton.ts
+++ b/tests/integration/helpers/global-singleton.ts
@@ -1,0 +1,17 @@
+/**
+ * Vitest's default `isolate: true` (the `forks` pool default) resets every
+ * test file's ES-module top-level bindings to a fresh instance, even under
+ * `pool:'forks', poolOptions.forks.singleFork:true` (one OS process, but one
+ * module registry per file). `globalThis` is the one thing that per-file
+ * isolation does NOT reset — same JS realm/object across files in the same
+ * fork. Use this to persist state across integration test files within a
+ * single suite run. See OMN-261.
+ */
+export function getGlobalSlot<T>(key: string, initial: () => T): T {
+  const globalKey = Symbol.for(`omnifocus-mcp:${key}`);
+  const store = globalThis as unknown as Record<symbol, T>;
+  if (store[globalKey] === undefined) {
+    store[globalKey] = initial();
+  }
+  return store[globalKey];
+}

--- a/tests/integration/helpers/global-singleton.ts
+++ b/tests/integration/helpers/global-singleton.ts
@@ -7,11 +7,26 @@
  * fork. Use this to persist state across integration test files within a
  * single suite run. See OMN-261.
  */
+/**
+ * Builds the same globalThis-registry key getGlobalSlot() uses internally.
+ * Exported so callers that need to CLEAR a slot (test beforeEach hooks,
+ * mainly) never hand-reconstruct the `omnifocus-mcp:${key}` string — a
+ * hand-built copy silently stops matching if this prefix or scheme changes.
+ */
+export function globalSlotKey(key: string): symbol {
+  return Symbol.for(`omnifocus-mcp:${key}`);
+}
+
 export function getGlobalSlot<T>(key: string, initial: () => T): T {
-  const globalKey = Symbol.for(`omnifocus-mcp:${key}`);
+  const globalKey = globalSlotKey(key);
   const store = globalThis as unknown as Record<symbol, T>;
   if (store[globalKey] === undefined) {
     store[globalKey] = initial();
   }
   return store[globalKey];
+}
+
+/** Deletes a slot's globalThis-registry entry, e.g. to reset state between tests. */
+export function clearGlobalSlot(key: string): void {
+  delete (globalThis as unknown as Record<symbol, unknown>)[globalSlotKey(key)];
 }

--- a/tests/integration/helpers/mcp-test-client.ts
+++ b/tests/integration/helpers/mcp-test-client.ts
@@ -59,6 +59,11 @@ export class MCPTestClient {
   private sessionId: string = generateSessionId(); // Unique session tag for efficient cleanup
   private options: MCPTestClientOptions;
 
+  /** PID of the spawned server child process, once `startServer()` has run. */
+  get pid(): number | undefined {
+    return this.transport.child.pid;
+  }
+
   private cleanupMetrics: CleanupMetrics = {
     startTime: 0,
     operations: 0,

--- a/tests/integration/helpers/mcp-test-client.ts
+++ b/tests/integration/helpers/mcp-test-client.ts
@@ -59,9 +59,18 @@ export class MCPTestClient {
   private sessionId: string = generateSessionId(); // Unique session tag for efficient cleanup
   private options: MCPTestClientOptions;
 
-  /** PID of the spawned server child process, once `startServer()` has run. */
+  /**
+   * PID of the spawned server child process, once `startServer()` has run.
+   * `undefined` (not throwing) if the transport never got that far — e.g.
+   * startServer() itself rejected before spawning — so callers can safely
+   * probe this from a catch block without their own try/catch.
+   */
   get pid(): number | undefined {
-    return this.transport.child.pid;
+    try {
+      return this.transport.child.pid;
+    } catch {
+      return undefined;
+    }
   }
 
   private cleanupMetrics: CleanupMetrics = {

--- a/tests/integration/helpers/run-id.ts
+++ b/tests/integration/helpers/run-id.ts
@@ -36,6 +36,7 @@
 import { randomBytes } from 'crypto';
 
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
+import { getGlobalSlot } from './global-singleton.js';
 
 /**
  * Process-scoped run identifier, cached on `globalThis` rather than a plain
@@ -56,30 +57,25 @@ import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
  * exactly what made the OMN-126 empty-string-project dedup test intermittently
  * fail (OMN-262): the dedup CODE was never wrong, the fixture name just no
  * longer matched what the test asserted against. `globalThis` is the one
- * thing per-file isolation does not reset, so caching here — rather than
- * importing a shared helper module, to keep this fix independent of any
- * unmerged shared-client work — makes RUN_ID genuinely process-scoped again.
+ * thing per-file isolation does not reset, so caching here makes RUN_ID
+ * genuinely process-scoped again — via global-singleton.ts's getGlobalSlot,
+ * the same shared mechanism shared-server.ts and fixture-profiler.ts use for
+ * the identical problem. (OMN-261 review: this used to hand-roll its own
+ * globalThis-Symbol slot to stay independent of that then-unmerged work;
+ * both land in the same PR now, so the independence no longer buys anything
+ * and only risked drifting out of sync with the shared implementation.)
  *
  * Format: `<base36(Date.now())>-<6 hex chars>`.
  */
-// Exported (not inlined) so run-id.test.ts's globalThis-clearing helper —
-// which simulates a genuinely separate process, since vi.resetModules()
-// alone no longer changes RUN_ID — imports the real key instead of
-// duplicating the string, which would otherwise be free to drift out of
-// sync with this one and silently clear the wrong slot.
-export const RUN_ID_GLOBAL_KEY = Symbol.for('omnifocus-mcp:integration-test-run-id');
+// Exported so run-id.test.ts's globalThis-clearing helper (which simulates a
+// genuinely separate process) can pass the real slot name to
+// global-singleton.ts's clearGlobalSlot() instead of duplicating it.
+export const RUN_ID_SLOT_KEY = 'integration-test-run-id';
 
-function getOrCreateRunId(): string {
-  // `| undefined` keeps the `??=` guard's necessity visible to the type
-  // system — a plain `string` type would let a future refactor "simplify"
-  // this into a bare read that compiles fine but returns undefined on a
-  // fresh process.
-  const store = globalThis as unknown as Record<symbol, string | undefined>;
-  store[RUN_ID_GLOBAL_KEY] ??= `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`;
-  return store[RUN_ID_GLOBAL_KEY];
-}
-
-export const RUN_ID: string = getOrCreateRunId();
+export const RUN_ID: string = getGlobalSlot(
+  RUN_ID_SLOT_KEY,
+  () => `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`,
+);
 
 /**
  * Per-run inbox-task / project name prefix: `__TEST__-<runId>-`.

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -43,21 +43,53 @@ export function recordSharedServerPid(pid: number | undefined, pidFilePath: stri
   }
 }
 
+// OMN-261 review: src/index.ts's SIGTERM handler can legitimately take up to
+// its own SIGNAL_EXIT_TIMEOUT_MS (5s) draining pending operations, plus
+// FORCE_CLOSE_GRACE_MS (1s) attempting a bounded server.close(), before it
+// is guaranteed to have called process.exit() — a 6s worst case. REAP_TIMEOUT_MS
+// gives real margin over that for signal delivery / OS scheduling latency,
+// not just enough to match it.
+const REAP_TIMEOUT_MS = 8000;
+const REAP_POLL_INTERVAL_MS = 100;
+
 /**
  * OMN-261: call from a DIFFERENT process than the one that spawned the
  * server (e.g. globalTeardown) — see Task 3b for why no hook registered
  * inside the vitest worker fork process can be relied on here.
+ *
+ * By default, polls after sending SIGTERM so callers can rely on the orphan
+ * actually being gone (or log a warning that it wasn't) before touching
+ * OmniFocus themselves — a fire-and-forget kill left a window where both the
+ * dying orphan and the caller's own cleanup sweep could drive OmniFocus at
+ * once. This matters for setup()'s startup sweep, which runs fullCleanup()
+ * right after.
+ *
+ * Pass `waitForExit: false` when nothing OmniFocus-related follows the call
+ * (e.g. teardown()'s final, nothing-left-to-protect kill) — polling there
+ * doesn't just cost time, it produces a FALSE ALARM: `pidIsAlive`
+ * (`kill(pid, 0)`) can't distinguish "still executing" from "already called
+ * process.exit(), now a zombie awaiting reap by its real parent" (the vitest
+ * worker fork that spawned it — a different process from the one calling
+ * killOrphanedSharedServer here, which can never observe that reap). A real
+ * run hit exactly this: the warning fired on a normal, non-hung shutdown,
+ * at a point where nothing was actually at risk.
  */
-export function killOrphanedSharedServer(
+export async function killOrphanedSharedServer(
   opts: {
     pidFilePath?: string;
     isPidAlive?: (pid: number) => boolean;
     kill?: (pid: number, signal: string) => void;
+    reapTimeoutMs?: number;
+    reapPollIntervalMs?: number;
+    waitForExit?: boolean;
   } = {},
-): void {
+): Promise<void> {
   const pidFilePath = opts.pidFilePath ?? SHARED_SERVER_PID_PATH;
   const isAlive = opts.isPidAlive ?? pidIsAlive;
   const kill = opts.kill ?? ((pid, signal) => process.kill(pid, signal));
+  const reapTimeoutMs = opts.reapTimeoutMs ?? REAP_TIMEOUT_MS;
+  const reapPollIntervalMs = opts.reapPollIntervalMs ?? REAP_POLL_INTERVAL_MS;
+  const waitForExit = opts.waitForExit ?? true;
 
   let raw: string;
   try {
@@ -78,6 +110,20 @@ export function killOrphanedSharedServer(
     kill(pid, 'SIGTERM');
   } catch {
     /* gone between the liveness check and the kill; harmless */
+    return;
+  }
+
+  if (!waitForExit) return;
+
+  const deadline = Date.now() + reapTimeoutMs;
+  while (isAlive(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, reapPollIntervalMs));
+  }
+  if (isAlive(pid)) {
+    console.warn(
+      `[shared-server] Orphaned server PID ${pid} did not exit within ${reapTimeoutMs}ms of SIGTERM — ` +
+        'proceeding with cleanup anyway; it may still be driving OmniFocus concurrently.',
+    );
   }
 }
 
@@ -258,8 +304,13 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
     console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
     const client = new MCPTestClient({ enableCacheWarming: true });
     try {
-      state.client = client;
+      // OMN-261 review: publish state.client only once startServer() has
+      // actually resolved — publishing it earlier let a concurrent caller's
+      // synchronous `if (state.client)` check (above) see a non-null client
+      // and skip the `state.initPromise` wait entirely, handing back a
+      // client whose transport/child process hadn't finished starting.
       await client.startServer();
+      state.client = client;
       recordSharedServerPid(client.pid);
       console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
       await warmupOmniFocus(client);

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -51,6 +51,14 @@ export function recordSharedServerPid(pid: number | undefined, pidFilePath: stri
 // not just enough to match it.
 const REAP_TIMEOUT_MS = 8000;
 const REAP_POLL_INTERVAL_MS = 100;
+// OMN-261 review: if SIGTERM doesn't land within REAP_TIMEOUT_MS (e.g. the
+// server is wedged on a hung osascript/OmniFocus dialog — src/index.ts's own
+// handler names this), escalate to an unignorable SIGKILL and give it this
+// much longer to be reaped before giving up. The transport.close() path this
+// PID-file mechanism replaced had exactly this SIGTERM→SIGKILL escalation
+// bound; dropping to SIGTERM-only would let a wedged prior-run orphan keep
+// driving OmniFocus during setup()'s fullCleanup sweep.
+const SIGKILL_REAP_TIMEOUT_MS = 2000;
 
 /**
  * OMN-261: call from a DIFFERENT process than the one that spawned the
@@ -64,6 +72,10 @@ const REAP_POLL_INTERVAL_MS = 100;
  * once. This matters for setup()'s startup sweep, which runs fullCleanup()
  * right after.
  *
+ * When waiting, this escalates SIGTERM → SIGKILL if the process outlives
+ * REAP_TIMEOUT_MS, matching the SIGTERM+SIGKILL bound the transport.close()
+ * path had before this PID-file mechanism replaced it.
+ *
  * Pass `waitForExit: false` when nothing OmniFocus-related follows the call
  * (e.g. teardown()'s final, nothing-left-to-protect kill) — polling there
  * doesn't just cost time, it produces a FALSE ALARM: `pidIsAlive`
@@ -72,7 +84,11 @@ const REAP_POLL_INTERVAL_MS = 100;
  * worker fork that spawned it — a different process from the one calling
  * killOrphanedSharedServer here, which can never observe that reap). A real
  * run hit exactly this: the warning fired on a normal, non-hung shutdown,
- * at a point where nothing was actually at risk.
+ * at a point where nothing was actually at risk. The tradeoff is that this
+ * path sends only SIGTERM with no SIGKILL escalation; a process wedged AT
+ * teardown is left for the OS to reap when the run's process tree exits,
+ * which is acceptable because (unlike setup) nothing here runs OmniFocus
+ * cleanup afterward that a lingering orphan could corrupt.
  */
 export async function killOrphanedSharedServer(
   opts: {
@@ -81,6 +97,7 @@ export async function killOrphanedSharedServer(
     kill?: (pid: number, signal: string) => void;
     reapTimeoutMs?: number;
     reapPollIntervalMs?: number;
+    sigkillReapTimeoutMs?: number;
     waitForExit?: boolean;
   } = {},
 ): Promise<void> {
@@ -89,6 +106,7 @@ export async function killOrphanedSharedServer(
   const kill = opts.kill ?? ((pid, signal) => process.kill(pid, signal));
   const reapTimeoutMs = opts.reapTimeoutMs ?? REAP_TIMEOUT_MS;
   const reapPollIntervalMs = opts.reapPollIntervalMs ?? REAP_POLL_INTERVAL_MS;
+  const sigkillReapTimeoutMs = opts.sigkillReapTimeoutMs ?? SIGKILL_REAP_TIMEOUT_MS;
   const waitForExit = opts.waitForExit ?? true;
 
   let raw: string;
@@ -119,10 +137,25 @@ export async function killOrphanedSharedServer(
   while (isAlive(pid) && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, reapPollIntervalMs));
   }
+  if (!isAlive(pid)) return;
+
+  // SIGTERM didn't land within the budget — escalate to SIGKILL, which the
+  // process cannot ignore, then give it a shorter window to actually die.
+  try {
+    kill(pid, 'SIGKILL');
+  } catch {
+    /* died between the check and the escalation; fine */
+    return;
+  }
+  const killDeadline = Date.now() + sigkillReapTimeoutMs;
+  while (isAlive(pid) && Date.now() < killDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, reapPollIntervalMs));
+  }
   if (isAlive(pid)) {
     console.warn(
-      `[shared-server] Orphaned server PID ${pid} did not exit within ${reapTimeoutMs}ms of SIGTERM — ` +
-        'proceeding with cleanup anyway; it may still be driving OmniFocus concurrently.',
+      `[shared-server] Orphaned server PID ${pid} survived SIGTERM+SIGKILL within ` +
+        `${reapTimeoutMs + sigkillReapTimeoutMs}ms — proceeding with cleanup anyway; ` +
+        'it may still be driving OmniFocus concurrently.',
     );
   }
 }
@@ -133,12 +166,17 @@ interface SharedServerState {
   isFirstAccess: boolean;
 }
 
+// Exported so tests that clear this slot in beforeEach import the real key
+// rather than re-typing the literal — the same drift-safety the RUN_ID_SLOT_KEY
+// export gives run-id.ts (OMN-261 review).
+export const SHARED_SERVER_STATE_SLOT = 'shared-server-state';
+
 // OMN-261: module-scope `let` bindings reset on every test file under
 // vitest's default per-file isolation, even inside the single OS process
 // `singleFork:true` guarantees — defeating the "one server per run" design
 // this file's docstring already describes. globalThis survives the reset.
 function getState(): SharedServerState {
-  return getGlobalSlot<SharedServerState>('shared-server-state', () => ({
+  return getGlobalSlot<SharedServerState>(SHARED_SERVER_STATE_SLOT, () => ({
     client: null,
     initPromise: null,
     isFirstAccess: true,
@@ -304,17 +342,22 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
     console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
     const client = new MCPTestClient({ enableCacheWarming: true });
     try {
-      // OMN-261 review: publish state.client only once startServer() has
-      // actually resolved — publishing it earlier let a concurrent caller's
-      // synchronous `if (state.client)` check (above) see a non-null client
-      // and skip the `state.initPromise` wait entirely, handing back a
-      // client whose transport/child process hadn't finished starting.
       await client.startServer();
-      state.client = client;
       recordSharedServerPid(client.pid);
       console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
       await warmupOmniFocus(client);
       console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
+      // OMN-261 review: publish state.client ONLY once the client is fully
+      // ready — startServer() AND warmupOmniFocus() both done. The read-path
+      // fast check at the top (`if (state.client)`) does not await
+      // state.initPromise, so any earlier publish let a concurrent caller in
+      // the startServer-done-but-warmup-pending window take that fast path and
+      // receive a client that (a) wasn't warmed yet, and (b) this init's own
+      // catch block below would then stop() on a warmup failure — handing the
+      // concurrent caller a killed-child client instead of the clean
+      // "not initialized, retry via initPromise" behavior. Keeping state.client
+      // null for the whole init keeps every concurrent caller on initPromise.
+      state.client = client;
       state.isFirstAccess = false; // First access complete
       return client;
     } catch (error) {
@@ -329,11 +372,25 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
       // NEXT getSharedClient() call overwrites recordSharedServerPid's PID
       // file with the new client's PID before killOrphanedSharedServer ever
       // runs, permanently losing the only reference to this orphan.
-      if (client.pid !== undefined) {
+      const orphanPid = client.pid;
+      if (orphanPid !== undefined) {
         try {
           await client.stop();
         } catch (stopError) {
-          console.warn('[shared-server] Failed to stop client after init failure:', stopError);
+          // OMN-261 review: graceful stop() (transport.close) failed, so the
+          // child may still be alive — and since the PID file is about to be
+          // overwritten by the next retry, this is the last reference to it.
+          // Escalate to an unignorable SIGKILL rather than leak an untracked
+          // stray that can still drive OmniFocus.
+          console.warn(
+            `[shared-server] Graceful stop failed after init failure; escalating to SIGKILL for PID ${orphanPid}:`,
+            stopError,
+          );
+          try {
+            process.kill(orphanPid, 'SIGKILL');
+          } catch {
+            /* already dead between stop() failing and here — fine */
+          }
         }
       }
       state.client = null;
@@ -361,9 +418,11 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
  * the one holding `state.client`, so it can only send a blunt SIGTERM, not
  * invoke this function's graceful ID-based cleanup. Whether/how to wire
  * graceful cleanup back in (e.g. from the last test file's own afterAll) is
- * tracked in OMN-264 — kept here as a tested, reusable unit rather than
- * deleted outright, since fullCleanup()'s prefix-based scan is a coarser
- * safety net, not a replacement for ID-based cleanup.
+ * tracked in OMN-264 — kept here as a reusable unit rather than deleted
+ * outright, since fullCleanup()'s prefix-based scan is a coarser safety net,
+ * not a replacement for ID-based cleanup. It is covered by
+ * shared-server-init-failure.test.ts ('shutdownSharedClient …') so it can't
+ * bit-rot silently while it waits for a caller.
  */
 export async function shutdownSharedClient(): Promise<void> {
   // OMN-186: profiled when FIXTURE_PROFILE=1, for whenever this is invoked.

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -26,14 +26,20 @@ import { pidIsAlive } from '../../support/integration-guard.js';
 // exit hook can be relied on to shut this down.
 const SHARED_SERVER_PID_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'shared-server.pid');
 
-function recordSharedServerPid(pid: number | undefined): void {
+export function recordSharedServerPid(pid: number | undefined, pidFilePath: string = SHARED_SERVER_PID_PATH): void {
   if (pid === undefined) return;
   try {
-    mkdirSync(path.dirname(SHARED_SERVER_PID_PATH), { recursive: true });
-    writeFileSync(SHARED_SERVER_PID_PATH, String(pid), 'utf-8');
-  } catch {
-    // Best-effort — losing this only loses the deterministic-cleanup path,
-    // not correctness of the suite itself.
+    mkdirSync(path.dirname(pidFilePath), { recursive: true });
+    writeFileSync(pidFilePath, String(pid), 'utf-8');
+  } catch (error) {
+    // OMN-261 review: silent failure here defeats the only shutdown path
+    // that's actually load-bearing (the beforeExit hook realistically never
+    // fires — see registerShutdownHook). Losing this doesn't break suite
+    // correctness, but it must be visible, not silent.
+    console.warn(
+      `[shared-server] Failed to record shared-server PID ${pid} at ${pidFilePath} — deterministic shutdown cleanup will not run for this process:`,
+      error,
+    );
   }
 }
 
@@ -253,15 +259,28 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
   state.initPromise = (async () => {
     console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
     const client = new MCPTestClient({ enableCacheWarming: true });
-    state.client = client;
-    await client.startServer();
-    recordSharedServerPid(client.pid);
-    console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
-    await warmupOmniFocus(client);
-    console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
-    state.isFirstAccess = false; // First access complete
-    registerShutdownHook();
-    return client;
+    try {
+      state.client = client;
+      await client.startServer();
+      recordSharedServerPid(client.pid);
+      console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
+      await warmupOmniFocus(client);
+      console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
+      state.isFirstAccess = false; // First access complete
+      registerShutdownHook();
+      return client;
+    } catch (error) {
+      // OMN-261 review: state is now genuinely shared across the whole run
+      // (that's this file's entire point), so a cold-OmniFocus/init failure
+      // must not permanently poison every subsequent file's getSharedClient()
+      // call — reset so the NEXT call gets a fresh attempt instead of
+      // inheriting this broken client/rejected promise forever. The PID file
+      // (if recordSharedServerPid already ran) still lets
+      // killOrphanedSharedServer reap the partially-started process.
+      state.client = null;
+      state.initPromise = null;
+      throw error;
+    }
   })();
 
   return state.initPromise;

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -33,8 +33,8 @@ export function recordSharedServerPid(pid: number | undefined, pidFilePath: stri
     writeFileSync(pidFilePath, String(pid), 'utf-8');
   } catch (error) {
     // OMN-261 review: silent failure here defeats the only shutdown path
-    // that's actually load-bearing (the beforeExit hook realistically never
-    // fires — see registerShutdownHook). Losing this doesn't break suite
+    // that's actually load-bearing (killOrphanedSharedServer, called from
+    // globalTeardown — see below). Losing this doesn't break suite
     // correctness, but it must be visible, not silent.
     console.warn(
       `[shared-server] Failed to record shared-server PID ${pid} at ${pidFilePath} — deterministic shutdown cleanup will not run for this process:`,
@@ -85,7 +85,6 @@ interface SharedServerState {
   client: MCPTestClient | null;
   initPromise: Promise<MCPTestClient> | null;
   isFirstAccess: boolean;
-  shutdownHookRegistered: boolean;
 }
 
 // OMN-261: module-scope `let` bindings reset on every test file under
@@ -97,7 +96,6 @@ function getState(): SharedServerState {
     client: null,
     initPromise: null,
     isFirstAccess: true,
-    shutdownHookRegistered: false,
   }));
 }
 
@@ -267,7 +265,6 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
       await warmupOmniFocus(client);
       console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
       state.isFirstAccess = false; // First access complete
-      registerShutdownHook();
       return client;
     } catch (error) {
       // OMN-261 review: state is now genuinely shared across the whole run
@@ -286,28 +283,28 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
   return state.initPromise;
 }
 
-// OMN-261: setup-integration.ts's globalTeardown runs in a separate OS
-// process from the worker fork that actually owns this client — its call to
-// shutdownSharedClient() can never reach `state.client` there (confirmed:
-// the 2026-07-08 profiler logged that call at 1 call/0s, impossible for a
-// real IPC-round-trip shutdown). Register a real in-process graceful
-// shutdown instead, once, the first time a client is created.
-function registerShutdownHook(): void {
-  const state = getState();
-  if (state.shutdownHookRegistered) return;
-  state.shutdownHookRegistered = true;
-  process.once('beforeExit', () => {
-    void shutdownSharedClient();
-  });
-}
-
 /**
- * Shutdown the shared server (called by teardown script)
+ * Gracefully shut down the shared server: drains via thoroughCleanup() (an
+ * ID-based bulk delete of everything this client created) then stops the
+ * process.
+ *
+ * OMN-261 review: this function currently has NO automatic caller. It used
+ * to be wired to a `process.once('beforeExit', ...)` hook, but that hook was
+ * removed after investigation confirmed it realistically never fires under
+ * a real `vitest --run` (Vitest's forks-pool teardown is an external
+ * SIGTERM/SIGKILL from tinypool with no in-worker signal handler registered
+ * outside Node's profiling flags — see git history for the investigation).
+ * The actual load-bearing cleanup path is killOrphanedSharedServer() below,
+ * called from globalTeardown — but that runs in a SEPARATE OS process from
+ * the one holding `state.client`, so it can only send a blunt SIGTERM, not
+ * invoke this function's graceful ID-based cleanup. Whether/how to wire
+ * graceful cleanup back in (e.g. from the last test file's own afterAll) is
+ * tracked in OMN-263 — kept here as a tested, reusable unit rather than
+ * deleted outright, since fullCleanup()'s prefix-based scan is a coarser
+ * safety net, not a replacement for ID-based cleanup.
  */
 export async function shutdownSharedClient(): Promise<void> {
-  // OMN-186/OMN-261: real end-of-run cost now (called from the beforeExit
-  // hook inside the actual worker-fork process) — profiled when
-  // FIXTURE_PROFILE=1.
+  // OMN-186: profiled when FIXTURE_PROFILE=1, for whenever this is invoked.
   return profileFixture('globalTeardown', 'shutdownSharedClient', async () => {
     const state = getState();
     if (state.client) {

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -15,10 +15,27 @@
 import { MCPTestClient } from './mcp-test-client.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
 import { profileFixture } from './fixture-profiler.js';
+import { getGlobalSlot } from './global-singleton.js';
 
-let sharedClient: MCPTestClient | null = null;
-let initPromise: Promise<MCPTestClient> | null = null;
-let isFirstAccess = true;
+interface SharedServerState {
+  client: MCPTestClient | null;
+  initPromise: Promise<MCPTestClient> | null;
+  isFirstAccess: boolean;
+  shutdownHookRegistered: boolean;
+}
+
+// OMN-261: module-scope `let` bindings reset on every test file under
+// vitest's default per-file isolation, even inside the single OS process
+// `singleFork:true` guarantees — defeating the "one server per run" design
+// this file's docstring already describes. globalThis survives the reset.
+function getState(): SharedServerState {
+  return getGlobalSlot<SharedServerState>('shared-server-state', () => ({
+    client: null,
+    initPromise: null,
+    isFirstAccess: true,
+    shutdownHookRegistered: false,
+  }));
+}
 
 /**
  * Warm up OmniFocus + the JXA script execution path inside the spawned MCP server.
@@ -149,55 +166,79 @@ async function warmupOmniFocus(client: MCPTestClient): Promise<void> {
  * between test files.
  */
 export async function getSharedClient(): Promise<MCPTestClient> {
-  // OMN-186: first access pays server start + cache warm + OmniFocus warm;
-  // later per-file accesses pay a cache clear. Split ops so a profiled run
-  // (FIXTURE_PROFILE=1) can tell the one-time warm from the per-file cost.
-  const op = sharedClient || initPromise ? 'getSharedClient.reuse' : 'getSharedClient.init';
+  // OMN-186/OMN-261: first access pays server start + cache warm + OmniFocus
+  // warm; later accesses (now genuinely cross-file, via the global slot) pay
+  // a cache clear. Split ops so a profiled run (FIXTURE_PROFILE=1) can tell
+  // the one-time warm from the per-file cost.
+  const state = getState();
+  const op = state.client || state.initPromise ? 'getSharedClient.reuse' : 'getSharedClient.init';
   return profileFixture('beforeAll', op, getSharedClientImpl);
 }
 
 async function getSharedClientImpl(): Promise<MCPTestClient> {
-  if (sharedClient) {
+  const state = getState();
+
+  if (state.client) {
     // Clear cache between test file accesses to prevent pollution
-    if (!isFirstAccess) {
-      await sharedClient.clearCache();
+    if (!state.isFirstAccess) {
+      await state.client.clearCache();
     }
-    isFirstAccess = false;
-    return sharedClient;
+    state.isFirstAccess = false;
+    return state.client;
   }
 
   // Prevent race conditions if multiple tests start simultaneously
-  if (initPromise) {
-    return initPromise;
+  if (state.initPromise) {
+    return state.initPromise;
   }
 
-  initPromise = (async () => {
+  state.initPromise = (async () => {
     console.log('🚀 Starting shared MCP server for integration tests (with cache warming)...');
-    sharedClient = new MCPTestClient({ enableCacheWarming: true });
-    await sharedClient.startServer();
+    const client = new MCPTestClient({ enableCacheWarming: true });
+    state.client = client;
+    await client.startServer();
     console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
-    await warmupOmniFocus(sharedClient);
+    await warmupOmniFocus(client);
     console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');
-    isFirstAccess = false; // First access complete
-    return sharedClient;
+    state.isFirstAccess = false; // First access complete
+    registerShutdownHook();
+    return client;
   })();
 
-  return initPromise;
+  return state.initPromise;
+}
+
+// OMN-261: setup-integration.ts's globalTeardown runs in a separate OS
+// process from the worker fork that actually owns this client — its call to
+// shutdownSharedClient() can never reach `state.client` there (confirmed:
+// the 2026-07-08 profiler logged that call at 1 call/0s, impossible for a
+// real IPC-round-trip shutdown). Register a real in-process graceful
+// shutdown instead, once, the first time a client is created.
+function registerShutdownHook(): void {
+  const state = getState();
+  if (state.shutdownHookRegistered) return;
+  state.shutdownHookRegistered = true;
+  process.once('beforeExit', () => {
+    void shutdownSharedClient();
+  });
 }
 
 /**
  * Shutdown the shared server (called by teardown script)
  */
 export async function shutdownSharedClient(): Promise<void> {
-  // OMN-186: end-of-run cost — profiled when FIXTURE_PROFILE=1
+  // OMN-186/OMN-261: real end-of-run cost now (called from the beforeExit
+  // hook inside the actual worker-fork process) — profiled when
+  // FIXTURE_PROFILE=1.
   return profileFixture('globalTeardown', 'shutdownSharedClient', async () => {
-    if (sharedClient) {
+    const state = getState();
+    if (state.client) {
       console.log('🧹 Shutting down shared MCP server...');
-      await sharedClient.thoroughCleanup();
-      await sharedClient.stop();
-      sharedClient = null;
-      initPromise = null;
-      isFirstAccess = true; // Reset for next test run
+      await state.client.thoroughCleanup();
+      await state.client.stop();
+      state.client = null;
+      state.initPromise = null;
+      state.isFirstAccess = true; // Reset for next test run
       console.log('✅ Shared MCP server shutdown complete');
     }
   });
@@ -207,8 +248,9 @@ export async function shutdownSharedClient(): Promise<void> {
  * Export for tests that want synchronous access (after initialization)
  */
 export function getSharedClientSync(): MCPTestClient {
-  if (!sharedClient) {
+  const state = getState();
+  if (!state.client) {
     throw new Error('Shared MCP client not initialized. Call getSharedClient() first.');
   }
-  return sharedClient;
+  return state.client;
 }

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -19,7 +19,7 @@ import { MCPTestClient } from './mcp-test-client.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
 import { profileFixture } from './fixture-profiler.js';
 import { getGlobalSlot } from './global-singleton.js';
-import { pidIsAlive } from '../../support/integration-guard.js';
+import { pidIsAlive, parseLockPid } from '../../support/integration-guard.js';
 
 // OMN-261: mirrors the OMN-143 lock's PID-in-a-file pattern (integration-guard.ts's
 // DEFAULT_LOCK_PATH/pidIsAlive) — see Task 3b's rationale for why no in-process
@@ -71,8 +71,8 @@ export function killOrphanedSharedServer(
     /* already gone — fine, we still act on what we read */
   }
 
-  const pid = Number.parseInt(raw, 10);
-  if (!Number.isFinite(pid) || pid <= 0) return;
+  const pid = parseLockPid(raw);
+  if (pid === undefined) return;
   if (!isAlive(pid)) return;
   try {
     kill(pid, 'SIGTERM');
@@ -271,9 +271,20 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
       // (that's this file's entire point), so a cold-OmniFocus/init failure
       // must not permanently poison every subsequent file's getSharedClient()
       // call — reset so the NEXT call gets a fresh attempt instead of
-      // inheriting this broken client/rejected promise forever. The PID file
-      // (if recordSharedServerPid already ran) still lets
-      // killOrphanedSharedServer reap the partially-started process.
+      // inheriting this broken client/rejected promise forever.
+      //
+      // If startServer() already succeeded (warmupOmniFocus is what threw),
+      // stop the live child now rather than leaning on the PID file: the
+      // NEXT getSharedClient() call overwrites recordSharedServerPid's PID
+      // file with the new client's PID before killOrphanedSharedServer ever
+      // runs, permanently losing the only reference to this orphan.
+      if (client.pid !== undefined) {
+        try {
+          await client.stop();
+        } catch (stopError) {
+          console.warn('[shared-server] Failed to stop client after init failure:', stopError);
+        }
+      }
       state.client = null;
       state.initPromise = null;
       throw error;

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -12,10 +12,68 @@
  * test pollution. This ensures each test file starts with a fresh cache state.
  */
 
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { MCPTestClient } from './mcp-test-client.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
 import { profileFixture } from './fixture-profiler.js';
 import { getGlobalSlot } from './global-singleton.js';
+import { pidIsAlive } from '../../support/integration-guard.js';
+
+// OMN-261: mirrors the OMN-143 lock's PID-in-a-file pattern (integration-guard.ts's
+// DEFAULT_LOCK_PATH/pidIsAlive) — see Task 3b's rationale for why no in-process
+// exit hook can be relied on to shut this down.
+const SHARED_SERVER_PID_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'shared-server.pid');
+
+function recordSharedServerPid(pid: number | undefined): void {
+  if (pid === undefined) return;
+  try {
+    mkdirSync(path.dirname(SHARED_SERVER_PID_PATH), { recursive: true });
+    writeFileSync(SHARED_SERVER_PID_PATH, String(pid), 'utf-8');
+  } catch {
+    // Best-effort — losing this only loses the deterministic-cleanup path,
+    // not correctness of the suite itself.
+  }
+}
+
+/**
+ * OMN-261: call from a DIFFERENT process than the one that spawned the
+ * server (e.g. globalTeardown) — see Task 3b for why no hook registered
+ * inside the vitest worker fork process can be relied on here.
+ */
+export function killOrphanedSharedServer(
+  opts: {
+    pidFilePath?: string;
+    isPidAlive?: (pid: number) => boolean;
+    kill?: (pid: number, signal: string) => void;
+  } = {},
+): void {
+  const pidFilePath = opts.pidFilePath ?? SHARED_SERVER_PID_PATH;
+  const isAlive = opts.isPidAlive ?? pidIsAlive;
+  const kill = opts.kill ?? ((pid, signal) => process.kill(pid, signal));
+
+  let raw: string;
+  try {
+    raw = readFileSync(pidFilePath, 'utf-8').trim();
+  } catch {
+    return; // no PID file — nothing to do
+  }
+  try {
+    unlinkSync(pidFilePath);
+  } catch {
+    /* already gone — fine, we still act on what we read */
+  }
+
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return;
+  if (!isAlive(pid)) return;
+  try {
+    kill(pid, 'SIGTERM');
+  } catch {
+    /* gone between the liveness check and the kill; harmless */
+  }
+}
 
 interface SharedServerState {
   client: MCPTestClient | null;
@@ -197,6 +255,7 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
     const client = new MCPTestClient({ enableCacheWarming: true });
     state.client = client;
     await client.startServer();
+    recordSharedServerPid(client.pid);
     console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
     await warmupOmniFocus(client);
     console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -299,7 +299,7 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
  * the one holding `state.client`, so it can only send a blunt SIGTERM, not
  * invoke this function's graceful ID-based cleanup. Whether/how to wire
  * graceful cleanup back in (e.g. from the last test file's own afterAll) is
- * tracked in OMN-263 — kept here as a tested, reusable unit rather than
+ * tracked in OMN-264 — kept here as a tested, reusable unit rather than
  * deleted outright, since fullCleanup()'s prefix-based scan is a coarser
  * safety net, not a replacement for ID-based cleanup.
  */

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -41,7 +41,7 @@ export function pidIsAlive(pid: number): boolean {
 }
 
 /** Parses lock-file content into a valid holder PID, or undefined if missing/garbage. */
-function parseLockPid(raw: string): number | undefined {
+export function parseLockPid(raw: string): number | undefined {
   const pid = Number.parseInt(raw, 10);
   return Number.isFinite(pid) && pid > 0 ? pid : undefined;
 }

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -61,8 +61,10 @@ export async function setup() {
 
   // OMN-261: a crashed prior run may have left its shared server's PID file
   // behind with the process still alive (or, more likely, already dead) —
-  // clear it before this run starts its own.
-  killOrphanedSharedServer();
+  // clear it before this run starts its own. Awaited: killOrphanedSharedServer
+  // polls until the orphan is confirmed gone (or times out) so the sweep
+  // below doesn't drive OmniFocus concurrently with a still-exiting orphan.
+  await killOrphanedSharedServer();
 
   try {
     // OMN-186 Phase 2: explicit full — the lock acquired above would make an
@@ -173,7 +175,12 @@ export async function teardown() {
   // non-profiling runs — see shared-server.ts's shutdownSharedClient
   // docstring). This PID-file kill runs from THIS process instead, which
   // always executes regardless of how the worker fork itself was torn down.
-  killOrphanedSharedServer();
+  // `waitForExit: false`: nothing OmniFocus-related follows this call
+  // (teardown is nearly done), so there's no race to protect against — and
+  // waiting would just produce a false-alarm "didn't exit" warning on a
+  // zombie awaiting reap by the worker fork, which this process can never
+  // observe (see killOrphanedSharedServer's docstring).
+  await killOrphanedSharedServer({ waitForExit: false });
 
   // OMN-143: release the single-instance guard LAST, after all teardown work.
   stopOrphanWatchdog?.();

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -15,6 +15,7 @@
  */
 
 import { fullCleanup, scanForFixtures } from '../integration/helpers/sandbox-manager.js';
+import { killOrphanedSharedServer } from '../integration/helpers/shared-server.js';
 import {
   acquireIntegrationLock,
   DEFAULT_LOCK_PATH,
@@ -57,6 +58,11 @@ export async function setup() {
   stopOrphanWatchdog = startOrphanWatchdog();
 
   console.log('[Integration Setup] Running startup cleanup sweep...');
+
+  // OMN-261: a crashed prior run may have left its shared server's PID file
+  // behind with the process still alive (or, more likely, already dead) —
+  // clear it before this run starts its own.
+  killOrphanedSharedServer();
 
   try {
     // OMN-186 Phase 2: explicit full — the lock acquired above would make an
@@ -161,11 +167,14 @@ export async function teardown() {
     console.warn('[Integration Teardown] Post-cleanup scan failed:', error);
   }
 
-  // OMN-261: shared-client shutdown no longer lives here — globalTeardown
-  // runs in a separate OS process from the worker fork that owns the real
-  // client, so this call could never reach it (confirmed dead at 1 call/0s
-  // in the 2026-07-08 profile). shared-server.ts now registers its own
-  // process.once('beforeExit', ...) hook inside the worker fork itself.
+  // OMN-261: the beforeExit hook shared-server.ts registers inside the
+  // worker fork is defense-in-depth only — investigation confirmed Vitest's
+  // forks-pool teardown (an external SIGTERM/SIGKILL from tinypool, no
+  // in-worker signal handler for non-profiling runs) gives the worker zero
+  // JS-level teardown opportunity, so beforeExit realistically never fires.
+  // This PID-file kill runs from THIS process instead, which always executes
+  // regardless of how the worker fork itself was torn down.
+  killOrphanedSharedServer();
 
   // OMN-143: release the single-instance guard LAST, after all teardown work.
   stopOrphanWatchdog?.();

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -14,7 +14,6 @@
  * @see docs/plans/2025-12-11-test-sandbox-design.md
  */
 
-import { shutdownSharedClient } from '../integration/helpers/shared-server.js';
 import { fullCleanup, scanForFixtures } from '../integration/helpers/sandbox-manager.js';
 import {
   acquireIntegrationLock,
@@ -162,8 +161,11 @@ export async function teardown() {
     console.warn('[Integration Teardown] Post-cleanup scan failed:', error);
   }
 
-  // Shutdown shared client
-  await shutdownSharedClient();
+  // OMN-261: shared-client shutdown no longer lives here — globalTeardown
+  // runs in a separate OS process from the worker fork that owns the real
+  // client, so this call could never reach it (confirmed dead at 1 call/0s
+  // in the 2026-07-08 profile). shared-server.ts now registers its own
+  // process.once('beforeExit', ...) hook inside the worker fork itself.
 
   // OMN-143: release the single-instance guard LAST, after all teardown work.
   stopOrphanWatchdog?.();

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -167,13 +167,12 @@ export async function teardown() {
     console.warn('[Integration Teardown] Post-cleanup scan failed:', error);
   }
 
-  // OMN-261: the beforeExit hook shared-server.ts registers inside the
-  // worker fork is defense-in-depth only — investigation confirmed Vitest's
-  // forks-pool teardown (an external SIGTERM/SIGKILL from tinypool, no
-  // in-worker signal handler for non-profiling runs) gives the worker zero
-  // JS-level teardown opportunity, so beforeExit realistically never fires.
-  // This PID-file kill runs from THIS process instead, which always executes
-  // regardless of how the worker fork itself was torn down.
+  // OMN-261: the worker fork that owns the shared client gets zero JS-level
+  // teardown opportunity under Vitest's forks-pool teardown (an external
+  // SIGTERM/SIGKILL from tinypool, no in-worker signal handler for
+  // non-profiling runs — see shared-server.ts's shutdownSharedClient
+  // docstring). This PID-file kill runs from THIS process instead, which
+  // always executes regardless of how the worker fork itself was torn down.
   killOrphanedSharedServer();
 
   // OMN-143: release the single-instance guard LAST, after all teardown work.

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -167,6 +167,8 @@ describe('server entrypoint', () => {
     process.stdin.removeAllListeners('close');
     process.stdout.removeAllListeners('error');
     process.stderr.removeAllListeners('error');
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
   });
 
   it('connects the transport before cache warming completes (OMN-228)', async () => {
@@ -331,6 +333,62 @@ describe('server entrypoint', () => {
 
       lastRegisteredPendingOps?.add(deferred.promise);
       (process.stdin as any).emit('end');
+      expect(serverCloseMock).not.toHaveBeenCalled();
+
+      deferred.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(serverCloseMock).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('waits for pending operations on SIGTERM before exiting (OMN-261 review)', async () => {
+    // Previously stdio mode registered no SIGTERM handler at all, so an
+    // external SIGTERM (e.g. a test harness killing this process directly)
+    // hit Node's default disposition — immediate termination, no drain of
+    // pendingOperations — instead of the same graceful path stdin-close uses.
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development' });
+    const deferred = createDeferred<void>();
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+      lastRegisteredPendingOps = pendingOps;
+    });
+    const { runServer } = await importEntry();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    try {
+      await runServer();
+
+      lastRegisteredPendingOps?.add(deferred.promise);
+      process.emit('SIGTERM');
+      expect(serverCloseMock).not.toHaveBeenCalled();
+
+      deferred.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(serverCloseMock).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('waits for pending operations on SIGINT before exiting (OMN-261 review)', async () => {
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development' });
+    const deferred = createDeferred<void>();
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+      lastRegisteredPendingOps = pendingOps;
+    });
+    const { runServer } = await importEntry();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    try {
+      await runServer();
+
+      lastRegisteredPendingOps?.add(deferred.promise);
+      process.emit('SIGINT');
       expect(serverCloseMock).not.toHaveBeenCalled();
 
       deferred.resolve();

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -459,4 +459,42 @@ describe('server entrypoint', () => {
       exitSpy.mockRestore();
     }
   });
+
+  it('does not double-close or exit 0 when the drain finishes just after the force-exit committed (OMN-261 review)', async () => {
+    // The force-exit timer and the (un-cancellable) gracefulExit drain both
+    // continue running; a shared exitCommitted guard must ensure only the
+    // first path to commit closes the server and picks the exit code, so a
+    // drain that blew its bounded deadline can't still report a clean exit 0.
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development' });
+    const deferred = createDeferred<void>();
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+      lastRegisteredPendingOps = pendingOps;
+    });
+    const { runServer } = await importEntry();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    try {
+      await runServer();
+      lastRegisteredPendingOps?.add(deferred.promise);
+
+      vi.useFakeTimers();
+      process.emit('SIGTERM');
+      await vi.advanceTimersByTimeAsync(5000); // force timer commits: close() + exit(1)
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(serverCloseMock).toHaveBeenCalledTimes(1);
+
+      // Drain now finishes, AFTER the forced exit already committed. The
+      // guard must make gracefulExit's own commitExit(0) a no-op.
+      deferred.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+
+      expect(serverCloseMock).toHaveBeenCalledTimes(1);
+      expect(exitSpy).not.toHaveBeenCalledWith(0);
+    } finally {
+      vi.useRealTimers();
+      exitSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -422,8 +422,38 @@ describe('server entrypoint', () => {
       process.emit('SIGTERM');
       await vi.advanceTimersByTimeAsync(5000);
 
+      // Forcing exit must still attempt a bounded close() — CLAUDE.md's
+      // MCP-lifecycle rule requires closing before exit to flush any
+      // already-computed response — it just can't wait on it unboundedly
+      // (that unbounded wait is exactly what's being forced past here).
+      expect(serverCloseMock).toHaveBeenCalledTimes(1);
       expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(serverCloseMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('force-exits after a bounded grace period even if close() itself hangs (OMN-261 review)', async () => {
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development' });
+    const neverResolves = new Promise<void>(() => {});
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+      lastRegisteredPendingOps = pendingOps;
+    });
+    serverCloseMock.mockImplementationOnce(() => new Promise<void>(() => {}));
+    const { runServer } = await importEntry();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    try {
+      await runServer();
+      lastRegisteredPendingOps?.add(neverResolves);
+
+      vi.useFakeTimers();
+      process.emit('SIGTERM');
+      await vi.advanceTimersByTimeAsync(5000); // main drain timeout fires, close() called but hangs
+      await vi.advanceTimersByTimeAsync(1000); // belt-and-suspenders grace timer fires
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       vi.useRealTimers();
       exitSpy.mockRestore();

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -400,4 +400,33 @@ describe('server entrypoint', () => {
       exitSpy.mockRestore();
     }
   });
+
+  it('force-exits if pending operations never drain within the SIGTERM/SIGINT timeout (OMN-261 review)', async () => {
+    // A hung osascript/JXA call (e.g. blocked on an OmniFocus permission
+    // dialog) must not make the process permanently unkillable — the signal
+    // handlers bound the drain wait and force-exit if it's exceeded, unlike
+    // the unbounded stdin-close/EPIPE paths.
+    resetEnv({ MCP_SKIP_AUTO_START: 'true', NODE_ENV: 'development' });
+    const neverResolves = new Promise<void>(() => {});
+    registerToolsMock.mockImplementation((_server, _cache, pendingOps: Set<Promise<unknown>>) => {
+      lastRegisteredPendingOps = pendingOps;
+    });
+    const { runServer } = await importEntry();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    try {
+      await runServer();
+      lastRegisteredPendingOps?.add(neverResolves);
+
+      vi.useFakeTimers();
+      process.emit('SIGTERM');
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(serverCloseMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      exitSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/integration-helpers/fixture-profiler.test.ts
+++ b/tests/unit/integration-helpers/fixture-profiler.test.ts
@@ -11,7 +11,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, readFileSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { profileFixture, fixtureProfilingEnabled } from '../../../tests/integration/helpers/fixture-profiler.js';
+import {
+  profileFixture,
+  fixtureProfilingEnabled,
+  FIXTURE_PROFILER_STATE_SLOT,
+} from '../../../tests/integration/helpers/fixture-profiler.js';
 import { clearGlobalSlot } from '../../../tests/integration/helpers/global-singleton.js';
 
 let logDir: string;
@@ -143,7 +147,7 @@ describe('profileFixture', () => {
     // ("warns once") already flipped warnedWriteFailure to true there, and
     // (unlike module-scope `let`) that state now outlives this test's own
     // vi.resetModules() call below, so it must be cleared explicitly first.
-    clearGlobalSlot('fixture-profiler-state');
+    clearGlobalSlot(FIXTURE_PROFILER_STATE_SLOT);
 
     try {
       const mod1 = await import('../../../tests/integration/helpers/fixture-profiler.js');

--- a/tests/unit/integration-helpers/fixture-profiler.test.ts
+++ b/tests/unit/integration-helpers/fixture-profiler.test.ts
@@ -125,4 +125,39 @@ describe('profileFixture', () => {
       warnSpy.mockRestore();
     }
   });
+
+  it('remembers warnedWriteFailure across a module reset (OMN-261 review: same vitest per-file isolation bug fixed elsewhere)', async () => {
+    // warnedWriteFailure/logDirEnsured used to be plain module-scope `let`
+    // bindings — the exact pattern OMN-261 diagnosed and fixed for
+    // shared-server.ts, left unconverted here. vi.resetModules() simulates
+    // vitest's per-file module-registry reset; the warn-once guard must
+    // still hold across the reset-reimported module instance, proving this
+    // state now lives on globalThis rather than resetting per file.
+    process.env.FIXTURE_PROFILE = '1';
+    process.env.FIXTURE_PROFILE_LOG = join(logPath, 'child.jsonl'); // parent is a FILE, so every write fails
+    const { writeFileSync } = await import('fs');
+    writeFileSync(logPath, 'occupied');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Reset the shared globalThis slot — an earlier test in this same file
+    // ("warns once") already flipped warnedWriteFailure to true there, and
+    // (unlike module-scope `let`) that state now outlives this test's own
+    // vi.resetModules() call below, so it must be cleared explicitly first.
+    delete (globalThis as unknown as Record<symbol, unknown>)[Symbol.for('omnifocus-mcp:fixture-profiler-state')];
+
+    try {
+      const mod1 = await import('../../../tests/integration/helpers/fixture-profiler.js');
+      await mod1.profileFixture('beforeAll', 'first', () => Promise.resolve('a'));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      vi.resetModules();
+      const mod2 = await import('../../../tests/integration/helpers/fixture-profiler.js');
+      await mod2.profileFixture('beforeAll', 'second', () => Promise.resolve('b'));
+
+      // Still 1, not 2 — the reset-reimported module instance saw
+      // warnedWriteFailure already true via the shared globalThis slot.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/integration-helpers/fixture-profiler.test.ts
+++ b/tests/unit/integration-helpers/fixture-profiler.test.ts
@@ -12,6 +12,7 @@ import { existsSync, readFileSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { profileFixture, fixtureProfilingEnabled } from '../../../tests/integration/helpers/fixture-profiler.js';
+import { clearGlobalSlot } from '../../../tests/integration/helpers/global-singleton.js';
 
 let logDir: string;
 let logPath: string;
@@ -142,7 +143,7 @@ describe('profileFixture', () => {
     // ("warns once") already flipped warnedWriteFailure to true there, and
     // (unlike module-scope `let`) that state now outlives this test's own
     // vi.resetModules() call below, so it must be cleared explicitly first.
-    delete (globalThis as unknown as Record<symbol, unknown>)[Symbol.for('omnifocus-mcp:fixture-profiler-state')];
+    clearGlobalSlot('fixture-profiler-state');
 
     try {
       const mod1 = await import('../../../tests/integration/helpers/fixture-profiler.js');

--- a/tests/unit/integration-helpers/global-singleton.test.ts
+++ b/tests/unit/integration-helpers/global-singleton.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 describe('getGlobalSlot', () => {
   const KEY = 'unit-test-probe';
-  const globalKey = Symbol.for(`omnifocus-mcp:${KEY}`);
 
-  beforeEach(() => {
-    delete (globalThis as unknown as Record<symbol, unknown>)[globalKey];
+  beforeEach(async () => {
+    const { clearGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
+    clearGlobalSlot(KEY);
   });
 
   it('returns the same instance on repeated calls, ignoring the factory after first creation', async () => {

--- a/tests/unit/integration-helpers/global-singleton.test.ts
+++ b/tests/unit/integration-helpers/global-singleton.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('getGlobalSlot', () => {
+  const KEY = 'unit-test-probe';
+  const globalKey = Symbol.for(`omnifocus-mcp:${KEY}`);
+
+  beforeEach(() => {
+    delete (globalThis as unknown as Record<symbol, unknown>)[globalKey];
+  });
+
+  it('returns the same instance on repeated calls, ignoring the factory after first creation', async () => {
+    const { getGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
+    const a = getGlobalSlot(KEY, () => ({ n: 0 }));
+    const b = getGlobalSlot(KEY, () => ({ n: 999 }));
+    expect(b).toBe(a);
+    expect(b.n).toBe(0);
+  });
+
+  it('survives a fresh module re-import (the mechanism vitest per-file isolation relies on)', async () => {
+    const mod1 = await import('../../integration/helpers/global-singleton.js');
+    const slot1 = mod1.getGlobalSlot(KEY, () => ({ n: 0 }));
+    slot1.n = 42;
+
+    vi.resetModules();
+    const mod2 = await import('../../integration/helpers/global-singleton.js');
+    const slot2 = mod2.getGlobalSlot(KEY, () => ({ n: 0 }));
+
+    expect(slot2.n).toBe(42);
+  });
+});

--- a/tests/unit/integration-helpers/mcp-test-client-pid.test.ts
+++ b/tests/unit/integration-helpers/mcp-test-client-pid.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { MCPTestClient } from '../../integration/helpers/mcp-test-client.js';
+
+describe('MCPTestClient.pid', () => {
+  it('returns undefined (does not throw) before startServer() has spawned a child', () => {
+    // OMN-261 review: shared-server.ts's init-failure recovery path probes
+    // client.pid from a catch block to decide whether to stop an
+    // already-spawned child. The transport's own `child` getter throws when
+    // never started — pid must swallow that, or the catch block that's
+    // guarding against poisoned shared state can itself throw and skip the
+    // reset it exists to guarantee.
+    const client = new MCPTestClient();
+    expect(() => client.pid).not.toThrow();
+    expect(client.pid).toBeUndefined();
+  });
+});

--- a/tests/unit/integration-helpers/run-id.test.ts
+++ b/tests/unit/integration-helpers/run-id.test.ts
@@ -19,15 +19,14 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { RUN_ID_GLOBAL_KEY } from '../../integration/helpers/run-id.js';
+import { RUN_ID_SLOT_KEY } from '../../integration/helpers/run-id.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from '../../integration/helpers/sandbox-manager.js';
+import { clearGlobalSlot } from '../../integration/helpers/global-singleton.js';
 
 // Imported (not duplicated as a string literal) so this can never drift out
-// of sync with the real key run-id.ts caches RUN_ID under — Symbol.for(key)
-// is idempotent from the global symbol registry, so this stays valid even
-// after vi.resetModules() re-evaluates run-id.ts's module bindings.
+// of sync with the real slot run-id.ts caches RUN_ID under.
 function clearGlobalRunId(): void {
-  delete (globalThis as unknown as Record<symbol, unknown>)[RUN_ID_GLOBAL_KEY];
+  clearGlobalSlot(RUN_ID_SLOT_KEY);
 }
 
 // Reset the runId module before each test so each block starts clean.

--- a/tests/unit/integration-helpers/shared-server-init-failure.test.ts
+++ b/tests/unit/integration-helpers/shared-server-init-failure.test.ts
@@ -1,29 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const startServerMock = vi.fn();
+const stopMock = vi.fn();
+const defaultCallToolImpl = (tool: string, args: unknown) => {
+  if (tool === 'omnifocus_read') {
+    return { success: true, data: { tasks: [] } };
+  }
+  if (tool === 'omnifocus_write') {
+    const operation = (args as { mutation?: { operation?: string } })?.mutation?.operation;
+    if (operation === 'create') {
+      return { success: true, data: { task: { taskId: 'mock-task-id' } } };
+    }
+    return { success: true, data: {} };
+  }
+  return { success: true, data: {} };
+};
+const callToolMock = vi.fn().mockImplementation(defaultCallToolImpl);
 
 vi.mock('../../integration/helpers/mcp-test-client.js', () => {
   return {
-    MCPTestClient: vi.fn().mockImplementation(() => ({
-      pid: 1234,
-      startServer: startServerMock,
-      clearCache: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      thoroughCleanup: vi.fn().mockResolvedValue(undefined),
-      callTool: vi.fn().mockImplementation((tool: string, args: unknown) => {
-        if (tool === 'omnifocus_read') {
-          return { success: true, data: { tasks: [] } };
-        }
-        if (tool === 'omnifocus_write') {
-          const operation = (args as { mutation?: { operation?: string } })?.mutation?.operation;
-          if (operation === 'create') {
-            return { success: true, data: { task: { taskId: 'mock-task-id' } } };
-          }
-          return { success: true, data: {} };
-        }
-        return { success: true, data: {} };
-      }),
-    })),
+    // pid mirrors the real MCPTestClient: undefined until startServer()
+    // actually spawns the child, so tests can distinguish "startServer
+    // itself rejected" (pid stays undefined) from "startServer succeeded but
+    // warmup failed afterward" (pid is set).
+    MCPTestClient: vi.fn().mockImplementation(() => {
+      const instance = {
+        pid: undefined as number | undefined,
+        startServer: async (...args: unknown[]) => {
+          const result = await startServerMock(...args);
+          instance.pid = 1234;
+          return result;
+        },
+        clearCache: vi.fn().mockResolvedValue(undefined),
+        stop: stopMock,
+        thoroughCleanup: vi.fn().mockResolvedValue(undefined),
+        callTool: callToolMock,
+      };
+      return instance;
+    }),
   };
 });
 
@@ -37,6 +51,8 @@ describe('getSharedClient init-failure recovery', () => {
   beforeEach(() => {
     vi.resetModules();
     startServerMock.mockReset();
+    stopMock.mockReset().mockResolvedValue(undefined);
+    callToolMock.mockReset().mockImplementation(defaultCallToolImpl);
     delete (globalThis as unknown as Record<symbol, unknown>)[SHARED_SERVER_STATE_KEY];
   });
 
@@ -55,5 +71,36 @@ describe('getSharedClient init-failure recovery', () => {
     const client = await getSharedClient();
     expect(client).toBeDefined();
     expect(startServerMock).toHaveBeenCalledTimes(2);
+    // startServer() rejected outright — no child was ever spawned, so there's
+    // nothing to stop.
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  it('stops the spawned client when warmupOmniFocus fails after startServer already succeeded, instead of leaking an orphaned process', async () => {
+    vi.useFakeTimers();
+    try {
+      startServerMock.mockResolvedValue(undefined);
+      // Every warmup read attempt fails, forcing warmupOmniFocus's 15s
+      // read-phase retry loop to run out the clock and throw.
+      callToolMock.mockImplementation((tool: string) => {
+        if (tool === 'omnifocus_read') {
+          return { success: false, error: 'simulated cold OmniFocus read failure' };
+        }
+        return { success: true, data: {} };
+      });
+
+      const { getSharedClient } = await import('../../integration/helpers/shared-server.js');
+
+      const pending = getSharedClient();
+      const assertion = expect(pending).rejects.toThrow(/warm-up/i);
+      await vi.advanceTimersByTimeAsync(20000);
+      await assertion;
+
+      // Before the fix: the catch block reset in-memory state but never
+      // called client.stop(), leaking the already-spawned child process.
+      expect(stopMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/integration-helpers/shared-server-init-failure.test.ts
+++ b/tests/unit/integration-helpers/shared-server-init-failure.test.ts
@@ -45,15 +45,16 @@ vi.mock('../../integration/helpers/mcp-test-client.js', () => {
 // (see global-singleton.ts) specifically so it survives vitest's per-file
 // module reset — which means it does NOT reset between tests in THIS file
 // on its own. Clear it manually so each test starts fresh.
-const SHARED_SERVER_STATE_KEY = Symbol.for('omnifocus-mcp:shared-server-state');
+const SHARED_SERVER_STATE_SLOT = 'shared-server-state';
 
 describe('getSharedClient init-failure recovery', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
     startServerMock.mockReset();
     stopMock.mockReset().mockResolvedValue(undefined);
     callToolMock.mockReset().mockImplementation(defaultCallToolImpl);
-    delete (globalThis as unknown as Record<symbol, unknown>)[SHARED_SERVER_STATE_KEY];
+    const { clearGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
+    clearGlobalSlot(SHARED_SERVER_STATE_SLOT);
   });
 
   it('resets shared state after an init failure so the next call retries fresh instead of inheriting the broken client forever', async () => {
@@ -102,5 +103,42 @@ describe('getSharedClient init-failure recovery', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('a second concurrent call waits for the same in-flight startServer() instead of reusing an unstarted client', async () => {
+    let resolveStartServer!: () => void;
+    startServerMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStartServer = resolve;
+        }),
+    );
+
+    const { getSharedClient } = await import('../../integration/helpers/shared-server.js');
+
+    let secondResolved = false;
+    const first = getSharedClient();
+    const second = getSharedClient().then((client) => {
+      secondResolved = true;
+      return client;
+    });
+
+    // OMN-261 review: before the fix, state.client was published BEFORE
+    // startServer() resolved, so this second call's synchronous
+    // `if (state.client)` check took the "reuse" branch immediately and
+    // returned the not-yet-started client here, instead of waiting on
+    // `state.initPromise` like this first call is. Flush via a macrotask
+    // (not just a couple of microtask ticks) so this is robust regardless of
+    // how many promise-chain links sit between the reuse branch and here —
+    // a microtask-only flush passed even against the buggy ordering because
+    // it didn't wait out the whole chain.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(secondResolved).toBe(false);
+
+    resolveStartServer();
+    const [clientA, clientB] = await Promise.all([first, second]);
+
+    expect(clientB).toBe(clientA);
+    expect(startServerMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/integration-helpers/shared-server-init-failure.test.ts
+++ b/tests/unit/integration-helpers/shared-server-init-failure.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const startServerMock = vi.fn();
 const stopMock = vi.fn();
+const thoroughCleanupMock = vi.fn();
 const defaultCallToolImpl = (tool: string, args: unknown) => {
   if (tool === 'omnifocus_read') {
     return { success: true, data: { tasks: [] } };
@@ -33,7 +34,7 @@ vi.mock('../../integration/helpers/mcp-test-client.js', () => {
         },
         clearCache: vi.fn().mockResolvedValue(undefined),
         stop: stopMock,
-        thoroughCleanup: vi.fn().mockResolvedValue(undefined),
+        thoroughCleanup: thoroughCleanupMock,
         callTool: callToolMock,
       };
       return instance;
@@ -44,16 +45,18 @@ vi.mock('../../integration/helpers/mcp-test-client.js', () => {
 // OMN-261 review: the shared-server state lives on a globalThis-keyed slot
 // (see global-singleton.ts) specifically so it survives vitest's per-file
 // module reset — which means it does NOT reset between tests in THIS file
-// on its own. Clear it manually so each test starts fresh.
-const SHARED_SERVER_STATE_SLOT = 'shared-server-state';
-
+// on its own. Clear it manually so each test starts fresh. Import the slot
+// key from the module under test rather than re-typing the literal, so a
+// rename can't silently make clearGlobalSlot a no-op.
 describe('getSharedClient init-failure recovery', () => {
   beforeEach(async () => {
     vi.resetModules();
     startServerMock.mockReset();
     stopMock.mockReset().mockResolvedValue(undefined);
+    thoroughCleanupMock.mockReset().mockResolvedValue(undefined);
     callToolMock.mockReset().mockImplementation(defaultCallToolImpl);
     const { clearGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
+    const { SHARED_SERVER_STATE_SLOT } = await import('../../integration/helpers/shared-server.js');
     clearGlobalSlot(SHARED_SERVER_STATE_SLOT);
   });
 
@@ -140,5 +143,76 @@ describe('getSharedClient init-failure recovery', () => {
 
     expect(clientB).toBe(clientA);
     expect(startServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a second call that arrives during the warmup window does not reuse the not-yet-warmed client', async () => {
+    startServerMock.mockResolvedValue(undefined);
+    // Block warmupOmniFocus's phase-1 read so the FIRST init parks in the
+    // startServer-resolved-but-warmup-pending state. resolveRead being set is
+    // our signal that we've reached that window.
+    let resolveRead: (() => void) | undefined;
+    callToolMock.mockImplementation((tool: string, args: unknown) => {
+      if (tool === 'omnifocus_read') {
+        return new Promise((resolve) => {
+          resolveRead = () => resolve({ success: true, data: { tasks: [] } });
+        });
+      }
+      return defaultCallToolImpl(tool, args);
+    });
+
+    const { getSharedClient } = await import('../../integration/helpers/shared-server.js');
+
+    const first = getSharedClient();
+
+    // Wait until the first init has actually reached the warmup window
+    // (startServer resolved, phase-1 read pending). The SECOND call must
+    // arrive HERE — not synchronously before startServer resolves — for this
+    // to exercise the window: publishing state.client before warmup lets this
+    // late arrival take the `if (state.client)` reuse fast-path.
+    while (!resolveRead) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    let secondResolved = false;
+    const second = getSharedClient().then((client) => {
+      secondResolved = true;
+      return client;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    // Fixed: state.client is still null through warmup, so `second` is parked
+    // on initPromise. Buggy: `second` reused the un-warmed client and already
+    // resolved.
+    expect(secondResolved).toBe(false);
+
+    resolveRead();
+    const [clientA, clientB] = await Promise.all([first, second]);
+
+    expect(clientB).toBe(clientA);
+    expect(startServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shutdownSharedClient thoroughCleanup()s then stop()s the live client and resets state for the next run', async () => {
+    startServerMock.mockResolvedValue(undefined);
+    const mod = await import('../../integration/helpers/shared-server.js');
+
+    const client = await mod.getSharedClient();
+    expect(client).toBeDefined();
+
+    await mod.shutdownSharedClient();
+
+    // ID-based cleanup runs BEFORE the process is stopped, and state is reset
+    // so a subsequent getSharedClient() starts a fresh server.
+    expect(thoroughCleanupMock).toHaveBeenCalledTimes(1);
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(() => mod.getSharedClientSync()).toThrow(/not initialized/i);
+  });
+
+  it('shutdownSharedClient is a no-op when no shared client is active', async () => {
+    const mod = await import('../../integration/helpers/shared-server.js');
+
+    await expect(mod.shutdownSharedClient()).resolves.toBeUndefined();
+    expect(thoroughCleanupMock).not.toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/integration-helpers/shared-server-init-failure.test.ts
+++ b/tests/unit/integration-helpers/shared-server-init-failure.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const startServerMock = vi.fn();
+
+vi.mock('../../integration/helpers/mcp-test-client.js', () => {
+  return {
+    MCPTestClient: vi.fn().mockImplementation(() => ({
+      pid: 1234,
+      startServer: startServerMock,
+      clearCache: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      thoroughCleanup: vi.fn().mockResolvedValue(undefined),
+      callTool: vi.fn().mockImplementation((tool: string, args: unknown) => {
+        if (tool === 'omnifocus_read') {
+          return { success: true, data: { tasks: [] } };
+        }
+        if (tool === 'omnifocus_write') {
+          const operation = (args as { mutation?: { operation?: string } })?.mutation?.operation;
+          if (operation === 'create') {
+            return { success: true, data: { task: { taskId: 'mock-task-id' } } };
+          }
+          return { success: true, data: {} };
+        }
+        return { success: true, data: {} };
+      }),
+    })),
+  };
+});
+
+// OMN-261 review: the shared-server state lives on a globalThis-keyed slot
+// (see global-singleton.ts) specifically so it survives vitest's per-file
+// module reset — which means it does NOT reset between tests in THIS file
+// on its own. Clear it manually so each test starts fresh.
+const SHARED_SERVER_STATE_KEY = Symbol.for('omnifocus-mcp:shared-server-state');
+
+describe('getSharedClient init-failure recovery', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    startServerMock.mockReset();
+    delete (globalThis as unknown as Record<symbol, unknown>)[SHARED_SERVER_STATE_KEY];
+  });
+
+  it('resets shared state after an init failure so the next call retries fresh instead of inheriting the broken client forever', async () => {
+    startServerMock.mockRejectedValueOnce(new Error('cold OmniFocus, simulated failure'));
+    startServerMock.mockResolvedValue(undefined);
+
+    const { getSharedClient } = await import('../../integration/helpers/shared-server.js');
+
+    await expect(getSharedClient()).rejects.toThrow('cold OmniFocus, simulated failure');
+
+    // Before the fix, the first call's broken client/rejected promise would
+    // be permanently stuck in the shared globalThis state, and this second
+    // call would immediately return/reject with the SAME broken state
+    // instead of attempting a fresh init.
+    const client = await getSharedClient();
+    expect(client).toBeDefined();
+    expect(startServerMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -51,23 +51,57 @@ describe('killOrphanedSharedServer', () => {
     expect(existsSync(pidFilePath)).toBe(false);
   });
 
-  it('warns instead of hanging when the PID outlives the reap timeout', async () => {
+  it('escalates to SIGKILL when SIGTERM does not land within the reap timeout', async () => {
     const fs = await import('fs');
     fs.writeFileSync(pidFilePath, '4242', 'utf-8');
     const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
+      const killed: string[] = [];
+      let alive = true;
       await killOrphanedSharedServer({
         pidFilePath,
-        isPidAlive: () => true, // never reports dead
-        kill: () => {},
+        // survives SIGTERM, dies on SIGKILL
+        isPidAlive: () => alive,
+        kill: (_pid, signal) => {
+          killed.push(signal);
+          if (signal === 'SIGKILL') alive = false;
+        },
         reapTimeoutMs: 30,
+        sigkillReapTimeoutMs: 30,
         reapPollIntervalMs: 5,
       });
 
+      expect(killed).toEqual(['SIGTERM', 'SIGKILL']);
+      // it actually died on SIGKILL, so no leftover warning
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns instead of hanging when the PID survives even SIGKILL', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const killed: string[] = [];
+      await killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true, // never reports dead, even after SIGKILL
+        kill: (_pid, signal) => killed.push(signal),
+        reapTimeoutMs: 30,
+        sigkillReapTimeoutMs: 30,
+        reapPollIntervalMs: 5,
+      });
+
+      expect(killed).toEqual(['SIGTERM', 'SIGKILL']);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
+      expect(String(warnSpy.mock.calls[0][0])).toContain('SIGKILL');
     } finally {
       warnSpy.mockRestore();
     }

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, chmodSync, rmSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -59,5 +59,55 @@ describe('killOrphanedSharedServer', () => {
     });
 
     expect(existsSync(pidFilePath)).toBe(false);
+  });
+});
+
+describe('recordSharedServerPid', () => {
+  let dir: string;
+  let readonlyParent: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'omn261-pidfile-write-'));
+    readonlyParent = join(dir, 'readonly');
+    mkdirSync(readonlyParent);
+    chmodSync(readonlyParent, 0o555); // read + execute, no write — blocks creating new entries
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    chmodSync(readonlyParent, 0o755); // restore so rmSync can clean up
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('warns loudly instead of silently swallowing a write failure', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(readonlyParent, 'nested', 'shared-server.pid');
+
+    expect(() => recordSharedServerPid(4242, pidFilePath)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
+  });
+
+  it('writes the PID file successfully when the path is writable', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(dir, 'shared-server.pid');
+
+    recordSharedServerPid(4242, pidFilePath);
+
+    expect(existsSync(pidFilePath)).toBe(true);
+    expect(readFileSync(pidFilePath, 'utf-8')).toBe('4242');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when pid is undefined', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(dir, 'shared-server.pid');
+
+    recordSharedServerPid(undefined, pidFilePath);
+
+    expect(existsSync(pidFilePath)).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('killOrphanedSharedServer', () => {
+  let dir: string;
+  let pidFilePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'omn261-pidfile-'));
+    pidFilePath = join(dir, 'shared-server.pid');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('does nothing when no PID file exists', async () => {
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    expect(() =>
+      killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true,
+        kill: () => {
+          throw new Error('should not be called');
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('sends SIGTERM to a live PID and removes the file', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    const killed: Array<{ pid: number; signal: string }> = [];
+    killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: (pid) => pid === 4242,
+      kill: (pid, signal) => killed.push({ pid, signal }),
+    });
+
+    expect(killed).toEqual([{ pid: 4242, signal: 'SIGTERM' }]);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  it('removes the file but does not kill when the recorded PID is no longer alive', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => false,
+      kill: () => {
+        throw new Error('should not be called');
+      },
+    });
+
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+});

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -18,7 +18,7 @@ describe('killOrphanedSharedServer', () => {
 
   it('does nothing when no PID file exists', async () => {
     const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
-    expect(() =>
+    await expect(
       killOrphanedSharedServer({
         pidFilePath,
         isPidAlive: () => true,
@@ -26,23 +26,74 @@ describe('killOrphanedSharedServer', () => {
           throw new Error('should not be called');
         },
       }),
-    ).not.toThrow();
+    ).resolves.not.toThrow();
   });
 
-  it('sends SIGTERM to a live PID and removes the file', async () => {
+  it('sends SIGTERM to a live PID, removes the file, and polls until it reports dead', async () => {
     const fs = await import('fs');
     fs.writeFileSync(pidFilePath, '4242', 'utf-8');
     const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
 
     const killed: Array<{ pid: number; signal: string }> = [];
-    killOrphanedSharedServer({
+    let alive = true;
+    await killOrphanedSharedServer({
       pidFilePath,
-      isPidAlive: (pid) => pid === 4242,
-      kill: (pid, signal) => killed.push({ pid, signal }),
+      isPidAlive: (pid) => pid === 4242 && alive,
+      kill: (pid, signal) => {
+        killed.push({ pid, signal });
+        alive = false; // simulate the process dying right after SIGTERM
+      },
+      reapTimeoutMs: 200,
+      reapPollIntervalMs: 5,
     });
 
     expect(killed).toEqual([{ pid: 4242, signal: 'SIGTERM' }]);
     expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  it('warns instead of hanging when the PID outlives the reap timeout', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true, // never reports dead
+        kill: () => {},
+        reapTimeoutMs: 30,
+        reapPollIntervalMs: 5,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('waitForExit: false sends SIGTERM and returns immediately without polling or warning', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const killed: Array<{ pid: number; signal: string }> = [];
+      await killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true, // stays "alive" throughout — would trigger the timeout warning if polled
+        kill: (pid, signal) => killed.push({ pid, signal }),
+        waitForExit: false,
+        reapTimeoutMs: 60_000, // would make the test hang if the poll ran anyway
+      });
+
+      expect(killed).toEqual([{ pid: 4242, signal: 'SIGTERM' }]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('removes the file but does not kill when the recorded PID is no longer alive', async () => {
@@ -50,7 +101,7 @@ describe('killOrphanedSharedServer', () => {
     fs.writeFileSync(pidFilePath, '4242', 'utf-8');
     const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
 
-    killOrphanedSharedServer({
+    await killOrphanedSharedServer({
       pidFilePath,
       isPidAlive: () => false,
       kill: () => {


### PR DESCRIPTION
## Summary
- Root cause: vitest's default `isolate:true` (forks pool) resets shared-server.ts's module-scope singleton on every test file, even under `singleFork:true` (one process, many fresh module registries) — so 13 of 17 `getSharedClient()` calls spawned a fresh MCP server instead of reusing one, and the file's own docstring's "one server per run" design never actually worked.
- Fix: move the singleton state onto a `globalThis`-keyed slot (survives the per-file reset); shutdown is a PID-file kill (`killOrphanedSharedServer`, mirroring the OMN-143 lock pattern) called from `globalTeardown` — investigation confirmed a `process.once('beforeExit', ...)` hook realistically never fires under a real `vitest --run` (tinypool SIGTERMs the worker externally with no in-worker handler registered outside Node's profiling flags), so that hook was removed as confirmed dead code rather than kept as speculative defense-in-depth.
- Zero test-file edits — same invariant OMN-186 held to.
- New permanent regression-pinning test (`tests/integration/_diagnostics/module-isolation-probe-*`) proves the vitest isolation behavior this fix depends on, against the real integration-suite config.

## Code-review fixes (2026-07-12)
`/code-review high` surfaced 6 verified findings; all fixed in this PR rather than deferred:
- Init-failure cascade: a cold-OmniFocus failure in file 1 used to permanently poison the shared client for the rest of the run — now resets state so the next file retries fresh.
- Silent PID-file write failure now `console.warn`s instead of being swallowed (it could silently defeat the whole shutdown mechanism).
- `src/index.ts`'s stdio-mode server registered no SIGTERM/SIGINT handler at all (only HTTP mode did) — added, routed through the same graceful drain path stdin-close/EPIPE already use.
- Removed the confirmed-dead `beforeExit` hook (see Summary above).
- Converted `fixture-profiler.ts`'s `warnedWriteFailure`/`logDirEnsured` off module-scope `let` — an unconverted instance of the exact same isolation bug this PR fixes elsewhere.

Two remaining findings need more design work than a same-session fix warrants — deferred to **OMN-263** (PID-reuse identity verification, shared gap with the pre-existing OMN-143 lock) and **OMN-264** (`shutdownSharedClient()` now has no automatic caller — open question on wiring it in vs. retiring it).

## Test plan
- [x] `npm run test:unit` green (170 files / 3819 tests, via pre-push hook)
- [x] Supervised `FIXTURE_PROFILE=1` full-suite run: `getSharedClient.init` 13→1, `getSharedClient.reuse` 4→16, zero orphaned `dist/index.js` processes, 202/202 tests passing (0 failures) — see `tests/integration/PERFORMANCE.md` for full numbers, including one earlier same-day run whose single isolated failure was traced to an OmniFocus app crash mid-run, not a regression (reproduced clean on both an isolated single-file rerun and a full clean suite rerun)
- [x] Every review-fix commit verified red-green individually (temporarily reverted, confirmed the new/existing test fails, restored, confirmed green)
- [ ] Kip's `/code-review` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
