### PR TITLE
fix(OMN-264): remove shutdownSharedClient() as provably redundant dead code

### DIFF
--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -182,8 +182,13 @@ run, in case a crashed prior run left its server alive. An earlier design also r
 `process.once('beforeExit', ...)` hook inside the worker fork as a second layer, but investigation found it
 realistically never fires under a real `vitest --run` (tinypool's `ProcessWorker.terminate()` SIGTERMs the worker
 externally, no in-worker signal handler registered outside Node's own profiling flags) — it was removed as confirmed
-dead code (`/code-review high` finding, 2026-07-12). `shutdownSharedClient()`'s graceful, ID-based cleanup
-(`thoroughCleanup()`) is kept as a tested, reusable unit but currently has no automatic caller — tracked in OMN-264.
+dead code (`/code-review high` finding, 2026-07-12). This orphaned `shutdownSharedClient()` (its ID-based graceful
+cleanup via `thoroughCleanup()`), which was then removed too (OMN-264, 2026-07-12): `thoroughCleanup()` only
+bulk-deletes the client's own tracked task/project IDs and explicitly skips tag cleanup for performance, while
+`teardown()` already unconditionally runs `fullCleanup({scope:'full'})` + `scanForFixtures()` — a whole-DB,
+prefix/location-based sweep — before `killOrphanedSharedServer` is even called. That sweep catches everything the
+ID-based cleanup would have (plus tags and escaped orphans) regardless of whether the shared client's own tracking
+arrays were ever drained, so the removed function was provably redundant rather than merely unwired.
 
 **Call-count delta:**
 
@@ -205,9 +210,10 @@ figure, and is called out as such rather than presented as data.
   passed 9/9 clean, and the subsequent full clean re-run passed 202/202.)
 - Zero orphaned `dist/index.js` processes: before/after `pgrep -fl 'dist/index.js'` snapshots were byte-identical across
   every run.
-- `shutdownSharedClient` shows zero entries in `fixture-profile.jsonl` in every run — expected, since it currently has
-  no automatic caller (see above). The PID-file path is invisible to this profiler (it runs from a different process)
-  but is confirmed working by the zero-orphan-process result.
+- `shutdownSharedClient` showed zero entries in `fixture-profile.jsonl` in every run at the time of this verification —
+  expected, since it had no automatic caller (see above); it was subsequently removed (OMN-264). The PID-file path is
+  invisible to this profiler (it runs from a different process) but is confirmed working by the zero-orphan-process
+  result.
 - As with OMN-186, raw suite wall is not the tracked metric here — this is a correctness/resource-leak fix (spawning 13
   servers instead of 1 wasted OS processes and OmniFocus warm-up time, but the suite was already fixture-noise-dominated
   per the TL;DR above, so wall-clock delta is not a reliable signal for this change either).

--- a/tests/integration/PERFORMANCE.md
+++ b/tests/integration/PERFORMANCE.md
@@ -182,12 +182,12 @@ run, in case a crashed prior run left its server alive. An earlier design also r
 `process.once('beforeExit', ...)` hook inside the worker fork as a second layer, but investigation found it
 realistically never fires under a real `vitest --run` (tinypool's `ProcessWorker.terminate()` SIGTERMs the worker
 externally, no in-worker signal handler registered outside Node's own profiling flags) — it was removed as confirmed
-dead code (`/code-review high` finding, 2026-07-12). This orphaned `shutdownSharedClient()` (its ID-based graceful
-cleanup via `thoroughCleanup()`), which was then removed too (OMN-264, 2026-07-12): `thoroughCleanup()` only
-bulk-deletes the client's own tracked task/project IDs and explicitly skips tag cleanup for performance, while
-`teardown()` already unconditionally runs `fullCleanup({scope:'full'})` + `scanForFixtures()` — a whole-DB,
-prefix/location-based sweep — before `killOrphanedSharedServer` is even called. That sweep catches everything the
-ID-based cleanup would have (plus tags and escaped orphans) regardless of whether the shared client's own tracking
+dead code (`/code-review high` finding, 2026-07-12). Removing that hook orphaned `shutdownSharedClient()` (its ID-based
+graceful cleanup via `thoroughCleanup()`) — that function was then removed too (OMN-264, 2026-07-12).
+`thoroughCleanup()` only bulk-deletes the client's own tracked task/project IDs and explicitly skips tag cleanup for
+performance, while `teardown()` already unconditionally runs `fullCleanup({scope:'full'})` + `scanForFixtures()` — a
+whole-DB, prefix/location-based sweep — before `killOrphanedSharedServer` is even called. That sweep catches everything
+the ID-based cleanup would have (plus tags and escaped orphans) regardless of whether the shared client's own tracking
 arrays were ever drained, so the removed function was provably redundant rather than merely unwired.
 
 **Call-count delta:**

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -65,6 +65,28 @@ const SIGKILL_REAP_TIMEOUT_MS = 2000;
  * server (e.g. globalTeardown) — see Task 3b for why no hook registered
  * inside the vitest worker fork process can be relied on here.
  *
+ * OMN-264: this SIGTERM is the ONLY shutdown path — there is deliberately no
+ * in-process graceful drain (an earlier `shutdownSharedClient()`, ID-based
+ * bulk-delete via `thoroughCleanup()`, was removed). It's provably redundant:
+ * `thoroughCleanup()` only bulk-deletes the client's own tracked
+ * task/project IDs (it explicitly skips tag cleanup for performance), while
+ * `setup-integration.ts`'s `teardown()` unconditionally runs
+ * `fullCleanup({scope:'full'})` + `scanForFixtures()` before this function is
+ * even called — a whole-DB, prefix/location-based sweep (`__TEST__` tasks,
+ * sandbox-folder projects, `__test-` tags, orphan escapees) that requires no
+ * knowledge of which IDs the shared client created, so it catches everything
+ * ID-based cleanup would have and more (orphans, tags). Since the shared
+ * client only ever needs draining once per run anyway, wiring the ID-based
+ * path back in would only add a second, strictly weaker sweep at the same
+ * point in the run — not a safety improvement.
+ *
+ * By default, polls after sending SIGTERM so callers can rely on the orphan
+ * actually being gone (or log a warning that it wasn't) before touching
+ * OmniFocus themselves — a fire-and-forget kill left a window where both the
+ * dying orphan and the caller's own cleanup sweep could drive OmniFocus at
+ * once. This matters for setup()'s startup sweep, which runs fullCleanup()
+ * right after.
+ *
  * By default, polls after sending SIGTERM so callers can rely on the orphan
  * actually being gone (or log a warning that it wasn't) before touching
  * OmniFocus themselves — a fire-and-forget kill left a window where both the
@@ -400,44 +422,6 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
   })();
 
   return state.initPromise;
-}
-
-/**
- * Gracefully shut down the shared server: drains via thoroughCleanup() (an
- * ID-based bulk delete of everything this client created) then stops the
- * process.
- *
- * OMN-261 review: this function currently has NO automatic caller. It used
- * to be wired to a `process.once('beforeExit', ...)` hook, but that hook was
- * removed after investigation confirmed it realistically never fires under
- * a real `vitest --run` (Vitest's forks-pool teardown is an external
- * SIGTERM/SIGKILL from tinypool with no in-worker signal handler registered
- * outside Node's profiling flags — see git history for the investigation).
- * The actual load-bearing cleanup path is killOrphanedSharedServer() below,
- * called from globalTeardown — but that runs in a SEPARATE OS process from
- * the one holding `state.client`, so it can only send a blunt SIGTERM, not
- * invoke this function's graceful ID-based cleanup. Whether/how to wire
- * graceful cleanup back in (e.g. from the last test file's own afterAll) is
- * tracked in OMN-264 — kept here as a reusable unit rather than deleted
- * outright, since fullCleanup()'s prefix-based scan is a coarser safety net,
- * not a replacement for ID-based cleanup. It is covered by
- * shared-server-init-failure.test.ts ('shutdownSharedClient …') so it can't
- * bit-rot silently while it waits for a caller.
- */
-export async function shutdownSharedClient(): Promise<void> {
-  // OMN-186: profiled when FIXTURE_PROFILE=1, for whenever this is invoked.
-  return profileFixture('globalTeardown', 'shutdownSharedClient', async () => {
-    const state = getState();
-    if (state.client) {
-      console.log('🧹 Shutting down shared MCP server...');
-      await state.client.thoroughCleanup();
-      await state.client.stop();
-      state.client = null;
-      state.initPromise = null;
-      state.isFirstAccess = true; // Reset for next test run
-      console.log('✅ Shared MCP server shutdown complete');
-    }
-  });
 }
 
 /**

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -87,13 +87,6 @@ const SIGKILL_REAP_TIMEOUT_MS = 2000;
  * once. This matters for setup()'s startup sweep, which runs fullCleanup()
  * right after.
  *
- * By default, polls after sending SIGTERM so callers can rely on the orphan
- * actually being gone (or log a warning that it wasn't) before touching
- * OmniFocus themselves — a fire-and-forget kill left a window where both the
- * dying orphan and the caller's own cleanup sweep could drive OmniFocus at
- * once. This matters for setup()'s startup sweep, which runs fullCleanup()
- * right after.
- *
  * When waiting, this escalates SIGTERM → SIGKILL if the process outlives
  * REAP_TIMEOUT_MS, matching the SIGTERM+SIGKILL bound the transport.close()
  * path had before this PID-file mechanism replaced it.

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -172,8 +172,9 @@ export async function teardown() {
   // OMN-261: the worker fork that owns the shared client gets zero JS-level
   // teardown opportunity under Vitest's forks-pool teardown (an external
   // SIGTERM/SIGKILL from tinypool, no in-worker signal handler for
-  // non-profiling runs — see shared-server.ts's shutdownSharedClient
-  // docstring). This PID-file kill runs from THIS process instead, which
+  // non-profiling runs — see killOrphanedSharedServer's docstring, including
+  // its OMN-264 note on why there's no in-process graceful drain either).
+  // This PID-file kill runs from THIS process instead, which
   // always executes regardless of how the worker fork itself was torn down.
   // `waitForExit: false`: nothing OmniFocus-related follows this call
   // (teardown is nearly done), so there's no race to protect against — and

--- a/tests/unit/integration-helpers/shared-server-init-failure.test.ts
+++ b/tests/unit/integration-helpers/shared-server-init-failure.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const startServerMock = vi.fn();
 const stopMock = vi.fn();
-const thoroughCleanupMock = vi.fn();
 const defaultCallToolImpl = (tool: string, args: unknown) => {
   if (tool === 'omnifocus_read') {
     return { success: true, data: { tasks: [] } };
@@ -34,7 +33,6 @@ vi.mock('../../integration/helpers/mcp-test-client.js', () => {
         },
         clearCache: vi.fn().mockResolvedValue(undefined),
         stop: stopMock,
-        thoroughCleanup: thoroughCleanupMock,
         callTool: callToolMock,
       };
       return instance;
@@ -53,7 +51,6 @@ describe('getSharedClient init-failure recovery', () => {
     vi.resetModules();
     startServerMock.mockReset();
     stopMock.mockReset().mockResolvedValue(undefined);
-    thoroughCleanupMock.mockReset().mockResolvedValue(undefined);
     callToolMock.mockReset().mockImplementation(defaultCallToolImpl);
     const { clearGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
     const { SHARED_SERVER_STATE_SLOT } = await import('../../integration/helpers/shared-server.js');
@@ -190,29 +187,5 @@ describe('getSharedClient init-failure recovery', () => {
 
     expect(clientB).toBe(clientA);
     expect(startServerMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('shutdownSharedClient thoroughCleanup()s then stop()s the live client and resets state for the next run', async () => {
-    startServerMock.mockResolvedValue(undefined);
-    const mod = await import('../../integration/helpers/shared-server.js');
-
-    const client = await mod.getSharedClient();
-    expect(client).toBeDefined();
-
-    await mod.shutdownSharedClient();
-
-    // ID-based cleanup runs BEFORE the process is stopped, and state is reset
-    // so a subsequent getSharedClient() starts a fresh server.
-    expect(thoroughCleanupMock).toHaveBeenCalledTimes(1);
-    expect(stopMock).toHaveBeenCalledTimes(1);
-    expect(() => mod.getSharedClientSync()).toThrow(/not initialized/i);
-  });
-
-  it('shutdownSharedClient is a no-op when no shared client is active', async () => {
-    const mod = await import('../../integration/helpers/shared-server.js');
-
-    await expect(mod.shutdownSharedClient()).resolves.toBeUndefined();
-    expect(thoroughCleanupMock).not.toHaveBeenCalled();
-    expect(stopMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- OMN-261's code review orphaned `shutdownSharedClient()` (its `process.once('beforeExit', ...)` caller was removed as confirmed-dead code). OMN-264 asked: wire it into a real trigger, or remove it?
- **Decision: remove it.** `thoroughCleanup()`/`shutdownSharedClient()` only bulk-deletes the shared client's own tracked task/project IDs and explicitly skips tag cleanup for performance. `setup-integration.ts`'s `teardown()` already unconditionally runs `fullCleanup({scope:'full'})` + `scanForFixtures()` — a whole-DB, prefix/location-based sweep (`__TEST__` tasks, sandbox-folder projects, `__test-` tags, orphan escapees) — *before* `killOrphanedSharedServer`'s PID-file SIGTERM is even sent. That sweep needs no knowledge of which IDs the shared client created, so it catches everything the ID-based cleanup would have, plus tags and escaped orphans it explicitly didn't cover.
- Wiring `shutdownSharedClient()` into a real in-process trigger (the ticket's other investigated option) would only add a second, strictly weaker sweep at the same point in the run — not a safety improvement — so removal is the correct outcome, not a rushed patch.

## Changes

- `tests/integration/helpers/shared-server.ts` — removed `shutdownSharedClient()`; added an OMN-264 note to `killOrphanedSharedServer`'s docstring explaining why the PID-file SIGTERM is the only shutdown path and why that's sufficient.
- `tests/unit/integration-helpers/shared-server-init-failure.test.ts` — removed the two tests covering the deleted function and its now-unused `thoroughCleanupMock`.
- `tests/support/setup-integration.ts` — updated a stale comment pointing at the removed function's docstring.
- `tests/integration/PERFORMANCE.md` — updated the OMN-261 section to record the OMN-264 resolution instead of "tracked in OMN-264."

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 171 files / 3829 tests passing (down from 3831 — the two removed tests), including re-run by the pre-push hook
- [x] `grep -rn "shutdownSharedClient"` — zero remaining call sites outside historical plan docs and the explanatory comments added here
- [ ] Full live `npm run test:integration` was **not** run for this change. The deletion is provably inert (no remaining callers anywhere in the codebase, confirmed by grep + a successful `tsc` build that would fail on a dangling reference), so I judged it low-risk to skip the ~17-minute live run — but flagging this explicitly per the project's "no silent gaps" norm. Happy to kick one off before merge if you'd like belt-and-suspenders confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)