### PR TITLE
fix(OMN-266): stop unit tests writing mock PID 1234 to the real machine-global shared-server.pid

### DIFF
--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -44,6 +44,22 @@ const SHARED_SERVER_PID_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'shared
 // Legacy fallback for a bare-PID file written by code predating this format:
 const LEGACY_SHARED_SERVER_COMMAND_SUBSTRING = 'dist/index.js';
 
+// OMN-266: unit tests exercise the REAL getSharedClientImpl() with a mocked
+// MCPTestClient (pid 1234); without an override, its recordSharedServerPid()
+// call writes that mock PID to the machine-global PID file above — clobbering
+// a genuine crashed-run's record (the file's whole point is surviving a crash
+// so the next run can reap the orphan). getSharedClient() takes no arguments,
+// so the path can't be threaded per-call like killOrphanedSharedServer's
+// opts.pidFilePath; a module-scope override is the seam instead. Deliberately
+// NOT in the globalThis state slot: vitest's per-file module reset returns
+// this to undefined (= the real path) automatically, so a test's override can
+// never leak into another file — the reset direction is safe here, unlike the
+// shared-state case documented at getState().
+let pidFilePathForTests: string | undefined;
+export function setSharedServerPidFilePathForTests(pidFilePath: string | undefined): void {
+  pidFilePathForTests = pidFilePath;
+}
+
 /** Second line of the PID file: the recorded spawn path, if present. */
 function parseRecordedCommand(raw: string): string | undefined {
   const newline = raw.indexOf('\n');
@@ -449,7 +465,10 @@ async function getSharedClientImpl(): Promise<MCPTestClient> {
     const client = new MCPTestClient({ enableCacheWarming: true });
     try {
       await client.startServer();
-      recordSharedServerPid(client.pid);
+      // undefined → recordSharedServerPid's default (the real machine-global
+      // path); only tests that called setSharedServerPidFilePathForTests
+      // divert it (OMN-266).
+      recordSharedServerPid(client.pid, pidFilePathForTests);
       console.log('🔥 Warming up OmniFocus (read + mutation paths)...');
       await warmupOmniFocus(client);
       console.log('✅ Shared MCP server ready (cache warmed, OmniFocus warmed)');

--- a/tests/unit/integration-helpers/shared-server-init-failure.test.ts
+++ b/tests/unit/integration-helpers/shared-server-init-failure.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
 
 const startServerMock = vi.fn();
 const stopMock = vi.fn();
@@ -47,14 +50,46 @@ vi.mock('../../integration/helpers/mcp-test-client.js', () => {
 // key from the module under test rather than re-typing the literal, so a
 // rename can't silently make clearGlobalSlot a no-op.
 describe('getSharedClient init-failure recovery', () => {
+  let tempDir: string;
+
   beforeEach(async () => {
     vi.resetModules();
     startServerMock.mockReset();
     stopMock.mockReset().mockResolvedValue(undefined);
     callToolMock.mockReset().mockImplementation(defaultCallToolImpl);
     const { clearGlobalSlot } = await import('../../integration/helpers/global-singleton.js');
-    const { SHARED_SERVER_STATE_SLOT } = await import('../../integration/helpers/shared-server.js');
+    const { SHARED_SERVER_STATE_SLOT, setSharedServerPidFilePathForTests } =
+      await import('../../integration/helpers/shared-server.js');
     clearGlobalSlot(SHARED_SERVER_STATE_SLOT);
+    // OMN-266: these tests run the REAL getSharedClientImpl(), whose
+    // recordSharedServerPid(client.pid) call writes the mocked PID (1234) to
+    // the machine-global ~/.omnifocus-mcp/shared-server.pid by default —
+    // clobbering a genuine crashed-run record every time the unit suite runs.
+    // Point the module at a per-test temp path. vi.resetModules() above
+    // re-creates the module (override back to undefined) each test, so the
+    // override must be re-applied here and can never leak past this file.
+    tempDir = mkdtempSync(join(tmpdir(), 'omn-266-shared-server-'));
+    setSharedServerPidFilePathForTests(join(tempDir, 'shared-server.pid'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('records the mocked PID to the injected path, never the real machine-global PID file (OMN-266)', async () => {
+    startServerMock.mockResolvedValue(undefined);
+    const realPidPath = join(homedir(), '.omnifocus-mcp', 'shared-server.pid');
+    const realBefore = existsSync(realPidPath) ? readFileSync(realPidPath, 'utf-8') : undefined;
+
+    const { getSharedClient } = await import('../../integration/helpers/shared-server.js');
+    await getSharedClient();
+
+    // The write landed at the injected path, in the OMN-263 two-line format.
+    expect(readFileSync(join(tempDir, 'shared-server.pid'), 'utf-8')).toMatch(/^1234\n/);
+    // And the real machine-global file is byte-identical (or still absent) —
+    // the ticket's acceptance criterion, checked read-only.
+    const realAfter = existsSync(realPidPath) ? readFileSync(realPidPath, 'utf-8') : undefined;
+    expect(realAfter).toBe(realBefore);
   });
 
   it('resets shared state after an init failure so the next call retries fresh instead of inheriting the broken client forever', async () => {


### PR DESCRIPTION
## What

The `shared-server-init-failure.test.ts` unit tests exercise the **real** `getSharedClientImpl()` with a mocked `MCPTestClient` whose `pid` is 1234 — and the impl's `recordSharedServerPid(client.pid)` call wrote that mock PID to the real machine-global `~/.omnifocus-mcp/shared-server.pid` on every `npm run test:unit` run, clobbering a genuine crashed-run record (the file's whole purpose is letting the next integration run rediscover an orphan). Observed live during OMN-263's post-merge shakeout.

## Approach

`getSharedClient()` takes no arguments, so the path can't be injected per-call the way `killOrphanedSharedServer`'s `opts.pidFilePath` and `recordSharedServerPid`'s positional param allow (the pattern `shared-server-pid-file.test.ts` uses). Instead: a module-scope `setSharedServerPidFilePathForTests()` override that the impl's record call respects, `undefined` meaning the real path.

Module scope is deliberate — the inverse of the OMN-261 globalThis-slot lesson documented in the same file: vitest's per-file module reset returns the override to `undefined` (the safe default) automatically, so a test's diversion can never leak into another file. The test file's `beforeEach` re-applies it after `vi.resetModules()`, pointing at a per-test temp dir.

## Verification (TDD, watched-it-fail)

- **Bug reproduced live first**: with the real PID file *absent*, one run of the unpatched test file left it containing `1234\n<worktree dist path>`.
- **Red**: new guard test (asserts the write lands at the injected path AND the real file is byte-identical/absent before-after) fails on the unpatched module.
- **Green**: full suite 172 files / 3,849 tests pass.
- **Acceptance criterion (from the ticket), verified at suite level**: `~/.omnifocus-mcp/shared-server.pid` absent before AND after a complete `npm run test:unit` run.

Closes OMN-266

🤖 Generated with [Claude Code](https://claude.com/claude-code)