### PR TITLE
feat(OMN-265): integration lock records holder start time for exact PID-reuse detection

### DIFF
--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -20,7 +20,12 @@ import { SERVER_PATH } from './server-path.js';
 import { TEST_INBOX_PREFIX, TEST_TAG_PREFIX } from './sandbox-manager.js';
 import { profileFixture } from './fixture-profiler.js';
 import { getGlobalSlot } from './global-singleton.js';
-import { pidIsAlive, parseLockPid, commandMatchesPid } from '../../support/integration-guard.js';
+import {
+  pidIsAlive,
+  parseLockPid,
+  parseRecordedSecondLine,
+  commandMatchesPid,
+} from '../../support/integration-guard.js';
 
 // OMN-261: mirrors the OMN-143 lock's PID-in-a-file pattern (integration-guard.ts's
 // DEFAULT_LOCK_PATH/pidIsAlive) — see Task 3b's rationale for why no in-process
@@ -60,13 +65,10 @@ export function setSharedServerPidFilePathForTests(pidFilePath: string | undefin
   pidFilePathForTests = pidFilePath;
 }
 
-/** Second line of the PID file: the recorded spawn path, if present. */
-function parseRecordedCommand(raw: string): string | undefined {
-  const newline = raw.indexOf('\n');
-  if (newline === -1) return undefined;
-  const recorded = raw.slice(newline + 1).trim();
-  return recorded.length > 0 ? recorded : undefined;
-}
+// Second line of the PID file — the recorded spawn path, if present — parsed
+// by the shared parseRecordedSecondLine (OMN-265 review: it was a
+// byte-identical private copy here; only the MEANING of the second line
+// differs between the two record files, not the parsing).
 
 export function recordSharedServerPid(
   pid: number | undefined,
@@ -238,7 +240,7 @@ export async function killOrphanedSharedServer(
   // pattern in integration-guard.ts's acquireIntegrationLock and
   // isIntegrationLockLive, whose unverifiable fallback points the OPPOSITE
   // way — refuse — see the NOTE there before unifying anything.)
-  if (verifyIdentity({ pid, recordedCommand: parseRecordedCommand(raw) }) === false) {
+  if (verifyIdentity({ pid, recordedCommand: parseRecordedSecondLine(raw) }) === false) {
     console.warn(
       `[shared-server] PID ${pid} from ${pidFilePath} is alive but its command line doesn't look like our ` +
         'spawned server (OMN-263 PID-reuse check) — skipping SIGTERM to avoid signaling an unrelated process.',

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -154,6 +154,16 @@ export function commandMatchesPid(
  * process is gone or `ps` fails, mirroring getProcessCommand above (same
  * timeout rationale: this can sit on setup/teardown's critical path and must
  * degrade to the documented fallback, not hang the run).
+ *
+ * The child env pins LC_ALL and TZ (/code-review finding on PR #222):
+ * lstart renders in the CALLING process's locale and timezone, not the
+ * target's — empirically, fr_FR renders 'lun. 13 juil. …' and TZ=UTC shifts
+ * the wall-clock digits for the SAME instant. Unpinned, a checker whose
+ * environment differs from the writer's (launchd job vs. interactive shell,
+ * SSH, CI) reads a different string for a LIVE holder, the exact comparison
+ * declares it stale, and the lock is stolen from a running suite — the
+ * dangerous direction this whole scheme must never err toward. Pinning makes
+ * the rendering a pure function of the process's start instant.
  */
 export function getProcessStartTime(pid: number): string | undefined {
   try {
@@ -161,6 +171,7 @@ export function getProcessStartTime(pid: number): string | undefined {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
+      env: { ...process.env, LC_ALL: 'C', TZ: 'UTC' },
     });
     const trimmed = out.trim();
     return trimmed.length > 0 ? trimmed : undefined;

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -80,15 +80,17 @@ export function parseLockPid(raw: string): number | undefined {
 }
 
 /**
- * OMN-265: second line of the lock file — the holder's recorded process start
- * time, if present. Undefined for a legacy bare-PID lock (written by code
- * predating the format) so callers degrade to the OMN-263 substring chain.
- * Same shape as shared-server.ts's parseRecordedCommand, whose PID file
- * records a spawn path instead (a path can't discriminate here: any
- * worktree's vitest is a legitimate lock holder — see the substring comment
- * above).
+ * Second line of a `<pid>\n<recorded value>` PID-record file, or undefined
+ * for a legacy bare-PID file (written by code predating the two-line format)
+ * so callers degrade to their pre-record fallback chain. Shared by both
+ * record-based identity schemes — the OMN-265 lock (second line = the
+ * holder's process start time; a spawn path can't discriminate here because
+ * any worktree's vitest is a legitimate holder) and shared-server.ts's
+ * OMN-263 PID file (second line = the recorded spawn path). What the value
+ * MEANS stays per-site; only the parsing is shared, so a fix to the
+ * newline/whitespace handling can't drift between the siblings.
  */
-function parseRecordedStartTime(raw: string): string | undefined {
+export function parseRecordedSecondLine(raw: string): string | undefined {
   const newline = raw.indexOf('\n');
   if (newline === -1) return undefined;
   const recorded = raw.slice(newline + 1).trim();
@@ -342,7 +344,7 @@ export function acquireIntegrationLock(
     // only costs a delay), but PROCEED with the kill in shared-server.ts
     // (an unnecessary skip risks a wedged orphan driving OmniFocus). Don't
     // unify them into one helper without preserving that per-site choice.
-    const identity = verifyIdentity({ pid: holder, recordedStartTime: parseRecordedStartTime(raw) });
+    const identity = verifyIdentity({ pid: holder, recordedStartTime: parseRecordedSecondLine(raw) });
     if (identity !== false) {
       return { acquired: false, holderPid: holder };
     }
@@ -407,7 +409,7 @@ export function isIntegrationLockLive(
   // shared-server.ts's killOrphanedSharedServer — see the NOTE in
   // acquireIntegrationLock above on why the three sites' unverifiable
   // fallbacks deliberately differ and must not be blindly unified.)
-  if (verifyIdentity({ pid: holder, recordedStartTime: parseRecordedStartTime(raw) }) === false) {
+  if (verifyIdentity({ pid: holder, recordedStartTime: parseRecordedSecondLine(raw) }) === false) {
     // Pass 4: warn like the siblings do — a confirmed mismatch here flips
     // fullCleanup from scoped to full mode, and doing that silently would
     // leave no trace of why cleanup scope changed if anyone ever debugs it.

--- a/tests/support/integration-guard.ts
+++ b/tests/support/integration-guard.ts
@@ -41,10 +41,14 @@ export const DEFAULT_LOCK_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'inte
 // direction: a stale lock whose PID the OS reused for some unrelated
 // vitest process (e.g. a unit run in another worktree) is falsely treated
 // as held, and the new run is refused with an error message that already
-// names the manual remedy. Closing that residual exactly — with no false
-// negatives — requires recording the holder's process START TIME in the
-// lock file and comparing it on check; that lock-format change is tracked
-// in OMN-265 rather than rushed into incident-history-bearing code here.
+// names the manual remedy.
+//
+// OMN-265: this substring is now the FALLBACK, not the primary check. The
+// lock records its writer's process start time (`<pid>\n<lstart>`), and a
+// readable live start time decides identity EXACTLY (PID + start time is
+// unique per boot — no false refusals, no false steals), so the substring is
+// consulted only for a legacy bare-PID lock file or when `ps` can't read the
+// live process's start time.
 const LOCK_HOLDER_COMMAND_SUBSTRING = 'vitest';
 
 export interface LockResult {
@@ -73,6 +77,22 @@ export function pidIsAlive(pid: number): boolean {
 export function parseLockPid(raw: string): number | undefined {
   const pid = Number.parseInt(raw, 10);
   return Number.isFinite(pid) && pid > 0 ? pid : undefined;
+}
+
+/**
+ * OMN-265: second line of the lock file — the holder's recorded process start
+ * time, if present. Undefined for a legacy bare-PID lock (written by code
+ * predating the format) so callers degrade to the OMN-263 substring chain.
+ * Same shape as shared-server.ts's parseRecordedCommand, whose PID file
+ * records a spawn path instead (a path can't discriminate here: any
+ * worktree's vitest is a legitimate lock holder — see the substring comment
+ * above).
+ */
+function parseRecordedStartTime(raw: string): string | undefined {
+  const newline = raw.indexOf('\n');
+  if (newline === -1) return undefined;
+  const recorded = raw.slice(newline + 1).trim();
+  return recorded.length > 0 ? recorded : undefined;
 }
 
 /**
@@ -127,6 +147,29 @@ export function commandMatchesPid(
 }
 
 /**
+ * OMN-265: reads a live process's start time via `ps -o lstart=` — constant
+ * for the process's whole lifetime and second-granular, so PID + start time
+ * identifies a process uniquely per boot (reusing a dead process's PID number
+ * within the same second is not a real interleaving). Undefined when the
+ * process is gone or `ps` fails, mirroring getProcessCommand above (same
+ * timeout rationale: this can sit on setup/teardown's critical path and must
+ * degrade to the documented fallback, not hang the run).
+ */
+export function getProcessStartTime(pid: number): string | undefined {
+  try {
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    });
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * OMN-263 code-review follow-up: the default `verifyPidIdentity` for
  * acquireIntegrationLock/isIntegrationLockLive. Two EXACT shortcuts run
  * before any `ps` shellout, matching the two processes that legitimately
@@ -158,30 +201,63 @@ export function commandMatchesPid(
  * later unrelated process such as `npm run test:cleanup`) pay for the real
  * command-line comparison.
  *
- * Known corner (OMN-263 review pass 5, accepted): if a crashed holder's PID
- * is later reused as THIS process's own pid, the self-PID shortcut confirms
- * a lock this process never wrote, and acquire refuses against a phantom
- * holder. That outcome is IDENTICAL under pre-OMN-263 bare liveness (self
- * is alive) and under the command-substring fallback (this process is
- * itself vitest) — it's an inherent limit of liveness/command-based
- * identity, not a regression of this shortcut, it fails in the safe
- * direction (refuse, with the error message naming the manual remedy), and
- * only OMN-265's recorded-start-time comparison can close it.
+ * OMN-265: after the fast paths, a recorded start time in the lock file
+ * (see acquireIntegrationLock's write) decides identity EXACTLY when the
+ * live process's start time is readable: match → this IS the writer
+ * (confirmed holder, no substring needed — a live holder from any sibling
+ * worktree matches its own record, so no false steals), mismatch → the PID
+ * number was reused after the writer died (confirmed stale — even when the
+ * squatter is itself some vitest process, the case the substring
+ * false-refused). Unreadable start time or a legacy bare-PID lock falls
+ * back to the OMN-263 substring chain unchanged.
  *
- * Exported, with an injectable `commandMatches` fallback, for the
- * fast-path regression tests: review pass 4 proved the earlier mock-based
- * test file couldn't detect removal of these shortcuts (its child_process
- * mock never intercepted this module's import, and the real-`ps` fallback
- * returned identical outcomes). A test injecting a THROWING fallback and
- * calling this function directly fails loudly the moment a fast path stops
- * short-circuiting — no module-mock interception required.
+ * Known corner (OMN-263 review pass 5; still open post-OMN-265, accepted):
+ * if a crashed holder's PID is later reused as THIS process's own pid (or
+ * its parent's), the fast paths confirm a lock this process never wrote
+ * BEFORE the start-time comparison runs, and acquire refuses against a
+ * phantom holder. That outcome is IDENTICAL under pre-OMN-263 bare liveness
+ * and under the command-substring fallback — an inherent limit of the fast
+ * paths, kept because they are what hold the hot per-file teardown path to
+ * two integer compares with zero shellouts (reordering the start-time
+ * comparison ahead of them would put a `ps` call on every per-file check).
+ * It fails in the safe direction (refuse, with the error message naming
+ * the manual remedy) and needs two PID-reuse coincidences landing on this
+ * very run's own/parent pid.
+ *
+ * The check parameter is a single OBJECT (same rationale as
+ * killOrphanedSharedServer's verifyPidIdentity, pass 5): a positional
+ * `(pid, recordedStartTime)` signature would let a 1-arg verifier copied
+ * from elsewhere structurally typecheck while silently dropping the
+ * start-time comparison. The property is named recordedStartTime — not
+ * shared-server's recordedCommand — so cross-module copy-paste of the
+ * OTHER sibling's verifier is also a hard type error, not a silent
+ * behavior change.
+ *
+ * Exported, with injectable `commandMatches`/`getStartTime` fallbacks, for
+ * the fast-path regression tests: review pass 4 proved the earlier
+ * mock-based test file couldn't detect removal of these shortcuts (its
+ * child_process mock never intercepted this module's import, and the
+ * real-`ps` fallback returned identical outcomes). A test injecting a
+ * THROWING fallback and calling this function directly fails loudly the
+ * moment a fast path stops short-circuiting — no module-mock interception
+ * required.
  */
 export function verifyLockHolderIdentity(
-  holderPid: number,
-  opts: { commandMatches?: (pid: number) => boolean | undefined } = {},
+  check: { pid: number; recordedStartTime: string | undefined },
+  opts: {
+    commandMatches?: (pid: number) => boolean | undefined;
+    getStartTime?: (pid: number) => string | undefined;
+  } = {},
 ): boolean | undefined {
+  const holderPid = check.pid;
   if (holderPid === process.pid) return true;
   if (holderPid === process.ppid && holderPid !== 1) return true;
+  if (check.recordedStartTime !== undefined) {
+    const getStartTime = opts.getStartTime ?? getProcessStartTime;
+    const liveStartTime = getStartTime(holderPid);
+    if (liveStartTime !== undefined) return liveStartTime === check.recordedStartTime;
+    // Start time unreadable — fall through to the substring chain below.
+  }
   const commandMatches =
     opts.commandMatches ?? ((pid: number) => commandMatchesPid(pid, LOCK_HOLDER_COMMAND_SUBSTRING));
   return commandMatches(holderPid);
@@ -192,19 +268,31 @@ export function acquireIntegrationLock(
     lockPath?: string;
     pid?: number;
     isPidAlive?: (pid: number) => boolean;
-    verifyPidIdentity?: (pid: number) => boolean | undefined;
+    verifyPidIdentity?: (check: { pid: number; recordedStartTime: string | undefined }) => boolean | undefined;
+    /** OMN-265: reads the acquiring process's own start time for the lock record. */
+    getProcessStartTime?: (pid: number) => string | undefined;
   } = {},
 ): LockResult {
   const lockPath = opts.lockPath ?? DEFAULT_LOCK_PATH;
   const pid = opts.pid ?? process.pid;
   const isAlive = opts.isPidAlive ?? pidIsAlive;
   const verifyIdentity = opts.verifyPidIdentity ?? verifyLockHolderIdentity;
+  const readStartTime = opts.getProcessStartTime ?? getProcessStartTime;
+
+  // OMN-265: record our own start time next to the PID so a LATER process
+  // examining this lock can tell "this PID is still the writer" from "the OS
+  // reused the writer's PID number" exactly, instead of via the broad
+  // command substring. One `ps` shellout per acquire — once per run, off
+  // every hot path. Unreadable start time degrades to the legacy bare-PID
+  // format (checks then use the substring chain, exactly as pre-OMN-265).
+  const ownStartTime = readStartTime(pid);
+  const lockContents = ownStartTime !== undefined ? `${pid}\n${ownStartTime}` : String(pid);
 
   fs.mkdirSync(path.dirname(lockPath), { recursive: true });
 
   // Happy path: atomic create-exclusive. Anything but EEXIST is a real error.
   try {
-    fs.writeFileSync(lockPath, String(pid), { flag: 'wx' });
+    fs.writeFileSync(lockPath, lockContents, { flag: 'wx' });
     return { acquired: true };
   } catch (e) {
     if ((e as { code?: string }).code !== 'EEXIST') throw e;
@@ -218,7 +306,7 @@ export function acquireIntegrationLock(
     // the atomic create once; a second EEXIST means a new holder won the race.
     if ((e as { code?: string }).code !== 'ENOENT') throw e;
     try {
-      fs.writeFileSync(lockPath, String(pid), { flag: 'wx' });
+      fs.writeFileSync(lockPath, lockContents, { flag: 'wx' });
       return { acquired: true };
     } catch (e2) {
       if ((e2 as { code?: string }).code !== 'EEXIST') throw e2;
@@ -243,13 +331,14 @@ export function acquireIntegrationLock(
     // only costs a delay), but PROCEED with the kill in shared-server.ts
     // (an unnecessary skip risks a wedged orphan driving OmniFocus). Don't
     // unify them into one helper without preserving that per-site choice.
-    const identity = verifyIdentity(holder);
+    const identity = verifyIdentity({ pid: holder, recordedStartTime: parseRecordedStartTime(raw) });
     if (identity !== false) {
       return { acquired: false, holderPid: holder };
     }
     console.warn(
-      `[Integration Guard] Lock at ${lockPath} names PID ${holder}, which is alive but its command line doesn't ` +
-        'look like a vitest process (OMN-263 PID-reuse check) — treating the lock as stale rather than trusting bare liveness.',
+      `[Integration Guard] Lock at ${lockPath} names PID ${holder}, which is alive but fails the identity check ` +
+        '(OMN-263/OMN-265 PID-reuse detection: recorded start time or command line does not match) — ' +
+        'treating the lock as stale rather than trusting bare liveness.',
     );
   }
 
@@ -265,7 +354,7 @@ export function acquireIntegrationLock(
     if ((e as { code?: string }).code !== 'ENOENT') throw e;
   }
   try {
-    fs.writeFileSync(lockPath, String(pid), { flag: 'wx' });
+    fs.writeFileSync(lockPath, lockContents, { flag: 'wx' });
   } catch (e) {
     if ((e as { code?: string }).code !== 'EEXIST') throw e;
     const winner = parseLockPid(fs.readFileSync(lockPath, 'utf8').trim());
@@ -286,7 +375,7 @@ export function isIntegrationLockLive(
   opts: {
     lockPath?: string;
     isPidAlive?: (pid: number) => boolean;
-    verifyPidIdentity?: (pid: number) => boolean | undefined;
+    verifyPidIdentity?: (check: { pid: number; recordedStartTime: string | undefined }) => boolean | undefined;
   } = {},
 ): boolean {
   const lockPath = opts.lockPath ?? DEFAULT_LOCK_PATH;
@@ -307,7 +396,7 @@ export function isIntegrationLockLive(
   // shared-server.ts's killOrphanedSharedServer — see the NOTE in
   // acquireIntegrationLock above on why the three sites' unverifiable
   // fallbacks deliberately differ and must not be blindly unified.)
-  if (verifyIdentity(holder) === false) {
+  if (verifyIdentity({ pid: holder, recordedStartTime: parseRecordedStartTime(raw) }) === false) {
     // Pass 4: warn like the siblings do — a confirmed mismatch here flips
     // fullCleanup from scoped to full mode, and doing that silently would
     // leave no trace of why cleanup scope changed if anyone ever debugs it.
@@ -323,6 +412,10 @@ export function isIntegrationLockLive(
 /**
  * Release ONLY if the lock still contains our PID — never delete a lock a
  * later run legitimately reclaimed (e.g. after we were SIGKILLed and restarted).
+ *
+ * OMN-265: compares the PARSED pid, not raw content — the lock now carries a
+ * second start-time line, so an exact string compare against the bare PID
+ * would never match and the owner could never release its own lock.
  */
 export function releaseIntegrationLock(
   opts: {
@@ -334,7 +427,7 @@ export function releaseIntegrationLock(
   const pid = opts.pid ?? process.pid;
   try {
     const raw = fs.readFileSync(lockPath, 'utf8').trim();
-    if (raw !== String(pid)) return false;
+    if (parseLockPid(raw) !== pid) return false;
     fs.unlinkSync(lockPath);
     return true;
   } catch {

--- a/tests/unit/support/integration-guard-self-pid.test.ts
+++ b/tests/unit/support/integration-guard-self-pid.test.ts
@@ -1,8 +1,11 @@
 // OMN-263: proves the self-PID / parent-PID fast paths in
-// verifyLockHolderIdentity short-circuit BEFORE any command-line lookup —
+// verifyLockHolderIdentity short-circuit BEFORE any process lookup —
 // these are what keep every per-file teardown (worker checking the vitest
 // main's lock via ppid) and the global setup/teardown sweeps (main checking
-// its own lock via pid) free of `ps` shellouts.
+// its own lock via pid) free of `ps` shellouts. OMN-265 added a recorded
+// start-time comparison AFTER the fast paths; the fast-path pins below now
+// forbid BOTH lookups (command line AND start time), so neither check can
+// silently creep onto the hot path.
 //
 // Review pass 4 found the previous version of this file NON-DISCRIMINATING:
 // it mocked 'child_process' module-wide, but the mock never intercepted
@@ -16,34 +19,113 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { verifyLockHolderIdentity } from '../../support/integration-guard.js';
 
-describe('verifyLockHolderIdentity fast paths (no command-line lookup for in-run checks)', () => {
-  const forbidden = vi.fn((): boolean | undefined => {
+describe('verifyLockHolderIdentity fast paths (no process lookups for in-run checks)', () => {
+  const forbiddenCommandMatches = vi.fn((): boolean | undefined => {
     throw new Error('command-line lookup must not run for the pid/ppid fast paths');
   });
+  const forbiddenGetStartTime = vi.fn((): string | undefined => {
+    throw new Error('start-time lookup must not run for the pid/ppid fast paths');
+  });
+  const forbidden = { commandMatches: forbiddenCommandMatches, getStartTime: forbiddenGetStartTime };
 
   beforeEach(() => {
-    forbidden.mockClear();
+    forbiddenCommandMatches.mockClear();
+    forbiddenGetStartTime.mockClear();
   });
 
   it('our own pid short-circuits true (vitest main examining the lock it wrote)', () => {
-    expect(verifyLockHolderIdentity(process.pid, { commandMatches: forbidden })).toBe(true);
-    expect(forbidden).not.toHaveBeenCalled();
+    expect(verifyLockHolderIdentity({ pid: process.pid, recordedStartTime: undefined }, forbidden)).toBe(true);
+    expect(forbiddenCommandMatches).not.toHaveBeenCalled();
+    expect(forbiddenGetStartTime).not.toHaveBeenCalled();
   });
 
   it("our parent's pid short-circuits true (forked worker examining the vitest main's lock)", () => {
     // This test process is itself a vitest fork worker, so process.ppid IS
     // the live worker→main relationship the fast path exists for — not a
     // simulation of it.
-    expect(verifyLockHolderIdentity(process.ppid, { commandMatches: forbidden })).toBe(true);
-    expect(forbidden).not.toHaveBeenCalled();
+    expect(verifyLockHolderIdentity({ pid: process.ppid, recordedStartTime: undefined }, forbidden)).toBe(true);
+    expect(forbiddenCommandMatches).not.toHaveBeenCalled();
+    expect(forbiddenGetStartTime).not.toHaveBeenCalled();
+  });
+
+  it('the fast paths short-circuit even when a recorded start time is present (per-file teardowns stay two integer compares)', () => {
+    // Post-OMN-265 every in-run lock DOES carry a start time — the hot
+    // per-file path must still never pay a shellout for it.
+    expect(
+      verifyLockHolderIdentity({ pid: process.ppid, recordedStartTime: 'Sun Jul 13 05:00:00 2026' }, forbidden),
+    ).toBe(true);
+    expect(forbiddenCommandMatches).not.toHaveBeenCalled();
+    expect(forbiddenGetStartTime).not.toHaveBeenCalled();
   });
 
   it('any other pid goes to the injected fallback, whose verdict is returned as-is', () => {
     const commandMatches = vi.fn((): boolean | undefined => false);
     const otherPid = process.pid + 424242; // matches neither pid nor ppid
 
-    expect(verifyLockHolderIdentity(otherPid, { commandMatches })).toBe(false);
+    expect(
+      verifyLockHolderIdentity(
+        { pid: otherPid, recordedStartTime: undefined },
+        { commandMatches, getStartTime: forbiddenGetStartTime },
+      ),
+    ).toBe(false);
     expect(commandMatches).toHaveBeenCalledTimes(1);
     expect(commandMatches).toHaveBeenCalledWith(otherPid);
+    // No recorded start time (legacy lock) — nothing to compare against.
+    expect(forbiddenGetStartTime).not.toHaveBeenCalled();
+  });
+});
+
+// OMN-265: for a genuine cross-process check (neither self nor parent), a
+// recorded start time is an EXACT identity — PID + start time is unique per
+// boot — so a readable live start time decides the question outright and the
+// broad 'vitest' command substring is never consulted. Only an unreadable
+// start time (or a legacy bare-PID lock) falls back to the OMN-263 chain.
+describe('verifyLockHolderIdentity recorded start-time comparison (OMN-265)', () => {
+  const otherPid = process.pid + 424242; // matches neither pid nor ppid
+  const RECORDED = 'Sat Jul 12 09:00:00 2026';
+
+  it('live start time MATCHES the record → confirmed holder (true), substring never consulted', () => {
+    const commandMatches = vi.fn((): boolean | undefined => false); // would say "not a holder" — must not matter
+    expect(
+      verifyLockHolderIdentity(
+        { pid: otherPid, recordedStartTime: RECORDED },
+        { getStartTime: () => RECORDED, commandMatches },
+      ),
+    ).toBe(true);
+    expect(commandMatches).not.toHaveBeenCalled();
+  });
+
+  it('live start time DIFFERS from the record → confirmed PID reuse (false), substring never consulted', () => {
+    const commandMatches = vi.fn((): boolean | undefined => true); // would say "holder" — the pre-OMN-265 false refusal
+    expect(
+      verifyLockHolderIdentity(
+        { pid: otherPid, recordedStartTime: RECORDED },
+        { getStartTime: () => 'Sun Jul 13 05:00:00 2026', commandMatches },
+      ),
+    ).toBe(false);
+    expect(commandMatches).not.toHaveBeenCalled();
+  });
+
+  it('live start time UNREADABLE → falls back to the OMN-263 command-substring chain', () => {
+    const commandMatches = vi.fn((): boolean | undefined => undefined);
+    expect(
+      verifyLockHolderIdentity(
+        { pid: otherPid, recordedStartTime: RECORDED },
+        { getStartTime: () => undefined, commandMatches },
+      ),
+    ).toBeUndefined();
+    expect(commandMatches).toHaveBeenCalledTimes(1);
+  });
+
+  it('legacy bare-PID lock (no recorded start time) → straight to the substring chain, no start-time lookup', () => {
+    const getStartTime = vi.fn((): string | undefined => {
+      throw new Error('nothing recorded — must not look up a start time to compare against nothing');
+    });
+    const commandMatches = vi.fn((): boolean | undefined => true);
+    expect(
+      verifyLockHolderIdentity({ pid: otherPid, recordedStartTime: undefined }, { getStartTime, commandMatches }),
+    ).toBe(true);
+    expect(getStartTime).not.toHaveBeenCalled();
+    expect(commandMatches).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/support/integration-guard.test.ts
+++ b/tests/unit/support/integration-guard.test.ts
@@ -482,4 +482,30 @@ describe('getProcessStartTime (OMN-265)', () => {
   it('undefined for a PID that does not exist', () => {
     expect(getProcessStartTime(99999998)).toBeUndefined();
   });
+
+  it("rendering is pinned against the caller's TZ/locale — writer and checker must agree byte-for-byte across environments", () => {
+    // /code-review finding on PR #222: `ps -o lstart=` renders in the CALLING
+    // process's LC_TIME and TZ (empirically: fr_FR gives 'lun. 13 juil. …',
+    // TZ=UTC shifts the wall-clock digits), so an unpinned reader lets a
+    // checker under a different environment (launchd job, SSH, CI) see a
+    // DIFFERENT string for the same live holder → exact-compare says
+    // "confirmed stale" → a LIVE lock is reclaimed: the dangerous direction.
+    // Pin: the function must return the same rendering no matter what
+    // TZ/LC_ALL this process carries.
+    const originalTZ = process.env.TZ;
+    const originalLcAll = process.env.LC_ALL;
+    try {
+      process.env.TZ = 'UTC';
+      process.env.LC_ALL = 'C';
+      const rendered = getProcessStartTime(process.pid);
+      process.env.TZ = 'Asia/Tokyo'; // UTC+9, no DST — guaranteed different wall clock
+      process.env.LC_ALL = 'fr_FR.UTF-8';
+      expect(getProcessStartTime(process.pid)).toBe(rendered);
+    } finally {
+      if (originalTZ === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTZ;
+      if (originalLcAll === undefined) delete process.env.LC_ALL;
+      else process.env.LC_ALL = originalLcAll;
+    }
+  });
 });

--- a/tests/unit/support/integration-guard.test.ts
+++ b/tests/unit/support/integration-guard.test.ts
@@ -15,7 +15,16 @@ import {
   pidIsAlive,
   commandMatchesPid,
   getProcessCommand,
+  getProcessStartTime,
+  verifyLockHolderIdentity,
 } from '../../support/integration-guard.js';
+
+// OMN-265: acquire now reads its own process start time (via `ps`) to record
+// it in the lock file. Every acquire call in this file injects this stub so
+// the suite's default paths never spawn a real subprocess (the same rule the
+// OMN-263 verifyPidIdentity stubs follow). Tests exercising the recorded
+// start time inject their own reader instead.
+const NO_START_TIME = { getProcessStartTime: (): string | undefined => undefined };
 
 describe('acquireIntegrationLock / releaseIntegrationLock', () => {
   let dir: string;
@@ -30,14 +39,14 @@ describe('acquireIntegrationLock / releaseIntegrationLock', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it('fresh acquire creates the lock containing the PID', () => {
-    const res = acquireIntegrationLock({ lockPath, pid: 12345 });
+  it('fresh acquire creates the lock containing the PID (bare format when the start time is unreadable)', () => {
+    const res = acquireIntegrationLock({ lockPath, pid: 12345, ...NO_START_TIME });
     expect(res).toEqual({ acquired: true });
     expect(fs.readFileSync(lockPath, 'utf8')).toBe('12345');
   });
 
   it('refuses when a LIVE holder owns the lock, reporting the holder PID', () => {
-    acquireIntegrationLock({ lockPath, pid: 11111 });
+    acquireIntegrationLock({ lockPath, pid: 11111, ...NO_START_TIME });
     // OMN-263: verifyPidIdentity mocked true (confirmed match) so this test
     // stays fully dependency-injected — it must not shell out to the real
     // `ps` binary for a fake PID.
@@ -46,6 +55,7 @@ describe('acquireIntegrationLock / releaseIntegrationLock', () => {
       pid: 22222,
       isPidAlive: () => true,
       verifyPidIdentity: () => true,
+      ...NO_START_TIME,
     });
     expect(res).toEqual({ acquired: false, holderPid: 11111 });
     // the holder's lock is untouched
@@ -53,8 +63,8 @@ describe('acquireIntegrationLock / releaseIntegrationLock', () => {
   });
 
   it('reclaims a stale lock when the holder is dead', () => {
-    acquireIntegrationLock({ lockPath, pid: 11111 });
-    const res = acquireIntegrationLock({ lockPath, pid: 22222, isPidAlive: () => false });
+    acquireIntegrationLock({ lockPath, pid: 11111, ...NO_START_TIME });
+    const res = acquireIntegrationLock({ lockPath, pid: 22222, isPidAlive: () => false, ...NO_START_TIME });
     expect(res).toEqual({ acquired: true, stale: true, holderPid: 11111 });
     expect(fs.readFileSync(lockPath, 'utf8')).toBe('22222');
   });
@@ -68,13 +78,14 @@ describe('acquireIntegrationLock / releaseIntegrationLock', () => {
       isPidAlive: () => {
         throw new Error('must not probe liveness for garbage content');
       },
+      ...NO_START_TIME,
     });
     expect(res).toEqual({ acquired: true, stale: true });
     expect(fs.readFileSync(lockPath, 'utf8')).toBe('33333');
   });
 
   it('release is owner-only: a non-owner release leaves the lock in place', () => {
-    acquireIntegrationLock({ lockPath, pid: 11111 });
+    acquireIntegrationLock({ lockPath, pid: 11111, ...NO_START_TIME });
     expect(releaseIntegrationLock({ lockPath, pid: 99999 })).toBe(false);
     expect(fs.existsSync(lockPath)).toBe(true);
     expect(releaseIntegrationLock({ lockPath, pid: 11111 })).toBe(true);
@@ -86,10 +97,140 @@ describe('acquireIntegrationLock / releaseIntegrationLock', () => {
   });
 
   it('acquire-after-release round-trip works (the teardown→next-run path)', () => {
-    acquireIntegrationLock({ lockPath, pid: 11111 });
+    acquireIntegrationLock({ lockPath, pid: 11111, ...NO_START_TIME });
     releaseIntegrationLock({ lockPath, pid: 11111 });
-    const res = acquireIntegrationLock({ lockPath, pid: 22222 });
+    const res = acquireIntegrationLock({ lockPath, pid: 22222, ...NO_START_TIME });
     expect(res).toEqual({ acquired: true });
+  });
+});
+
+// OMN-265: the lock file records the holder's process start time alongside
+// its PID (`<pid>\n<lstart>`), so a stale lock whose PID number the OS reused
+// can be told apart from the real holder EXACTLY — PID + start time is unique
+// per boot — instead of via the deliberately broad 'vitest' command
+// substring (which false-refuses when the reused PID belongs to any other
+// vitest process on the machine).
+describe('acquireIntegrationLock — OMN-265 recorded start-time identity', () => {
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omn265-'));
+    lockPath = path.join(dir, 'integration.lock');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('fresh acquire records `<pid>\\n<start time>` when the start time is readable', () => {
+    const res = acquireIntegrationLock({
+      lockPath,
+      pid: 12345,
+      getProcessStartTime: () => 'Sun Jul 13 05:00:00 2026',
+    });
+    expect(res).toEqual({ acquired: true });
+    expect(fs.readFileSync(lockPath, 'utf8')).toBe('12345\nSun Jul 13 05:00:00 2026');
+  });
+
+  it('stale reclaim also writes the new format (the reclaimer records its own start time)', () => {
+    acquireIntegrationLock({ lockPath, pid: 11111, getProcessStartTime: () => 'Sat Jul 12 09:00:00 2026' });
+    const res = acquireIntegrationLock({
+      lockPath,
+      pid: 22222,
+      isPidAlive: () => false,
+      getProcessStartTime: () => 'Sun Jul 13 05:00:00 2026',
+    });
+    expect(res).toEqual({ acquired: true, stale: true, holderPid: 11111 });
+    expect(fs.readFileSync(lockPath, 'utf8')).toBe('22222\nSun Jul 13 05:00:00 2026');
+  });
+
+  it("round-trips: the FILE's recorded start time (not any ambient value) reaches verifyPidIdentity", () => {
+    acquireIntegrationLock({ lockPath, pid: 11111, getProcessStartTime: () => 'Sat Jul 12 09:00:00 2026' });
+    const verifyPidIdentity = vi.fn((): boolean | undefined => true);
+    const res = acquireIntegrationLock({
+      lockPath,
+      pid: 22222,
+      isPidAlive: () => true,
+      verifyPidIdentity,
+      ...NO_START_TIME,
+    });
+    expect(res).toEqual({ acquired: false, holderPid: 11111 });
+    expect(verifyPidIdentity).toHaveBeenCalledWith({
+      pid: 11111,
+      recordedStartTime: 'Sat Jul 12 09:00:00 2026',
+    });
+  });
+
+  it('a legacy bare-PID lock reaches verifyPidIdentity with recordedStartTime undefined', () => {
+    fs.writeFileSync(lockPath, '11111');
+    const verifyPidIdentity = vi.fn((): boolean | undefined => true);
+    acquireIntegrationLock({ lockPath, pid: 22222, isPidAlive: () => true, verifyPidIdentity, ...NO_START_TIME });
+    expect(verifyPidIdentity).toHaveBeenCalledWith({ pid: 11111, recordedStartTime: undefined });
+  });
+
+  it('HEADLINE: a stale lock whose PID was reused by an unrelated vitest process is reclaimed on a start-time mismatch', () => {
+    // The pre-OMN-265 trap: the reused PID belongs to a process whose command
+    // line DOES contain 'vitest' (say, a unit run in a sibling worktree), so
+    // the substring check confirms a holder that is not the writer. The
+    // recorded start time disagrees with the live process's — that exact
+    // comparison must win, and the substring must not even be consulted.
+    fs.writeFileSync(lockPath, '11111\nSat Jul 12 09:00:00 2026');
+    const commandMatches = vi.fn((): boolean | undefined => true); // it IS some vitest process…
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const res = acquireIntegrationLock({
+        lockPath,
+        pid: 22222,
+        isPidAlive: () => true,
+        verifyPidIdentity: (check) =>
+          verifyLockHolderIdentity(check, {
+            getStartTime: () => 'Sun Jul 13 04:59:59 2026', // …but not the one that wrote the lock
+            commandMatches,
+          }),
+        getProcessStartTime: () => 'Sun Jul 13 05:00:00 2026',
+      });
+      expect(res).toEqual({ acquired: true, stale: true, holderPid: 11111 });
+      expect(commandMatches).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('NO FALSE NEGATIVES: a live holder from a different worktree (start times match) is still refused', () => {
+    fs.writeFileSync(lockPath, '11111\nSat Jul 12 09:00:00 2026');
+    const commandMatches = vi.fn((): boolean | undefined => true);
+    const res = acquireIntegrationLock({
+      lockPath,
+      pid: 22222,
+      isPidAlive: () => true,
+      verifyPidIdentity: (check) =>
+        verifyLockHolderIdentity(check, {
+          getStartTime: () => 'Sat Jul 12 09:00:00 2026', // exact match — this IS the writer
+          commandMatches,
+        }),
+      ...NO_START_TIME,
+    });
+    expect(res).toEqual({ acquired: false, holderPid: 11111 });
+    expect(commandMatches).not.toHaveBeenCalled();
+  });
+
+  it('release works on the two-line format (owner-only, parsed-PID comparison)', () => {
+    acquireIntegrationLock({ lockPath, pid: 11111, getProcessStartTime: () => 'Sun Jul 13 05:00:00 2026' });
+    expect(releaseIntegrationLock({ lockPath, pid: 99999 })).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(releaseIntegrationLock({ lockPath, pid: 11111 })).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('isIntegrationLockLive passes the recorded start time through to verifyPidIdentity', () => {
+    fs.writeFileSync(lockPath, '12345\nSat Jul 12 09:00:00 2026');
+    const verifyPidIdentity = vi.fn((): boolean | undefined => true);
+    expect(isIntegrationLockLive({ lockPath, isPidAlive: () => true, verifyPidIdentity })).toBe(true);
+    expect(verifyPidIdentity).toHaveBeenCalledWith({
+      pid: 12345,
+      recordedStartTime: 'Sat Jul 12 09:00:00 2026',
+    });
   });
 });
 
@@ -111,7 +252,7 @@ describe('acquireIntegrationLock — OMN-263 PID-reuse identity verification', (
   });
 
   it('a CONFIRMED identity mismatch (alive PID, wrong command) is treated as stale and reclaimed', () => {
-    acquireIntegrationLock({ lockPath, pid: 11111 });
+    acquireIntegrationLock({ lockPath, pid: 11111, ...NO_START_TIME });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const res = acquireIntegrationLock({
@@ -130,7 +271,7 @@ describe('acquireIntegrationLock — OMN-263 PID-reuse identity verification', (
   });
 
   it('an UNVERIFIABLE identity (ps could not confirm either way) preserves the pre-OMN-263 behavior: refuse', () => {
-    acquireIntegrationLock({ lockPath, pid: 11111 });
+    acquireIntegrationLock({ lockPath, pid: 11111, ...NO_START_TIME });
     const res = acquireIntegrationLock({
       lockPath,
       pid: 22222,
@@ -326,5 +467,19 @@ describe('getProcessCommand', () => {
     // Near the macOS pid_max ceiling — overwhelmingly unlikely to exist; see
     // the identical rationale on pidIsAlive's test above.
     expect(getProcessCommand(99999998)).toBeUndefined();
+  });
+});
+
+describe('getProcessStartTime (OMN-265)', () => {
+  it('reads a stable lstart for the current process (live ps invocation, no mock — same rationale as getProcessCommand)', () => {
+    const startTime = getProcessStartTime(process.pid);
+    expect(startTime).toBeDefined();
+    // lstart is per-process-constant: two reads must agree exactly, which is
+    // the property the whole OMN-265 comparison scheme rests on.
+    expect(getProcessStartTime(process.pid)).toBe(startTime);
+  });
+
+  it('undefined for a PID that does not exist', () => {
+    expect(getProcessStartTime(99999998)).toBeUndefined();
   });
 });

--- a/tests/unit/support/integration-guard.test.ts
+++ b/tests/unit/support/integration-guard.test.ts
@@ -260,6 +260,7 @@ describe('acquireIntegrationLock — OMN-263 PID-reuse identity verification', (
         pid: 22222,
         isPidAlive: () => true, // OS says the PID is alive...
         verifyPidIdentity: () => false, // ...but it's confirmed NOT our lock holder (PID reuse)
+        ...NO_START_TIME,
       });
       expect(res).toEqual({ acquired: true, stale: true, holderPid: 11111 });
       expect(fs.readFileSync(lockPath, 'utf8')).toBe('22222');
@@ -277,6 +278,7 @@ describe('acquireIntegrationLock — OMN-263 PID-reuse identity verification', (
       pid: 22222,
       isPidAlive: () => true,
       verifyPidIdentity: () => undefined, // could not check — must NOT be treated as a mismatch
+      ...NO_START_TIME,
     });
     expect(res).toEqual({ acquired: false, holderPid: 11111 });
     expect(fs.readFileSync(lockPath, 'utf8')).toBe('11111');


### PR DESCRIPTION
## What

Closes the OMN-263 residual: the OMN-143 lock's liveness check matched the holder against a deliberately broad `'vitest'` command substring, so a stale lock whose PID the OS reused for **any** vitest process on the machine was falsely confirmed as a live holder and a new integration run was refused. The substring couldn't be narrowed (any worktree's vitest is a legitimate holder — a checkout-specific match would *steal* live locks, the dangerous direction), so the residual had an irreducible floor — until the identity moves into the lock file itself.

## Approach (the ticket's own sketch, mechanics transferred from PR #220 `5c3192f9`)

- **Acquire records** `<pid>\n<lstart>` (one `ps -o lstart=` shellout per acquire — once per run). Unreadable start time degrades to the legacy bare-PID format.
- **Check compares exactly** when a record exists and the live process's start time is readable: match → confirmed writer (a sibling worktree's live holder matches its own record — **no false steals**); mismatch → confirmed PID reuse → reclaim (**closes the false refusal**, even when the squatter is itself some vitest process). Unreadable/legacy → the OMN-263 substring chain unchanged.
- **Chain order is fast paths → start time → substring.** The pid/ppid fast paths still hold per-file teardowns to two integer compares, zero shellouts (the PR #220 closing-audit property; a hot-path pin test now forbids *both* lookups even when a record is present). Consequence flagged for review: the pass-5 **phantom corner stays open** (PID reuse landing on this very run's own/parent pid still phantom-refuses) — its docstring is rewritten to say so accurately, since closing it would put `ps` on the hot path. It fails safe and needs a double coincidence.
- **Object-param verifier** `{pid, recordedStartTime}` (the pass-5 arity-trap defense); the property name deliberately differs from shared-server's `recordedCommand`, so cross-module verifier copy-paste is a hard type error in both directions.
- **`releaseIntegrationLock` now compares the parsed PID** — ticket gotcha #1 was real: the old `raw === String(pid)` could never match the two-line format, so the owner could never release its own lock and every subsequent acquire would have paid a stale-reclaim.

## Acceptance criteria → evidence

| Criterion | Evidence |
|---|---|
| Reused-PID-by-unrelated-vitest lock is reclaimed | HEADLINE test: substring says `true`, start-time mismatch wins, `commandMatches` never consulted, lock reclaimed |
| Live holder from a different worktree still refused | NO-FALSE-NEGATIVES test: start-time match confirms holder, refused |
| Legacy bare-PID locks degrade to current behavior | legacy-format tests (existing suite now runs them via injected `undefined` reader) + direct chain test |
| No real `ps` from unit tests' default paths | every acquire call injects the start-time reader; fast-path pins use throwing stubs for both lookups |

TDD: 15 red → implementation → 46 green in the guard files; full suite 3,863 unit tests / 172 files green; `tsc -p tsconfig.test.json` clean.

Closes OMN-265

🤖 Generated with [Claude Code](https://claude.com/claude-code)