### PR TITLE
fix(OMN-267): unlink the shared-server PID record only on confirmed death

### DIFF
--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -32,12 +32,21 @@ import {
 // exit hook can be relied on to shut this down.
 const SHARED_SERVER_PID_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'shared-server.pid');
 
+// OMN-267 gate round 2: catch blocks are exactly where arbitrary values
+// arrive (`throw null` via the injectable kill), so anything reading `.code`
+// off a caught value must be total over unknown — an unguarded read would
+// throw right back out of the catch, escaping killOrphanedSharedServer into
+// setup/teardown, which call it unguarded (stranding the OMN-143 lock).
+function errorCode(e: unknown): string | undefined {
+  return typeof e === 'object' && e !== null ? (e as { code?: string }).code : undefined;
+}
+
 // OMN-267 gate: only ESRCH ("no such process") confirms the target is gone.
 // EPERM means it EXISTS but we can't signal it — the same semantics
 // integration-guard.ts's pidIsAlive gives kill(pid, 0) errors. Treating any
 // thrown kill() error as death would delete a live process's record.
 function isEsrchError(e: unknown): boolean {
-  return (e as { code?: string }).code === 'ESRCH';
+  return errorCode(e) === 'ESRCH';
 }
 
 // OMN-263 review (pass 4): the identity check must be neither a bare
@@ -85,6 +94,9 @@ export function recordSharedServerPid(
   // run — possibly in a different worktree — verifies the orphan's identity
   // against this record instead of its own (different) checkout path.
   commandPath: string = SERVER_PATH,
+  // DI seam for the overwrite-warning liveness gate below (a fixed test PID
+  // like 4242 could genuinely be alive on the machine running the tests).
+  isAlive: (pid: number) => boolean = pidIsAlive,
 ): void {
   if (pid === undefined) return;
   try {
@@ -94,12 +106,18 @@ export function recordSharedServerPid(
     // untracked orphan. Accepted residual (a survivor of SIGKILL is usually
     // kernel-stuck and beyond further signaling anyway), but it must leave
     // a trace in the run log, not vanish silently.
+    //
+    // Gate round 2: warn only if the prior PID is STILL ALIVE — the warning
+    // must meet the same evidence standard as the reap. A dead prior PID
+    // here is the ordinary warmup-failure retry path (getSharedClientImpl's
+    // catch stop()s/SIGKILLs the old child without touching this file);
+    // warning about a confirmed-dead process would poison the signal.
     try {
       const existing = parseLockPid(readFileSync(pidFilePath, 'utf-8').trim());
-      if (existing !== undefined && existing !== pid) {
+      if (existing !== undefined && existing !== pid && isAlive(existing)) {
         console.warn(
           `[shared-server] Overwriting PID record for ${existing} with ${pid} at ${pidFilePath} — ` +
-            'if that process is still alive it is now untracked (SIGKILL-survivor slot loss, OMN-267).',
+            'that process is still alive and is now untracked (SIGKILL-survivor slot loss, OMN-267).',
         );
       }
     } catch {
@@ -340,7 +358,7 @@ export async function killOrphanedSharedServer(
       // privileges) can retry. No SIGKILL escalation either — it would hit
       // the identical permission failure.
       console.warn(
-        `[shared-server] Could not signal PID ${pid} (${String((e as { code?: string }).code ?? e)}) — ` +
+        `[shared-server] Could not signal PID ${pid} (${String(errorCode(e) ?? e)}) — ` +
           'it may still be alive; keeping its PID record so a later run retries.',
       );
     }
@@ -372,7 +390,7 @@ export async function killOrphanedSharedServer(
       removeRecord();
     } else {
       console.warn(
-        `[shared-server] Could not SIGKILL PID ${pid} (${String((e as { code?: string }).code ?? e)}) — ` +
+        `[shared-server] Could not SIGKILL PID ${pid} (${String(errorCode(e) ?? e)}) — ` +
           'it may still be alive; keeping its PID record so a later run retries.',
       );
     }

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -138,12 +138,17 @@ const SIGKILL_REAP_TIMEOUT_MS = 2000;
  * PID number to something unrelated after our orphan already exited," and
  * neither a bare substring (matches a production server) nor the reaper's
  * own checkout path (misses a sibling worktree's orphan) answers it; only
- * the writer's own record does. Unlinking the file BEFORE the identity
- * check stays correct under the recorded-path scheme: a CONFIRMED mismatch
- * means the recorded orphan's PID was reused, i.e. the orphan itself is
- * already dead — the record is garbage either way. See
- * integration-guard.ts's `commandMatchesPid` for the shared identity-check
- * primitive (also used by the OMN-143 lock).
+ * the writer's own record does. See integration-guard.ts's
+ * `commandMatchesPid` for the shared identity-check primitive (also used by
+ * the OMN-143 lock).
+ *
+ * OMN-267: the PID record is unlinked only where the recorded process is
+ * CONFIRMED gone (dead PID, confirmed reuse-mismatch, kill() throwing ESRCH,
+ * polled-to-death) or the record is confirmed garbage — never eagerly after
+ * the read. A branch that cannot know the outcome keeps the record so a
+ * later call can re-derive it. The pass-4 "unlink stays correct" argument
+ * (a confirmed mismatch implies the recorded orphan is dead) now lives on
+ * exactly the branch it covers: the mismatch branch.
  *
  * By default, polls after sending SIGTERM so callers can rely on the orphan
  * actually being gone (or log a warning that it wasn't) before touching
@@ -164,11 +169,20 @@ const SIGKILL_REAP_TIMEOUT_MS = 2000;
  * worker fork that spawned it — a different process from the one calling
  * killOrphanedSharedServer here, which can never observe that reap). A real
  * run hit exactly this: the warning fired on a normal, non-hung shutdown,
- * at a point where nothing was actually at risk. The tradeoff is that this
- * path sends only SIGTERM with no SIGKILL escalation; a process wedged AT
- * teardown is left for the OS to reap when the run's process tree exits,
- * which is acceptable because (unlike setup) nothing here runs OmniFocus
- * cleanup afterward that a lingering orphan could corrupt.
+ * at a point where nothing was actually at risk.
+ *
+ * The tradeoff is that this path sends only SIGTERM with no SIGKILL
+ * escalation and never learns whether it landed — and a wedged process (event
+ * loop blocked in a synchronous osascript call, so Node cannot run its signal
+ * handler) is NOT cleaned up by the run ending: orphans reparent to init
+ * (ppid 1) and persist indefinitely, they are not reaped at process-tree exit
+ * (observed live 2026-07-13: the run's own server outlived the whole vitest
+ * tree by ~3 minutes; same class as the 2026-06 dev-server CPU-peg
+ * incidents). That's why this path KEEPS the PID record (OMN-267): the next
+ * run's setup — full identity check plus awaited SIGTERM→SIGKILL escalation —
+ * rediscovers the record and finishes a wedged survivor. The common case
+ * (SIGTERM lands moments later) just leaves a dead-PID record the next setup
+ * clears silently; a crash record is the file's normal job.
  */
 export async function killOrphanedSharedServer(
   opts: {
@@ -218,15 +232,34 @@ export async function killOrphanedSharedServer(
   } catch {
     return; // no PID file — nothing to do
   }
-  try {
-    unlinkSync(pidFilePath);
-  } catch {
-    /* already gone — fine, we still act on what we read */
-  }
+
+  // OMN-267: the unlink happens at the branches where the recorded process is
+  // confirmed gone (or the record confirmed garbage) — NOT eagerly after the
+  // read. The `waitForExit: false` teardown path never learns the outcome, so
+  // it must leave the record for the next run's setup to finish; an eager
+  // unlink there turned a wedged survivor into a permanent, unrecorded orphan
+  // (observed live 2026-07-13). Read-once semantics are unchanged: every
+  // branch acts on `raw`, and the unlink tolerates the file already being gone.
+  const removeRecord = () => {
+    try {
+      unlinkSync(pidFilePath);
+    } catch {
+      /* already gone — fine */
+    }
+  };
 
   const pid = parseLockPid(raw);
-  if (pid === undefined) return;
-  if (!isAlive(pid)) return;
+  if (pid === undefined) {
+    removeRecord(); // garbage record — nothing to signal, nothing to keep
+    return;
+  }
+  if (!isAlive(pid)) {
+    // The recorded process exited (typically: teardown's SIGTERM landed and
+    // this is the next run's setup clearing the leftover record — silently,
+    // because a dead-PID record is the file's normal end-of-life state).
+    removeRecord();
+    return;
+  }
 
   // OMN-263: confirm this PID is plausibly the server the PID file's writer
   // spawned before signaling it — the OS can reassign a dead process's PID
@@ -241,6 +274,10 @@ export async function killOrphanedSharedServer(
   // isIntegrationLockLive, whose unverifiable fallback points the OPPOSITE
   // way — refuse — see the NOTE there before unifying anything.)
   if (verifyIdentity({ pid, recordedCommand: parseRecordedSecondLine(raw) }) === false) {
+    // A CONFIRMED mismatch means the recorded orphan's PID was reused, i.e.
+    // the orphan itself is already dead — the record is garbage (the OMN-263
+    // pass-4 argument, which covers exactly this branch and no other).
+    removeRecord();
     console.warn(
       `[shared-server] PID ${pid} from ${pidFilePath} is alive but its command line doesn't look like our ` +
         'spawned server (OMN-263 PID-reuse check) — skipping SIGTERM to avoid signaling an unrelated process.',
@@ -252,16 +289,24 @@ export async function killOrphanedSharedServer(
     kill(pid, 'SIGTERM');
   } catch {
     /* gone between the liveness check and the kill; harmless */
+    removeRecord();
     return;
   }
 
+  // Fire-and-forget (teardown): the outcome is unknowable here by design, so
+  // the record stays. See the docstring — the next run's setup finishes a
+  // wedged survivor; a normal exit just leaves a dead-PID record it clears
+  // silently.
   if (!waitForExit) return;
 
   const deadline = Date.now() + reapTimeoutMs;
   while (isAlive(pid) && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, reapPollIntervalMs));
   }
-  if (!isAlive(pid)) return;
+  if (!isAlive(pid)) {
+    removeRecord();
+    return;
+  }
 
   // SIGTERM didn't land within the budget — escalate to SIGKILL, which the
   // process cannot ignore, then give it a shorter window to actually die.
@@ -269,6 +314,7 @@ export async function killOrphanedSharedServer(
     kill(pid, 'SIGKILL');
   } catch {
     /* died between the check and the escalation; fine */
+    removeRecord();
     return;
   }
   const killDeadline = Date.now() + sigkillReapTimeoutMs;
@@ -276,12 +322,18 @@ export async function killOrphanedSharedServer(
     await new Promise((resolve) => setTimeout(resolve, reapPollIntervalMs));
   }
   if (isAlive(pid)) {
+    // Still alive after both budgets: keep the record so the next setup
+    // retries the full escalation (OMN-267 review decision: accept the
+    // repeated ~10s cost on an unkillable process — loud, rare, self-heals).
     console.warn(
       `[shared-server] Orphaned server PID ${pid} survived SIGTERM+SIGKILL within ` +
         `${reapTimeoutMs + sigkillReapTimeoutMs}ms — proceeding with cleanup anyway; ` +
-        'it may still be driving OmniFocus concurrently.',
+        'it may still be driving OmniFocus concurrently. Keeping its PID record so the ' +
+        'next run retries.',
     );
+    return;
   }
+  removeRecord();
 }
 
 interface SharedServerState {

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -109,19 +109,36 @@ export function recordSharedServerPid(
     //
     // Gate round 2: warn only if the prior PID is STILL ALIVE — the warning
     // must meet the same evidence standard as the reap. A dead prior PID
-    // here is the ordinary warmup-failure retry path (getSharedClientImpl's
+    // here is the common warmup-failure retry case (getSharedClientImpl's
     // catch stop()s/SIGKILLs the old child without touching this file);
     // warning about a confirmed-dead process would poison the signal.
+    // Gate round 3: that retry's prior PID is USUALLY dead, not always —
+    // transport close() resolves at SIGKILL issuance without confirming
+    // exit, so a wedged old child can still be alive here. The warning
+    // firing then is CORRECT: however the slot came to be lost, a live
+    // process is losing its only record. (Residual: a dead-but-unreaped
+    // zombie also reads as alive; the full startServer between the SIGKILL
+    // and this write makes that window negligible.)
     try {
       const existing = parseLockPid(readFileSync(pidFilePath, 'utf-8').trim());
       if (existing !== undefined && existing !== pid && isAlive(existing)) {
         console.warn(
           `[shared-server] Overwriting PID record for ${existing} with ${pid} at ${pidFilePath} — ` +
-            'that process is still alive and is now untracked (SIGKILL-survivor slot loss, OMN-267).',
+            'that process appears still alive and is now untracked (SIGKILL-survivor slot loss, OMN-267).',
         );
       }
-    } catch {
-      /* no existing record — the normal case */
+    } catch (readError) {
+      // Gate round 3: only ENOENT means "no existing record — the normal
+      // case". Any other read failure leaves the survivor check unrun; the
+      // whole point of this block is that a lost record must not vanish
+      // without a trace, so say the check itself could not happen.
+      if (errorCode(readError) !== 'ENOENT') {
+        console.warn(
+          `[shared-server] Could not check for an existing PID record at ${pidFilePath} before overwriting — ` +
+            'if a survivor record was present, its loss is untraced:',
+          readError,
+        );
+      }
     }
     mkdirSync(path.dirname(pidFilePath), { recursive: true });
     writeFileSync(pidFilePath, `${pid}\n${commandPath}`, 'utf-8');
@@ -302,7 +319,7 @@ export async function killOrphanedSharedServer(
       // Warn rather than throw (unlike integration-guard's ENOENT-rethrow
       // sibling): this runs inside setup/teardown, where a throw would fail
       // the whole run over a cleanup bookkeeping problem.
-      if ((e as { code?: string }).code !== 'ENOENT') {
+      if (errorCode(e) !== 'ENOENT') {
         console.warn(`[shared-server] Failed to remove PID record ${pidFilePath} — a stale record may persist:`, e);
       }
     }

--- a/tests/integration/helpers/shared-server.ts
+++ b/tests/integration/helpers/shared-server.ts
@@ -32,6 +32,14 @@ import {
 // exit hook can be relied on to shut this down.
 const SHARED_SERVER_PID_PATH = path.join(os.homedir(), '.omnifocus-mcp', 'shared-server.pid');
 
+// OMN-267 gate: only ESRCH ("no such process") confirms the target is gone.
+// EPERM means it EXISTS but we can't signal it — the same semantics
+// integration-guard.ts's pidIsAlive gives kill(pid, 0) errors. Treating any
+// thrown kill() error as death would delete a live process's record.
+function isEsrchError(e: unknown): boolean {
+  return (e as { code?: string }).code === 'ESRCH';
+}
+
 // OMN-263 review (pass 4): the identity check must be neither a bare
 // 'dist/index.js' substring (matches a real PRODUCTION server on PID reuse —
 // pass-2 finding) nor the reaper's OWN checkout-specific SERVER_PATH (the
@@ -80,6 +88,23 @@ export function recordSharedServerPid(
 ): void {
   if (pid === undefined) return;
   try {
+    // OMN-267 gate: this file has exactly ONE slot. If setup() kept a
+    // SIGKILL-survivor's record (see killOrphanedSharedServer), this write
+    // is the point where that record is lost — the survivor becomes an
+    // untracked orphan. Accepted residual (a survivor of SIGKILL is usually
+    // kernel-stuck and beyond further signaling anyway), but it must leave
+    // a trace in the run log, not vanish silently.
+    try {
+      const existing = parseLockPid(readFileSync(pidFilePath, 'utf-8').trim());
+      if (existing !== undefined && existing !== pid) {
+        console.warn(
+          `[shared-server] Overwriting PID record for ${existing} with ${pid} at ${pidFilePath} — ` +
+            'if that process is still alive it is now untracked (SIGKILL-survivor slot loss, OMN-267).',
+        );
+      }
+    } catch {
+      /* no existing record — the normal case */
+    }
     mkdirSync(path.dirname(pidFilePath), { recursive: true });
     writeFileSync(pidFilePath, `${pid}\n${commandPath}`, 'utf-8');
   } catch (error) {
@@ -143,12 +168,22 @@ const SIGKILL_REAP_TIMEOUT_MS = 2000;
  * the OMN-143 lock).
  *
  * OMN-267: the PID record is unlinked only where the recorded process is
- * CONFIRMED gone (dead PID, confirmed reuse-mismatch, kill() throwing ESRCH,
+ * CONFIRMED gone (dead PID, confirmed reuse-mismatch, kill() throwing ESRCH
+ * — and ONLY ESRCH; EPERM means alive-but-unsignalable, see isEsrchError —
  * polled-to-death) or the record is confirmed garbage — never eagerly after
  * the read. A branch that cannot know the outcome keeps the record so a
  * later call can re-derive it. The pass-4 "unlink stays correct" argument
  * (a confirmed mismatch implies the recorded orphan is dead) now lives on
  * exactly the branch it covers: the mismatch branch.
+ *
+ * INVARIANT for future edits: every return path out of this function must
+ * either call removeRecord() (outcome: confirmed dead / record garbage) or
+ * deliberately keep the record (outcome: unknown or still alive) — there is
+ * no third state. Each existing branch is pinned by a unit test in
+ * shared-server-pid-file.test.ts; a new branch needs its own pin. A kept
+ * record is best-effort across a run boundary only: within a run, this
+ * run's own recordSharedServerPid() overwrite is the point where a kept
+ * survivor record is lost (loudly — see the warn there).
  *
  * By default, polls after sending SIGTERM so callers can rely on the orphan
  * actually being gone (or log a warning that it wasn't) before touching
@@ -243,8 +278,15 @@ export async function killOrphanedSharedServer(
   const removeRecord = () => {
     try {
       unlinkSync(pidFilePath);
-    } catch {
-      /* already gone — fine */
+    } catch (e) {
+      // ENOENT is fine (already gone); anything else means a stale record
+      // will persist — say so instead of proceeding as if cleanup succeeded.
+      // Warn rather than throw (unlike integration-guard's ENOENT-rethrow
+      // sibling): this runs inside setup/teardown, where a throw would fail
+      // the whole run over a cleanup bookkeeping problem.
+      if ((e as { code?: string }).code !== 'ENOENT') {
+        console.warn(`[shared-server] Failed to remove PID record ${pidFilePath} — a stale record may persist:`, e);
+      }
     }
   };
 
@@ -287,9 +329,21 @@ export async function killOrphanedSharedServer(
 
   try {
     kill(pid, 'SIGTERM');
-  } catch {
-    /* gone between the liveness check and the kill; harmless */
-    removeRecord();
+  } catch (e) {
+    if (isEsrchError(e)) {
+      // Gone between the liveness check and the kill — confirmed dead.
+      removeRecord();
+    } else {
+      // EPERM etc.: the process exists but we can't signal it — the same
+      // semantics pidIsAlive gives kill(pid, 0) errors. NOT confirmed dead:
+      // keep the record so a future run (possibly with different
+      // privileges) can retry. No SIGKILL escalation either — it would hit
+      // the identical permission failure.
+      console.warn(
+        `[shared-server] Could not signal PID ${pid} (${String((e as { code?: string }).code ?? e)}) — ` +
+          'it may still be alive; keeping its PID record so a later run retries.',
+      );
+    }
     return;
   }
 
@@ -312,9 +366,16 @@ export async function killOrphanedSharedServer(
   // process cannot ignore, then give it a shorter window to actually die.
   try {
     kill(pid, 'SIGKILL');
-  } catch {
-    /* died between the check and the escalation; fine */
-    removeRecord();
+  } catch (e) {
+    if (isEsrchError(e)) {
+      // Died between the poll and the escalation — confirmed dead.
+      removeRecord();
+    } else {
+      console.warn(
+        `[shared-server] Could not SIGKILL PID ${pid} (${String((e as { code?: string }).code ?? e)}) — ` +
+          'it may still be alive; keeping its PID record so a later run retries.',
+      );
+    }
     return;
   }
   const killDeadline = Date.now() + sigkillReapTimeoutMs;

--- a/tests/support/setup-integration.ts
+++ b/tests/support/setup-integration.ts
@@ -180,7 +180,9 @@ export async function teardown() {
   // (teardown is nearly done), so there's no race to protect against — and
   // waiting would just produce a false-alarm "didn't exit" warning on a
   // zombie awaiting reap by the worker fork, which this process can never
-  // observe (see killOrphanedSharedServer's docstring).
+  // observe (see killOrphanedSharedServer's docstring). OMN-267: this call
+  // deliberately leaves the PID record behind — the next run's setup clears
+  // it (silently if the SIGTERM landed; by escalating if the server wedged).
   await killOrphanedSharedServer({ waitForExit: false });
 
   // OMN-143: release the single-instance guard LAST, after all teardown work.

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -107,6 +107,11 @@ describe('killOrphanedSharedServer', () => {
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
       expect(String(warnSpy.mock.calls[0][0])).toContain('SIGKILL');
+      // OMN-267: a SIGKILL survivor is still alive, so its record must be
+      // KEPT — the next run's setup retries the escalation. (Kip's review
+      // call: accept the repeated ~10s retry cost on an unkillable process;
+      // it's loud, rare, and self-heals when the process finally dies.)
+      expect(existsSync(pidFilePath)).toBe(true);
     } finally {
       warnSpy.mockRestore();
     }
@@ -134,6 +139,150 @@ describe('killOrphanedSharedServer', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  // ── OMN-267: teardown's fire-and-forget SIGTERM must leave the PID record
+  // behind. `waitForExit: false` never learns whether the SIGTERM landed
+  // (polling there false-alarms on zombies — the OMN-261 pass-2 constraint),
+  // so the unlink moves to the points where death IS confirmed. A wedged
+  // survivor (event loop blocked in a sync osascript call; observed live
+  // 2026-07-13) is then rediscovered and finished by the NEXT run's setup,
+  // instead of becoming a permanent, unrecorded ppid-1 orphan.
+  // Spec: Technical/specs/OMN-267-teardown-wedged-server-stranding.md
+
+  it('waitForExit: false keeps the record when the process ignores SIGTERM (wedge), preserving its contents', async () => {
+    const fs = await import('fs');
+    const record = '4242\n/worktree-a/dist/index.js';
+    fs.writeFileSync(pidFilePath, record, 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    const killed: string[] = [];
+    await killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => true, // wedged: still alive after SIGTERM
+      verifyPidIdentity: () => true,
+      kill: (_pid, signal) => {
+        killed.push(signal); // no-op: the wedge ignores the signal
+      },
+      waitForExit: false,
+    });
+
+    expect(killed).toEqual(['SIGTERM']);
+    expect(existsSync(pidFilePath)).toBe(true);
+    expect(readFileSync(pidFilePath, 'utf-8')).toBe(record);
+  });
+
+  it('waitForExit: false keeps the record even when the process exits promptly (teardown cannot tell the cases apart)', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    let alive = true;
+    await killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => alive,
+      verifyPidIdentity: () => true,
+      kill: () => {
+        alive = false; // normal case: SIGTERM lands immediately
+      },
+      waitForExit: false,
+    });
+
+    // The record stays either way; the next run's setup clears a dead-PID
+    // record silently (see the silent-clear test below).
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
+  it('a record left by teardown is finished by the next setup: escalation runs, file unlinked on confirmed death', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242\n/worktree-a/dist/index.js', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    // Run 1's teardown: fire-and-forget against a wedge — record survives.
+    await killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => true,
+      verifyPidIdentity: () => true,
+      kill: () => {},
+      waitForExit: false,
+    });
+    expect(existsSync(pidFilePath)).toBe(true);
+
+    // Run 2's setup: awaited escalation finishes the wedged survivor.
+    const killed: string[] = [];
+    let alive = true;
+    await killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => alive,
+      verifyPidIdentity: () => true,
+      kill: (_pid, signal) => {
+        killed.push(signal);
+        if (signal === 'SIGKILL') alive = false; // still ignoring SIGTERM
+      },
+      reapTimeoutMs: 30,
+      sigkillReapTimeoutMs: 30,
+      reapPollIntervalMs: 5,
+    });
+
+    expect(killed).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  it('clears a dead-PID record silently: unlink, no signal, no warning', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242\n/worktree-a/dist/index.js', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => false, // the teardown-killed server exited normally
+        kill: () => {
+          throw new Error('should not be called');
+        },
+      });
+
+      expect(existsSync(pidFilePath)).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('unlinks a garbage record without signaling', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, 'not-a-pid', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    await killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => true,
+      kill: () => {
+        throw new Error('should not be called');
+      },
+    });
+
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  it('unlinks when SIGTERM throws because the process died in the read-to-kill gap', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    await expect(
+      killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true,
+        verifyPidIdentity: () => true,
+        kill: () => {
+          throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+        },
+      }),
+    ).resolves.not.toThrow();
+
+    expect(existsSync(pidFilePath)).toBe(false);
   });
 
   it('removes the file but does not kill when the recorded PID is no longer alive', async () => {

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -684,6 +684,31 @@ describe('recordSharedServerPid', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  // OMN-267 gate round 3: only ENOENT means "no existing record". Any other
+  // read failure (EACCES, EMFILE, …) leaves the survivor check silently
+  // skipped — the exact vanish-without-a-trace outcome the check exists to
+  // prevent — so it must at least say the check could not run.
+  it('warns when the existing record cannot be read for a non-ENOENT reason, instead of silently skipping the survivor check', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(dir, 'shared-server.pid');
+
+    recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
+    chmodSync(pidFilePath, 0o200); // write-only: read fails EACCES, overwrite still succeeds
+
+    try {
+      recordSharedServerPid(5555, pidFilePath, '/worktree-b/dist/index.js', () => {
+        throw new Error('liveness must not be probed when the record could not be read');
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain(pidFilePath);
+      chmodSync(pidFilePath, 0o644);
+      expect(readFileSync(pidFilePath, 'utf-8')).toBe('5555\n/worktree-b/dist/index.js');
+    } finally {
+      chmodSync(pidFilePath, 0o644);
+    }
+  });
+
   it('does not warn when re-recording the same pid, without even probing liveness', async () => {
     const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
     const pidFilePath = join(dir, 'shared-server.pid');

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -412,6 +412,39 @@ describe('killOrphanedSharedServer', () => {
     expect(existsSync(pidFilePath)).toBe(false);
   });
 
+  // OMN-267 gate round 2: the errno classifier is called from catch blocks,
+  // which is exactly where arbitrary values arrive (`throw null` via the
+  // injectable kill). It must be total over unknown — if it throws, the
+  // TypeError escapes killOrphanedSharedServer into global setup/teardown,
+  // which call it unguarded, stranding the OMN-143 lock.
+  it('survives a non-object throw from kill(): no crash, record kept, warning still emitted', async () => {
+    const fs = await import('fs');
+    const record = '4242\n/worktree-a/dist/index.js';
+    fs.writeFileSync(pidFilePath, record, 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await expect(
+        killOrphanedSharedServer({
+          pidFilePath,
+          isPidAlive: () => true,
+          verifyPidIdentity: () => true,
+          kill: () => {
+            throw null;
+          },
+        }),
+      ).resolves.not.toThrow();
+
+      // Not ESRCH → not confirmed dead → record kept, outcome warned.
+      expect(existsSync(pidFilePath)).toBe(true);
+      expect(readFileSync(pidFilePath, 'utf-8')).toBe(record);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('removes the file but does not kill when the recorded PID is no longer alive', async () => {
     const fs = await import('fs');
     fs.writeFileSync(pidFilePath, '4242', 'utf-8');
@@ -623,24 +656,42 @@ describe('recordSharedServerPid', () => {
   // a SIGKILL-survivor's record, this run's own server registration is the
   // point where that record is lost — it must at least be loud about it, so
   // an untracked orphan leaves a trace in the run log.
-  it('warns when overwriting an existing record for a DIFFERENT pid (survivor slot loss)', async () => {
+  // Gate round 2: the warning must hold itself to the same evidence standard
+  // as the reap — only a STILL-ALIVE prior PID is a survivor being lost. A
+  // dead prior PID is the ordinary warmup-failure retry path (whose own
+  // catch already stop()'d/SIGKILLed the old child without touching the
+  // file); warning there would poison the signal.
+  it('warns when overwriting an existing record for a DIFFERENT, still-alive pid (survivor slot loss)', async () => {
     const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
     const pidFilePath = join(dir, 'shared-server.pid');
 
     recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
-    recordSharedServerPid(5555, pidFilePath, '/worktree-b/dist/index.js');
+    recordSharedServerPid(5555, pidFilePath, '/worktree-b/dist/index.js', () => true);
 
     expect(readFileSync(pidFilePath, 'utf-8')).toBe('5555\n/worktree-b/dist/index.js');
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
   });
 
-  it('does not warn when re-recording the same pid', async () => {
+  it('does not warn when the overwritten record names a DEAD pid (warmup-failure retry path)', async () => {
     const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
     const pidFilePath = join(dir, 'shared-server.pid');
 
     recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
+    recordSharedServerPid(5555, pidFilePath, '/worktree-b/dist/index.js', () => false);
+
+    expect(readFileSync(pidFilePath, 'utf-8')).toBe('5555\n/worktree-b/dist/index.js');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when re-recording the same pid, without even probing liveness', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(dir, 'shared-server.pid');
+
     recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
+    recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js', () => {
+      throw new Error('liveness must not be probed for a same-pid re-record');
+    });
 
     expect(warnSpy).not.toHaveBeenCalled();
   });

--- a/tests/unit/integration-helpers/shared-server-pid-file.test.ts
+++ b/tests/unit/integration-helpers/shared-server-pid-file.test.ts
@@ -266,6 +266,133 @@ describe('killOrphanedSharedServer', () => {
     expect(existsSync(pidFilePath)).toBe(false);
   });
 
+  // ── OMN-267 gate round 1: only ESRCH confirms death. EPERM (and any other
+  // non-ESRCH error) means the process may well be alive but unsignalable —
+  // deleting its record there reintroduces the unrecorded-orphan class.
+  // pidIsAlive in integration-guard.ts encodes the same semantics (EPERM =
+  // alive, "we must not steal its lock").
+
+  it('keeps the record and warns when SIGTERM throws a non-ESRCH error (process alive but unsignalable)', async () => {
+    const fs = await import('fs');
+    const record = '4242\n/worktree-a/dist/index.js';
+    fs.writeFileSync(pidFilePath, record, 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const killed: string[] = [];
+      await killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true,
+        verifyPidIdentity: () => true,
+        kill: (_pid, signal) => {
+          killed.push(signal);
+          throw Object.assign(new Error('kill EPERM'), { code: 'EPERM' });
+        },
+        reapTimeoutMs: 30,
+        reapPollIntervalMs: 5,
+      });
+
+      // No SIGKILL escalation attempt — the same permission failure would
+      // just repeat; the kept record lets a future run (possibly with
+      // different privileges) retry.
+      expect(killed).toEqual(['SIGTERM']);
+      expect(existsSync(pidFilePath)).toBe(true);
+      expect(readFileSync(pidFilePath, 'utf-8')).toBe(record);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('keeps the record and warns when the SIGKILL escalation throws a non-ESRCH error', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242\n/worktree-a/dist/index.js', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const killed: string[] = [];
+      await killOrphanedSharedServer({
+        pidFilePath,
+        isPidAlive: () => true, // survives SIGTERM, forcing the escalation
+        verifyPidIdentity: () => true,
+        kill: (_pid, signal) => {
+          killed.push(signal);
+          if (signal === 'SIGKILL') {
+            throw Object.assign(new Error('kill EPERM'), { code: 'EPERM' });
+          }
+        },
+        reapTimeoutMs: 30,
+        sigkillReapTimeoutMs: 30,
+        reapPollIntervalMs: 5,
+      });
+
+      expect(killed).toEqual(['SIGTERM', 'SIGKILL']);
+      expect(existsSync(pidFilePath)).toBe(true);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('unlinks when the SIGKILL escalation throws ESRCH (died between the poll and the escalation)', async () => {
+    const fs = await import('fs');
+    fs.writeFileSync(pidFilePath, '4242', 'utf-8');
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+
+    await killOrphanedSharedServer({
+      pidFilePath,
+      isPidAlive: () => true,
+      verifyPidIdentity: () => true,
+      kill: (_pid, signal) => {
+        if (signal === 'SIGKILL') {
+          throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+        }
+      },
+      reapTimeoutMs: 30,
+      sigkillReapTimeoutMs: 30,
+      reapPollIntervalMs: 5,
+    });
+
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  // OMN-267 gate round 1: removeRecord must not silently swallow non-ENOENT
+  // unlink failures — seven branches would proceed believing cleanup
+  // succeeded while a stale record persists. (Warn, not throw: unlike the
+  // integration-guard sibling, this runs inside setup/teardown, where a
+  // throw would fail the whole run over a cleanup bookkeeping problem.)
+  it('warns when the unlink fails for a reason other than ENOENT, instead of silently proceeding', async () => {
+    const fs = await import('fs');
+    const lockedDir = join(dir, 'locked');
+    mkdirSync(lockedDir);
+    const lockedPidPath = join(lockedDir, 'shared-server.pid');
+    fs.writeFileSync(lockedPidPath, '4242', 'utf-8');
+    chmodSync(lockedDir, 0o555); // unlink permission comes from the directory
+    const { killOrphanedSharedServer } = await import('../../integration/helpers/shared-server.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await killOrphanedSharedServer({
+        pidFilePath: lockedPidPath,
+        isPidAlive: () => false, // dead-PID branch → removeRecord()
+        kill: () => {
+          throw new Error('should not be called');
+        },
+      });
+
+      expect(existsSync(lockedPidPath)).toBe(true); // the unlink really failed
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain(lockedPidPath);
+    } finally {
+      chmodSync(lockedDir, 0o755);
+      warnSpy.mockRestore();
+    }
+  });
+
   it('unlinks when SIGTERM throws because the process died in the read-to-kill gap', async () => {
     const fs = await import('fs');
     fs.writeFileSync(pidFilePath, '4242', 'utf-8');
@@ -489,6 +616,32 @@ describe('recordSharedServerPid', () => {
     recordSharedServerPid(undefined, pidFilePath);
 
     expect(existsSync(pidFilePath)).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  // OMN-267 gate round 1: the PID file has exactly ONE slot. If setup() kept
+  // a SIGKILL-survivor's record, this run's own server registration is the
+  // point where that record is lost — it must at least be loud about it, so
+  // an untracked orphan leaves a trace in the run log.
+  it('warns when overwriting an existing record for a DIFFERENT pid (survivor slot loss)', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(dir, 'shared-server.pid');
+
+    recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
+    recordSharedServerPid(5555, pidFilePath, '/worktree-b/dist/index.js');
+
+    expect(readFileSync(pidFilePath, 'utf-8')).toBe('5555\n/worktree-b/dist/index.js');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('4242');
+  });
+
+  it('does not warn when re-recording the same pid', async () => {
+    const { recordSharedServerPid } = await import('../../integration/helpers/shared-server.js');
+    const pidFilePath = join(dir, 'shared-server.pid');
+
+    recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
+    recordSharedServerPid(4242, pidFilePath, '/worktree-a/dist/index.js');
+
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

Observed live 2026-07-13 (OMN-263 post-merge shakeout): the run's own shared server survived teardown's SIGTERM by ~3 minutes as a ppid-1 orphan. `killOrphanedSharedServer` unlinked the PID file **before** signaling, so teardown's fire-and-forget SIGTERM (`waitForExit: false`) left a wedged survivor with no record — a permanent, unrecorded orphan that can still drive OmniFocus. The docstring's justification ("the OS reaps it at tree exit") was false: orphans reparent to init and persist (same class as the 2026-06 dev-server CPU-peg incidents).

Spec (approved by Kip 2026-07-13, Option A + C): `Technical/specs/OMN-267-teardown-wedged-server-stranding.md` (Obsidian).

## What

- **Unlink moves from "eagerly after read" to confirmed-death points**: garbage record, dead PID, confirmed reuse-mismatch, `kill()` throwing (died in the gap), or polled-to-death after SIGTERM/SIGKILL.
- **`waitForExit: false` (teardown) keeps the record** — the next run's setup, which already has identity checking + awaited SIGTERM→SIGKILL escalation, rediscovers and finishes a wedged survivor. Normal case: a dead-PID record the next setup clears silently (no signal, no warning).
- **SIGKILL-survivor branch keeps the record too** (review decision: accept the repeated ~10s escalation retry on an unkillable process — loud, rare, self-heals).
- **Docstring corrections (Option C)**: dropped the false tree-exit-reap premise; the OMN-263 pass-4 "unlink stays correct" argument now lives on exactly the branch it covers (confirmed mismatch).

Lineage constraints preserved: teardown still never polls (OMN-261 pass-2 zombie false-alarm cannot return); setup's reap stays awaited + escalating; identity verification unchanged (OMN-263); zero hot-path cost.

## Tests (TDD — watched all four new record-keeping tests fail red first)

- `waitForExit: false` + wedge → record kept with original two-line contents
- `waitForExit: false` + prompt exit → record kept (teardown can't tell the cases apart)
- Two-run round-trip: record left by teardown → next setup escalates SIGTERM→SIGKILL, unlinks on confirmed death
- SIGKILL survivor → warn AND record kept
- Branch pins: dead-PID silent clear, garbage record, ESRCH-in-gap, mismatch (existing tests unchanged and passing)

`npm run test:unit`: 3871 passed. `tsc -p tsconfig.test.json`: clean. Lint: clean.

## Acceptance criteria (OMN-267)

- [x] A wedged server (simulated via DI) remains discoverable by the next run's setup
- [x] No reintroduction of the false-alarm warning on normal shutdowns (teardown still never polls)
- [x] Docstring teardown-tradeoff paragraph corrected

## Live verify (Kip, supervised — after merge, per spec)

1. Full `test:integration` run; confirm `~/.omnifocus-mcp/shared-server.pid` exists post-teardown, and a second run clears it silently.
2. Wedge repro: `kill -STOP` the shared server near end of a run; second run's setup must SIGKILL it and proceed.
3. Bystander check: production server PID set byte-identical before/after.

Closes OMN-267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)