### PR TITLE
fix(OMN-268): pattern_analysis fetch failure returns an error envelope, not fabricated healthy zeros

### DIFF
--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -1111,8 +1111,8 @@ SCOPE FILTERING:
         return createErrorResponseV2(
           'analyze_patterns',
           'EXECUTION_ERROR',
-          'Failed to fetch data from OmniFocus - received null response',
-          'Check that OmniFocus is running and accessible',
+          'Failed to fetch data from OmniFocus - the data scan errored or timed out before any items were read',
+          'Check that OmniFocus is running and not blocked by a dialog, then retry',
           undefined,
           { query_time_ms: Date.now() - startTime },
         );
@@ -1278,9 +1278,14 @@ SCOPE FILTERING:
     };
   }
 
+  // OMN-268: returns null when the fetch script fails (timeout, script error,
+  // unusable shape). Returning empty arrays here made a failed scan
+  // indistinguishable from an empty database, so every detector downstream
+  // reported zero-count "healthy" findings fabricated from data that was never
+  // read. The caller maps null to an EXECUTION_ERROR envelope.
   private async fetchSlimmedData(
     options: Record<string, unknown>,
-  ): Promise<{ tasks: SlimTask[]; projects: ProjectData[]; tags: TagData[] }> {
+  ): Promise<{ tasks: SlimTask[]; projects: ProjectData[]; tags: TagData[] } | null> {
     const taskScript = `(() => {
       const app = Application('OmniFocus');
       const doc = app.defaultDocument();
@@ -1395,17 +1400,17 @@ SCOPE FILTERING:
 
     if (isScriptError(scriptResult)) {
       this.patternLogger.error('fetchSlimmedData failed', { error: scriptResult.error });
-      return { tasks: [], projects: [], tags: [] };
+      return null;
     }
 
     if (!isScriptSuccess(scriptResult)) {
       this.patternLogger.error('fetchSlimmedData returned unexpected format', { result: scriptResult });
-      return { tasks: [], projects: [], tags: [] };
+      return null;
     }
 
     const result = scriptResult.data;
     if (!result) {
-      return { tasks: [], projects: [], tags: [] };
+      return null;
     }
 
     if (typeof result === 'string') {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1538,18 +1538,42 @@ describe('OmniFocusAnalyzeTool', () => {
   // Pattern Analysis
   // ==========================================================================
   describe('pattern_analysis', () => {
-    it('handles fetch failure gracefully', async () => {
-      mockOmni.executeJson.mockResolvedValue({
-        success: false,
-        error: 'Script failed',
-      });
+    // OMN-268: a fetch failure (script timeout/error) must surface as an error
+    // envelope — never as success:true with zero-initialized "healthy" findings.
+    it('returns an error envelope when the data fetch script fails', async () => {
+      mockOmni.executeJson.mockResolvedValue(createScriptError('Script execution timed out', 'timeout after 120000ms'));
 
       const res: any = await tool.execute({
         analysis: { type: 'pattern_analysis', params: { insights: ['duplicates'] } },
       });
 
-      // Should return error or empty results (not throw)
-      expect(res).toBeDefined();
+      expect(res.success).toBe(false);
+      expect(res.error?.code).toBe('EXECUTION_ERROR');
+      // No fabricated findings may ride along on the failure
+      expect(res.data?.duplicates).toBeUndefined();
+    });
+
+    it('returns an error envelope when the fetch returns an unusable shape', async () => {
+      mockOmni.executeJson.mockResolvedValue(createScriptSuccess(null));
+
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis' },
+      });
+
+      expect(res.success).toBe(false);
+      expect(res.error?.code).toBe('EXECUTION_ERROR');
+      expect(res.data?.deadline_health).toBeUndefined();
+    });
+
+    it('still succeeds honestly on a genuinely empty (but fetched) database', async () => {
+      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({ tasks: [], projects: [], tags: [] }));
+
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['duplicates'] } },
+      });
+
+      expect(res.success).toBe(true);
+      expect(res.metadata?.tasks_analyzed).toBe(0);
     });
   });
 


### PR DESCRIPTION
## What

`fetchSlimmedData` swallowed script errors (including the 120s timeout) by returning `{ tasks: [], projects: [], tags: [] }` — indistinguishable from an empty database. Every pattern detector then ran on zero data and the tool returned `success: true` with all-zero, upbeat findings.

**Live incident (2026-07-13):** `pattern_analysis` reported "Deadline distribution looks manageable" / `overdue_count: 0` seconds after `omnifocus_read` measured 88 real overdue tasks and 189-of-195 projects overdue for review. The only honest signals were buried in metadata (`tasks_analyzed: 0`, `query_time_ms: 120010`).

## How

- `fetchSlimmedData` now returns `null` on script error, unexpected format, or missing data (was: fake-empty arrays). The caller's existing `!slimData` guard emits the `EXECUTION_ERROR` envelope — no new error machinery.
- Error message/suggestion updated to name the actual failure (scan errored or timed out) and the likely remedy.
- A genuinely empty-but-fetched database still succeeds honestly with `tasks_analyzed: 0` (pinned by test).

## Tests

Replaced the vacuous `handles fetch failure gracefully` test (`expect(res).toBeDefined()` — passed either way) with three discriminating tests: script error → error envelope; unusable shape → error envelope; empty-DB → honest success. **Red-verified before the fix** (both lie-path tests failed against the old code). Full unit suite: 3,882 passed.

## Out of scope

Sibling audit (workflow_analysis, overdue_analysis, productivity_stats zero-data paths) — no other `return { tasks: [] ...}` swallow found by grep, but a per-operation envelope audit is separate work if wanted.

Closes OMN-268

🤖 Generated with [Claude Code](https://claude.com/claude-code)