### PR TITLE
feat(OMN-255): missing_next_actions pattern detector — active projects with no available next action

### DIFF
--- a/src/omnifocus/response-schemas/read.ts
+++ b/src/omnifocus/response-schemas/read.ts
@@ -467,7 +467,8 @@ const SlimTaskSchema = z
  * id, name, status always set. taskCount/availableTaskCount are in the projectData literal
  * (direct property access, NOT inner try/catch) → always present; the outer try/catch skips
  * the whole project on error rather than emitting a partial object.
- * All dates are conditional (inner try/catch).
+ * All dates and `folder` are conditional (inner try/catch); folder is additionally
+ * null for root-level projects.
  */
 const SlimProjectSchema = z
   .object({

--- a/src/omnifocus/response-schemas/read.ts
+++ b/src/omnifocus/response-schemas/read.ts
@@ -476,6 +476,8 @@ const SlimProjectSchema = z
     status: z.string(),
     taskCount: z.number(),
     availableTaskCount: z.number(),
+    // OMN-255: containing folder name; conditional (inner try/catch) and null for root projects
+    folder: z.string().nullable().optional(),
     lastReviewDate: z.string().optional(),
     nextReviewDate: z.string().optional(),
     creationDate: z.string().optional(),

--- a/src/omnifocus/scripts/analytics/review-gaps-analyzer.ts
+++ b/src/omnifocus/scripts/analytics/review-gaps-analyzer.ts
@@ -25,11 +25,9 @@ interface ReviewGapsResult {
 
 export function analyzeReviewGaps(projects: Project[]): ReviewGapsResult {
   const now = new Date();
-  // Canonical status vocabulary is safeGetStatus's ('active'/'onHold'/'done'/'dropped');
-  // 'on-hold' kept for callers that pre-date the normalization.
-  const activeProjects = projects.filter(
-    (p) => p.status === 'active' || p.status === 'onHold' || p.status === 'on-hold',
-  );
+  // Canonical status vocabulary (fetchSlimmedData → normalizeProjectStatus):
+  // 'active'/'onHold'/'done'/'dropped'.
+  const activeProjects = projects.filter((p) => p.status === 'active' || p.status === 'onHold');
 
   // Projects never reviewed (no nextReviewDate or lastReviewDate)
   const neverReviewed = activeProjects

--- a/src/omnifocus/scripts/analytics/review-gaps-analyzer.ts
+++ b/src/omnifocus/scripts/analytics/review-gaps-analyzer.ts
@@ -25,7 +25,11 @@ interface ReviewGapsResult {
 
 export function analyzeReviewGaps(projects: Project[]): ReviewGapsResult {
   const now = new Date();
-  const activeProjects = projects.filter((p) => p.status === 'active' || p.status === 'on-hold');
+  // Canonical status vocabulary is safeGetStatus's ('active'/'onHold'/'done'/'dropped');
+  // 'on-hold' kept for callers that pre-date the normalization.
+  const activeProjects = projects.filter(
+    (p) => p.status === 'active' || p.status === 'onHold' || p.status === 'on-hold',
+  );
 
   // Projects never reviewed (no nextReviewDate or lastReviewDate)
   const neverReviewed = activeProjects

--- a/src/omnifocus/scripts/analytics/wip-limits-analyzer.ts
+++ b/src/omnifocus/scripts/analytics/wip-limits-analyzer.ts
@@ -43,7 +43,8 @@ function isTaskAvailable(task: Task): boolean {
 
 export function analyzeWipLimits(projects: Project[], options: WipLimitsOptions): WipLimitsResult {
   const { wipLimit } = options;
-  const activeProjects = projects.filter((p) => p.status === 'active' || p.status === 'on-hold');
+  // Canonical status vocabulary (fetchSlimmedData → normalizeProjectStatus): 'onHold', not 'on-hold'.
+  const activeProjects = projects.filter((p) => p.status === 'active' || p.status === 'onHold');
 
   const analyzed = activeProjects.map((project) => {
     let availableTasks: number;

--- a/src/prompts/gtd/WeeklyReviewPrompt.ts
+++ b/src/prompts/gtd/WeeklyReviewPrompt.ts
@@ -173,7 +173,7 @@ Finally, let's ensure every active project has at least one clear next action.`,
         role: 'user',
         content: {
           type: 'text',
-          text: 'Find all active projects that have zero available tasks. These need immediate attention to define next actions.',
+          text: "Run omnifocus_analyze with type 'pattern_analysis' and params.insights ['missing_next_actions'] — it returns every active project with zero available next actions in one call (id, name, folder). These need immediate attention to define next actions.",
         },
       },
       {

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -142,6 +142,7 @@ interface ProjectData {
   status: string;
   taskCount?: number;
   availableTaskCount?: number;
+  folder?: string | null;
   lastReviewDate?: string;
   nextReviewDate?: string;
   creationDate?: string;
@@ -279,7 +280,7 @@ ANALYSIS TYPES:
 - productivity_stats: GTD health metrics (completion rates, velocity)
 - task_velocity: Completion trends over time
 - overdue_analysis: Bottleneck identification
-- pattern_analysis: Database-wide patterns (tags, projects, stale items)
+- pattern_analysis: Database-wide patterns (tags, projects, stale items, missing next actions)
 - workflow_analysis: Deep workflow analysis
 - recurring_tasks: Recurring task patterns and frequencies
 - parse_meeting_notes: Structure meeting action items into OmniFocus.
@@ -1101,6 +1102,7 @@ SCOPE FILTERING:
             'review_gaps',
             'wip_limits',
             'due_date_bunching',
+            'missing_next_actions',
           ]
         : rawPatterns;
 
@@ -1193,6 +1195,9 @@ SCOPE FILTERING:
             break;
           case 'due_date_bunching':
             findings.due_date_bunching = this.analyzeBunchingPattern(slimData.tasks, options.bunching_threshold);
+            break;
+          case 'missing_next_actions':
+            findings.missing_next_actions = this.detectMissingNextActions(slimData.projects);
             break;
         }
       }
@@ -1361,6 +1366,10 @@ SCOPE FILTERING:
             taskCount: project.numberOfTasks(),
             availableTaskCount: project.numberOfAvailableTasks()
           };
+
+          // OMN-255: folder works via method-call in JXA here (live-probed 2026-07-14),
+          // unlike the parent relationships that require the OmniJS bridge.
+          try { projectData.folder = project.folder() ? project.folder().name() : null; } catch(e) {}
 
           try { projectData.lastReviewDate = project.lastReviewDate()?.toISOString(); } catch(e) {}
           try { projectData.nextReviewDate = project.nextReviewDate()?.toISOString(); } catch(e) {}
@@ -1556,6 +1565,38 @@ SCOPE FILTERING:
         dormant.length > 0
           ? `${dormant.length} projects haven't been modified in over ${thresholdDays} days. Consider reviewing, completing, or dropping them.`
           : 'All projects show recent activity.',
+    };
+  }
+
+  // OMN-255: the core GTD weekly-review check — every ACTIVE project must have
+  // at least one available (actionable-now) task. availableTaskCount is OmniFocus's
+  // numberOfAvailableTasks(), live-verified equivalent to ACTIONABLE_STATUSES
+  // semantics (2026-07-14 fixture probe; spec OMN-255-projects-without-next-action.md):
+  // a sequential project with a deferred head, a deferred-only project, and an
+  // all-tasks-completed project all count 0; on-hold status propagates to 0 but is
+  // excluded here by the active-status gate.
+  private detectMissingNextActions(projects: ProjectData[]): PatternFinding {
+    // JXA status().toString() renders as 'active status'; accept the bare form too.
+    const isActive = (status: string) => status === 'active' || status === 'active status';
+
+    const stalled = projects
+      .filter((p) => isActive(p.status) && p.availableTaskCount === 0)
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        folder: p.folder ?? null,
+        task_count: p.taskCount,
+      }));
+
+    return {
+      type: 'missing_next_actions',
+      severity: stalled.length > 0 ? 'warning' : 'info',
+      count: stalled.length,
+      items: stalled,
+      recommendation:
+        stalled.length > 0
+          ? `${stalled.length} active project(s) have no available next action. Each needs a next action defined, or should be completed, put on hold, or dropped.`
+          : 'Every active project has at least one available next action.',
     };
   }
 

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -1576,8 +1576,14 @@ SCOPE FILTERING:
   // all-tasks-completed project all count 0; on-hold status propagates to 0 but is
   // excluded here by the active-status gate.
   private detectMissingNextActions(projects: ProjectData[]): PatternFinding {
-    // JXA status().toString() renders as 'active status'; accept the bare form too.
-    const isActive = (status: string) => status === 'active' || status === 'active status';
+    // Mirrors safeGetStatus (scripts/shared/helpers.ts, the canonical normalization
+    // of JXA's 'active status' / 'on hold status' renderings): substring match with
+    // an ACTIVE default. Failing open matters here — a status string this code
+    // doesn't recognize must surface the project in the review, never hide it.
+    const isActive = (status: string) => {
+      const s = status.toLowerCase();
+      return !(s.includes('hold') || s.includes('done') || s.includes('dropped'));
+    };
 
     const stalled = projects
       .filter((p) => isActive(p.status) && p.availableTaskCount === 0)

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -136,6 +136,20 @@ interface SlimTask {
   children?: number;
 }
 
+// Canonical project-status vocabulary, mirroring safeGetStatus in
+// scripts/shared/helpers.ts: JXA renders status as 'active status',
+// 'on hold status', etc.; every ProjectData consumer gets THIS normalized
+// form (applied once in fetchSlimmedData). The unknown-string default is
+// 'active' on purpose — detectors that gate on activity must fail open
+// (surface the project) rather than silently drop it.
+function normalizeProjectStatus(raw: string): 'active' | 'onHold' | 'done' | 'dropped' {
+  const s = raw.toLowerCase();
+  if (s.includes('hold')) return 'onHold';
+  if (s.includes('done')) return 'done';
+  if (s.includes('dropped')) return 'dropped';
+  return 'active';
+}
+
 interface ProjectData {
   id: string;
   name: string;
@@ -1106,8 +1120,11 @@ SCOPE FILTERING:
           ]
         : rawPatterns;
 
-      // Fetch slimmed task data
-      const slimData = await this.fetchSlimmedData(options);
+      // Fetch slimmed task data (folder lookup costs one JXA call per project —
+      // only pay it when a requested pattern actually uses the folder field)
+      const slimData = await this.fetchSlimmedData(options, {
+        includeFolder: patterns.includes('missing_next_actions'),
+      });
 
       if (!slimData) {
         return createErrorResponseV2(
@@ -1290,6 +1307,7 @@ SCOPE FILTERING:
   // read. The caller maps null to an EXECUTION_ERROR envelope.
   private async fetchSlimmedData(
     options: Record<string, unknown>,
+    { includeFolder = false }: { includeFolder?: boolean } = {},
   ): Promise<{ tasks: SlimTask[]; projects: ProjectData[]; tags: TagData[] } | null> {
     const taskScript = `(() => {
       const app = Application('OmniFocus');
@@ -1367,9 +1385,14 @@ SCOPE FILTERING:
             availableTaskCount: project.numberOfAvailableTasks()
           };
 
-          // OMN-255: folder works via method-call in JXA here (live-probed 2026-07-14),
-          // unlike the parent relationships that require the OmniJS bridge.
-          try { projectData.folder = project.folder() ? project.folder().name() : null; } catch(e) {}
+          ${
+            includeFolder
+              ? `// OMN-255: folder works via method-call in JXA here (live-probed 2026-07-14),
+          // unlike the parent relationships that require the OmniJS bridge. One call,
+          // cached in a local (each JXA method call is an Apple Event round trip).
+          try { const projFolder = project.folder(); projectData.folder = projFolder ? projFolder.name() : null; } catch(e) {}`
+              : ''
+          }
 
           try { projectData.lastReviewDate = project.lastReviewDate()?.toISOString(); } catch(e) {}
           try { projectData.nextReviewDate = project.nextReviewDate()?.toISOString(); } catch(e) {}
@@ -1422,10 +1445,20 @@ SCOPE FILTERING:
       return null;
     }
 
-    if (typeof result === 'string') {
-      return JSON.parse(result) as { tasks: SlimTask[]; projects: ProjectData[]; tags: TagData[] };
-    }
-    return result as { tasks: SlimTask[]; projects: ProjectData[]; tags: TagData[] };
+    const parsed = (typeof result === 'string' ? JSON.parse(result) : result) as {
+      tasks: SlimTask[];
+      projects: ProjectData[];
+      tags: TagData[];
+    };
+
+    // Normalize status ONCE at the boundary so every detector inherits the
+    // canonical vocabulary instead of re-interpreting raw JXA renderings
+    // (the raw/normalized split had already broken dormant_projects' and
+    // review_gaps' status checks — see normalizeProjectStatus).
+    return {
+      ...parsed,
+      projects: parsed.projects.map((p) => ({ ...p, status: normalizeProjectStatus(p.status) })),
+    };
   }
 
   private detectDuplicates(tasks: SlimTask[], options: Record<string, unknown>): PatternFinding {
@@ -1576,17 +1609,10 @@ SCOPE FILTERING:
   // all-tasks-completed project all count 0; on-hold status propagates to 0 but is
   // excluded here by the active-status gate.
   private detectMissingNextActions(projects: ProjectData[]): PatternFinding {
-    // Mirrors safeGetStatus (scripts/shared/helpers.ts, the canonical normalization
-    // of JXA's 'active status' / 'on hold status' renderings): substring match with
-    // an ACTIVE default. Failing open matters here — a status string this code
-    // doesn't recognize must surface the project in the review, never hide it.
-    const isActive = (status: string) => {
-      const s = status.toLowerCase();
-      return !(s.includes('hold') || s.includes('done') || s.includes('dropped'));
-    };
-
+    // status arrives normalized (fetchSlimmedData → normalizeProjectStatus),
+    // whose unknown-string default is 'active' — so drift still fails open.
     const stalled = projects
-      .filter((p) => isActive(p.status) && p.availableTaskCount === 0)
+      .filter((p) => p.status === 'active' && p.availableTaskCount === 0)
       .map((p) => ({
         id: p.id,
         name: p.name,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -144,6 +144,10 @@ interface SlimTask {
 // (surface the project) rather than silently drop it.
 function normalizeProjectStatus(raw: string): 'active' | 'onHold' | 'done' | 'dropped' {
   const s = raw.toLowerCase();
+  // Same check ORDER as safeGetStatus: 'active' wins first, so an ambiguous
+  // string containing both an active-ish and a terminal-ish substring
+  // classifies toward inclusion (fail-open), matching the default below.
+  if (s.includes('active')) return 'active';
   if (s.includes('hold')) return 'onHold';
   if (s.includes('done')) return 'done';
   if (s.includes('dropped')) return 'dropped';

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1633,6 +1633,93 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(ids).not.toContain('py'); // recognized terminal status → excluded
     });
 
+    // Round-2 review: ProjectData.status is normalized ONCE at the fetch boundary
+    // (safeGetStatus vocabulary: active/onHold/done/dropped). These pin the two
+    // latent consumer bugs the raw/normalized split had already caused.
+    it('dormant_projects excludes done/dropped projects (raw JXA status strings)', async () => {
+      const old = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          tasks: [],
+          projects: [
+            {
+              id: 'd1',
+              name: 'Old active',
+              status: 'active status',
+              taskCount: 1,
+              availableTaskCount: 1,
+              modificationDate: old,
+            },
+            {
+              id: 'd2',
+              name: 'Old done',
+              status: 'done status',
+              taskCount: 1,
+              availableTaskCount: 0,
+              modificationDate: old,
+            },
+            {
+              id: 'd3',
+              name: 'Old dropped',
+              status: 'dropped status',
+              taskCount: 1,
+              availableTaskCount: 0,
+              modificationDate: old,
+            },
+          ],
+          tags: [],
+        }),
+      );
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['dormant_projects'] } },
+      });
+
+      const ids = (res.data.dormant_projects.items as Array<{ id: string }>).map((i) => i.id);
+      expect(ids).toContain('d1');
+      expect(ids).not.toContain('d2');
+      expect(ids).not.toContain('d3');
+    });
+
+    it('review_gaps sees active and on-hold projects despite raw JXA status strings', async () => {
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          tasks: [],
+          projects: [
+            { id: 'r1', name: 'Never reviewed active', status: 'active status', taskCount: 1, availableTaskCount: 1 },
+            { id: 'r2', name: 'Never reviewed on hold', status: 'on hold status', taskCount: 1, availableTaskCount: 0 },
+            { id: 'r3', name: 'Done project', status: 'done status', taskCount: 1, availableTaskCount: 0 },
+          ],
+          tags: [],
+        }),
+      );
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['review_gaps'] } },
+      });
+
+      const never = (res.data.review_gaps.items.never_reviewed as Array<{ id: string }>).map((i) => i.id);
+      expect(never).toContain('r1');
+      expect(never).toContain('r2');
+      expect(never).not.toContain('r3');
+    });
+
+    // Round-2 review: folder lookup is one JXA call, and only emitted when a
+    // requested pattern actually uses the folder field.
+    it('fetches folder with a single cached call, only when missing_next_actions runs', async () => {
+      mockDb();
+      await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['missing_next_actions'] } },
+      });
+      const withFolderScript = mockOmni.executeJson.mock.calls.at(-1)[0] as string;
+      expect(withFolderScript.match(/project\.folder\(\)/g)?.length).toBe(1);
+
+      mockDb();
+      await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['duplicates'] } },
+      });
+      const withoutFolderScript = mockOmni.executeJson.mock.calls.at(-1)[0] as string;
+      expect(withoutFolderScript).not.toContain('project.folder()');
+    });
+
     it('is included in the default "all" expansion', async () => {
       mockDb();
       const res: any = await tool.execute({ analysis: { type: 'pattern_analysis' } });

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1592,7 +1592,7 @@ describe('OmniFocusAnalyzeTool', () => {
       mockOmni.executeJson.mockResolvedValue(createScriptSuccess({ tasks: [], projects, tags: [] }));
     }
 
-    it('reports only active projects with zero available tasks (id, name, folder)', async () => {
+    it('reports only active zero-available projects (id, name, folder), excluding on-hold and healthy ones', async () => {
       mockDb();
       const res: any = await tool.execute({
         analysis: { type: 'pattern_analysis', params: { insights: ['missing_next_actions'] } },
@@ -1604,20 +1604,33 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(finding.severity).toBe('warning');
       expect(finding.count).toBe(2);
       const items = finding.items as Array<{ id: string; name: string; folder: string | null }>;
+      // p2 (has available task) and p3 (on hold) are excluded; p1/p4 reported
       expect(items.map((i) => i.id).sort()).toEqual(['p1', 'p4']);
       const p1 = items.find((i) => i.id === 'p1');
       expect(p1).toMatchObject({ id: 'p1', name: 'Stalled seq', folder: 'Work' });
     });
 
-    it('excludes on-hold projects and projects with available tasks', async () => {
-      mockDb();
+    it('fails open: an unrecognized status string is treated as active, never silently dropped', async () => {
+      // Mirrors safeGetStatus (helpers.ts): normalization defaults to 'active',
+      // so status-string drift (new OF version, locale) surfaces the project
+      // rather than hiding it from the weekly review.
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          tasks: [],
+          projects: [
+            { id: 'px', name: 'Drifted status', status: 'mystery rendering', taskCount: 1, availableTaskCount: 0 },
+            { id: 'py', name: 'Dropped', status: 'dropped status', taskCount: 1, availableTaskCount: 0 },
+          ],
+          tags: [],
+        }),
+      );
       const res: any = await tool.execute({
         analysis: { type: 'pattern_analysis', params: { insights: ['missing_next_actions'] } },
       });
 
       const ids = (res.data.missing_next_actions.items as Array<{ id: string }>).map((i) => i.id);
-      expect(ids).not.toContain('p2');
-      expect(ids).not.toContain('p3');
+      expect(ids).toContain('px'); // unknown → fail open → reported
+      expect(ids).not.toContain('py'); // recognized terminal status → excluded
     });
 
     it('is included in the default "all" expansion', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1702,6 +1702,34 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(never).not.toContain('r3');
     });
 
+    it('wip_limits sees on-hold projects despite raw JXA status strings', async () => {
+      const mkTask = (i: number) => ({
+        id: `t${i}`,
+        name: `task ${i}`,
+        completed: false,
+        flagged: false,
+        status: 'available',
+        tags: [],
+        projectId: 'w1',
+        estimatedMinutes: null,
+      });
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          tasks: [1, 2, 3, 4, 5, 6, 7].map(mkTask),
+          projects: [
+            { id: 'w1', name: 'Overloaded on hold', status: 'on hold status', taskCount: 7, availableTaskCount: 7 },
+          ],
+          tags: [],
+        }),
+      );
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['wip_limits'] } },
+      });
+
+      const over = (res.data.wip_limits.items.projects_over_limit as Array<{ project: string }>).map((p) => p.project);
+      expect(over).toContain('Overloaded on hold');
+    });
+
     // Round-2 review: folder lookup is one JXA call, and only emitted when a
     // requested pattern actually uses the folder field.
     it('fetches folder with a single cached call, only when missing_next_actions runs', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1620,6 +1620,7 @@ describe('OmniFocusAnalyzeTool', () => {
           projects: [
             { id: 'px', name: 'Drifted status', status: 'mystery rendering', taskCount: 1, availableTaskCount: 0 },
             { id: 'py', name: 'Dropped', status: 'dropped status', taskCount: 1, availableTaskCount: 0 },
+            { id: 'pz', name: 'Ambiguous', status: 'active (hold)', taskCount: 1, availableTaskCount: 0 },
           ],
           tags: [],
         }),
@@ -1631,6 +1632,7 @@ describe('OmniFocusAnalyzeTool', () => {
       const ids = (res.data.missing_next_actions.items as Array<{ id: string }>).map((i) => i.id);
       expect(ids).toContain('px'); // unknown → fail open → reported
       expect(ids).not.toContain('py'); // recognized terminal status → excluded
+      expect(ids).toContain('pz'); // ambiguous active+hold → active wins (safeGetStatus order)
     });
 
     // Round-2 review: ProjectData.status is normalized ONCE at the fetch boundary

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1577,6 +1577,76 @@ describe('OmniFocusAnalyzeTool', () => {
     });
   });
 
+  // OMN-255: missing_next_actions — active projects with zero available tasks.
+  // "Available" is OmniFocus's numberOfAvailableTasks(), live-verified equivalent
+  // to ACTIONABLE_STATUSES semantics (spec: OMN-255-projects-without-next-action.md).
+  describe('pattern_analysis missing_next_actions (OMN-255)', () => {
+    const projects = [
+      { id: 'p1', name: 'Stalled seq', status: 'active status', taskCount: 2, availableTaskCount: 0, folder: 'Work' },
+      { id: 'p2', name: 'Healthy', status: 'active status', taskCount: 1, availableTaskCount: 1, folder: null },
+      { id: 'p3', name: 'On hold', status: 'on hold status', taskCount: 1, availableTaskCount: 0, folder: 'Work' },
+      { id: 'p4', name: 'All done', status: 'active status', taskCount: 1, availableTaskCount: 0, folder: null },
+    ];
+
+    function mockDb() {
+      mockOmni.executeJson.mockResolvedValue(createScriptSuccess({ tasks: [], projects, tags: [] }));
+    }
+
+    it('reports only active projects with zero available tasks (id, name, folder)', async () => {
+      mockDb();
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['missing_next_actions'] } },
+      });
+
+      expect(res.success).toBe(true);
+      const finding = res.data.missing_next_actions;
+      expect(finding).toBeDefined();
+      expect(finding.severity).toBe('warning');
+      expect(finding.count).toBe(2);
+      const items = finding.items as Array<{ id: string; name: string; folder: string | null }>;
+      expect(items.map((i) => i.id).sort()).toEqual(['p1', 'p4']);
+      const p1 = items.find((i) => i.id === 'p1');
+      expect(p1).toMatchObject({ id: 'p1', name: 'Stalled seq', folder: 'Work' });
+    });
+
+    it('excludes on-hold projects and projects with available tasks', async () => {
+      mockDb();
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['missing_next_actions'] } },
+      });
+
+      const ids = (res.data.missing_next_actions.items as Array<{ id: string }>).map((i) => i.id);
+      expect(ids).not.toContain('p2');
+      expect(ids).not.toContain('p3');
+    });
+
+    it('is included in the default "all" expansion', async () => {
+      mockDb();
+      const res: any = await tool.execute({ analysis: { type: 'pattern_analysis' } });
+
+      expect(res.data.missing_next_actions).toBeDefined();
+      expect(res.metadata.patterns_checked).toContain('missing_next_actions');
+    });
+
+    it('reports info severity with an honest empty list when nothing is stalled', async () => {
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          tasks: [],
+          projects: [{ id: 'p2', name: 'Healthy', status: 'active status', taskCount: 1, availableTaskCount: 1 }],
+          tags: [],
+        }),
+      );
+      const res: any = await tool.execute({
+        analysis: { type: 'pattern_analysis', params: { insights: ['missing_next_actions'] } },
+      });
+
+      const finding = res.data.missing_next_actions;
+      expect(finding.severity).toBe('info');
+      expect(finding.count).toBe(0);
+      expect(finding.items).toEqual([]);
+    });
+  });
+
   // ─── ADVERTISED SCHEMA ──────────────────────────────────────────────
 
   describe('inputSchema (MCP advertisement)', () => {


### PR DESCRIPTION
## What

The core GTD weekly-review check ("every active project has ≥1 available next action") as a one-call server capability: a `missing_next_actions` detector in `pattern_analysis`, per the ticket's **Option A** (approved by Kip 2026-07-14).

## Why this shape

`fetchSlimmedData` already collects `availableTaskCount` (`numberOfAvailableTasks()`) per project, so the detector is a pure-TS filter over existing scan data — no new JXA scan, and no Zod input change (`insights` is a free string array). The one external-seam risk was **verified live pre-build**: a five-fixture probe (sequential-deferred / deferred-only / on-hold / healthy / all-done) showed perfect equivalence between `numberOfAvailableTasks()` and ACTIONABLE_STATUSES `available`-mode semantics. Results table in the spec.

## Changes

- `detectMissingNextActions()`: active projects with `availableTaskCount === 0` → PatternFinding (warning severity when any; items carry id/name/folder/task_count)
- `fetchSlimmedData` projects the containing folder (JXA `project.folder()` — live-probed working, conditional, null at root) + matching `SlimProjectSchema` field (`.strict()` requires both sides)
- Wired into the `'all'` expansion + switch; tool description mentions the new pattern
- `WeeklyReviewPrompt` Step 8 instructs the one-call detector instead of the manual per-project fan-out
- 4 red-verified unit tests (reported/excluded rows incl. on-hold gate, `'all'` inclusion, honest empty state); full suite 3,886 green

## Spec

`Technical/specs/OMN-255-projects-without-next-action.md` — Option A approval, verification results, probe gotchas.

Closes OMN-255

🤖 Generated with [Claude Code](https://claude.com/claude-code)