### PR TITLE
feat(OMN-273): drop clear_schedule — OmniFocus has no clearable review state

### DIFF
--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -1469,8 +1469,8 @@ export interface SetReviewScheduleInput {
  *
  * Fail-loud (Kip 2026-07-06, with OMN-136): a request with NEITHER
  * reviewInterval NOR nextReviewDate throws at build time — the legacy script
- * silently reported per-project success with empty changes (the clear_schedule
- * silent no-op class).
+ * silently reported per-project success with empty changes (the silent no-op
+ * class behind the since-removed clear_schedule operation, OMN-273).
  */
 export function buildSetReviewScheduleProgram(data: SetReviewScheduleInput): Program {
   const _exhaustive: Record<keyof SetReviewScheduleInput, true> = {

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -323,8 +323,8 @@ ANALYSIS TYPES:
 - manage_reviews: Project review operations
   params: { operation, projectId, reviewDate, reviewInterval }
   - set_schedule accepts reviewInterval: { unit: 'day'|'week'|'month'|'year', steps: positive int }
-  - clear_schedule always returns UNSUPPORTED (OmniJS cannot remove a project reviewInterval —
-    OMN-41/OMN-58); set a different interval with set_schedule or clear it in the OmniFocus app
+  - review schedules cannot be removed, only changed: OmniFocus has no "not scheduled
+    for review" project state (OMN-41/OMN-58/OMN-273)
 
 PERFORMANCE WARNINGS:
 - pattern_analysis on 1000+ items: ~5-10 seconds
@@ -3353,14 +3353,12 @@ SCOPE FILTERING:
           return this.reviewsMarkReviewed(compiled, timer);
         case 'set_schedule':
           return this.reviewsSetSchedule(compiled, timer);
-        case 'clear_schedule':
-          return this.reviewsClearSchedule(compiled, timer);
         default:
           return createErrorResponseV2(
             'manage_reviews',
             'INVALID_OPERATION',
             `Unknown operation: ${String(operation)}`,
-            'Use one of: list_for_review, mark_reviewed, set_schedule (clear_schedule is unsupported — OMN-41/OMN-58)',
+            'Use one of: list_for_review, mark_reviewed, set_schedule',
             { operation },
             timer.toMetadata(),
           );
@@ -3595,27 +3593,5 @@ SCOPE FILTERING:
       projects_updated: brandedProjectIds.length,
       input_params: { projectId },
     });
-  }
-
-  private reviewsClearSchedule(
-    compiled: Extract<CompiledAnalysis, { type: 'manage_reviews' }>,
-    timer: OperationTimerV2,
-  ): StandardResponseV2<unknown> {
-    const projectId = compiled.params?.projectId;
-
-    // OMN-106 fail-loud (Kip 2026-07-06, with OMN-136): the legacy path sent
-    // {reviewInterval:null, nextReviewDate:null}, which the script if-gated
-    // into a per-project SUCCESS with empty changes — nothing was ever cleared.
-    // OmniJS cannot construct or null a Project.ReviewInterval (OMN-41/OMN-58),
-    // so a clear cannot take effect through this seam; say so instead of lying.
-    return createErrorResponseV2(
-      'manage_reviews',
-      'UNSUPPORTED',
-      'clear_schedule cannot clear a review schedule: OmniJS cannot remove or null a project reviewInterval ' +
-        '(OMN-41/OMN-58). The previous behavior reported success without changing anything.',
-      'Set a different interval with set_schedule, or clear the review schedule in the OmniFocus app',
-      { projectId },
-      timer.toMetadata(),
-    );
   }
 }

--- a/src/tools/unified/compilers/AnalysisCompiler.ts
+++ b/src/tools/unified/compilers/AnalysisCompiler.ts
@@ -76,7 +76,7 @@ export type CompiledAnalysis =
   | {
       type: 'manage_reviews';
       params?: {
-        operation?: 'list_for_review' | 'mark_reviewed' | 'set_schedule' | 'clear_schedule';
+        operation?: 'list_for_review' | 'mark_reviewed' | 'set_schedule';
         projectId?: string;
         reviewDate?: string;
         // OMN-60: review interval for set_schedule, passed through to the script.

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -162,6 +162,10 @@ const AnalysisSchema = z.discriminatedUnion('type', [
           // OMN-273: clear_schedule removed — OmniFocus has no "not scheduled
           // for review" state (reviewInterval is non-nullable; nulling
           // nextReviewDate just recomputes it), so the op can never take effect.
+          // Failure-mode change is deliberate (Kip, 2026-07-17): stale callers
+          // now get a thrown McpError(InvalidParams) naming the valid ops, not
+          // the old UNSUPPORTED envelope. Acceptable break: the op returned
+          // only errors since OMN-106, so no caller ever got value from it.
           operation: z.enum(['list_for_review', 'mark_reviewed', 'set_schedule']).optional(),
           projectId: z.string().optional(),
           reviewDate: z.string().optional(),

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -159,7 +159,10 @@ const AnalysisSchema = z.discriminatedUnion('type', [
       type: z.literal('manage_reviews'),
       params: z
         .object({
-          operation: z.enum(['list_for_review', 'mark_reviewed', 'set_schedule', 'clear_schedule']).optional(),
+          // OMN-273: clear_schedule removed — OmniFocus has no "not scheduled
+          // for review" state (reviewInterval is non-nullable; nulling
+          // nextReviewDate just recomputes it), so the op can never take effect.
+          operation: z.enum(['list_for_review', 'mark_reviewed', 'set_schedule']).optional(),
           projectId: z.string().optional(),
           reviewDate: z.string().optional(),
           // OMN-60: review interval for set_schedule. Object shape — passed

--- a/tests/unit/contracts/ast/mutation/set-review-schedule.test.ts
+++ b/tests/unit/contracts/ast/mutation/set-review-schedule.test.ts
@@ -173,13 +173,13 @@ describe('set-review-schedule — behavior goldens (exact JSON, vm-executed)', (
     });
   });
 
-  it('FAIL LOUD: the clear_schedule shape (both params null) now throws at build time', async () => {
+  it('FAIL LOUD: the both-params-null shape throws at build time', async () => {
     // Replaces the legacy silent no-op pinned in the pre-port commit: the
     // script reported per-project success with empty changes while clearing
     // nothing (OMN-106/OMN-136 fail-loud decision, Kip 2026-07-06). The
-    // analyze tool's clear_schedule handler no longer builds a script at all —
-    // it returns an explicit UNSUPPORTED error — and the builder refuses the
-    // shape too, so no caller can regress into the silent path.
+    // clear_schedule operation that produced this shape was removed outright
+    // in OMN-273, but the builder still refuses it so no future caller can
+    // regress into the silent path.
     await expect(
       buildSetReviewScheduleScript({ projectIds: ['p1'], reviewInterval: null, nextReviewDate: null }),
     ).rejects.toThrow(/requires reviewInterval or nextReviewDate/);

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1933,19 +1933,23 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(result.error?.code).toBe('VALIDATION_ERROR');
     });
 
-    it('FAIL LOUD (OMN-106): clear_schedule returns UNSUPPORTED without executing', async () => {
+    it('OMN-273: clear_schedule is no longer an operation — rejected at the schema, nothing executes', async () => {
+      // OmniFocus has no "not scheduled for review" state (reviewInterval is
+      // non-nullable and nextReviewDate:null just recomputes from the interval),
+      // so the operation was dropped entirely rather than kept as a runtime
+      // UNSUPPORTED refusal (OMN-41/OMN-58/OMN-106 lineage).
       mockCache.get.mockReturnValue(null);
 
-      const result = (await tool.execute({
-        analysis: {
-          type: 'manage_reviews',
-          params: { operation: 'clear_schedule', projectId: 'p1' },
-        },
-      })) as { success: boolean; error?: { code?: string } };
+      await expect(
+        tool.execute({
+          analysis: {
+            type: 'manage_reviews',
+            params: { operation: 'clear_schedule', projectId: 'p1' },
+          },
+        }),
+      ).rejects.toThrow(/Invalid parameters/);
 
       expect(mockOmni.executeJson).not.toHaveBeenCalled();
-      expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('UNSUPPORTED');
     });
   });
 });


### PR DESCRIPTION
## Summary

Removes the `clear_schedule` operation from `manage_reviews` entirely. Live probes (2026-07-16/17, throwaway projects) confirmed OmniFocus has no "not scheduled for review" state:

- `Project.reviewInterval` is non-nullable — `= null` / `= undefined` throw (`must be set to a non-null value`)
- every new project is born with a default interval (2 weeks here)
- `nextReviewDate = null` doesn't persist — OF recomputes it from `lastReviewDate + reviewInterval` immediately

Since OMN-106 the op was a pure runtime UNSUPPORTED refusal with no other behavior; a schema-level rejection is more honest advertising and saves clients the round-trip.

## Changes

- `analyze-schema.ts`: operation enum drops `clear_schedule` (with a why-comment)
- `AnalysisCompiler.ts`: type union drops it
- `OmniFocusAnalyzeTool.ts`: routing case + `reviewsClearSchedule` handler deleted; description now says review schedules can be changed but not removed
- tests: UNSUPPORTED pin replaced by a schema-rejection pin (**red-verified** against the pre-removal code); the builder's both-params-null fail-loud guard is retained unchanged as regression armor

## Vertical Contract Matrix

| # | Layer | Status |
|---|-------|--------|
| 1 | Schema (both) | ✅ Zod enum; inputSchema override has no operation enum (loose `params: object`) — description string updated |
| 2 | Normalization | N/A — no `WRAPPER_HINTS` entry references the op |
| 3 | Single-item path | ✅ handler deleted, routing falls to INVALID_OPERATION |
| 4 | Batch path | N/A — op never had a batch route |
| 5 | Script lowering | N/A — op never lowered a script (post-OMN-106); builder guard retained |
| 6 | Live bridge | ✅ MCPTestClient against real server + OmniFocus: `clear_schedule` → `MCP error -32602 Invalid enum value` naming the three valid ops; `list_for_review` returns success |
| 7 | Response validation | N/A — no response shape change (UNSUPPORTED envelope deleted with its op) |
| 8 | Cache key | N/A — no cached output influenced by the op |

## Ripple

The OMN-256 batch-manage_reviews spec's "clear_schedule symmetry" acceptance criterion resolves by deletion (spec + ticket updated separately in Obsidian/Linear).

Lineage: OMN-41 (setter audit) → OMN-58 (rejection forms) → OMN-106 (fail-loud envelope) → this removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpsm2cmXuJs7Wcp3ZW2r6v