### PR TITLE
feat(OMN-260): reject-and-hint for root data-only write payloads + mandatory-envelope description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- **Envelope guidance for root data-only write payloads** (OMN-260) — a bare `{"data":{...}}` sent to `omnifocus_write`
+  with no `operation` key still rejects (the accepted-input surface is unchanged; inferring the operation was declined —
+  the ambiguity analysis lives at the wrapper-lift gate in `src/tools/normalization/` and in the OMN-260 spec), but the
+  root-level error now names the missing `mutation` envelope with the required `operation` key, and the tool description
+  opens with the mandatory envelope shape plus canonical create/update examples — the recorded small-model failure shape
+  (qwen2.5:7b, OMN-168 re-baseline) now gets an actionable correction instead of
+  `Unrecognized key(s) in object: 'data'`.
+
 - **Readable `sequential` field on tasks** (OMN-207) — `type:"tasks"` queries can now request `sequential` via
   `fields:["sequential"]`, closing the settable-but-not-readable gap left by the write side (OMN-198/206). Reported as
   the raw stored boolean on every task (not conditional on child count): OmniFocus persists `sequential` across

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -147,6 +147,17 @@ function normalizeArgs(args: unknown, hint: NormalizationHint): { args: unknown;
   // ── Leniency #1: wrapper-lift ──────────────────────────────────────────────
   // The model emitted the inner payload at the root, missing the wrapper key but
   // carrying the discriminant (e.g. `{type:'tasks'}` → `{query:{type:'tasks'}}`).
+  //
+  // OMN-260 adjudication — the discriminant gate is deliberate; do NOT widen it
+  // to infer a missing `operation` from a bare root `{data:{...}}` payload. The
+  // ambiguity matrix (Technical/specs/OMN-260-root-data-only-wrapper-lift.md)
+  // kills that inference: the create-shaped case would ALSO need `target`
+  // invented (required on create, no default — inventing dispatch, the OMN-247
+  // hazard class), and the update/complete/delete-shaped cases are multi-match
+  // by construction, so a fire-only-when-unambiguous rule helps neither
+  // recorded payload. The adopted fix is reject-and-hint at the schema layer
+  // (write-schema.ts ROOT_DATA_ENVELOPE_HINT) + envelope examples in the tool
+  // description.
   if (isPlainObject(current) && !(hint.wrapperKey in current) && hint.discriminant in current) {
     current = { [hint.wrapperKey]: { ...current } };
     applied.push('wrapper-lift');

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -44,7 +44,7 @@ export interface NormalizeResult<T> {
   applied: string[];
 }
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -112,6 +112,11 @@ export class OmniFocusWriteTool extends BaseTool<typeof WriteSchema, unknown> {
   name = 'omnifocus_write';
   description = `Create, update, complete, or delete OmniFocus tasks and projects.
 
+ENVELOPE (required on every call): {"mutation":{"operation":<op>, ...}} — the "mutation" wrapper and its "operation" key are mandatory; a bare {"data":{...}} without an operation cannot be routed and is rejected.
+Canonical minimal examples:
+  create: {"mutation":{"operation":"create","target":"task","data":{"name":"Buy milk"}}}
+  update: {"mutation":{"operation":"update","id":"<taskId>","changes":{"flagged":true}}}
+
 OPERATIONS:
 - create: New task/project with data
 - create_folder: New folder (name required, optional parentFolder for nesting)

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -120,6 +120,10 @@ const WRITE_FIELD_REDIRECTS: Record<string, string> = {
 // names the missing envelope so the caller gets an actionable correction.
 // Root-only (path []): a misplaced `data` at a nested level has an envelope
 // already — the generic unrecognized-key error is the right one there.
+// Also gated on `mutation` being genuinely ABSENT from the root object
+// (ctx.data): a valid `mutation` envelope alongside an unrelated stray root
+// `data` key already HAS its envelope — claiming it's "missing" there would
+// be actively misleading, not actionable.
 const ROOT_DATA_ENVELOPE_HINT =
   'missing the mutation envelope: wrap the payload as ' +
   '{"mutation":{"operation":"create"|"update"|"complete"|"delete"|..., ...}} — ' +
@@ -128,7 +132,10 @@ const ROOT_DATA_ENVELOPE_HINT =
 const writeAliasErrorMap: z.ZodErrorMap = (issue, ctx) => {
   if (issue.code === z.ZodIssueCode.unrecognized_keys) {
     const hints = issue.keys.filter((k) => k in WRITE_FIELD_REDIRECTS).map((k) => `${k} → ${WRITE_FIELD_REDIRECTS[k]}`);
-    if (issue.path.length === 0 && issue.keys.includes('data')) {
+    const rootData = ctx.data as unknown;
+    const envelopeAbsent =
+      typeof rootData === 'object' && rootData !== null && !('mutation' in (rootData as Record<string, unknown>));
+    if (issue.path.length === 0 && issue.keys.includes('data') && envelopeAbsent) {
       hints.push(ROOT_DATA_ENVELOPE_HINT);
     }
     if (hints.length > 0) {

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -112,9 +112,25 @@ const WRITE_FIELD_REDIRECTS: Record<string, string> = {
   subtasks: "create children via a batch op with 'parentTempId' (or set 'parentTaskId' on create)",
 };
 
+// OMN-260: a bare root `{data:{...}}` (no `operation`, no `mutation`) is the
+// recorded small-model failure shape that wrapper-lift structurally cannot
+// repair — its discriminant gate is `'operation' in current`, and inferring
+// the operation was declined with data (see normalize-input.ts at that gate).
+// Reject-and-hint: the strict surface is unchanged, but the root-level error
+// names the missing envelope so the caller gets an actionable correction.
+// Root-only (path []): a misplaced `data` at a nested level has an envelope
+// already — the generic unrecognized-key error is the right one there.
+const ROOT_DATA_ENVELOPE_HINT =
+  'missing the mutation envelope: wrap the payload as ' +
+  '{"mutation":{"operation":"create"|"update"|"complete"|"delete"|..., ...}} — ' +
+  "'operation' is required and cannot be inferred from a bare 'data' object";
+
 const writeAliasErrorMap: z.ZodErrorMap = (issue, ctx) => {
   if (issue.code === z.ZodIssueCode.unrecognized_keys) {
     const hints = issue.keys.filter((k) => k in WRITE_FIELD_REDIRECTS).map((k) => `${k} → ${WRITE_FIELD_REDIRECTS[k]}`);
+    if (issue.path.length === 0 && issue.keys.includes('data')) {
+      hints.push(ROOT_DATA_ENVELOPE_HINT);
+    }
     if (hints.length > 0) {
       return { message: `${ctx.defaultError}. ${hints.join('; ')}` };
     }

--- a/src/tools/unified/schemas/write-schema.ts
+++ b/src/tools/unified/schemas/write-schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { coerceBoolean, coerceObject } from '../../schemas/coercion-helpers.js';
 import type { RepetitionRule } from '../../../contracts/mutations.js';
+import { isPlainObject } from '../../normalization/normalize-input.js';
 
 // ── Schema ↔ contract sync guards ────────────────────────────────────
 // Two complementary compile-time checks prevent schema/contract drift:
@@ -133,8 +134,7 @@ const writeAliasErrorMap: z.ZodErrorMap = (issue, ctx) => {
   if (issue.code === z.ZodIssueCode.unrecognized_keys) {
     const hints = issue.keys.filter((k) => k in WRITE_FIELD_REDIRECTS).map((k) => `${k} → ${WRITE_FIELD_REDIRECTS[k]}`);
     const rootData = ctx.data as unknown;
-    const envelopeAbsent =
-      typeof rootData === 'object' && rootData !== null && !('mutation' in (rootData as Record<string, unknown>));
+    const envelopeAbsent = isPlainObject(rootData) && !('mutation' in rootData);
     if (issue.path.length === 0 && issue.keys.includes('data') && envelopeAbsent) {
       hints.push(ROOT_DATA_ENVELOPE_HINT);
     }

--- a/tests/unit/tools/unified/schemas/write-root-data-hint.test.ts
+++ b/tests/unit/tools/unified/schemas/write-root-data-hint.test.ts
@@ -57,4 +57,19 @@ describe('OMN-260 — root data-only payloads reject WITH an envelope hint', () 
     expect(r.success).toBe(true);
     expect(r.applied).toEqual([]);
   });
+
+  it('the hint does NOT fire when a valid mutation envelope is present alongside a stray root data key', () => {
+    // The envelope IS present here — 'data' is just an unrelated extra root
+    // key. Claiming "missing the mutation envelope" would be actively
+    // misleading (the envelope exists and is correct); the plain
+    // unrecognized-key error is the right one.
+    const r = WriteSchema.safeParse({
+      mutation: { operation: 'update', target: 'task', id: 'x', changes: { flagged: true } },
+      data: { legacy: true },
+    });
+    expect(r.success).toBe(false);
+    const message = r.success ? '' : joinedIssues(r.error);
+    expect(message).not.toContain('missing the mutation envelope');
+    expect(message).not.toContain("'operation' is required");
+  });
 });

--- a/tests/unit/tools/unified/schemas/write-root-data-hint.test.ts
+++ b/tests/unit/tools/unified/schemas/write-root-data-hint.test.ts
@@ -1,0 +1,60 @@
+// OMN-260 (spec: Technical/specs/OMN-260-root-data-only-wrapper-lift.md):
+// root data-only mutation payloads ({data:{...}} with NO operation key) bypass
+// wrapper-lift by construction — the leniency's discriminant gate is
+// `'operation' in current`, and inferring the operation was declined with data
+// (the create case would need a second inference for `target`, which has no
+// default; the flag-update case is irreducibly multi-match). The adopted fix
+// is REJECT-AND-HINT: the strict surface is unchanged (these payloads still
+// fail), but the root-level unrecognized-'data' error now names the missing
+// mutation envelope so any model/caller gets an actionable correction.
+import { describe, it, expect } from 'vitest';
+import { WriteSchema } from '../../../../../src/tools/unified/schemas/write-schema.js';
+import { parseWithNormalization } from '../../../../../src/tools/normalization/normalize-input.js';
+
+/** The two payloads recorded verbatim from the OMN-168 re-baseline (qwen2.5:7b, 2026-07-08). */
+const RECORDED_PAYLOADS: Array<[string, Record<string, unknown>]> = [
+  ['create-task-tags', { data: { name: 'Email Bob', tags: ['work', 'urgent'] } }],
+  ['flag-update', { data: { flagged: true, id: 'xyz789' } }],
+];
+
+function joinedIssues(error: import('zod').ZodError): string {
+  return error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ');
+}
+
+describe('OMN-260 — root data-only payloads reject WITH an envelope hint', () => {
+  it.each(RECORDED_PAYLOADS)('%s: still fails validation (strict surface unchanged)', (_name, payload) => {
+    const r = parseWithNormalization(WriteSchema, payload, 'omnifocus_write');
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]); // no leniency fires — nothing infers the operation
+  });
+
+  it.each(RECORDED_PAYLOADS)('%s: the error names the missing mutation envelope', (_name, payload) => {
+    const r = parseWithNormalization(WriteSchema, payload, 'omnifocus_write');
+    expect(r.success).toBe(false);
+    const message = joinedIssues(r.error!);
+    expect(message).toContain('mutation');
+    expect(message).toContain("'operation' is required");
+    expect(message).toContain('cannot be inferred');
+  });
+
+  it('the hint is root-only: an unrecognized data key at a NESTED level keeps the plain error', () => {
+    // 'data' misplaced inside update.changes must not claim the envelope is
+    // missing — the envelope is present; the field is just wrong.
+    const r = WriteSchema.safeParse({
+      mutation: { operation: 'update', target: 'task', id: 'x', changes: { data: { flagged: true } } },
+    });
+    expect(r.success).toBe(false);
+    const message = r.success ? '' : joinedIssues(r.error);
+    expect(message).not.toContain("'operation' is required");
+  });
+
+  it('canonical payloads are untouched (no hint, parse succeeds)', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      { mutation: { operation: 'create', target: 'task', data: { name: 'Buy milk' } } },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Implements OMN-260's adopted decision (3+1, Kip 2026-07-18 — `Technical/specs/OMN-260-root-data-only-wrapper-lift.md`): the recorded qwen root data-only payloads (`{"data":{"name":...,"tags":[...]}}`, `{"data":{"flagged":true,"id":...}}`) **still reject** — the accepted-input surface is unchanged — but they now get an actionable error and the tool description states the mandatory envelope up front.

1. **Reject-and-hint** (`write-schema.ts`): root-level `unrecognized_keys` containing `data` appends `ROOT_DATA_ENVELOPE_HINT` ("missing the mutation envelope … 'operation' is required and cannot be inferred from a bare 'data' object"). Root-only (`path.length === 0`) — a misplaced nested `data` keeps the plain strict error, since its envelope exists.
2. **Description tuning** (`OmniFocusWriteTool`): the description now opens with the required `{"mutation":{"operation":…}}` envelope and canonical minimal create/update examples — previously the only full envelope shown was the batch example. This is the lever that can actually move qwen's 17/19 (the hint improves DX but the model must stop emitting the shape).
3. **Inference declined, recorded at the code site** (`normalize-input.ts`, wrapper-lift's discriminant gate): the ambiguity matrix — create would need `target` invented (required, no default → inventing dispatch, the OMN-247 hazard class); flag-update matches update/complete/delete → a fire-only-when-unambiguous rule helps neither recorded payload.

The llama `data.changes` nest is a different class (envelope present) and is split to **OMN-277** (`agent-ready`).

## Vertical Contract Matrix

| # | Layer | Status |
|---|---|---|
| 1 | Schema (both) | No shape change to Zod or `inputSchema` (error message + description text only). Description updated ✅. |
| 2 | Normalization | Deliberately unchanged — decline comment added at the wrapper-lift gate. |
| 3–5 | Single/batch/lowering | N/A — no mutation semantics touched. |
| 6 | Live bridge | N/A — validation-layer change; no OmniFocus interaction. **Supervised conformance re-baseline owed post-merge** (Ollama, OMN-168 gate rule) to measure the description's effect; number to be recorded on OMN-260. |
| 7 | Response validation | N/A. |
| 8 | Cache key | N/A. |

## Tests

- New `tests/unit/tools/unified/schemas/write-root-data-hint.test.ts` (6 tests, watched fail → pass): both recorded payloads still fail with `applied: []`; both errors name the envelope; root-only guard (nested misplaced `data` keeps plain error); canonical payload untouched.
- `npm run build` ✅ · lint `--max-warnings=0` ✅ · `npm run test:unit` **3923/3923** ✅.

Closes OMN-260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udg9nbYq7YMLBecJt3P764
