### PR TITLE
feat(OMN-277): unwrap update's data.changes nest in the data-hoist leniency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   (qwen2.5:7b, OMN-168 re-baseline) now gets an actionable correction instead of
   `Unrecognized key(s) in object: 'data'`.
 
+- **Update `data.changes` nest unwrap** (OMN-277, parent OMN-260) — the recorded llama3.1:8b shape
+  `{"mutation":{"operation":"update","data":{"changes":{...},"id":...}}}` now normalizes: when `changes` is the SOLE
+  residual key inside `data` after the id hoist, it unwraps to the mutation's `changes` (previously the hoist
+  double-wrapped it and the recovery failed). Collision-safe per the established leniency rules: an outer `changes`
+  alongside, or a stray sibling field in `data`, aborts the recovery and the original strict error stands.
+
 - **Readable `sequential` field on tasks** (OMN-207) — `type:"tasks"` queries can now request `sequential` via
   `fields:["sequential"]`, closing the settable-but-not-readable gap left by the write side (OMN-198/206). Reported as
   the raw stored boolean on every task (not conditional on child count): OmniFocus persists `sequential` across

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -220,11 +220,22 @@ function routeUpdateResidual(
   outerChanges: unknown,
 ): Record<string, unknown> | undefined {
   const keys = Object.keys(residual);
+  // Candidate `changes` value BEFORE the collision check: the nested-unwrap
+  // shape (`changes` is the sole residual key) unwraps to its value; any other
+  // non-`changes`-bearing residual is used verbatim (leniency #3's original
+  // behavior). A residual that mixes `changes` with other keys is unroutable
+  // (no candidate) regardless of collision.
+  let candidate: Record<string, unknown> | undefined;
   if (keys.length === 1 && keys[0] === 'changes' && isPlainObject(residual.changes)) {
-    return outerChanges === undefined ? residual.changes : undefined;
+    candidate = residual.changes;
+  } else if (!keys.includes('changes')) {
+    candidate = residual;
   }
-  if (keys.includes('changes')) return undefined;
-  return outerChanges === undefined ? residual : undefined;
+  if (candidate === undefined) return undefined;
+  // Single collision gate for every candidate shape: an outer `changes`
+  // already present must abort the recovery, not be silently overwritten
+  // (the OMN-97 anti-pattern the rest of this function guards against).
+  return outerChanges === undefined ? candidate : undefined;
 }
 
 /**

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -208,6 +208,12 @@ function normalizeArgs(args: unknown, hint: NormalizationHint): { args: unknown;
  * alongside is a both-present collision (same rule as aliasMutationFields) —
  * both return undefined so the recovery aborts and the original strict error
  * stands.
+ *
+ * The plain (non-nested) residual — leniency #3's original behavior, e.g.
+ * `data: {id, flagged: true}` — is also collision-checked: an outer `changes`
+ * already present must abort the recovery for the same reason, rather than
+ * being silently overwritten by the caller (the OMN-97 anti-pattern the rest
+ * of this function guards against).
  */
 function routeUpdateResidual(
   residual: Record<string, unknown>,
@@ -218,7 +224,7 @@ function routeUpdateResidual(
     return outerChanges === undefined ? residual.changes : undefined;
   }
   if (keys.includes('changes')) return undefined;
-  return residual;
+  return outerChanges === undefined ? residual : undefined;
 }
 
 /**

--- a/src/tools/normalization/normalize-input.ts
+++ b/src/tools/normalization/normalize-input.ts
@@ -198,6 +198,30 @@ function normalizeArgs(args: unknown, hint: NormalizationHint): { args: unknown;
 }
 
 /**
+ * OMN-277 (leniency #3 extension): route an update's residual `data` fields to
+ * `changes`. The recorded llama3.1:8b shape nests the whole changes object
+ * INSIDE data (`data: { changes: {...}, id }`); mapping that residual to
+ * `changes` verbatim double-wraps it (changes.changes) and strict
+ * re-validation rejects the recovery. Unwrap ONLY the unambiguous shape:
+ * `changes` is the SOLE residual key and a plain object. A stray sibling field
+ * would need inference about where it belongs, and an outer `changes`
+ * alongside is a both-present collision (same rule as aliasMutationFields) —
+ * both return undefined so the recovery aborts and the original strict error
+ * stands.
+ */
+function routeUpdateResidual(
+  residual: Record<string, unknown>,
+  outerChanges: unknown,
+): Record<string, unknown> | undefined {
+  const keys = Object.keys(residual);
+  if (keys.length === 1 && keys[0] === 'changes' && isPlainObject(residual.changes)) {
+    return outerChanges === undefined ? residual.changes : undefined;
+  }
+  if (keys.includes('changes')) return undefined;
+  return residual;
+}
+
+/**
  * Leniency #3 worker: hoist `data.id` to the mutation level on non-create
  * operations. Returns the rewritten mutation, or undefined when the shape
  * doesn't match.
@@ -247,7 +271,9 @@ function hoistDataId(m: Record<string, unknown>): Record<string, unknown> | unde
   // deleted before re-validation ever saw the leftovers.
   if (Object.keys(data).length > 0) {
     if (op === 'update') {
-      newMutation.changes = data;
+      const routed = routeUpdateResidual(data, m.changes);
+      if (routed === undefined) return undefined;
+      newMutation.changes = routed;
     } else if (op === 'complete') {
       Object.assign(newMutation, data);
     } else {

--- a/tests/unit/tools/normalization/normalize-input.test.ts
+++ b/tests/unit/tools/normalization/normalize-input.test.ts
@@ -210,6 +210,69 @@ describe('leniency #3 — data-hoist on non-create mutations (malformed-in → c
   });
 });
 
+describe('leniency #3 extension — update data.changes unwrap (OMN-277)', () => {
+  it('recovers the recorded llama3.1:8b artifact: changes nested inside data (2026-07-08)', () => {
+    // Verbatim shape from the OMN-168 re-baseline that regressed llama to
+    // 18/19: operation present (wrapper intact), but the update payload nests
+    // `changes` INSIDE `data` alongside the id. Pre-OMN-277 the hoist fired
+    // and produced a double-nested changes:{changes:{...}} that strict
+    // re-validation rejected — original error stood.
+    const r = parseWithNormalization(
+      WriteSchema,
+      {
+        mutation: {
+          data: { changes: { flagged: true }, id: 'xyz789' },
+          minimalResponse: false,
+          operation: 'update',
+          target: 'task',
+        },
+      },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(true);
+    expect(r.applied).toContain('data-hoist-id');
+    expect(r.data).toMatchObject({
+      mutation: { operation: 'update', target: 'task', id: 'xyz789', changes: { flagged: true } },
+    });
+  });
+
+  it('collision-safe: top-level changes AND data.changes both present → recovery aborts', () => {
+    const r = parseWithNormalization(
+      WriteSchema,
+      {
+        mutation: {
+          operation: 'update',
+          target: 'task',
+          changes: { note: 'outer' },
+          data: { changes: { flagged: true }, id: 'xyz789' },
+        },
+      },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+
+  it('mixed residual (changes nest + stray sibling field) is NOT unwrapped — original error stands', () => {
+    // Guessing where the stray sibling belongs would be inference; the
+    // unwrap fires only when `changes` is the SOLE residual after the id
+    // hoist (the unambiguous recorded shape).
+    const r = parseWithNormalization(
+      WriteSchema,
+      {
+        mutation: {
+          operation: 'update',
+          target: 'task',
+          data: { changes: { flagged: true }, note: 'stray', id: 'xyz789' },
+        },
+      },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+});
+
 describe('leniency #4 — mutation-field-alias (OMN-168)', () => {
   it('recovers the recorded qwen complete artifact: root {operation, target_id} (2026-06-12)', () => {
     // Verbatim shape from the OMN-168 ticket: strict error was

--- a/tests/unit/tools/normalization/normalize-input.test.ts
+++ b/tests/unit/tools/normalization/normalize-input.test.ts
@@ -271,6 +271,29 @@ describe('leniency #3 extension — update data.changes unwrap (OMN-277)', () =>
     expect(r.success).toBe(false);
     expect(r.applied).toEqual([]);
   });
+
+  it('collision-safe on the PLAIN (non-nested) residual too: an outer changes already present must abort, not be silently overwritten', () => {
+    // Pre-existing leniency #3 behavior (data:{id, flagged:true}, no `changes`
+    // key in the residual) must still abort when a top-level `changes` is
+    // already present — routeUpdateResidual's fallback branch used to return
+    // the residual unconditionally, silently clobbering the outer changes
+    // (the OMN-97 anti-pattern) instead of aborting like every other
+    // collision case in this function.
+    const r = parseWithNormalization(
+      WriteSchema,
+      {
+        mutation: {
+          operation: 'update',
+          target: 'task',
+          changes: { note: 'outer' },
+          data: { flagged: true, id: 'xyz789' },
+        },
+      },
+      'omnifocus_write',
+    );
+    expect(r.success).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
 });
 
 describe('leniency #4 — mutation-field-alias (OMN-168)', () => {


### PR DESCRIPTION
## What

Closes the llama `data.changes` nest split from OMN-260 (Kip's 2026-07-18 spec decision — `Technical/specs/OMN-260-root-data-only-wrapper-lift.md` §"The llama changes-wrap case").

The recorded llama3.1:8b payload (`{"mutation":{"operation":"update","data":{"changes":{"flagged":true},"id":"xyz789"},...}}`) has its envelope intact — the failure is `changes` nested inside `data`. `hoistDataId` fired but mapped the residual verbatim, producing a double-wrapped `changes:{changes:{...}}` that strict re-validation rejected. A new `routeUpdateResidual` helper unwraps **only the unambiguous shape**: `changes` is the sole residual key after the id hoist and a plain object. Aborts (original strict error stands) when: an outer `changes` exists alongside (both-present collision, the `aliasMutationFields` rule) or a stray sibling field sits next to the nest (routing it would be inference, the OMN-247 hazard class).

## Vertical Contract Matrix

N/A across the board — normalization-layer leniency only: no schema shape change, no `inputSchema`/description change, no mutation semantics, no OmniFocus interaction, no cache inputs. Strict-first architecture bounds the blast radius: canonical callers never reach this code.

## Tests

- TDD in the existing `normalize-input.test.ts` leniency pattern (watched fail → pass): the recorded payload verbatim recovers to `{operation:'update', id:'xyz789', changes:{flagged:true}}`; both-present collision aborts; mixed-residual aborts.
- `npm run build` ✅ · lint `--max-warnings=0` ✅ (cognitive-complexity kept under the gate by extracting the helper) · `npm run test:unit` **3920/3920** ✅.
- Supervised conformance re-baseline (Ollama) owed alongside OMN-260's — expected to restore llama's 19/19.

Closes OMN-277
Parent: OMN-260 (PR #234)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udg9nbYq7YMLBecJt3P764
