### PR TITLE
docs(OMN-274): point write-echo adjudication comment at OMN-278

### DIFF
--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -797,7 +797,7 @@ const PROJECT_STATUS_UPDATE_ENUM: Record<string, string> = {
  * drifted copy of the 'onHold' map; changing only the OnHold spelling would
  * create a THIRD, mixed vocabulary. If this echo ever converges on the wire
  * form, move 'completed'→'done' and the response schema enum in the same
- * change. See Technical/specs/OMN-274-read-path-status-vocabulary.md. */
+ * change. Tracked as OMN-278. See Technical/specs/OMN-274-read-path-status-vocabulary.md. */
 const PROJECT_STATUS_READBACK =
   "proj.status === Project.Status.Active ? 'active' : " +
   "proj.status === Project.Status.OnHold ? 'on_hold' : " +


### PR DESCRIPTION
## Summary
- One-line comment update at `src/contracts/ast/mutation/defs.ts` (write-echo status adjudication) naming the tracked follow-up ticket, OMN-278, which owns converging the write-path status echo onto the canonical `onHold`/`done` vocabulary.
- Companion Obsidian spec note (`Technical/specs/OMN-274-read-path-status-vocabulary.md`) updated separately with a "POST-BUILD REVERSAL" section and a pointer to OMN-278.

No behavior change — comment only.

## Test plan
- [x] `npm run typecheck` / `npm run lint` / `npm run test:unit` all passed via pre-push hook (3935/3935 unit tests)

https://claude.ai/code/session_01DC4WmdXTqYFvTwE2c4Vqjv