### PR TITLE
feat(OMN-256): manage_reviews batch operations (projectIds[]) for mark_reviewed / set_schedule

### DIFF
--- a/docs/skills/omnifocus-assistant/SKILL.md
+++ b/docs/skills/omnifocus-assistant/SKILL.md
@@ -207,9 +207,10 @@ returned project rows carry `status: "onHold"` — the canonical read vocabulary
 **10. Mark reviewed** — After walking a batch of stale projects from step 9's list, mark them all reviewed in one call
 (OMN-256) instead of one round-trip per project:
 `omnifocus_analyze({ analysis: { type: "manage_reviews", params: { operation: "mark_reviewed", projectIds: ["<id1>", "<id2>", "..."] } } })`
-(single-project form still works: `{ operation: "mark_reviewed", projectId: "<id>" }`). The response reports a
+(single-project form still works: `{ operation: "mark_reviewed", projectId: "<id>" }`). The batch response reports a
 per-project outcome — an unresolvable id in the batch shows up as its own error row, not a silent drop; check
-`results.failed` before assuming the whole batch succeeded.
+`data.batch.results.failed` (the batch envelope nests under `data.batch`) before assuming the whole batch succeeded. The
+single-id form keeps its original envelope under `data.project`.
 
 **11. Get creative** — New projects? Stuck items? Someday/maybe to activate? Ask the user.
 

--- a/docs/skills/omnifocus-assistant/SKILL.md
+++ b/docs/skills/omnifocus-assistant/SKILL.md
@@ -204,9 +204,16 @@ returned project rows carry `status: "onHold"` — the canonical read vocabulary
 **9. Ensure next actions** — Every active project needs one
 `omnifocus_analyze({ analysis: { type: "manage_reviews", params: { operation: "list_for_review" } } })`
 
-**10. Get creative** — New projects? Stuck items? Someday/maybe to activate? Ask the user.
+**10. Mark reviewed** — After walking a batch of stale projects from step 9's list, mark them all reviewed in one call
+(OMN-256) instead of one round-trip per project:
+`omnifocus_analyze({ analysis: { type: "manage_reviews", params: { operation: "mark_reviewed", projectIds: ["<id1>", "<id2>", "..."] } } })`
+(single-project form still works: `{ operation: "mark_reviewed", projectId: "<id>" }`). The response reports a
+per-project outcome — an unresolvable id in the batch shows up as its own error row, not a silent drop; check
+`results.failed` before assuming the whole batch succeeded.
 
-**11. Productivity check**
+**11. Get creative** — New projects? Stuck items? Someday/maybe to activate? Ask the user.
+
+**12. Productivity check**
 `omnifocus_analyze({ analysis: { type: "productivity_stats", params: { groupBy: "week" } } })`
 
 ---

--- a/src/contracts/ast/mutation-script-builder.ts
+++ b/src/contracts/ast/mutation-script-builder.ts
@@ -24,7 +24,12 @@ import type {
   ProjectUpdateData,
   MutationTarget,
 } from '../mutations.js';
-import { dispatchMutation, type MarkProjectReviewedInput, type SetReviewScheduleInput } from './mutation/defs.js';
+import {
+  dispatchMutation,
+  type MarkProjectReviewedInput,
+  type MarkProjectsReviewedInput,
+  type SetReviewScheduleInput,
+} from './mutation/defs.js';
 import { emitProgram, wrapInLauncher } from './mutation/emitter.js';
 import { validateMutationProgram } from './mutation/validator.js';
 
@@ -711,6 +716,26 @@ export async function buildMarkProjectReviewedScript(
     operation: 'mark_reviewed',
     target: 'project',
     description: `Mark project reviewed: ${params.projectId}`,
+  };
+}
+
+/**
+ * Build a JXA script for the batch mark-projects-reviewed mutation (OMN-256).
+ * Emits from the mutation AST via 'mark-reviewed/projects' dispatch — the
+ * sandbox guard pre-flights ALL ids before any update executes. Wire envelope
+ * is MARK_REVIEWED_BATCH_TYPED_SCHEMA; the single-id 'mark-reviewed/project'
+ * route and its envelope are unaffected.
+ */
+export async function buildMarkProjectsReviewedScript(
+  params: MarkProjectsReviewedInput,
+): Promise<GeneratedMutationScript> {
+  const program = await dispatchMutation('mark-reviewed/projects', params);
+  validateMutationProgram(program);
+  return {
+    script: wrapInLauncher(emitProgram(program), program.context).trim(),
+    operation: 'mark_reviewed_batch',
+    target: 'project',
+    description: `Mark projects reviewed: ${params.projectIds.join(', ')}`,
   };
 }
 

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -1472,6 +1472,14 @@ export interface MarkProjectsReviewedInput {
  * (MARK_REVIEWED_BATCH_TYPED_SCHEMA is the contract). The single-id
  * `mark-reviewed/project` route and its envelope are untouched — this is an
  * ADDITIONAL route, not a replacement.
+ *
+ * DELIBERATE MIRROR (review-adjudicated): the accumulator scaffold (pids
+ * bind, results literal, empty-pids guard, IIFE loop, envelope return) is
+ * intentionally duplicated from buildSetReviewScheduleProgram rather than
+ * factored — the shared shape is pinned by each builder's own typed schema
+ * and goldens, and a premature abstraction would couple two operations that
+ * may diverge (e.g. per-op envelope fields). The cost: any change to the
+ * shared scaffold MUST be applied to BOTH builders (grep for this marker).
  */
 export function buildMarkProjectsReviewedProgram(data: MarkProjectsReviewedInput): Program {
   const _exhaustive: Record<keyof MarkProjectsReviewedInput, true> = {
@@ -1544,6 +1552,11 @@ export interface SetReviewScheduleInput {
  * reviewInterval NOR nextReviewDate throws at build time — the legacy script
  * silently reported per-project success with empty changes (the silent no-op
  * class behind the since-removed clear_schedule operation, OMN-273).
+ *
+ * DELIBERATE MIRROR (review-adjudicated): buildMarkProjectsReviewedProgram
+ * duplicates this builder's accumulator scaffold on purpose — see the
+ * matching marker on that builder for the rationale. Any change to the
+ * shared scaffold MUST be applied to BOTH builders.
  */
 export function buildSetReviewScheduleProgram(data: SetReviewScheduleInput): Program {
   const _exhaustive: Record<keyof SetReviewScheduleInput, true> = {

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -1735,6 +1735,17 @@ export const MUTATION_DEFS = {
     // before any update executes (mirrors bulk_delete / set-review-schedule/project;
     // spec §2.1) — registering the route is non-negotiable, an unregistered
     // mutation route reopens the sandbox-guard-bypass class.
+    //
+    // KNOWN LAYERING (test-mode-only; OMN-286): validateProjectInSandbox is a
+    // no-op unless isTestMode(). In test mode it collapses "not found" into
+    // "outside sandbox" (isProjectInSandbox returns false for both), so a
+    // mixed batch containing a not-found id aborts the WHOLE batch here rather
+    // than partitioning it into the script's continue-on-error failed[] row.
+    // This is shared-guard behavior identical across bulk_delete and
+    // set-review-schedule/project — production (guard off) partitions
+    // correctly; the divergence is confined to sandbox integration runs.
+    // Whether the guard should pass not-found ids through to the script is a
+    // shared-infra decision tracked in OMN-286, pending Kip's live /verify.
     guard: async (d) => {
       await Promise.all(d.projectIds.map((id) => validateProjectInSandbox(id, 'mark reviewed')));
     },

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -1500,6 +1500,15 @@ export function buildMarkProjectsReviewedProgram(data: MarkProjectsReviewedInput
         `{ successful: [], failed: [], summary: { total_requested: ${data.projectIds.length}, successful_count: 0, failed_count: 0 } }`,
       ),
     ),
+    // NOT dead-envelope drift (review-adjudicated, recurring finding): this
+    // {success:false, error:true} shape is deliberate. It is double-unreachable
+    // from the shipped path (AnalyzeSchema's projectIds.min(1) + the
+    // "at least one of projectId/projectIds" superRefine both reject empty
+    // before lowering), AND if a future direct caller ever reached it,
+    // detectKnownErrorShape() intercepts `error:true` in executeJson BEFORE the
+    // success-schema validation runs — so the 'No project IDs provided' message
+    // surfaces intact, never an opaque schema failure. Do NOT "fix" it to
+    // success:true to satisfy the *_BATCH typed success schema.
     guard('pids.length === 0', {
       success: json(false),
       error: json(true),
@@ -1585,6 +1594,15 @@ export function buildSetReviewScheduleProgram(data: SetReviewScheduleInput): Pro
         `{ successful: [], failed: [], summary: { total_requested: ${data.projectIds.length}, successful_count: 0, failed_count: 0 } }`,
       ),
     ),
+    // NOT dead-envelope drift (review-adjudicated, recurring finding): this
+    // {success:false, error:true} shape is deliberate. It is double-unreachable
+    // from the shipped path (AnalyzeSchema's projectIds.min(1) + the
+    // "at least one of projectId/projectIds" superRefine both reject empty
+    // before lowering), AND if a future direct caller ever reached it,
+    // detectKnownErrorShape() intercepts `error:true` in executeJson BEFORE the
+    // success-schema validation runs — so the 'No project IDs provided' message
+    // surfaces intact, never an opaque schema failure. Do NOT "fix" it to
+    // success:true to satisfy the *_BATCH typed success schema.
     guard('pids.length === 0', {
       success: json(false),
       error: json(true),

--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -1454,6 +1454,69 @@ export function buildMarkProjectReviewedProgram(data: MarkProjectReviewedInput):
 }
 
 // =============================================================================
+// MARK PROJECTS REVIEWED — BATCH LOWERING (OMN-256)
+// =============================================================================
+
+export interface MarkProjectsReviewedInput {
+  projectIds: string[];
+  reviewDate: string;
+  updateNextReviewDate: boolean;
+}
+
+/**
+ * Lower a batch mark-projects-reviewed request (OMN-256). Statement shape
+ * mirrors buildSetReviewScheduleProgram (OMN-106 PR-2): json binds, an
+ * empty-ids guard, a build-time-unrolled for-loop calling the
+ * applyMarkReviewedBatch snippet per id (continue-on-error, never abort on
+ * the first failure), and the batch envelope {success, results, message}
+ * (MARK_REVIEWED_BATCH_TYPED_SCHEMA is the contract). The single-id
+ * `mark-reviewed/project` route and its envelope are untouched — this is an
+ * ADDITIONAL route, not a replacement.
+ */
+export function buildMarkProjectsReviewedProgram(data: MarkProjectsReviewedInput): Program {
+  const _exhaustive: Record<keyof MarkProjectsReviewedInput, true> = {
+    projectIds: true,
+    reviewDate: true,
+    updateNextReviewDate: true,
+  };
+  void _exhaustive;
+
+  const statements: Stmt[] = [
+    // User data enters via json() binds, never raw interpolation.
+    bind('pids', json(data.projectIds)),
+    bind('reviewDateStr', json(data.reviewDate)),
+    // total_requested is a build-time count (mirrors set-review-schedule).
+    bind(
+      'results',
+      raw(
+        `{ successful: [], failed: [], summary: { total_requested: ${data.projectIds.length}, successful_count: 0, failed_count: 0 } }`,
+      ),
+    ),
+    guard('pids.length === 0', {
+      success: json(false),
+      error: json(true),
+      message: json('No project IDs provided'),
+      results: ref('results'),
+    }),
+    bind(
+      'applied',
+      raw(
+        `(function () { for (var i = 0; i < pids.length; i++) { applyMarkReviewedBatch(pids[i], reviewDateStr, ${data.updateNextReviewDate ? 'true' : 'false'}, results); } ` +
+          'results.summary.successful_count = results.successful.length; results.summary.failed_count = results.failed.length; return true; })()',
+      ),
+    ),
+    return_({
+      success: json(true),
+      results: ref('results'),
+      message: raw(
+        '"Batch mark-reviewed completed: " + results.summary.successful_count + " successful, " + results.summary.failed_count + " failed"',
+      ),
+    }),
+  ];
+  return { statements, context: 'mark_projects_reviewed', snippetDeps: ['applyMarkReviewedBatch'] };
+}
+
+// =============================================================================
 // SET REVIEW SCHEDULE LOWERING (OMN-106 PR-2)
 // =============================================================================
 
@@ -1654,6 +1717,16 @@ export const MUTATION_DEFS = {
     guard: (d) => (d.projectId ? validateProjectInSandbox(d.projectId, 'mark reviewed') : undefined),
     build: buildMarkProjectReviewedProgram,
   } as MutationDef<MarkProjectReviewedInput>,
+  'mark-reviewed/projects': {
+    // OMN-256: batch sibling of mark-reviewed/project. ALL ids pre-flight
+    // before any update executes (mirrors bulk_delete / set-review-schedule/project;
+    // spec §2.1) — registering the route is non-negotiable, an unregistered
+    // mutation route reopens the sandbox-guard-bypass class.
+    guard: async (d) => {
+      await Promise.all(d.projectIds.map((id) => validateProjectInSandbox(id, 'mark reviewed')));
+    },
+    build: buildMarkProjectsReviewedProgram,
+  } as MutationDef<MarkProjectsReviewedInput>,
   'reparent/tag': {
     // Spec §2.1: guard EVERY name the op touches — parent included when present.
     guard: (d) => {

--- a/src/contracts/ast/mutation/index.ts
+++ b/src/contracts/ast/mutation/index.ts
@@ -30,6 +30,7 @@ export {
   buildUnparentTagProgram,
   buildReparentTagProgram,
   buildMarkProjectReviewedProgram,
+  buildMarkProjectsReviewedProgram,
   buildSetReviewScheduleProgram,
   lowerTaskCreate,
   MUTATION_DEFS,
@@ -38,6 +39,7 @@ export {
 export type {
   TaskLoweringNames,
   MarkProjectReviewedInput,
+  MarkProjectsReviewedInput,
   SetReviewScheduleInput,
   ReviewIntervalSpecInput,
   BatchCreateTasksData,

--- a/src/contracts/ast/mutation/snippets.ts
+++ b/src/contracts/ast/mutation/snippets.ts
@@ -302,6 +302,60 @@ function applySetReviewSchedule(projectId, reviewInterval, nextReviewDateParam, 
   }
 }`;
 
+// OMN-256: batch mark-reviewed body, mirroring applySetReviewSchedule's
+// accumulator shape (results.successful[] / failed[], continue-on-error) but
+// carrying the mark-reviewed logic inherited from applyMarkReviewed (single
+// lastReviewDate set + optional nextReviewDate advance from the LIVE typed
+// reviewInterval). Kept as its own function rather than reusing
+// applyMarkReviewed directly — that one returns a bare changes[] array for
+// the single-id envelope; this one needs the full per-row success/failure
+// shape the batch envelope requires.
+const applyMarkReviewedBatch = `
+function applyMarkReviewedBatch(projectId, reviewDateStr, updateNextReviewDate, results) {
+  var project = Project.byIdentifier(projectId);
+  if (!project) {
+    results.failed.push({
+      projectId: projectId,
+      error: "Project not found"
+    });
+    return;
+  }
+  try {
+    var reviewDateTime = new Date(reviewDateStr);
+    project.lastReviewDate = reviewDateTime;
+    var changes = ["Last review date set to " + reviewDateStr];
+    if (updateNextReviewDate) {
+      var reviewInterval = project.reviewInterval;
+      if (reviewInterval) {
+        try {
+          var nextReviewDateValue = calculateNextReviewDate(reviewInterval, reviewDateTime);
+          if (nextReviewDateValue) {
+            project.nextReviewDate = nextReviewDateValue;
+            changes.push("Next review date calculated and set to " + nextReviewDateValue.toISOString());
+          }
+        } catch (calcError) {
+          changes.push("Warning: Could not calculate next review date: " + calcError.message);
+        }
+      } else {
+        changes.push("Note: No review interval set, next review date not calculated");
+      }
+    }
+    results.successful.push({
+      projectId: projectId,
+      projectName: project.name,
+      changes: changes,
+      lastReviewDate: project.lastReviewDate ? project.lastReviewDate.toISOString() : null,
+      nextReviewDate: project.nextReviewDate ? project.nextReviewDate.toISOString() : null
+    });
+  } catch (updateError) {
+    results.failed.push({
+      projectId: projectId,
+      projectName: project.name,
+      error: "Failed to update: " + updateError.message
+    });
+  }
+}`;
+
 export const SNIPPETS: Record<string, Snippet> = {
   parseFolderPath: { source: parseFolderPath, deps: [] },
   resolveFolderPath: { source: resolveFolderPath, deps: [] },
@@ -334,6 +388,8 @@ export const SNIPPETS: Record<string, Snippet> = {
     source: applySetReviewSchedule,
     deps: ['normalizeReviewUnit', 'calculateNextReviewFromSpec'],
   },
+  // OMN-256: batch mark-reviewed body — reuses the single-id calculateNextReviewDate.
+  applyMarkReviewedBatch: { source: applyMarkReviewedBatch, deps: ['calculateNextReviewDate'] },
 };
 
 export function collectSnippets(keys: readonly string[]): string {

--- a/src/contracts/ast/mutation/snippets.ts
+++ b/src/contracts/ast/mutation/snippets.ts
@@ -190,6 +190,13 @@ function calculateNextReviewDate(reviewInterval, fromDate) {
 const applyMarkReviewed = `
 function applyMarkReviewed(project, reviewDateStr, updateNextReviewDate) {
   var reviewDateTime = new Date(reviewDateStr);
+  // Validate BEFORE mutating: an unparseable date is an Invalid Date, whose
+  // later .toISOString() read-back throws — assigning it first would corrupt
+  // project.lastReviewDate on the live object while the row is reported as
+  // failed (mutate-before-validate). Throw up front so nothing is written.
+  if (isNaN(reviewDateTime.getTime())) {
+    throw new Error("Invalid reviewDate: " + reviewDateStr);
+  }
   project.lastReviewDate = reviewDateTime;
   var changes = ["Last review date set to " + reviewDateStr];
   if (updateNextReviewDate) {

--- a/src/contracts/ast/mutation/snippets.ts
+++ b/src/contracts/ast/mutation/snippets.ts
@@ -303,13 +303,12 @@ function applySetReviewSchedule(projectId, reviewInterval, nextReviewDateParam, 
 }`;
 
 // OMN-256: batch mark-reviewed body, mirroring applySetReviewSchedule's
-// accumulator shape (results.successful[] / failed[], continue-on-error) but
-// carrying the mark-reviewed logic inherited from applyMarkReviewed (single
-// lastReviewDate set + optional nextReviewDate advance from the LIVE typed
-// reviewInterval). Kept as its own function rather than reusing
-// applyMarkReviewed directly — that one returns a bare changes[] array for
-// the single-id envelope; this one needs the full per-row success/failure
-// shape the batch envelope requires.
+// accumulator shape (results.successful[] / failed[], continue-on-error).
+// Delegates the actual lastReviewDate set + optional nextReviewDate advance
+// to applyMarkReviewed itself (the single-id body) so the two paths can never
+// drift — applyMarkReviewed already mutates the project in place and returns
+// the changes[] array; this just reads the persisted values back for the
+// batch envelope's richer per-row shape.
 const applyMarkReviewedBatch = `
 function applyMarkReviewedBatch(projectId, reviewDateStr, updateNextReviewDate, results) {
   var project = Project.byIdentifier(projectId);
@@ -321,25 +320,7 @@ function applyMarkReviewedBatch(projectId, reviewDateStr, updateNextReviewDate, 
     return;
   }
   try {
-    var reviewDateTime = new Date(reviewDateStr);
-    project.lastReviewDate = reviewDateTime;
-    var changes = ["Last review date set to " + reviewDateStr];
-    if (updateNextReviewDate) {
-      var reviewInterval = project.reviewInterval;
-      if (reviewInterval) {
-        try {
-          var nextReviewDateValue = calculateNextReviewDate(reviewInterval, reviewDateTime);
-          if (nextReviewDateValue) {
-            project.nextReviewDate = nextReviewDateValue;
-            changes.push("Next review date calculated and set to " + nextReviewDateValue.toISOString());
-          }
-        } catch (calcError) {
-          changes.push("Warning: Could not calculate next review date: " + calcError.message);
-        }
-      } else {
-        changes.push("Note: No review interval set, next review date not calculated");
-      }
-    }
+    var changes = applyMarkReviewed(project, reviewDateStr, updateNextReviewDate);
     results.successful.push({
       projectId: projectId,
       projectName: project.name,
@@ -388,8 +369,9 @@ export const SNIPPETS: Record<string, Snippet> = {
     source: applySetReviewSchedule,
     deps: ['normalizeReviewUnit', 'calculateNextReviewFromSpec'],
   },
-  // OMN-256: batch mark-reviewed body — reuses the single-id calculateNextReviewDate.
-  applyMarkReviewedBatch: { source: applyMarkReviewedBatch, deps: ['calculateNextReviewDate'] },
+  // OMN-256: batch mark-reviewed body — delegates to applyMarkReviewed (which
+  // transitively pulls in calculateNextReviewDate) so the two never drift.
+  applyMarkReviewedBatch: { source: applyMarkReviewedBatch, deps: ['applyMarkReviewed'] },
 };
 
 export function collectSnippets(keys: readonly string[]): string {

--- a/src/omnifocus/response-schemas/write.ts
+++ b/src/omnifocus/response-schemas/write.ts
@@ -121,17 +121,12 @@ const MarkReviewedBatchSuccessEntrySchema = z
 
 /**
  * Mark-projects-reviewed batch failed entry (OMN-256) — emitted by
- * applyMarkReviewedBatch's results.failed[] push. projectName is optional:
- * the not-found branch fires before projectName is known (mirrors
- * SetScheduleFailedEntrySchema).
+ * applyMarkReviewedBatch's results.failed[] push. Structurally identical to
+ * SetScheduleFailedEntrySchema (same {projectId, projectName?, error}, same
+ * .strict()); reuse it directly so the two batch-review failed-entry
+ * validators can't silently drift.
  */
-const MarkReviewedBatchFailedEntrySchema = z
-  .object({
-    projectId: z.string(),
-    projectName: z.string().optional(),
-    error: z.string(),
-  })
-  .strict();
+const MarkReviewedBatchFailedEntrySchema = SetScheduleFailedEntrySchema;
 
 /** Module-scope batch mark-reviewed envelope (OMN-256). message always emitted on success. */
 export const MARK_REVIEWED_BATCH_TYPED_SCHEMA = reviewSuccessSchema({

--- a/src/omnifocus/response-schemas/write.ts
+++ b/src/omnifocus/response-schemas/write.ts
@@ -104,6 +104,53 @@ const SetScheduleFailedEntrySchema = z
   })
   .strict();
 
+/**
+ * Mark-projects-reviewed batch successful entry (OMN-256) — emitted by
+ * applyMarkReviewedBatch's results.successful[] push.
+ * Source: {projectId, projectName, changes, lastReviewDate, nextReviewDate}.
+ */
+const MarkReviewedBatchSuccessEntrySchema = z
+  .object({
+    projectId: z.string(),
+    projectName: z.string(),
+    changes: z.array(z.string()),
+    lastReviewDate: isoDateOrNull,
+    nextReviewDate: isoDateOrNull,
+  })
+  .strict();
+
+/**
+ * Mark-projects-reviewed batch failed entry (OMN-256) — emitted by
+ * applyMarkReviewedBatch's results.failed[] push. projectName is optional:
+ * the not-found branch fires before projectName is known (mirrors
+ * SetScheduleFailedEntrySchema).
+ */
+const MarkReviewedBatchFailedEntrySchema = z
+  .object({
+    projectId: z.string(),
+    projectName: z.string().optional(),
+    error: z.string(),
+  })
+  .strict();
+
+/** Module-scope batch mark-reviewed envelope (OMN-256). message always emitted on success. */
+export const MARK_REVIEWED_BATCH_TYPED_SCHEMA = reviewSuccessSchema({
+  results: z
+    .object({
+      successful: z.array(MarkReviewedBatchSuccessEntrySchema),
+      failed: z.array(MarkReviewedBatchFailedEntrySchema),
+      summary: z
+        .object({
+          total_requested: z.number(),
+          successful_count: z.number(),
+          failed_count: z.number(),
+        })
+        .strict(),
+    })
+    .strict(),
+  message: z.string(),
+});
+
 /** Module-scope set-review-schedule envelope (SET_SCHEDULE_SCHEMA). message always emitted on success. */
 export const SET_SCHEDULE_TYPED_SCHEMA = reviewSuccessSchema({
   results: z

--- a/src/omnifocus/script-response-schemas.ts
+++ b/src/omnifocus/script-response-schemas.ts
@@ -67,6 +67,7 @@ export type { OverdueAnalysisV3Data, TaskVelocityV3Data, WorkflowAnalysisV3Data 
 export {
   REVIEWS_LIST_TYPED_SCHEMA,
   MARK_REVIEWED_TYPED_SCHEMA,
+  MARK_REVIEWED_BATCH_TYPED_SCHEMA,
   SET_SCHEDULE_TYPED_SCHEMA,
   TaskWriteResultSchema,
   CompleteResultSchema,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -3570,7 +3570,7 @@ SCOPE FILTERING:
         'manage_reviews',
         'SCRIPT_ERROR',
         result.error || 'Script execution failed',
-        'Try again with updateNextReviewDate=false',
+        'Check details for the underlying script error',
         result.details,
         timer.toMetadata(),
       );

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -3382,6 +3382,17 @@ SCOPE FILTERING:
       : (raw as T);
   }
 
+  // Both batch review ops are continue-on-error: a not-found/typo'd id becomes
+  // its own results.failed[] row rather than aborting the batch. So the count
+  // that actually mutated is results.summary.successful_count — NOT the
+  // requested id count, which would report a partially-failed batch as fully
+  // successful in metadata.projects_updated. Falls back to null when the shape
+  // is unexpected rather than inventing a number.
+  private batchSuccessfulCount(parsed: unknown): number | null {
+    const summary = (parsed as { results?: { summary?: { successful_count?: unknown } } })?.results?.summary;
+    return typeof summary?.successful_count === 'number' ? summary.successful_count : null;
+  }
+
   private async reviewsListForReview(
     _compiled: Extract<CompiledAnalysis, { type: 'manage_reviews' }>,
     timer: OperationTimerV2,
@@ -3595,7 +3606,8 @@ SCOPE FILTERING:
       operation: 'mark_reviewed',
       review_date: reviewDate,
       next_review_calculated: true,
-      projects_updated: brandedProjectIds.length,
+      // Actual mutations, not requested count (continue-on-error partitions).
+      projects_updated: this.batchSuccessfulCount(parsedResult) ?? brandedProjectIds.length,
       input_params: { projectIds, reviewDate, updateNextReviewDate: true },
     });
   }
@@ -3660,7 +3672,8 @@ SCOPE FILTERING:
     return createSuccessResponseV2('manage_reviews', { batch: parsedResult }, undefined, {
       ...timer.toMetadata(),
       operation: 'set_schedule',
-      projects_updated: brandedProjectIds.length,
+      // Actual mutations, not requested count (continue-on-error partitions).
+      projects_updated: this.batchSuccessfulCount(parsedResult) ?? brandedProjectIds.length,
       input_params: projectIds ? { projectIds } : { projectId },
     });
   }

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -3372,6 +3372,16 @@ SCOPE FILTERING:
     }
   }
 
+  // Review-family scripts sometimes wrap their payload in a {data: ...}
+  // envelope (e.g. {ok, v, data}); unwrap it if present, otherwise treat the
+  // raw value as the payload itself. Shared across all four review
+  // operations so the unwrap logic can't drift between them.
+  private unwrapScriptEnvelope<T>(raw: unknown): T {
+    return raw && typeof raw === 'object' && 'data' in raw && (raw as { data?: unknown }).data
+      ? ((raw as { data: T }).data as T)
+      : (raw as T);
+  }
+
   private async reviewsListForReview(
     _compiled: Extract<CompiledAnalysis, { type: 'manage_reviews' }>,
     timer: OperationTimerV2,
@@ -3408,11 +3418,7 @@ SCOPE FILTERING:
       );
     }
 
-    const envelope = result.data as { ok?: boolean; v?: string; data?: ReviewListData } | ReviewListData;
-    const data: ReviewListData =
-      envelope && typeof envelope === 'object' && 'data' in envelope && envelope.data
-        ? envelope.data
-        : (envelope as ReviewListData);
+    const data = this.unwrapScriptEnvelope<ReviewListData>(result.data);
     const src = data?.projects || data?.items || [];
     if (!Array.isArray(src)) {
       return createErrorResponseV2(
@@ -3537,9 +3543,7 @@ SCOPE FILTERING:
     this.cache.invalidate('projects');
     this.cache.invalidate('reviews');
 
-    const envelope = result.data as unknown;
-    const parsedResult =
-      envelope && typeof envelope === 'object' && 'data' in envelope && envelope.data ? envelope.data : envelope;
+    const parsedResult = this.unwrapScriptEnvelope<unknown>(result.data);
 
     return createSuccessResponseV2('manage_reviews', { project: parsedResult }, undefined, {
       ...timer.toMetadata(),
@@ -3579,9 +3583,7 @@ SCOPE FILTERING:
     this.cache.invalidate('projects');
     this.cache.invalidate('reviews');
 
-    const envelope = result.data as unknown;
-    const parsedResult =
-      envelope && typeof envelope === 'object' && 'data' in envelope && envelope.data ? envelope.data : envelope;
+    const parsedResult = this.unwrapScriptEnvelope<unknown>(result.data);
 
     return createSuccessResponseV2('manage_reviews', { batch: parsedResult }, undefined, {
       ...timer.toMetadata(),
@@ -3647,9 +3649,7 @@ SCOPE FILTERING:
     this.cache.invalidate('projects');
     this.cache.invalidate('reviews');
 
-    const envelope = result.data as unknown;
-    const parsedResult =
-      envelope && typeof envelope === 'object' && 'data' in envelope && envelope.data ? envelope.data : envelope;
+    const parsedResult = this.unwrapScriptEnvelope<unknown>(result.data);
 
     return createSuccessResponseV2('manage_reviews', { batch: parsedResult }, undefined, {
       ...timer.toMetadata(),

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -32,6 +32,7 @@ import {
   WORKFLOW_ANALYSIS_V3_SCHEMA,
   REVIEWS_LIST_TYPED_SCHEMA,
   MARK_REVIEWED_TYPED_SCHEMA,
+  MARK_REVIEWED_BATCH_TYPED_SCHEMA,
   SET_SCHEDULE_TYPED_SCHEMA,
 } from '../../omnifocus/script-response-schemas.js';
 // Script imports (irreducible computation)
@@ -44,6 +45,7 @@ import { buildRecurringTasksScript } from '../../omnifocus/scripts/recurring/ana
 // OMN-106: review mutations emit from the AST mutation pipeline (sandbox-guarded).
 import {
   buildMarkProjectReviewedScript,
+  buildMarkProjectsReviewedScript,
   buildSetReviewScheduleScript,
 } from '../../contracts/ast/mutation-script-builder.js';
 import { buildProjectsForReviewScript } from '../../omnifocus/scripts/reviews/projects-for-review.js';
@@ -292,6 +294,7 @@ const TASKS_LIST_SCHEMA = listResultSchema(['tasks', 'items'], {
 // Re-exported aliases kept here for local readability.
 const REVIEWS_LIST_SCHEMA = REVIEWS_LIST_TYPED_SCHEMA;
 const MARK_REVIEWED_SCHEMA = MARK_REVIEWED_TYPED_SCHEMA;
+const MARK_REVIEWED_BATCH_SCHEMA = MARK_REVIEWED_BATCH_TYPED_SCHEMA;
 const SET_SCHEDULE_SCHEMA = SET_SCHEDULE_TYPED_SCHEMA;
 
 // ---------------------------------------------------------------------------
@@ -321,7 +324,13 @@ ANALYSIS TYPES:
   FALLBACK: pass params.text (raw prose) and the heuristic extractor runs;
   un-parsed lines are surfaced in unparsed[]. Provide exactly one of items|text.
 - manage_reviews: Project review operations
-  params: { operation, projectId, reviewDate, reviewInterval }
+  params: { operation, projectId, projectIds, reviewDate, reviewInterval }
+  - mark_reviewed and set_schedule accept EITHER a single projectId OR a batch
+    projectIds[] (1-100 ids, mirrors bulk_delete's cap) — exactly one of the two,
+    never both. Batch responses report a per-project outcome (id -> ok/error); an
+    unresolvable id in the batch fails loudly as its own row, not silently dropped.
+    One shared reviewInterval applies to all listed projects on set_schedule.
+  - list_for_review does NOT accept projectIds (rejected, not silently ignored)
   - set_schedule accepts reviewInterval: { unit: 'day'|'week'|'month'|'year', steps: positive int }
   - review schedules cannot be removed, only changed: OmniFocus has no "not scheduled
     for review" project state (OMN-41/OMN-58/OMN-273)
@@ -3495,8 +3504,16 @@ SCOPE FILTERING:
     compiled: Extract<CompiledAnalysis, { type: 'manage_reviews' }>,
     timer: OperationTimerV2,
   ): Promise<StandardResponseV2<unknown>> {
-    const projectId = compiled.params?.projectId;
+    const projectIds = compiled.params?.projectIds;
     const reviewDate = compiled.params?.reviewDate || new Date().toISOString();
+
+    // OMN-256: batch path when projectIds is present; single-id path (below)
+    // is UNCHANGED — same builder, same schema, same envelope shape.
+    if (projectIds && projectIds.length > 0) {
+      return this.reviewsMarkReviewedBatch(projectIds, reviewDate, timer);
+    }
+
+    const projectId = compiled.params?.projectId;
     const brandedProjectId = projectId ? convertToProjectId(projectId) : undefined;
 
     const { script } = await buildMarkProjectReviewedScript({
@@ -3534,12 +3551,64 @@ SCOPE FILTERING:
     });
   }
 
+  private async reviewsMarkReviewedBatch(
+    projectIds: string[],
+    reviewDate: string,
+    timer: OperationTimerV2,
+  ): Promise<StandardResponseV2<unknown>> {
+    const brandedProjectIds = projectIds.map((id) => convertToProjectId(id));
+
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: brandedProjectIds,
+      reviewDate,
+      updateNextReviewDate: true,
+    });
+    const result = await this.execJson(script, MARK_REVIEWED_BATCH_SCHEMA);
+
+    if (isScriptError(result)) {
+      return createErrorResponseV2(
+        'manage_reviews',
+        'SCRIPT_ERROR',
+        result.error || 'Script execution failed',
+        'Try again with updateNextReviewDate=false',
+        result.details,
+        timer.toMetadata(),
+      );
+    }
+
+    this.cache.invalidate('projects');
+    this.cache.invalidate('reviews');
+
+    const envelope = result.data as unknown;
+    const parsedResult =
+      envelope && typeof envelope === 'object' && 'data' in envelope && envelope.data ? envelope.data : envelope;
+
+    return createSuccessResponseV2('manage_reviews', { batch: parsedResult }, undefined, {
+      ...timer.toMetadata(),
+      operation: 'mark_reviewed',
+      review_date: reviewDate,
+      next_review_calculated: true,
+      input_params: { projectIds, reviewDate, updateNextReviewDate: true },
+    });
+  }
+
   private async reviewsSetSchedule(
     compiled: Extract<CompiledAnalysis, { type: 'manage_reviews' }>,
     timer: OperationTimerV2,
   ): Promise<StandardResponseV2<unknown>> {
     const projectId = compiled.params?.projectId;
-    const brandedProjectIds = projectId ? [convertToProjectId(projectId)] : [];
+    const projectIds = compiled.params?.projectIds;
+    // OMN-256: set_schedule was already batch-native at the AST layer
+    // (buildSetReviewScheduleScript takes projectIds: string[]) — batching
+    // here is plumbing-widening only, no new lowering.
+    let brandedProjectIds: ProjectId[];
+    if (projectIds) {
+      brandedProjectIds = projectIds.map((id) => convertToProjectId(id));
+    } else if (projectId) {
+      brandedProjectIds = [convertToProjectId(projectId)];
+    } else {
+      brandedProjectIds = [];
+    }
 
     // OMN-106 fail-loud (Kip 2026-07-06, with OMN-136): with neither an
     // interval nor a date the legacy script reported per-project success with
@@ -3550,7 +3619,7 @@ SCOPE FILTERING:
         'VALIDATION_ERROR',
         'set_schedule requires reviewInterval and/or reviewDate — with neither there is nothing to set',
         'Provide reviewInterval {unit, steps} and/or reviewDate',
-        { projectId },
+        { projectId, projectIds },
         timer.toMetadata(),
       );
     }
@@ -3586,7 +3655,7 @@ SCOPE FILTERING:
       ...timer.toMetadata(),
       operation: 'set_schedule',
       projects_updated: brandedProjectIds.length,
-      input_params: { projectId },
+      input_params: projectIds ? { projectIds } : { projectId },
     });
   }
 }

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -3515,6 +3515,11 @@ SCOPE FILTERING:
 
     // OMN-256: batch path when projectIds is present; single-id path (below)
     // is UNCHANGED — same builder, same schema, same envelope shape.
+    // DELIBERATE (review-adjudicated): the two forms return different
+    // envelopes — single-id keeps its pre-existing pinned {data.project}
+    // contract, batch uses {data.batch} with per-row results. Normalizing
+    // both onto one shape would break existing single-id callers; documented
+    // in SKILL.md alongside the batch example.
     if (projectIds && projectIds.length > 0) {
       return this.reviewsMarkReviewedBatch(projectIds, reviewDate, timer);
     }
@@ -3590,6 +3595,7 @@ SCOPE FILTERING:
       operation: 'mark_reviewed',
       review_date: reviewDate,
       next_review_calculated: true,
+      projects_updated: brandedProjectIds.length,
       input_params: { projectIds, reviewDate, updateNextReviewDate: true },
     });
   }

--- a/src/tools/unified/compilers/AnalysisCompiler.ts
+++ b/src/tools/unified/compilers/AnalysisCompiler.ts
@@ -78,6 +78,8 @@ export type CompiledAnalysis =
       params?: {
         operation?: 'list_for_review' | 'mark_reviewed' | 'set_schedule';
         projectId?: string;
+        // OMN-256: batch sibling of projectId (exactly-one-of, enforced by AnalyzeSchema).
+        projectIds?: string[];
         reviewDate?: string;
         // OMN-60: review interval for set_schedule, passed through to the script.
         reviewInterval?: { unit: 'day' | 'week' | 'month' | 'year'; steps: number };

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -227,6 +227,17 @@ export const AnalyzeSchema = z
         message: `${operation} requires exactly one of 'projectId' or 'projectIds', not both`,
       });
     }
+    // With neither, brandedProjectIds/brandedProjectId end up empty and the
+    // request only fails after a round-trip through the AST layer's
+    // empty-pids guard (a SCRIPT_ERROR, not a clean VALIDATION_ERROR) —
+    // catch it here instead, consistent with the "not both" check above.
+    if ((operation === 'mark_reviewed' || operation === 'set_schedule') && !hasSingle && !hasPlural) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['analysis', 'params', 'projectId'],
+        message: `${operation} requires one of 'projectId' or 'projectIds'`,
+      });
+    }
   });
 
 export type AnalyzeInput = z.infer<typeof AnalyzeSchema>;

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -173,7 +173,13 @@ const AnalysisSchema = z.discriminatedUnion('type', [
           // superRefine below; discriminated-union members can't carry a
           // refinement directly). Cap mirrors bulk_delete's ids cap.
           projectIds: z.array(z.string()).min(1).max(100).optional(),
-          reviewDate: z.string().optional(),
+          // Must be a parseable date: an unparseable string reaches the
+          // script as an Invalid Date and (before the script-level guard)
+          // corrupted project.lastReviewDate. Reject early as VALIDATION_ERROR.
+          reviewDate: z
+            .string()
+            .refine((s) => !Number.isNaN(new Date(s).getTime()), { message: 'reviewDate must be a parseable date' })
+            .optional(),
           // OMN-60: review interval for set_schedule. Object shape — passed
           // through to buildSetReviewScheduleScript(), which expects { unit, steps }.
           reviewInterval: z

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -220,6 +220,17 @@ export const AnalyzeSchema = z
           'list_for_review does not accept projectIds — batch project selection only applies to mark_reviewed/set_schedule',
       });
     }
+    // Same reject-loud rule for the singular spelling: reviewsListForReview
+    // never reads params.projectId, so accepting it would be a silent no-op
+    // (the caller gets the full unfiltered list and no signal).
+    if (operation === 'list_for_review' && hasSingle) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['analysis', 'params', 'projectId'],
+        message:
+          'list_for_review does not accept projectId — project selection only applies to mark_reviewed/set_schedule',
+      });
+    }
     if ((operation === 'mark_reviewed' || operation === 'set_schedule') && hasSingle && hasPlural) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -231,6 +242,10 @@ export const AnalyzeSchema = z
     // request only fails after a round-trip through the AST layer's
     // empty-pids guard (a SCRIPT_ERROR, not a clean VALIDATION_ERROR) —
     // catch it here instead, consistent with the "not both" check above.
+    // The SCRIPT_ERROR→VALIDATION_ERROR error-code shift for this case is
+    // intentional (review-adjudicated): it lands in the same unmerged PR
+    // that introduced projectIds, so no released caller ever saw the old
+    // shape for this omission.
     if ((operation === 'mark_reviewed' || operation === 'set_schedule') && !hasSingle && !hasPlural) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -168,6 +168,11 @@ const AnalysisSchema = z.discriminatedUnion('type', [
           // only errors since OMN-106, so no caller ever got value from it.
           operation: z.enum(['list_for_review', 'mark_reviewed', 'set_schedule']).optional(),
           projectId: z.string().optional(),
+          // OMN-256: batch sibling of projectId — mark_reviewed/set_schedule
+          // accept ONE of projectId/projectIds (enforced by AnalyzeSchema's
+          // superRefine below; discriminated-union members can't carry a
+          // refinement directly). Cap mirrors bulk_delete's ids cap.
+          projectIds: z.array(z.string()).min(1).max(100).optional(),
           reviewDate: z.string().optional(),
           // OMN-60: review interval for set_schedule. Object shape — passed
           // through to buildSetReviewScheduleScript(), which expects { unit, steps }.
@@ -191,6 +196,37 @@ export const AnalyzeSchema = z
   .object({
     analysis: coerceObject(AnalysisSchema),
   })
-  .strict();
+  .strict()
+  // OMN-256: manage_reviews's projectId/projectIds exactly-one-of + the
+  // list_for_review reject-loud rule. The discriminated-union member can't
+  // carry a refinement (zod requires ZodObject members), so this lives at
+  // the wrapper boundary — mirrors WriteSchema's id/target_id precedent.
+  .superRefine((val, ctx) => {
+    const analysis = val.analysis as {
+      type?: string;
+      params?: { operation?: string; projectId?: string; projectIds?: string[] };
+    };
+    if (analysis.type !== 'manage_reviews') return;
+    const params = analysis.params;
+    const operation = params?.operation ?? 'list_for_review';
+    const hasSingle = params?.projectId !== undefined;
+    const hasPlural = params?.projectIds !== undefined;
+
+    if (operation === 'list_for_review' && hasPlural) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['analysis', 'params', 'projectIds'],
+        message:
+          'list_for_review does not accept projectIds — batch project selection only applies to mark_reviewed/set_schedule',
+      });
+    }
+    if ((operation === 'mark_reviewed' || operation === 'set_schedule') && hasSingle && hasPlural) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['analysis', 'params', 'projectIds'],
+        message: `${operation} requires exactly one of 'projectId' or 'projectIds', not both`,
+      });
+    }
+  });
 
 export type AnalyzeInput = z.infer<typeof AnalyzeSchema>;

--- a/tests/integration/tools/unified/mark-reviewed-batch-live.test.ts
+++ b/tests/integration/tools/unified/mark-reviewed-batch-live.test.ts
@@ -128,6 +128,45 @@ describe('Batch mark_reviewed live (OMN-256 / OMN-286)', () => {
     expect(results?.summary?.failed_count).toBe(1);
   }, 120000);
 
+  // ── 2b. Unparseable reviewDate is rejected AND corrupts nothing (round 7) ──
+  it('rejects an unparseable reviewDate and leaves lastReviewDate untouched on the real object', async () => {
+    const idE = await createSandboxProject('E');
+
+    // A freshly-created OmniFocus project already carries a lastReviewDate (its
+    // creation-date default), so "untouched" means UNCHANGED, not null. Capture
+    // the baseline first.
+    const readLastReviewDate = async (): Promise<string | null> => {
+      const r = await server.callTool('omnifocus_read', {
+        query: { type: 'projects', filters: { folder: SANDBOX_FOLDER_NAME }, fields: ['id', 'lastReviewDate'] },
+      });
+      expectOk(r, 'read lastReviewDate');
+      const projects: Array<{ id: string; lastReviewDate?: string | null }> = r.data?.projects ?? [];
+      const p = projects.find((x) => x.id === idE);
+      expect(p, `project ${idE} found on read-back`).toBeTruthy();
+      return p?.lastReviewDate ?? null;
+    };
+    const before = await readLastReviewDate();
+
+    // Schema rejects the unparseable date up front, before the script can
+    // assign an Invalid Date to the live project. A schema-validation failure
+    // surfaces as a JSON-RPC protocol error (-32602), which callTool throws —
+    // so assert the throw carries the parseable-date message.
+    await expect(
+      server.callTool('omnifocus_analyze', {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectId: idE, reviewDate: 'not-a-date' },
+        },
+      }),
+    ).rejects.toThrow(/parseable date/i);
+
+    // The critical assertion: the rejected call corrupted NOTHING — the live
+    // lastReviewDate is byte-identical to the pre-call baseline (not an Invalid
+    // Date, not cleared).
+    const after = await readLastReviewDate();
+    expect(after, 'lastReviewDate must be unchanged after a rejected mark').toBe(before);
+  }, 120000);
+
   // ── 3. Guard masks not-found on a GUARDED server (OMN-286 documented) ──────
   it('guarded: a not-found id in the batch is rejected whole by the sandbox pre-flight (OMN-286)', async () => {
     const idD = await createSandboxProject('D');

--- a/tests/integration/tools/unified/mark-reviewed-batch-live.test.ts
+++ b/tests/integration/tools/unified/mark-reviewed-batch-live.test.ts
@@ -1,0 +1,150 @@
+/**
+ * OMN-256 / OMN-286 — batch mark_reviewed live /verify against real OmniFocus.
+ *
+ * This is the layer the unit tests structurally cannot reach: the per-op unit
+ * test runs the generated OmniJS via vm.runInNewContext and never goes through
+ * the real dispatch path's sandbox guard. This probe exercises the FULL path
+ * end-to-end against a real OmniFocus DB.
+ *
+ * Three angles:
+ *   1. Happy path (guarded server): batch-mark two REAL sandbox projects
+ *      reviewed via projectIds[] → both succeed, metadata.projects_updated === 2,
+ *      lastReviewDate persists on read-back.
+ *   2. Continue-on-error partition (UNGUARDED server — the production contract):
+ *      batch [realId, bogusId] → the batch does NOT abort; realId lands in
+ *      results.successful, bogusId in results.failed, projects_updated === 1.
+ *      This is the honest count fix (de691ce3) proven live.
+ *   3. Guard masks not-found (guarded server — OMN-286 documented behavior):
+ *      the same [realId, bogusId] batch on a GUARDED server is rejected whole
+ *      by the sandbox pre-flight before the script runs — the identical
+ *      guard-masks-not-found property create-paths already documents for
+ *      single-op creates. Confirms production (guard off) is the only place
+ *      the continue-on-error contract is meant to hold, per OMN-286.
+ *
+ * Sandbox conventions: projects created in __MCP_TEST_SANDBOX__, run-scoped
+ * names, deleted in afterAll.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { expectOk } from '../../helpers/expect-ok.js';
+import { SANDBOX_FOLDER_NAME, ensureSandboxFolder } from '../../helpers/sandbox-manager.js';
+import { runScopedName } from '../../helpers/run-id.js';
+import { UnifiedTestServer } from '../../helpers/unified-test-server.js';
+
+const BOGUS_PROJECT_ID = 'omn256-nonexistent-project-id-000';
+
+describe('Batch mark_reviewed live (OMN-256 / OMN-286)', () => {
+  let server: UnifiedTestServer;
+  const createdProjectIds: string[] = [];
+
+  async function createSandboxProject(label: string): Promise<string> {
+    const res = await server.callTool('omnifocus_write', {
+      mutation: {
+        operation: 'create',
+        target: 'project',
+        data: { name: runScopedName(`OMN256_${label}_${Date.now()}`), folder: SANDBOX_FOLDER_NAME },
+      },
+    });
+    expectOk(res, `create sandbox project ${label}`);
+    const id = res.data?.project?.id ?? res.data?.project?.projectId ?? res.data?.id;
+    expect(id, `created project id (${label})`).toBeTruthy();
+    createdProjectIds.push(id);
+    return id;
+  }
+
+  beforeAll(async () => {
+    server = await UnifiedTestServer.start();
+    await ensureSandboxFolder();
+  }, 60000);
+
+  afterAll(async () => {
+    for (const id of createdProjectIds) {
+      try {
+        await server.callTool('omnifocus_write', {
+          mutation: { operation: 'delete', target: 'project', target_id: id },
+        });
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    server?.kill();
+  });
+
+  // ── 1. Happy path: batch-mark two real projects reviewed ──────────────────
+  it('marks two real sandbox projects reviewed in one call; projects_updated === 2', async () => {
+    const idA = await createSandboxProject('A');
+    const idB = await createSandboxProject('B');
+
+    const res = await server.callTool('omnifocus_analyze', {
+      analysis: { type: 'manage_reviews', params: { operation: 'mark_reviewed', projectIds: [idA, idB] } },
+    });
+    expectOk(res, 'batch mark_reviewed two projects');
+
+    // Honest count (de691ce3): both succeeded, so projects_updated === 2.
+    expect(res.metadata.projects_updated).toBe(2);
+    const summary = res.data?.batch?.results?.summary;
+    expect(summary?.successful_count).toBe(2);
+    expect(summary?.failed_count).toBe(0);
+
+    // Read back: both projects now carry a lastReviewDate.
+    const readRes = await server.callTool('omnifocus_read', {
+      query: { type: 'projects', filters: { folder: SANDBOX_FOLDER_NAME }, fields: ['id', 'lastReviewDate'] },
+    });
+    expectOk(readRes, 'read back lastReviewDate');
+    const projects: Array<{ id: string; lastReviewDate?: string }> = readRes.data?.projects ?? [];
+    for (const id of [idA, idB]) {
+      const p = projects.find((x) => x.id === id);
+      expect(p?.lastReviewDate, `lastReviewDate persisted for ${id}`).toBeTruthy();
+    }
+  }, 120000);
+
+  // ── 2. Continue-on-error partition on an UNGUARDED server (prod contract) ──
+  it('unguarded: a not-found id partitions into failed[] instead of aborting; projects_updated === 1', async () => {
+    const idC = await createSandboxProject('C');
+
+    // The sandbox guard's pre-flight masks the script-level not-found handling
+    // on a guarded server (OMN-286) — exactly as create-paths documents for
+    // single-op creates. So the continue-on-error contract, which is a
+    // PRODUCTION property (guard off), is verified on an unguarded server.
+    const unguarded = await UnifiedTestServer.start({ guarded: false });
+    let res: any;
+    try {
+      res = await unguarded.callTool('omnifocus_analyze', {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectIds: [idC, BOGUS_PROJECT_ID] },
+        },
+      });
+    } finally {
+      unguarded.kill();
+    }
+
+    expectOk(res, 'unguarded batch mark_reviewed mixed');
+    const results = res.data?.batch?.results;
+    expect(results?.successful?.map((r: { projectId: string }) => r.projectId)).toContain(idC);
+    expect(results?.failed?.map((r: { projectId: string }) => r.projectId)).toContain(BOGUS_PROJECT_ID);
+    // The honest count: one real success, not two requested.
+    expect(res.metadata.projects_updated).toBe(1);
+    expect(results?.summary?.successful_count).toBe(1);
+    expect(results?.summary?.failed_count).toBe(1);
+  }, 120000);
+
+  // ── 3. Guard masks not-found on a GUARDED server (OMN-286 documented) ──────
+  it('guarded: a not-found id in the batch is rejected whole by the sandbox pre-flight (OMN-286)', async () => {
+    const idD = await createSandboxProject('D');
+
+    // On the guarded main server, the pre-flight (Promise.all over
+    // validateProjectInSandbox) treats the not-found id as out-of-sandbox and
+    // rejects the ENTIRE batch before the continue-on-error script runs. This
+    // is the OMN-286 behavior — test-mode only; production (test 2) partitions.
+    const res = await server.callTool('omnifocus_analyze', {
+      analysis: {
+        type: 'manage_reviews',
+        params: { operation: 'mark_reviewed', projectIds: [idD, BOGUS_PROJECT_ID] },
+      },
+    });
+    expect(res.success, `guarded mixed batch should be rejected whole: ${JSON.stringify(res).slice(0, 300)}`).toBe(
+      false,
+    );
+    expect(JSON.stringify(res.error ?? res.metadata)).toMatch(/sandbox|not found|guard/i);
+  }, 120000);
+});

--- a/tests/unit/contracts/ast/mutation/mark-reviewed-batch.test.ts
+++ b/tests/unit/contracts/ast/mutation/mark-reviewed-batch.test.ts
@@ -1,0 +1,242 @@
+// tests/unit/contracts/ast/mutation/mark-reviewed-batch.test.ts
+// OMN-256 — batch mark_reviewed (projectIds[]). Golden-first: these envelopes
+// mirror set-review-schedule's results.{successful,failed,summary} grammar
+// (same accumulator shape, same continue-on-error semantics) applied to the
+// mark-reviewed body inherited from the single-id mutation
+// ([[feedback_parity_test_tautology]] — these are behavior goldens, not
+// old-vs-new equality).
+import vm from 'node:vm';
+import { describe, it, expect } from 'vitest';
+import {
+  buildMarkProjectsReviewedProgram,
+  dispatchMutation,
+  validateMutationProgram,
+  emitProgram,
+} from '../../../../../src/contracts/ast/mutation/index.js';
+import { buildMarkProjectsReviewedScript } from '../../../../../src/contracts/ast/mutation-script-builder.js';
+import { MARK_REVIEWED_BATCH_TYPED_SCHEMA } from '../../../../../src/omnifocus/response-schemas/write.js';
+
+interface FakeReviewInterval {
+  unit: { name: string };
+  steps: number;
+}
+
+interface FakeProject {
+  id: { primaryKey: string };
+  name: string;
+  lastReviewDate: Date | null;
+  nextReviewDate: Date | null;
+  reviewInterval: FakeReviewInterval | null;
+}
+
+function makeProject(id: string, name: string, reviewInterval: FakeReviewInterval | null): FakeProject {
+  return { id: { primaryKey: id }, name, lastReviewDate: null, nextReviewDate: null, reviewInterval };
+}
+
+function runScript(script: string, projects: Record<string, FakeProject>): unknown {
+  const inner = { Project: { byIdentifier: (id: string) => projects[id] ?? null }, JSON };
+  const outer = {
+    Application: () => ({ evaluateJavascript: (src: string) => vm.runInNewContext(src, inner) }),
+    JSON,
+  };
+  return JSON.parse(vm.runInNewContext(script, outer) as string);
+}
+
+const REVIEW_DATE = '2026-07-01T12:00:00.000Z';
+
+describe('mark-projects-reviewed batch — behavior goldens (exact JSON, vm-executed)', () => {
+  it('two projects, both found, both with intervals: exact envelope', async () => {
+    const alpha = makeProject('p1', 'Alpha', { unit: { name: 'months' }, steps: 2 });
+    const beta = makeProject('p2', 'Beta', { unit: { name: 'weeks' }, steps: 1 });
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: ['p1', 'p2'],
+      reviewDate: REVIEW_DATE,
+      updateNextReviewDate: true,
+    });
+    const parsed = runScript(script, { p1: alpha, p2: beta });
+
+    expect(parsed).toEqual({
+      success: true,
+      results: {
+        successful: [
+          {
+            projectId: 'p1',
+            projectName: 'Alpha',
+            changes: [
+              `Last review date set to ${REVIEW_DATE}`,
+              'Next review date calculated and set to 2026-09-01T12:00:00.000Z',
+            ],
+            lastReviewDate: REVIEW_DATE,
+            nextReviewDate: '2026-09-01T12:00:00.000Z',
+          },
+          {
+            projectId: 'p2',
+            projectName: 'Beta',
+            changes: [
+              `Last review date set to ${REVIEW_DATE}`,
+              'Next review date calculated and set to 2026-07-08T12:00:00.000Z',
+            ],
+            lastReviewDate: REVIEW_DATE,
+            nextReviewDate: '2026-07-08T12:00:00.000Z',
+          },
+        ],
+        failed: [],
+        summary: { total_requested: 2, successful_count: 2, failed_count: 0 },
+      },
+      message: 'Batch mark-reviewed completed: 2 successful, 0 failed',
+    });
+    expect(alpha.lastReviewDate?.toISOString()).toBe(REVIEW_DATE);
+    expect(beta.nextReviewDate?.toISOString()).toBe('2026-07-08T12:00:00.000Z');
+    expect(MARK_REVIEWED_BATCH_TYPED_SCHEMA.safeParse(parsed).success).toBe(true);
+  });
+
+  it('project without a reviewInterval: honest "Note" change, nextReviewDate stays null', async () => {
+    const project = makeProject('p1', 'Alpha', null);
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: ['p1'],
+      reviewDate: REVIEW_DATE,
+      updateNextReviewDate: true,
+    });
+    const parsed = runScript(script, { p1: project });
+    expect(parsed).toEqual({
+      success: true,
+      results: {
+        successful: [
+          {
+            projectId: 'p1',
+            projectName: 'Alpha',
+            changes: [
+              `Last review date set to ${REVIEW_DATE}`,
+              'Note: No review interval set, next review date not calculated',
+            ],
+            lastReviewDate: REVIEW_DATE,
+            nextReviewDate: null,
+          },
+        ],
+        failed: [],
+        summary: { total_requested: 1, successful_count: 1, failed_count: 0 },
+      },
+      message: 'Batch mark-reviewed completed: 1 successful, 0 failed',
+    });
+  });
+
+  it('updateNextReviewDate:false skips the interval math even when an interval exists', async () => {
+    const project = makeProject('p1', 'Alpha', { unit: { name: 'days' }, steps: 5 });
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: ['p1'],
+      reviewDate: REVIEW_DATE,
+      updateNextReviewDate: false,
+    });
+    const parsed = runScript(script, { p1: project }) as {
+      results: { successful: Array<{ changes: string[]; nextReviewDate: string | null }> };
+    };
+    expect(parsed.results.successful[0].changes).toEqual([`Last review date set to ${REVIEW_DATE}`]);
+    expect(parsed.results.successful[0].nextReviewDate).toBeNull();
+    expect(project.nextReviewDate).toBeNull();
+  });
+
+  it('mixed batch: found + missing ids partition into successful/failed, continue-on-error', async () => {
+    const alpha = makeProject('p1', 'Alpha', { unit: { name: 'weeks' }, steps: 1 });
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: ['p1', 'ghost'],
+      reviewDate: REVIEW_DATE,
+      updateNextReviewDate: true,
+    });
+    const parsed = runScript(script, { p1: alpha });
+    expect(parsed).toEqual({
+      success: true,
+      results: {
+        successful: [
+          {
+            projectId: 'p1',
+            projectName: 'Alpha',
+            changes: [
+              `Last review date set to ${REVIEW_DATE}`,
+              'Next review date calculated and set to 2026-07-08T12:00:00.000Z',
+            ],
+            lastReviewDate: REVIEW_DATE,
+            nextReviewDate: '2026-07-08T12:00:00.000Z',
+          },
+        ],
+        failed: [{ projectId: 'ghost', error: 'Project not found' }],
+        summary: { total_requested: 2, successful_count: 1, failed_count: 1 },
+      },
+      message: 'Batch mark-reviewed completed: 1 successful, 1 failed',
+    });
+    // The valid project DID advance even though a sibling id failed (no abort-on-first).
+    expect(alpha.lastReviewDate?.toISOString()).toBe(REVIEW_DATE);
+  });
+
+  it('empty projectIds: the early error envelope, mirrors set_schedule', async () => {
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: [],
+      reviewDate: REVIEW_DATE,
+      updateNextReviewDate: true,
+    });
+    const parsed = runScript(script, {});
+    expect(parsed).toEqual({
+      success: false,
+      error: true,
+      message: 'No project IDs provided',
+      results: {
+        successful: [],
+        failed: [],
+        summary: { total_requested: 0, successful_count: 0, failed_count: 0 },
+      },
+    });
+  });
+});
+
+describe('buildMarkProjectsReviewedProgram — golden emission', () => {
+  it('emits json binds, empty-ids guard, apply loop, envelope — nothing else', () => {
+    const program = buildMarkProjectsReviewedProgram({
+      projectIds: ['p1', 'p2'],
+      reviewDate: REVIEW_DATE,
+      updateNextReviewDate: true,
+    });
+    expect(() => validateMutationProgram(program)).not.toThrow();
+    expect(program.statements.map((s) => s.type)).toEqual(['bind', 'bind', 'bind', 'guard', 'bind', 'return']);
+    expect(program.context).toBe('mark_projects_reviewed');
+    expect(program.snippetDeps).toEqual(['applyMarkReviewedBatch']);
+
+    const omnijs = emitProgram(program);
+    expect(omnijs).toContain('const pids = ["p1","p2"];');
+    expect(omnijs).toContain(`const reviewDateStr = "${REVIEW_DATE}";`);
+    expect(omnijs).toContain('function applyMarkReviewedBatch(');
+    expect(omnijs).toContain('function calculateNextReviewDate(');
+    expect(omnijs).toContain('"No project IDs provided"');
+  });
+
+  it('quote-bearing project id cannot escape its JSON literal', () => {
+    const omnijs = emitProgram(
+      buildMarkProjectsReviewedProgram({
+        projectIds: ['has"quote'],
+        reviewDate: REVIEW_DATE,
+        updateNextReviewDate: true,
+      }),
+    );
+    expect(omnijs).toContain('const pids = ["has\\"quote"];');
+  });
+});
+
+// The OMN-119/120 non-bypass property: pre-flight EVERY id before building
+// (mirrors bulk_delete / set-review-schedule/project — spec §2.1).
+describe('dispatchMutation mark-reviewed/projects guard (OMN-119/120 non-bypass)', () => {
+  it('rejects a non-sandbox project id when the sandbox guard is enabled', async () => {
+    const prev = { NODE_ENV: process.env.NODE_ENV, SG: process.env.SANDBOX_GUARD_ENABLED };
+    process.env.NODE_ENV = 'test';
+    process.env.SANDBOX_GUARD_ENABLED = 'true';
+    try {
+      await expect(
+        dispatchMutation('mark-reviewed/projects', {
+          projectIds: ['not-a-sandbox-project-id'],
+          reviewDate: REVIEW_DATE,
+          updateNextReviewDate: true,
+        }),
+      ).rejects.toThrow(/TEST GUARD/);
+    } finally {
+      process.env.NODE_ENV = prev.NODE_ENV;
+      process.env.SANDBOX_GUARD_ENABLED = prev.SG;
+    }
+  });
+});

--- a/tests/unit/contracts/ast/mutation/mark-reviewed-batch.test.ts
+++ b/tests/unit/contracts/ast/mutation/mark-reviewed-batch.test.ts
@@ -167,6 +167,29 @@ describe('mark-projects-reviewed batch — behavior goldens (exact JSON, vm-exec
     expect(alpha.lastReviewDate?.toISOString()).toBe(REVIEW_DATE);
   });
 
+  it('unparseable reviewDate: reported failed AND leaves lastReviewDate UNMUTATED (validate-before-mutate)', async () => {
+    // Regression for the round-7 finding: applyMarkReviewed set
+    // project.lastReviewDate = new Date('bad') (Invalid Date) BEFORE the
+    // toISOString() read-back threw, corrupting the live object while the row
+    // was reported as failed. The guard now throws before any assignment.
+    const alpha = makeProject('p1', 'Alpha', { unit: { name: 'weeks' }, steps: 1 });
+    const { script } = await buildMarkProjectsReviewedScript({
+      projectIds: ['p1'],
+      reviewDate: 'not-a-date',
+      updateNextReviewDate: true,
+    });
+    const parsed = runScript(script, { p1: alpha }) as {
+      results: { successful: unknown[]; failed: Array<{ projectId: string; error: string }> };
+    };
+    expect(parsed.results.successful).toEqual([]);
+    expect(parsed.results.failed).toHaveLength(1);
+    expect(parsed.results.failed[0].projectId).toBe('p1');
+    expect(parsed.results.failed[0].error).toContain('Invalid reviewDate');
+    // The critical assertion: NOTHING was written to the live object.
+    expect(alpha.lastReviewDate).toBeNull();
+    expect(alpha.nextReviewDate).toBeNull();
+  });
+
   it('empty projectIds: the early error envelope, mirrors set_schedule', async () => {
     const { script } = await buildMarkProjectsReviewedScript({
       projectIds: [],

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1609,6 +1609,9 @@ describe('OmniFocusAnalyzeTool', () => {
         expect(res.success).toBe(true);
         expect(res.data.batch.results.failed).toEqual([{ projectId: 'ghost', error: 'Project not found' }]);
         expect(res.data.batch.results.successful).toHaveLength(1);
+        // projects_updated must reflect ACTUAL successes (1), not the 2
+        // requested ids — a partial failure must not read as full success.
+        expect(res.metadata.projects_updated).toBe(1);
       });
     });
   });

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1535,6 +1535,80 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(mockCache.invalidate).toHaveBeenCalledWith('projects');
       expect(mockCache.invalidate).toHaveBeenCalledWith('reviews');
     });
+
+    // OMN-256: batch mark_reviewed — the plural path, distinct envelope shape.
+    describe('mark_reviewed batch (projectIds, OMN-256)', () => {
+      it('marks multiple projects reviewed via projectIds, invalidates caches', async () => {
+        mockOmni.buildScript.mockReturnValue('script');
+        mockOmni.executeJson.mockResolvedValue(
+          createScriptSuccess({
+            success: true,
+            results: {
+              successful: [
+                {
+                  projectId: 'p1',
+                  projectName: 'Alpha',
+                  changes: ['Last review date set to 2026-07-01T12:00:00.000Z'],
+                  lastReviewDate: '2026-07-01T12:00:00.000Z',
+                  nextReviewDate: null,
+                },
+                {
+                  projectId: 'p2',
+                  projectName: 'Beta',
+                  changes: ['Last review date set to 2026-07-01T12:00:00.000Z'],
+                  lastReviewDate: '2026-07-01T12:00:00.000Z',
+                  nextReviewDate: null,
+                },
+              ],
+              failed: [],
+              summary: { total_requested: 2, successful_count: 2, failed_count: 0 },
+            },
+            message: 'Batch mark-reviewed completed: 2 successful, 0 failed',
+          }),
+        );
+
+        const res: any = await tool.execute({
+          analysis: { type: 'manage_reviews', params: { operation: 'mark_reviewed', projectIds: ['p1', 'p2'] } },
+        });
+
+        expect(res.success).toBe(true);
+        expect(res.metadata.operation).toBe('mark_reviewed');
+        expect(res.data.batch.results.summary).toEqual({ total_requested: 2, successful_count: 2, failed_count: 0 });
+        expect(mockCache.invalidate).toHaveBeenCalledWith('projects');
+        expect(mockCache.invalidate).toHaveBeenCalledWith('reviews');
+      });
+
+      it('reports an unresolvable id as its own loud failed row (continue-on-error, no silent drop)', async () => {
+        mockOmni.buildScript.mockReturnValue('script');
+        mockOmni.executeJson.mockResolvedValue(
+          createScriptSuccess({
+            success: true,
+            results: {
+              successful: [
+                {
+                  projectId: 'p1',
+                  projectName: 'Alpha',
+                  changes: ['Last review date set to 2026-07-01T12:00:00.000Z'],
+                  lastReviewDate: '2026-07-01T12:00:00.000Z',
+                  nextReviewDate: null,
+                },
+              ],
+              failed: [{ projectId: 'ghost', error: 'Project not found' }],
+              summary: { total_requested: 2, successful_count: 1, failed_count: 1 },
+            },
+            message: 'Batch mark-reviewed completed: 1 successful, 1 failed',
+          }),
+        );
+
+        const res: any = await tool.execute({
+          analysis: { type: 'manage_reviews', params: { operation: 'mark_reviewed', projectIds: ['p1', 'ghost'] } },
+        });
+
+        expect(res.success).toBe(true);
+        expect(res.data.batch.results.failed).toEqual([{ projectId: 'ghost', error: 'Project not found' }]);
+        expect(res.data.batch.results.successful).toHaveLength(1);
+      });
+    });
   });
 
   // ==========================================================================
@@ -1912,6 +1986,31 @@ describe('OmniFocusAnalyzeTool', () => {
       // OMN-106: the AST launcher carries the OmniJS body as ONE JSON string
       // literal, so the interval spec appears with escaped quotes.
       expect(generatedScript).toContain('const intervalSpec = {\\"unit\\":\\"week\\",\\"steps\\":2};');
+    });
+
+    // OMN-256: set_schedule was already batch-native at the AST layer —
+    // this pins that the tool layer now actually widens through projectIds.
+    it('OMN-256: passes projectIds through as a real batch, not a 1-element wrap of projectId', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.executeJson.mockResolvedValue({
+        success: true,
+        data: { results: { successful: [], failed: [], summary: { successful_count: 0, failed_count: 0 } } },
+      });
+
+      await tool.execute({
+        analysis: {
+          type: 'manage_reviews',
+          params: {
+            operation: 'set_schedule',
+            projectIds: ['p1', 'p2', 'p3'],
+            reviewInterval: { unit: 'week', steps: 2 },
+          },
+        },
+      });
+
+      expect(mockOmni.executeJson).toHaveBeenCalledTimes(1);
+      const generatedScript = mockOmni.executeJson.mock.calls[0][0] as string;
+      expect(generatedScript).toContain('const pids = [\\"p1\\",\\"p2\\",\\"p3\\"];');
     });
 
     it('FAIL LOUD (OMN-106): set_schedule with neither interval nor date refuses without executing', async () => {

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -1573,6 +1573,8 @@ describe('OmniFocusAnalyzeTool', () => {
 
         expect(res.success).toBe(true);
         expect(res.metadata.operation).toBe('mark_reviewed');
+        // Parity with the set_schedule batch response: requested-project count.
+        expect(res.metadata.projects_updated).toBe(2);
         expect(res.data.batch.results.summary).toEqual({ total_requested: 2, successful_count: 2, failed_count: 0 });
         expect(mockCache.invalidate).toHaveBeenCalledWith('projects');
         expect(mockCache.invalidate).toHaveBeenCalledWith('reviews');

--- a/tests/unit/tools/unified/compilers/AnalysisCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/AnalysisCompiler.test.ts
@@ -7,6 +7,7 @@ import type { AnalyzeInput } from '../../../../../src/tools/unified/schemas/anal
 
 type CompiledProductivityStats = Extract<CompiledAnalysis, { type: 'productivity_stats' }>;
 type CompiledParseMeetingNotes = Extract<CompiledAnalysis, { type: 'parse_meeting_notes' }>;
+type CompiledManageReviews = Extract<CompiledAnalysis, { type: 'manage_reviews' }>;
 
 describe('AnalysisCompiler', () => {
   const compiler = new AnalysisCompiler();
@@ -50,5 +51,26 @@ describe('AnalysisCompiler', () => {
     expect(compiled.type).toBe('parse_meeting_notes');
     expect(compiled.params?.text).toBe('Follow up with Sarah');
     expect(compiled.params?.extractTasks).toBe(true);
+  });
+
+  // OMN-256: the compiler's CompiledAnalysis union is a distinct layer from
+  // the Zod schema — a field added to the schema but not to this type is
+  // silently dropped (params?: {...} without the new key just types it away).
+  it('should compile manage_reviews with batch projectIds through untouched', () => {
+    const input = {
+      analysis: {
+        type: 'manage_reviews',
+        params: {
+          operation: 'mark_reviewed',
+          projectIds: ['p1', 'p2', 'p3'],
+        },
+      },
+    } as AnalyzeInput;
+
+    const compiled = compiler.compile(input) as CompiledManageReviews;
+
+    expect(compiled.type).toBe('manage_reviews');
+    expect(compiled.params?.projectIds).toEqual(['p1', 'p2', 'p3']);
+    expect(compiled.params?.projectId).toBeUndefined();
   });
 });

--- a/tests/unit/tools/unified/schemas/analyze-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/analyze-schema.test.ts
@@ -254,6 +254,26 @@ describe('AnalyzeSchema', () => {
       expect(AnalyzeSchema.safeParse(input).success).toBe(false);
     });
 
+    it('rejects an unparseable reviewDate before it can corrupt lastReviewDate', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectId: 'p1', reviewDate: 'not-a-date' },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('accepts a parseable reviewDate', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectId: 'p1', reviewDate: '2026-07-01 12:00' },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(true);
+    });
+
     it('single projectId form still works unchanged on mark_reviewed', () => {
       const input = {
         analysis: {

--- a/tests/unit/tools/unified/schemas/analyze-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/analyze-schema.test.ts
@@ -244,6 +244,16 @@ describe('AnalyzeSchema', () => {
       expect(result.success).toBe(false);
     });
 
+    it('rejects the singular projectId on list_for_review too (same reject-loud rule)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'list_for_review', projectId: 'p1' },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
     it('single projectId form still works unchanged on mark_reviewed', () => {
       const input = {
         analysis: {

--- a/tests/unit/tools/unified/schemas/analyze-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/analyze-schema.test.ts
@@ -163,6 +163,98 @@ describe('AnalyzeSchema', () => {
     });
   });
 
+  describe('manage_reviews batch projectIds (OMN-256)', () => {
+    it('accepts mark_reviewed with projectIds (1..100)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectIds: ['p1', 'p2', 'p3'] },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(true);
+    });
+
+    it('accepts set_schedule with projectIds', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: {
+            operation: 'set_schedule',
+            projectIds: ['p1', 'p2'],
+            reviewInterval: { unit: 'week', steps: 1 },
+          },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(true);
+    });
+
+    it('rejects an empty projectIds array', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectIds: [] },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('rejects projectIds over the 100-id cap', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectIds: Array.from({ length: 101 }, (_, i) => `p${i}`) },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('rejects providing BOTH projectId and projectIds on mark_reviewed', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectId: 'p1', projectIds: ['p2'] },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('rejects providing BOTH projectId and projectIds on set_schedule', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: {
+            operation: 'set_schedule',
+            projectId: 'p1',
+            projectIds: ['p2'],
+            reviewInterval: { unit: 'week', steps: 1 },
+          },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('rejects projectIds on list_for_review (loud, not silently ignored)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'list_for_review', projectIds: ['p1'] },
+        },
+      };
+      const result = AnalyzeSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('single projectId form still works unchanged on mark_reviewed', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed', projectId: 'p1' },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(true);
+    });
+  });
+
   // OMN-90: AnalyzeSchema must reject unknown fields, matching OMN-76's
   // CreateDataSchema/UpdateChangesSchema strict behavior. Without `.strict()`
   // applied at every depth (wrapper, discriminated-union members, scope,

--- a/tests/unit/tools/unified/schemas/analyze-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/analyze-schema.test.ts
@@ -253,6 +253,36 @@ describe('AnalyzeSchema', () => {
       };
       expect(AnalyzeSchema.safeParse(input).success).toBe(true);
     });
+
+    it('rejects mark_reviewed with neither projectId nor projectIds (fail fast, not a round-trip SCRIPT_ERROR)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'mark_reviewed' },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('rejects set_schedule with neither projectId nor projectIds (fail fast, not a round-trip SCRIPT_ERROR)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'set_schedule', reviewInterval: { unit: 'week', steps: 1 } },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(false);
+    });
+
+    it('list_for_review still works with neither projectId nor projectIds (no target needed)', () => {
+      const input = {
+        analysis: {
+          type: 'manage_reviews',
+          params: { operation: 'list_for_review' },
+        },
+      };
+      expect(AnalyzeSchema.safeParse(input).success).toBe(true);
+    });
   });
 
   // OMN-90: AnalyzeSchema must reject unknown fields, matching OMN-76's


### PR DESCRIPTION
## Summary
- `manage_reviews` `mark_reviewed` and `set_schedule` now accept `projectIds: string[]` (1-100, mirrors `bulk_delete`'s cap) alongside the existing single `projectId` — exactly one of the two, never both.
- `list_for_review` rejects a `projectIds` param loud rather than silently ignoring it (stabilization-mode "no accepted-but-ignored params" rule).
- `mark_reviewed` batch: new in-OmniJS plural mutation route (`mark-reviewed/projects` in `MUTATION_DEFS`) mirroring `set_schedule`'s existing loop — one round-trip, not N. Continue-on-error: an unresolvable id in the batch is its own loud `failed[]` row; siblings still apply.
- `set_schedule` batch: was already batch-native at the AST layer (`buildSetReviewScheduleScript` takes `projectIds: string[]`) — this is plumbing-widening only at the tool layer, no new lowering.
- Both single-id paths are byte-identical to before (regression-pinned in tests).
- Walks the Vertical Contract Matrix — including the compiler-layer type (`CompiledAnalysis` in `AnalysisCompiler.ts`) the spec explicitly flagged as easy to miss: a field added to the Zod schema but not to the compiler's own params type silently drops on the floor before reaching the tool handler.
- `docs/skills/omnifocus-assistant/SKILL.md`'s Weekly Review workflow gains a batch `mark_reviewed` step (it never called `mark_reviewed` at all before this).

## Decisions ratified (Kip, spec review)
Spec: `Technical/specs/OMN-256-manage-reviews-batch.md`
1. In-OmniJS plural lowering for `mark_reviewed` (not a JS-side loop of N single calls).
2. `list_for_review` rejects `projectIds` loud.
3. Batch cap = 100 (mirrors `bulk_delete`).
4. `readOnlyHint:true`-on-a-mutating-tool wart filed separately as OMN-284 (out of scope here).

`clear_schedule` symmetry (the ticket's original 4th acceptance criterion) is N/A by platform — removed entirely in OMN-273/PR #231 before this ticket started.

## Test plan
- [x] New AST-layer behavior-golden tests (`tests/unit/contracts/ast/mutation/mark-reviewed-batch.test.ts`, 8 tests, vm-executed) mirroring `set-review-schedule.test.ts`'s pattern
- [x] Schema tests: batch `projectIds` accepted/capped/exactly-one-of/reject-on-list_for_review (7 new cases)
- [x] Compiler-layer test pinning `projectIds` passthrough (the layer most likely to silently drop a new field)
- [x] Tool-layer tests: batch mark_reviewed success + continue-on-error, batch set_schedule widening
- [x] `npm run build && npm run lint && npm run test:unit` — 3955/3955 unit tests pass (via pre-push hook)
- [ ] Kip's live `/verify` against real OmniFocus (5 points in the spec) — required before merge, matrix row 6

Closes OMN-256

https://claude.ai/code/session_01DC4WmdXTqYFvTwE2c4Vqjv