### PR TITLE
fix(OMN-284): readOnlyHint honesty for OmniFocusAnalyzeTool + SystemTool

### DIFF
--- a/src/tools/system/SystemTool.ts
+++ b/src/tools/system/SystemTool.ts
@@ -82,7 +82,8 @@ export class SystemTool extends BaseTool<typeof SystemToolSchema> {
     stability: 'stable' as const,
     complexity: 'simple' as const,
     performanceClass: 'fast' as const,
-    tags: ['queries', 'read-only', 'diagnostics', 'system'],
+    // OMN-284: 'read-only' removed — operation:"cache" action:"clear" mutates cache state.
+    tags: ['queries', 'diagnostics', 'system'],
     capabilities: ['version', 'diagnostics', 'metrics', 'health-check'],
 
     // Phase 2: Capability & Performance Documentation
@@ -100,7 +101,14 @@ export class SystemTool extends BaseTool<typeof SystemToolSchema> {
 
   annotations = {
     title: 'System Utilities',
-    readOnlyHint: true,
+    // OMN-284: operation:"cache", cacheAction:"clear" mutates the server's
+    // own cache state (a real, user-directed side effect — unlike a read
+    // tool's incidental cache.set() while serving a query, which is
+    // transparent to the caller and not what readOnlyHint is meant to
+    // flag). No per-operation annotation granularity exists in the MCP
+    // spec, so the tool-level hint must reflect the most permissive
+    // operation a caller could trigger.
+    readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: false,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -395,7 +395,12 @@ SCOPE FILTERING:
 
   annotations = {
     title: 'Analyze OmniFocus Data',
-    readOnlyHint: true,
+    // OMN-284: this tool is NOT read-only — manage_reviews's mark_reviewed
+    // and set_schedule operations mutate OmniFocus project data. The MCP
+    // spec has no per-operation annotation granularity (ToolAnnotations is
+    // one flat object per tool), so the tool-level hint must reflect the
+    // most permissive case a caller could trigger.
+    readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,

--- a/tests/unit/tools/unified/tool-annotations-honesty.test.ts
+++ b/tests/unit/tools/unified/tool-annotations-honesty.test.ts
@@ -1,0 +1,47 @@
+// OMN-284 — readOnlyHint must accurately reflect whether a tool can mutate
+// state, not just whether it mutates OmniFocus task/project data. MCP
+// clients trust readOnlyHint for consent/confirmation UX (the MCP spec's own
+// caveat that clients "should never make tool use decisions based on"
+// annotations doesn't stop real clients from doing exactly that in practice
+// — see the ticket's rationale).
+//
+// Two tools were mislabeled `readOnlyHint: true` despite having a mutating
+// operation:
+//   - OmniFocusAnalyzeTool: manage_reviews.mark_reviewed / set_schedule
+//     mutate OmniFocus project data.
+//   - SystemTool: operation:"cache", cacheAction:"clear" mutates the
+//     server's own cache state (a real, user-directed, observable side
+//     effect — not incidental read-through cache population, which every
+//     cached read API does transparently and does NOT count as a mutation
+//     for this purpose).
+//
+// OmniFocusReadTool's incidental `cache.set()` calls (populating the cache
+// as a side effect of serving a read) are NOT the same class — they're
+// invisible to the caller and don't change anything the caller asked
+// about — so OmniFocusReadTool correctly stays readOnlyHint:true.
+import { describe, it, expect } from 'vitest';
+import { OmniFocusReadTool } from '../../../../src/tools/unified/OmniFocusReadTool.js';
+import { OmniFocusWriteTool } from '../../../../src/tools/unified/OmniFocusWriteTool.js';
+import { OmniFocusAnalyzeTool } from '../../../../src/tools/unified/OmniFocusAnalyzeTool.js';
+import { SystemTool } from '../../../../src/tools/system/SystemTool.js';
+import { CacheManager } from '../../../../src/cache/CacheManager.js';
+
+describe('OMN-284: readOnlyHint honesty across unified tools', () => {
+  const cache = new CacheManager();
+
+  it('OmniFocusReadTool stays readOnlyHint:true (genuinely read-only)', () => {
+    expect(new OmniFocusReadTool(cache).annotations.readOnlyHint).toBe(true);
+  });
+
+  it('OmniFocusWriteTool stays readOnlyHint:false (always was correct)', () => {
+    expect(new OmniFocusWriteTool(cache).annotations.readOnlyHint).toBe(false);
+  });
+
+  it('OmniFocusAnalyzeTool is readOnlyHint:false — manage_reviews mutates project data', () => {
+    expect(new OmniFocusAnalyzeTool(cache).annotations.readOnlyHint).toBe(false);
+  });
+
+  it('SystemTool is readOnlyHint:false — operation:"cache" action:"clear" mutates cache state', () => {
+    expect(new SystemTool(cache).annotations.readOnlyHint).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Both `OmniFocusAnalyzeTool` and `SystemTool` advertised `annotations.readOnlyHint: true` while having a mutating operation reachable through them. MCP clients that trust `readOnlyHint` for consent/confirmation UX would be misled into treating these as safe no-confirmation calls.

- **OmniFocusAnalyzeTool**: `manage_reviews`'s `mark_reviewed`/`set_schedule` mutate OmniFocus project data. Surfaced while spec'ing OMN-256's batch operations, which makes the mislabel slightly worse (more mutation surface under the same false hint).
- **SystemTool**: `operation:"cache"`, `action:"clear"` mutates the server's own cache state — a real, user-directed side effect, unlike a read tool's incidental `cache.set()` while serving a query (transparent to the caller, not what `readOnlyHint` is meant to flag). Also dropped the now-dishonest `'read-only'` self-tag from its `meta.tags`.

## Investigation (per the ticket's acceptance criteria)

Checked the MCP SDK's `ToolAnnotations` shape (`@modelcontextprotocol/sdk` ^1.25.1): it's one flat object per tool, no per-operation granularity. So each tool-level hint must reflect its *most permissive* operation.

Grepped `readOnlyHint` across `src/tools/unified/` + `src/tools/system/` — 4 tools total:
- `OmniFocusReadTool`: stays `true` — genuinely read-only. Its `cache.set()` calls are incidental read-through caching, not a user-directed mutation.
- `OmniFocusWriteTool`: already correctly `false`.
- `OmniFocusAnalyzeTool`, `SystemTool`: fixed in this PR.

## Test plan
- [x] New test (`tests/unit/tools/unified/tool-annotations-honesty.test.ts`) pins all four tools' `readOnlyHint` values, watched red→green
- [x] `npm run build && npm run lint && npm run test:unit` — 3939/3939 unit tests pass (via pre-push hook)

Closes OMN-284

https://claude.ai/code/session_01DC4WmdXTqYFvTwE2c4Vqjv