### PR TITLE
feat(OMN-278): converge write-path status echo onto canonical onHold/done vocabulary

### DIFF
--- a/src/contracts/ast/mutation/defs.ts
+++ b/src/contracts/ast/mutation/defs.ts
@@ -785,23 +785,24 @@ const PROJECT_STATUS_UPDATE_ENUM: Record<string, string> = {
 };
 
 /** Live status read-back for the update envelope (spec §2.4) — builder-internal
- * raw (no user data), mapping Project.Status constants to the legacy lowercase
- * strings so the envelope key keeps its shape. The legacy envelope ECHOED
- * `changes.status || 'active'` while the actual set could have silently failed.
+ * raw (no user data). The legacy envelope ECHOED `changes.status || 'active'`
+ * while the actual set could have silently failed; this reads the live value.
  *
- * OMN-274 adjudication — deliberately NOT the read/analytics wire vocabulary:
- * this echo speaks the write TRANSPORT enum ('active'|'on_hold'|'completed'|
- * 'dropped'), the same values the write schema accepts and the write response
- * schema pins (response-schemas/write.ts) — a client reads back the vocabulary
- * it wrote. It is a whole-vocabulary choice ('completed', not 'done'), not a
- * drifted copy of the 'onHold' map; changing only the OnHold spelling would
- * create a THIRD, mixed vocabulary. If this echo ever converges on the wire
- * form, move 'completed'→'done' and the response schema enum in the same
- * change. Tracked as OMN-278. See Technical/specs/OMN-274-read-path-status-vocabulary.md. */
+ * Vocabulary (OMN-278, converged 2026-07-20): the echo speaks the CANONICAL
+ * read/analytics wire form ('active'|'onHold'|'done'|'dropped') — the OmniJS
+ * Project.Status constant names camelCased — matching what a subsequent read
+ * of the same project returns. The INPUT side is unchanged: writes still
+ * accept the transport enum ('on_hold'/'completed', PROJECT_STATUS_UPDATE_ENUM
+ * above), so input and echo are asymmetric by design — the same asymmetry the
+ * read path has had since OMN-274 (filter input 'on_hold' → response 'onHold').
+ * This constant and the response schema enum (response-schemas/write.ts,
+ * ProjectWriteResultSchema update variant) MUST move together — see the
+ * OMN-274 spec's POST-BUILD REVERSAL section for the mixed-vocabulary hazard
+ * a partial edit reintroduces. */
 const PROJECT_STATUS_READBACK =
   "proj.status === Project.Status.Active ? 'active' : " +
-  "proj.status === Project.Status.OnHold ? 'on_hold' : " +
-  "proj.status === Project.Status.Done ? 'completed' : 'dropped'";
+  "proj.status === Project.Status.OnHold ? 'onHold' : " +
+  "proj.status === Project.Status.Done ? 'done' : 'dropped'";
 
 /**
  * Lower a project-update request into a typed mutation Program (OMN-128 slice 4).

--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -256,9 +256,9 @@ export const TASK_COUNTS_ZERO_LITERAL = `{ total: 0, available: 0, completed: 0 
  * Known non-splice sites, deliberately adjudicated elsewhere:
  * warm-projects-cache normalizes via substring match (adjudicated at that
  * site), and the write-path read-back echo (mutation/defs.ts
- * PROJECT_STATUS_READBACK) deliberately speaks the write TRANSPORT
- * vocabulary ('on_hold'/'completed'), echoing the same enum the write
- * schema accepts — see the adjudication comment at that site (OMN-274).
+ * PROJECT_STATUS_READBACK) — since OMN-278 it speaks this same canonical
+ * vocabulary, but as an inline ternary (an update envelope, not a splice
+ * of this list-shaped snippet); see the comment at that site.
  */
 export const PROJECT_STATUS_STRING_SNIPPET = `function projectStatusString(s) {
             if (s === Project.Status.Active) return 'active';

--- a/src/omnifocus/response-schemas/write.ts
+++ b/src/omnifocus/response-schemas/write.ts
@@ -300,7 +300,9 @@ export const ProjectWriteResultSchema = z.union([
       projectId: z.string(),
       name: z.string(),
       flagged: z.boolean(),
-      status: z.enum(['active', 'on_hold', 'completed', 'dropped']),
+      // OMN-278: canonical vocabulary (matches PROJECT_STATUS_READBACK in
+      // contracts/ast/mutation/defs.ts — the two must move together).
+      status: z.enum(['active', 'onHold', 'done', 'dropped']),
       updated: z.literal(true),
       warnings: warningsArray,
     })

--- a/tests/unit/contracts/ast/mutation/update-project.test.ts
+++ b/tests/unit/contracts/ast/mutation/update-project.test.ts
@@ -200,8 +200,8 @@ describe('buildUpdateProjectProgram — golden emission', () => {
   it('envelope status is a READ-BACK ternary over Project.Status, not an input echo', () => {
     const omnijs = emit({ status: 'on_hold' });
     expect(omnijs).toContain("proj.status === Project.Status.Active ? 'active'");
-    expect(omnijs).toContain("proj.status === Project.Status.OnHold ? 'on_hold'");
-    expect(omnijs).toContain("proj.status === Project.Status.Done ? 'completed' : 'dropped'");
+    expect(omnijs).toContain("proj.status === Project.Status.OnHold ? 'onHold'");
+    expect(omnijs).toContain("proj.status === Project.Status.Done ? 'done' : 'dropped'");
     expect(omnijs).not.toContain('"on_hold", updated'); // no echo of the requested value in the envelope
   });
 

--- a/tests/unit/omnifocus/script-response-schemas.test.ts
+++ b/tests/unit/omnifocus/script-response-schemas.test.ts
@@ -711,6 +711,38 @@ describe('ProjectWriteResultSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  // OMN-278: the update echo speaks the canonical read/analytics vocabulary
+  // (onHold/done), NOT the write-transport input enum (on_hold/completed).
+  // The enum pin and PROJECT_STATUS_READBACK moved together — a mismatch here
+  // means the schema and the emitted ternary have drifted apart.
+  it('(a) accepts canonical onHold/done status echoes on the update envelope', () => {
+    for (const status of ['onHold', 'done']) {
+      const result = ProjectWriteResultSchema.safeParse({
+        projectId: 'p123',
+        name: 'Updated Project',
+        flagged: true,
+        status,
+        updated: true,
+        warnings: [],
+      });
+      expect(result.success, `status '${status}' should parse`).toBe(true);
+    }
+  });
+
+  it('(b) rejects the retired write-transport spellings on_hold/completed on the update echo', () => {
+    for (const status of ['on_hold', 'completed']) {
+      const result = ProjectWriteResultSchema.safeParse({
+        projectId: 'p123',
+        name: 'Updated Project',
+        flagged: true,
+        status,
+        updated: true,
+        warnings: [],
+      });
+      expect(result.success, `status '${status}' should be rejected`).toBe(false);
+    }
+  });
+
   it('(b) rejects payload missing both created and updated discriminators', () => {
     const result = ProjectWriteResultSchema.safeParse({
       projectId: 'p123',


### PR DESCRIPTION
## What

Converges the project-update write-response `status` echo onto the canonical read/analytics vocabulary, atomically:

- `PROJECT_STATUS_READBACK` (`src/contracts/ast/mutation/defs.ts`): `'on_hold'` → `'onHold'`, `'completed'` → `'done'` (`active`/`dropped` already identical in both vocabularies).
- `ProjectWriteResultSchema` update-variant enum (`src/omnifocus/response-schemas/write.ts`): `['active','on_hold','completed','dropped']` → `['active','onHold','done','dropped']` — same commit, per the OMN-274 adjudication's own instruction that a partial edit recreates the mixed-vocabulary hazard.

**Input side unchanged.** Writes still accept `status: 'on_hold'`/`'completed'` (`write-schema.ts`, `PROJECT_STATUS_UPDATE_ENUM`). This creates a deliberate input/output asymmetry — write `on_hold`, read back `onHold` — which is the same asymmetry the read path has had since OMN-274 (filter input `on_hold` → response `onHold`). Converging the input enum is a breaking change for existing callers and stays a separate decision (called out in the spec, not folded in).

## Why

Kip's 2026-07-19/20 triage decision: full vocabulary consolidation rather than a permanent second write-transport vocabulary. The vocabulary question was closed 2026-07-20: `onHold`/`done` IS OmniFocus's own API vocabulary (`Project.Status.OnHold`/`.Done` — `src/omnifocus/api/OmniFocus.d.ts`); the transport `completed` is a Task-status word misapplied to projects.

Spec (approved): `Technical/specs/OMN-278-write-echo-vocabulary-convergence.md` (Obsidian).

## Vertical Contract Matrix (public write-response contract change)

| # | Layer | Disposition |
|---|-------|-------------|
| 1 | Schema (both) | ✅ `ProjectWriteResultSchema` enum changed (response contract). inputSchema/description: **N/A** — the advertised `status` description documents INPUT values only (unchanged); the response vocabulary is not advertised anywhere in the tool description, and the inputSchema has a hard <4000-byte budget with ~60 bytes headroom. |
| 2 | Normalization | **N/A** — no WRAPPER_HINTS involvement; the echo is a fixed literal in generated OmniJS. |
| 3 | Single-item path | ✅ `handleProjectUpdateDirect` → `buildUpdateProjectScript` → `buildUpdateProjectProgram` is the sole consumer of `PROJECT_STATUS_READBACK` (grep-verified at `defs.ts:905`, only reference). |
| 4 | Batch path | ✅ Batch project update (`dispatchBatchOp` case `'update'`) routes through the SAME `handleProjectUpdateDirect` — no independent echo. Batch create paths use the create envelope, which has no `status` field. Grep-verified: no other `ProjectWriteResultSchema` consumer echoes status. |
| 5 | Script lowering | ✅ The literal change in the `raw()` ternary — no snippet/bridge involvement. |
| 6 | Live bridge | ⚠️ **Owed — Kip's `/verify`** (4 points in the spec): update to `on_hold` → echo `onHold`; to `completed` → echo `done`; `active`/`dropped` round-trip unchanged; check no downstream client pattern-matches the old literals in write RESPONSES. Mocked/vm tests deliberately don't satisfy this row. |
| 7 | Response validation | ✅ Same edit as row 1 (schema pins the wire shape). New regression pins: canonical spellings parse, retired transport spellings REJECT (watched red first). |
| 8 | Cache key | **N/A** — no cache keys on write responses. |

## Tests

- Updated the literal-string pins in `tests/unit/contracts/ast/mutation/update-project.test.ts` (watched fail red against old code first).
- New schema pins in `tests/unit/omnifocus/script-response-schemas.test.ts`: update-variant accepts `onHold`/`done`, rejects `on_hold`/`completed` (both watched red).
- Adjudication comments updated at `defs.ts` and `types.ts` to record the convergence (the old "deliberately NOT canonical" framing became false).
- Full suite: `npm run build` ✅ · `npm run lint --max-warnings=0` ✅ · `npm run test:unit` 3964/3964 ✅ · `tsc -p tsconfig.test.json` ✅ · no stray `console.log`.

Closes OMN-278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017usHPNQhpKgpMMSQWVNE2Z