### PR TITLE
chore(OMN-282): diagnostics orphan dispositions — CLI-consumed exports kept, dead coarse classifier removed

### DIFF
--- a/src/diagnostics/clustering.ts
+++ b/src/diagnostics/clustering.ts
@@ -1,4 +1,8 @@
 // src/diagnostics/clustering.ts
+// intentionally-exposed-for-CLI (OMN-282): consumed by scripts/diagnose-failures.ts
+// (the `npm run diagnose-failures` entry the weekly ~/bin/of-mcp-diagnose launchd
+// job runs). scripts/ sits outside tsconfig's src/** include, so ts-prune flags
+// these exports as orphans; they are not.
 import { createHash } from 'crypto';
 import type { FailureRecord } from './failure-log.js';
 import { normalizeErrorMessage, normalizeInputShape } from './normalize.js';
@@ -74,11 +78,6 @@ export function isIgnored(c: FailureCluster): boolean {
   return cat !== undefined && IGNORE_SET.has(cat);
 }
 
-export type CoarseClass = 'VALIDATION' | 'EXECUTION' | 'DATA_ERROR';
-
-/** Coarse pre-classification. The fine SCHEMA_DRIFT/COERCION/DESCRIPTION split happens in the driver
- *  (deterministic via schema-drift) or the LLM agent (residual). */
-export function classifyCluster(c: FailureCluster): CoarseClass {
-  if (isIgnored(c)) return 'DATA_ERROR';
-  return c.example.errorType === 'VALIDATION_ERROR' ? 'VALIDATION' : 'EXECUTION';
-}
+// OMN-282: a coarse pre-classifier (classifyCluster/CoarseClass) lived here but
+// the driver never ran that step — it goes straight from isIgnored() filtering
+// to the fine deterministic/LLM split. Removed as a dead design remnant.

--- a/src/diagnostics/failure-log.ts
+++ b/src/diagnostics/failure-log.ts
@@ -1,4 +1,8 @@
 // src/diagnostics/failure-log.ts
+// intentionally-exposed-for-CLI (OMN-282): consumed by scripts/diagnose-failures.ts
+// (the `npm run diagnose-failures` entry the weekly ~/bin/of-mcp-diagnose launchd
+// job runs). scripts/ sits outside tsconfig's src/** include, so ts-prune flags
+// these exports as orphans; they are not.
 export interface FailureCategorization {
   errorType: string;
   severity?: string;

--- a/src/diagnostics/ledger.ts
+++ b/src/diagnostics/ledger.ts
@@ -1,4 +1,8 @@
 // src/diagnostics/ledger.ts
+// intentionally-exposed-for-CLI (OMN-282): consumed by scripts/diagnose-failures.ts
+// (the `npm run diagnose-failures` entry the weekly ~/bin/of-mcp-diagnose launchd
+// job runs). scripts/ sits outside tsconfig's src/** include, so ts-prune flags
+// these exports as orphans; they are not.
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { homedir } from 'os';

--- a/src/diagnostics/linear-filer.ts
+++ b/src/diagnostics/linear-filer.ts
@@ -1,4 +1,8 @@
 // src/diagnostics/linear-filer.ts
+// intentionally-exposed-for-CLI (OMN-282): fileDriftIssues is the designed
+// --create-issues DI seam for scripts/diagnose-failures.ts (its RunDiagnosisOpts
+// documents the closure shape; wiring is the tracked Phase-4 step, not built yet).
+// Guardrail behavior is pinned by tests/unit/diagnostics/linear-filer.test.ts.
 //
 // Guardrailed auto-Linear filer for SCHEMA_DRIFT clusters.
 //

--- a/src/diagnostics/schema-drift.ts
+++ b/src/diagnostics/schema-drift.ts
@@ -1,3 +1,7 @@
+// intentionally-exposed-for-CLI (OMN-282): consumed by scripts/diagnose-failures.ts
+// (the `npm run diagnose-failures` entry the weekly ~/bin/of-mcp-diagnose launchd
+// job runs). scripts/ sits outside tsconfig's src/** include, so ts-prune flags
+// these exports as orphans; they are not.
 import { z } from 'zod';
 import { byCodePoint } from './normalize.js';
 

--- a/src/diagnostics/tool-schema-registry.ts
+++ b/src/diagnostics/tool-schema-registry.ts
@@ -1,4 +1,8 @@
 // src/diagnostics/tool-schema-registry.ts
+// intentionally-exposed-for-CLI (OMN-282): consumed by scripts/diagnose-failures.ts
+// (the `npm run diagnose-failures` entry the weekly ~/bin/of-mcp-diagnose launchd
+// job runs). scripts/ sits outside tsconfig's src/** include, so ts-prune flags
+// these exports as orphans; they are not.
 import type { z } from 'zod';
 import { CacheManager } from '../cache/CacheManager.js';
 import { SystemTool } from '../tools/system/SystemTool.js';

--- a/src/diagnostics/triage-doc.ts
+++ b/src/diagnostics/triage-doc.ts
@@ -1,4 +1,8 @@
 // src/diagnostics/triage-doc.ts
+// intentionally-exposed-for-CLI (OMN-282): consumed by scripts/diagnose-failures.ts
+// (the `npm run diagnose-failures` entry the weekly ~/bin/of-mcp-diagnose launchd
+// job runs). scripts/ sits outside tsconfig's src/** include, so ts-prune flags
+// these exports as orphans; they are not.
 
 export interface TriageRow {
   fingerprint: string;

--- a/tests/unit/diagnostics/classify.test.ts
+++ b/tests/unit/diagnostics/classify.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/diagnostics/classify.test.ts
 import { describe, it, expect } from 'vitest';
-import { classifyCluster, isIgnored } from '../../../src/diagnostics/clustering.js';
+import { isIgnored } from '../../../src/diagnostics/clustering.js';
 import type { FailureCluster } from '../../../src/diagnostics/clustering.js';
 
 const cluster = (over: Partial<FailureCluster>): FailureCluster => ({
@@ -31,27 +31,5 @@ describe('isIgnored', () => {
   });
   it('does not ignore validation errors', () => {
     expect(isIgnored(cluster({}))).toBe(false);
-  });
-});
-
-describe('classifyCluster', () => {
-  it('classifies a Zod validation cluster as VALIDATION (candidate for drift/coercion/description)', () => {
-    expect(classifyCluster(cluster({}))).toBe('VALIDATION');
-  });
-  it('classifies an ignored cluster as DATA_ERROR', () => {
-    const c = cluster({
-      example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR', categorization: { errorType: 'INVALID_ID' } },
-    });
-    expect(classifyCluster(c)).toBe('DATA_ERROR');
-  });
-  it('classifies a non-ignored execution cluster as EXECUTION', () => {
-    // No categorization at all.
-    const noCat = cluster({ example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR' } });
-    expect(classifyCluster(noCat)).toBe('EXECUTION');
-    // Categorization present but errorType NOT in the ignore-set.
-    const nonIgnoredCat = cluster({
-      example: { ...cluster({}).example, errorType: 'EXECUTION_ERROR', categorization: { errorType: 'UNKNOWN_ERROR' } },
-    });
-    expect(classifyCluster(nonIgnoredCat)).toBe('EXECUTION');
   });
 });


### PR DESCRIPTION
## Verification pass (the ticket's required first step — run on the machine that owns the launchd job)

| Where | Found |
|-------|-------|
| `~/bin/` | `of-mcp-diagnose` (launchd wrapper) and `of-mcp-redeploy` (comment reference only) |
| `~/Library/LaunchAgents/` | `com.omnifocus-mcp.diagnose.plist` → runs `/bin/bash /Users/kip/bin/of-mcp-diagnose` weekly (Sun 09:00) |

`of-mcp-diagnose` invokes **`npm run diagnose-failures`** against the prod checkout — i.e. `npx tsx scripts/diagnose-failures.ts`. **No script outside the repo tsx-executes `src/diagnostics/` directly.** The external consumer chain terminates at the repo's own entry point, which imports every flagged symbol except `classifyCluster`. The orphan flags are an artifact of `scripts/` sitting outside tsconfig's `src/**` include — ts-prune never sees the driver.

## Per-symbol dispositions (acceptance criterion 2)

| Symbol | Disposition |
|--------|-------------|
| `clusterFailures` | **kept** — imported by driver; header comment |
| `classifyCluster` (+ `CoarseClass`) | **removed** — dead coarse pre-classifier: the driver goes straight from `isIgnored()` filtering to the fine deterministic/LLM split; the coarse VALIDATION/EXECUTION/DATA_ERROR step was designed but never wired. Its tautological describe block removed from `classify.test.ts` (the `isIgnored` tests stay — live symbol). |
| `loadLedger`, `isKnown`, `recordDiagnosis` | **kept** — imported by driver; header comment |
| `canonicalizeInputSchema`, `diffSchemas`, `canonicalizeZodSchema` | **kept** — imported by driver; header comment |
| `parseFailureLog` | **kept** — imported by driver; header comment |
| `fileDriftIssues` | **kept** — the designed `--create-issues` DI seam (`RunDiagnosisOpts.linearFiler` documents the exact closure shape; Phase-4 wiring is tracked, deliberately not built). Guardrail behavior pinned by `linear-filer.test.ts`. Tailored comment at the site. |
| `renderTriageDoc` | **kept** — imported by driver; header comment |
| `TOOL_SCHEMA_REGISTRY` | **kept** — imported by driver; header comment |

Each kept file carries an `intentionally-exposed-for-CLI (OMN-282)` header so the next ts-prune sweep doesn't re-litigate these.

## Validation

`npm run build` ✅ · `npm run lint --max-warnings=0` ✅ · `tsc -p tsconfig.test.json` ✅ · `npm run test:unit` 3959/3959 ✅ (−3 = the removed classifyCluster tests)

Closes OMN-282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017usHPNQhpKgpMMSQWVNE2Z