### PR TITLE
refactor(OMN-287): extract shared unwrapScriptEnvelope() to script-result-types

### DIFF
--- a/src/omnifocus/script-result-types.ts
+++ b/src/omnifocus/script-result-types.ts
@@ -246,3 +246,23 @@ function unwrapEffects(schema: z.ZodTypeAny): z.ZodTypeAny {
   }
   return s;
 }
+
+/**
+ * Unwrap a script payload from its optional {data: ...} envelope (OMN-287).
+ *
+ * Several script families (review ops, tag management) wrap their payload in
+ * an envelope like {ok, v, data}; others return the payload bare. This is the
+ * ONE unwrap implementation — OmniFocusAnalyzeTool and OmniFocusWriteTool
+ * previously carried byte-identical private copies, so an envelope-shape
+ * change could update one tool and silently leave the other returning a
+ * still-wrapped {data: ...} object.
+ *
+ * Semantics (preserved exactly from both original copies): unwraps ONLY when
+ * `data` exists AND is truthy; a falsy `data` (null/0/'') passes the raw
+ * value through whole.
+ */
+export function unwrapScriptEnvelope<T>(raw: unknown): T {
+  return raw && typeof raw === 'object' && 'data' in raw && (raw as { data?: unknown }).data
+    ? ((raw as { data: T }).data as T)
+    : (raw as T);
+}

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -11,7 +11,7 @@ import {
   OperationTimerV2,
   StandardResponseV2,
 } from '../../utils/response-format.js';
-import { isScriptError, isScriptSuccess } from '../../omnifocus/script-result-types.js';
+import { isScriptError, isScriptSuccess, unwrapScriptEnvelope } from '../../omnifocus/script-result-types.js';
 import {
   astEnvelopeSchema,
   listResultSchema,
@@ -3372,16 +3372,6 @@ SCOPE FILTERING:
     }
   }
 
-  // Review-family scripts sometimes wrap their payload in a {data: ...}
-  // envelope (e.g. {ok, v, data}); unwrap it if present, otherwise treat the
-  // raw value as the payload itself. Shared across all four review
-  // operations so the unwrap logic can't drift between them.
-  private unwrapScriptEnvelope<T>(raw: unknown): T {
-    return raw && typeof raw === 'object' && 'data' in raw && (raw as { data?: unknown }).data
-      ? ((raw as { data: T }).data as T)
-      : (raw as T);
-  }
-
   // Both batch review ops are continue-on-error: a not-found/typo'd id becomes
   // its own results.failed[] row rather than aborting the batch. So the count
   // that actually mutated is results.summary.successful_count — NOT the
@@ -3429,7 +3419,7 @@ SCOPE FILTERING:
       );
     }
 
-    const data = this.unwrapScriptEnvelope<ReviewListData>(result.data);
+    const data = unwrapScriptEnvelope<ReviewListData>(result.data);
     const src = data?.projects || data?.items || [];
     if (!Array.isArray(src)) {
       return createErrorResponseV2(
@@ -3559,7 +3549,7 @@ SCOPE FILTERING:
     this.cache.invalidate('projects');
     this.cache.invalidate('reviews');
 
-    const parsedResult = this.unwrapScriptEnvelope<unknown>(result.data);
+    const parsedResult = unwrapScriptEnvelope<unknown>(result.data);
 
     return createSuccessResponseV2('manage_reviews', { project: parsedResult }, undefined, {
       ...timer.toMetadata(),
@@ -3599,7 +3589,7 @@ SCOPE FILTERING:
     this.cache.invalidate('projects');
     this.cache.invalidate('reviews');
 
-    const parsedResult = this.unwrapScriptEnvelope<unknown>(result.data);
+    const parsedResult = unwrapScriptEnvelope<unknown>(result.data);
 
     return createSuccessResponseV2('manage_reviews', { batch: parsedResult }, undefined, {
       ...timer.toMetadata(),
@@ -3667,7 +3657,7 @@ SCOPE FILTERING:
     this.cache.invalidate('projects');
     this.cache.invalidate('reviews');
 
-    const parsedResult = this.unwrapScriptEnvelope<unknown>(result.data);
+    const parsedResult = unwrapScriptEnvelope<unknown>(result.data);
 
     return createSuccessResponseV2('manage_reviews', { batch: parsedResult }, undefined, {
       ...timer.toMetadata(),

--- a/src/tools/unified/OmniFocusWriteTool.ts
+++ b/src/tools/unified/OmniFocusWriteTool.ts
@@ -44,7 +44,7 @@ import type {
   RepetitionRule,
   TaskCreateData,
 } from '../../contracts/mutations.js';
-import { isScriptError, isScriptSuccess } from '../../omnifocus/script-result-types.js';
+import { isScriptError, isScriptSuccess, unwrapScriptEnvelope } from '../../omnifocus/script-result-types.js';
 import {
   TaskWriteResultSchema,
   CompleteResultSchema,
@@ -2442,12 +2442,8 @@ SAFETY:
       );
     }
 
-    // Unwrap double-wrapped data structure
-    const envelope = result.data as unknown;
-    const parsedResult =
-      envelope && typeof envelope === 'object' && 'data' in envelope && (envelope as { data?: unknown }).data
-        ? (envelope as { data: unknown }).data
-        : envelope;
+    // Unwrap the optional {data: ...} envelope (shared helper, OMN-287)
+    const parsedResult = unwrapScriptEnvelope<unknown>(result.data);
 
     // Smart cache invalidation for tag changes
     this.cache.invalidateTag(tagName);

--- a/tests/unit/omnifocus/script-result-types.test.ts
+++ b/tests/unit/omnifocus/script-result-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import {
+  unwrapScriptEnvelope,
   SCRIPT_ERROR_CONTEXT,
   detectKnownErrorShape,
   truncateRawOutput,
@@ -189,5 +190,30 @@ describe('truncateRawOutput', () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     expect(truncateRawOutput(circular)).toBe('[object Object]');
+  });
+});
+
+// OMN-287: shared envelope-unwrap — extracted from the byte-identical private
+// copies in OmniFocusAnalyzeTool and OmniFocusWriteTool so a future envelope
+// change happens in one place.
+describe('unwrapScriptEnvelope', () => {
+  it('unwraps a {data: ...} envelope', () => {
+    expect(unwrapScriptEnvelope<{ x: number }>({ ok: true, v: 'ast', data: { x: 1 } })).toEqual({ x: 1 });
+  });
+
+  it('returns the raw value when there is no data key', () => {
+    expect(unwrapScriptEnvelope<{ y: number }>({ y: 2 })).toEqual({ y: 2 });
+  });
+
+  it('returns the raw value when data is falsy (matches both original copies)', () => {
+    // Both pre-extraction copies required a TRUTHY data value to unwrap —
+    // {data: null} passes through whole, preserving exact legacy semantics.
+    expect(unwrapScriptEnvelope<unknown>({ data: null, other: 1 })).toEqual({ data: null, other: 1 });
+  });
+
+  it('passes primitives and null through untouched', () => {
+    expect(unwrapScriptEnvelope<string>('plain')).toBe('plain');
+    expect(unwrapScriptEnvelope<null>(null)).toBeNull();
+    expect(unwrapScriptEnvelope<number>(0)).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Extracts the script-envelope unwrap to ONE shared implementation in `src/omnifocus/script-result-types.ts` (the module both tools already import `isScriptError` from), per the round-8 PR #237 finding.

- **Identity verified before merging** (the ticket's explicit caution): `OmniFocusAnalyzeTool.unwrapScriptEnvelope<T>()` and `OmniFocusWriteTool`'s inline tag-management unwrap were byte-identical in semantics — same truthiness chain (`raw && typeof raw === 'object' && 'data' in raw && raw.data`).
- AnalyzeTool's private method deleted (4 call sites swapped); WriteTool's inline copy replaced with the shared call.
- **Exact legacy semantics preserved and test-pinned**, including the subtle edge: unwrap happens ONLY when `data` exists AND is truthy — `{data: null}` passes through whole. The new tests pin that edge explicitly so a future "fix" to falsy-data handling is a deliberate decision, not drift.

## Tests

TDD, red first: 4 new pins in `script-result-types.test.ts` (envelope unwrap, no-data pass-through, falsy-data pass-through, primitives/null). `npm run build` ✅ · `lint --max-warnings=0` ✅ · `tsc -p tsconfig.test.json` ✅ · `test:unit` 3966/3966 ✅

Closes OMN-287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017usHPNQhpKgpMMSQWVNE2Z