### PR TITLE
fix(OMN-290): non-root population everywhere — analytics fix wave 2

### DIFF
--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -239,6 +239,41 @@ export const ACTIONABLE_STATUSES_ARRAY_LITERAL = `[${ACTIONABLE_STATUSES.join(',
 export const TASK_COUNTS_ZERO_LITERAL = `{ total: 0, available: 0, completed: 0 }`;
 
 /**
+ * The project-root-row predicate (OMN-290): the global flattenedTasks
+ * collection includes each project's own root task, which reads as
+ * actionable — a non-null `task.project` is the live root marker (PR #227).
+ * Every analytics pass over flattenedTasks must skip these or a project's
+ * root row silently inflates totals (and, for completed/overdue projects,
+ * pollutes the completed/overdue counts too).
+ *
+ * A task whose `task.project` access itself throws is treated as NOT a
+ * root row (fail toward counting it, not dropping it) — the property read
+ * is the only thing being guarded here, not the rest of that task's
+ * analysis; a caller must not let this predicate's own defensiveness
+ * silently exclude an otherwise-readable task from unrelated metrics.
+ *
+ * ONE definition spliced by every emitter that walks flattenedTasks for
+ * task-level analytics (task-velocity-v3, productivity-stats-v3,
+ * analyze-overdue-v3, workflow-analysis-v3) so the root-skip marker and
+ * its failure semantics cannot drift between call paths independently —
+ * three of those four sites hand-rolled their own copy before this
+ * consolidation (/code-review of the OMN-290 PR). Deliberately NOT
+ * spliced into TASK_COUNTS_BY_PROJECT_PASS_SNIPPET below — that snippet
+ * is itself spliced inside a nested block at some call sites
+ * (productivity-stats-v3's includeProjectStats branch) alongside a
+ * top-level splice of this one, and two `function isProjectRootRow`
+ * declarations in the same OmniJS script is unnecessary risk for a
+ * pre-existing, already-vetted pass this PR doesn't touch.
+ */
+export const IS_PROJECT_ROOT_ROW_SNIPPET = `function isProjectRootRow(task) {
+            try {
+              return !!task.project;
+            } catch (e) {
+              return false;
+            }
+          }`;
+
+/**
  * Canonical Project.Status → wire-vocabulary map ('active' | 'onHold' |
  * 'done' | 'dropped', String(s) fail-open for statuses a future OmniFocus
  * adds — never a String()/.replace() of the enum, whose tag stringifies as

--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -212,13 +212,20 @@ export const ACTIONABLE_STATUSES_ARRAY_LITERAL = `[${ACTIONABLE_STATUSES.join(',
  * - Root tasks appear in the global collection and read as actionable; a
  *   non-null `t.project` marks a root and it is skipped (live-caught in
  *   PR #227: counting roots turned 12 of 13 stalled projects "healthy").
- *   The `t.project` read itself is fail-open (OMN-290 /code-review round
- *   2): a throw is treated as NOT a root, matching the fail-open contract
- *   of IS_PROJECT_ROOT_ROW_SNIPPET above (whose whole-DB summary this
- *   pass's per-project totals must agree with) — deliberately NOT via a
- *   second `function isProjectRootRow` declaration, just the same
- *   try/return-false shape inlined, since this snippet is spliced
- *   alongside a top-level splice of that one at some call sites.
+ *   This check is fail-CLOSED like the rest of the pass (a `t.project`
+ *   throw propagates to the per-task catch below, dropping that task from
+ *   every counter) — deliberately NOT the fail-open IS_PROJECT_ROOT_ROW_
+ *   SNIPPET predicate above. This snippet is shared by THREE call sites
+ *   (script-builder's includeTaskCounts, productivity-stats-v3,
+ *   projects-for-review), only one of which (productivity-stats-v3) has a
+ *   parallel fail-open whole-DB summary to weigh against; changing this
+ *   snippet's failure mode to chase agreement with that one caller would
+ *   silently change behavior for the other two, untested and out of scope
+ *   for whatever PR touches productivity-stats-v3 (/code-review round 3 of
+ *   the OMN-290 PR: exactly this happened and was reverted). A narrow
+ *   summary/per-project-total disagreement in the rare case where
+ *   `t.project` itself throws is accepted as a pre-existing, bounded
+ *   edge case — not a defect worth a shared-snippet behavior change.
  * - `completed` is the task's own completed flag (matching every other
  *   completed-count in the codebase), not effective status.
  * - One bad task costs only itself (inner catch); a failure of the pass
@@ -276,14 +283,12 @@ export const TASK_COUNTS_ZERO_LITERAL = `{ total: 0, available: 0, completed: 0 
  * throwing task at each site, not a style choice — match the existing
  * contract, don't unify it here.
  *
- * Also NOT spliced (as a function declaration) into
- * TASK_COUNTS_BY_PROJECT_PASS_SNIPPET below, since that snippet is itself
- * spliced inside a nested block at some call sites alongside a top-level
- * splice of this one, and two `function isProjectRootRow` declarations in
- * the same OmniJS script is unnecessary risk — but that snippet's root
- * check DOES match this predicate's fail-open contract (inlined, see that
- * snippet's own doc comment), so per-project totals stay consistent with
- * any whole-DB summary computed via this predicate in the same script.
+ * Also NOT spliced into TASK_COUNTS_BY_PROJECT_PASS_SNIPPET below — that
+ * snippet pre-dates this predicate, is shared by three call sites (only
+ * one of which pairs it with a fail-open whole-DB summary), and stays
+ * fail-CLOSED on its own root check; see that snippet's own doc comment
+ * for why unifying the two would be scope creep into untouched, untested
+ * callers (/code-review round 3 of the OMN-290 PR).
  */
 export const IS_PROJECT_ROOT_ROW_SNIPPET = `function isProjectRootRow(task) {
             try {
@@ -337,16 +342,7 @@ export const FOLDER_STATUS_STRING_SNIPPET = `function folderStatusString(s) {
 export const TASK_COUNTS_BY_PROJECT_PASS_SNIPPET = `const taskCountsByProject = {};
           flattenedTasks.forEach(t => {
             try {
-              // OMN-290 /code-review round 2: fail-open on the project read
-              // itself, matching IS_PROJECT_ROOT_ROW_SNIPPET's contract — a
-              // throw here means "not a root," not "drop this task."
-              let isRootRow;
-              try {
-                isRootRow = !!t.project;
-              } catch (e) {
-                isRootRow = false;
-              }
-              if (isRootRow) return;
+              if (t.project) return;
               const proj = t.containingProject;
               if (!proj) return;
               const pid = proj.id.primaryKey;

--- a/src/contracts/ast/types.ts
+++ b/src/contracts/ast/types.ts
@@ -212,6 +212,13 @@ export const ACTIONABLE_STATUSES_ARRAY_LITERAL = `[${ACTIONABLE_STATUSES.join(',
  * - Root tasks appear in the global collection and read as actionable; a
  *   non-null `t.project` marks a root and it is skipped (live-caught in
  *   PR #227: counting roots turned 12 of 13 stalled projects "healthy").
+ *   The `t.project` read itself is fail-open (OMN-290 /code-review round
+ *   2): a throw is treated as NOT a root, matching the fail-open contract
+ *   of IS_PROJECT_ROOT_ROW_SNIPPET above (whose whole-DB summary this
+ *   pass's per-project totals must agree with) — deliberately NOT via a
+ *   second `function isProjectRootRow` declaration, just the same
+ *   try/return-false shape inlined, since this snippet is spliced
+ *   alongside a top-level splice of that one at some call sites.
  * - `completed` is the task's own completed flag (matching every other
  *   completed-count in the codebase), not effective status.
  * - One bad task costs only itself (inner catch); a failure of the pass
@@ -252,18 +259,31 @@ export const TASK_COUNTS_ZERO_LITERAL = `{ total: 0, available: 0, completed: 0 
  * analysis; a caller must not let this predicate's own defensiveness
  * silently exclude an otherwise-readable task from unrelated metrics.
  *
- * ONE definition spliced by every emitter that walks flattenedTasks for
- * task-level analytics (task-velocity-v3, productivity-stats-v3,
- * analyze-overdue-v3, workflow-analysis-v3) so the root-skip marker and
- * its failure semantics cannot drift between call paths independently —
- * three of those four sites hand-rolled their own copy before this
- * consolidation (/code-review of the OMN-290 PR). Deliberately NOT
- * spliced into TASK_COUNTS_BY_PROJECT_PASS_SNIPPET below — that snippet
- * is itself spliced inside a nested block at some call sites
- * (productivity-stats-v3's includeProjectStats branch) alongside a
- * top-level splice of this one, and two `function isProjectRootRow`
- * declarations in the same OmniJS script is unnecessary risk for a
- * pre-existing, already-vetted pass this PR doesn't touch.
+ * ONE definition spliced by every emitter whose per-task failure handling
+ * matches this predicate's fail-open contract — task-velocity-v3,
+ * productivity-stats-v3, and analyze-overdue-v3 (the three OMN-290 sites,
+ * which had NO root check at all before this PR, so fail-open changes
+ * nothing there) — so the root-skip marker and failure semantics cannot
+ * drift between those call paths independently.
+ *
+ * Deliberately NOT spliced into workflow-analysis-v3, which pre-dates
+ * this predicate and is fail-CLOSED by construction (its root check sits
+ * inside a per-task try/catch that already drops the whole task on ANY
+ * throw, root-check included) — swapping it to this predicate would
+ * silently flip a task.project throw from "task dropped" to "task
+ * counted," a real regression caught in /code-review of the OMN-290 PR.
+ * Fail-open vs fail-closed is a property of what ALREADY happens to a
+ * throwing task at each site, not a style choice — match the existing
+ * contract, don't unify it here.
+ *
+ * Also NOT spliced (as a function declaration) into
+ * TASK_COUNTS_BY_PROJECT_PASS_SNIPPET below, since that snippet is itself
+ * spliced inside a nested block at some call sites alongside a top-level
+ * splice of this one, and two `function isProjectRootRow` declarations in
+ * the same OmniJS script is unnecessary risk — but that snippet's root
+ * check DOES match this predicate's fail-open contract (inlined, see that
+ * snippet's own doc comment), so per-project totals stay consistent with
+ * any whole-DB summary computed via this predicate in the same script.
  */
 export const IS_PROJECT_ROOT_ROW_SNIPPET = `function isProjectRootRow(task) {
             try {
@@ -317,7 +337,16 @@ export const FOLDER_STATUS_STRING_SNIPPET = `function folderStatusString(s) {
 export const TASK_COUNTS_BY_PROJECT_PASS_SNIPPET = `const taskCountsByProject = {};
           flattenedTasks.forEach(t => {
             try {
-              if (t.project) return;
+              // OMN-290 /code-review round 2: fail-open on the project read
+              // itself, matching IS_PROJECT_ROOT_ROW_SNIPPET's contract — a
+              // throw here means "not a root," not "drop this task."
+              let isRootRow;
+              try {
+                isRootRow = !!t.project;
+              } catch (e) {
+                isRootRow = false;
+              }
+              if (isRootRow) return;
               const proj = t.containingProject;
               if (!proj) return;
               const pid = proj.id.primaryKey;

--- a/src/omnifocus/scripts/analytics/analyze-overdue-v3.ts
+++ b/src/omnifocus/scripts/analytics/analyze-overdue-v3.ts
@@ -116,6 +116,13 @@ export const ANALYZE_OVERDUE_V3 = `
           // OmniJS: Iterate through all tasks for overdue analysis
           flattenedTasks.forEach(task => {
             try {
+              // OMN-290 (OMN-148 D11): project ROOT rows are never tasks in
+              // analytics — pre-fix every project inflated totalActive by one
+              // phantom row (and an overdue project's root counted as an
+              // overdue task). Non-null task.project is the live root marker
+              // (PR #227); same rule as workflow_analysis (OMN-270).
+              if (task.project) return;
+
               // OMN-187: one "active" predicate drives BOTH the overduePercentage
               // denominator (totalActive) and the overdue numerator below, so the
               // numerator is a subset of the denominator by construction (percentage

--- a/src/omnifocus/scripts/analytics/analyze-overdue-v3.ts
+++ b/src/omnifocus/scripts/analytics/analyze-overdue-v3.ts
@@ -22,6 +22,7 @@
  */
 
 import { ROUND1_HELPER, TERMINAL_STATUS_HELPER } from '../shared/helpers.js';
+import { IS_PROJECT_ROOT_ROW_SNIPPET } from '../../../contracts/ast/types.js';
 
 export const ANALYZE_OVERDUE_V3 = `
   (() => {
@@ -45,6 +46,7 @@ export const ANALYZE_OVERDUE_V3 = `
         (() => {
           ${ROUND1_HELPER}
           ${TERMINAL_STATUS_HELPER}
+          ${IS_PROJECT_ROOT_ROW_SNIPPET}
           const nowTime = \${nowTime};
           const maxTasks = \${maxTasks};
           const includeRecentlyCompleted = \${includeRecentlyCompleted};
@@ -119,9 +121,10 @@ export const ANALYZE_OVERDUE_V3 = `
               // OMN-290 (OMN-148 D11): project ROOT rows are never tasks in
               // analytics — pre-fix every project inflated totalActive by one
               // phantom row (and an overdue project's root counted as an
-              // overdue task). Non-null task.project is the live root marker
-              // (PR #227); same rule as workflow_analysis (OMN-270).
-              if (task.project) return;
+              // overdue task). isProjectRootRow (IS_PROJECT_ROOT_ROW_SNIPPET,
+              // contracts/ast/types) is the shared predicate every root-skip
+              // site splices; same rule as workflow_analysis (OMN-270).
+              if (isProjectRootRow(task)) return;
 
               // OMN-187: one "active" predicate drives BOTH the overduePercentage
               // denominator (totalActive) and the overdue numerator below, so the

--- a/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
+++ b/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
@@ -20,6 +20,7 @@
 
 import { ROUND1_HELPER, TERMINAL_STATUS_HELPER } from '../shared/helpers.js';
 import {
+  IS_PROJECT_ROOT_ROW_SNIPPET,
   PROJECT_STATUS_STRING_SNIPPET,
   TASK_COUNTS_BY_PROJECT_PASS_SNIPPET,
   TASK_COUNTS_ZERO_LITERAL,
@@ -84,6 +85,10 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
           // vocabulary contract and why String()-ing the enum is forbidden.
           ${PROJECT_STATUS_STRING_SNIPPET}
 
+          // OMN-290: single-definition project-root-row predicate — see
+          // IS_PROJECT_ROOT_ROW_SNIPPET (contracts/ast/types).
+          ${IS_PROJECT_ROOT_ROW_SNIPPET}
+
           // Overall task statistics
           let totalTasks = 0;
           let totalCompleted = 0;
@@ -96,10 +101,11 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
             try {
               // OMN-290 (OMN-148 D11/D15): project ROOT rows are never tasks
               // in analytics. The global flattenedTasks includes each
-              // project's root task; a non-null task.project is the live
-              // root marker (PR #227). Same rule as workflow_analysis
-              // (OMN-270) and the shared per-project counts pass.
-              if (task.project) return;
+              // project's root task; isProjectRootRow
+              // (IS_PROJECT_ROOT_ROW_SNIPPET, contracts/ast/types) is the
+              // shared predicate every root-skip site splices — same rule
+              // as workflow_analysis (OMN-270).
+              if (isProjectRootRow(task)) return;
 
               totalTasks++;
 

--- a/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
+++ b/src/omnifocus/scripts/analytics/productivity-stats-v3.ts
@@ -94,6 +94,13 @@ export const PRODUCTIVITY_STATS_SCRIPT_V3 = `
           // OmniJS: Iterate through all tasks for overall statistics
           flattenedTasks.forEach(task => {
             try {
+              // OMN-290 (OMN-148 D11/D15): project ROOT rows are never tasks
+              // in analytics. The global flattenedTasks includes each
+              // project's root task; a non-null task.project is the live
+              // root marker (PR #227). Same rule as workflow_analysis
+              // (OMN-270) and the shared per-project counts pass.
+              if (task.project) return;
+
               totalTasks++;
 
               const isCompleted = task.completed || false;

--- a/src/omnifocus/scripts/analytics/task-velocity-v3.ts
+++ b/src/omnifocus/scripts/analytics/task-velocity-v3.ts
@@ -64,9 +64,22 @@ export const TASK_VELOCITY_SCRIPT_V3 = `
           // Only count tasks completed within the specified date range
           let totalCompleted = 0;
           let totalCreated = 0;
+          let tasksAnalyzed = 0;
           const completionTimes = [];
 
           flattenedTasks.forEach(task => {
+            // OMN-290 (OMN-148 D11/D15): project ROOT rows are never tasks in
+            // analytics — a completed project's root row otherwise counts as a
+            // completed task. Non-null task.project is the live root marker
+            // (PR #227). Own try so a corrupted row skips (per-task swallow
+            // convention) instead of aborting the forEach.
+            try {
+              if (task.project) return;
+            } catch (e) {
+              return;
+            }
+            tasksAnalyzed++;
+
             try {
               // Completion analysis - only count if within date range
               const completionDate = task.completionDate;
@@ -147,7 +160,10 @@ export const TASK_VELOCITY_SCRIPT_V3 = `
               },
               breakdown: {
                 medianCompletionHours: medianCompletionTime.toFixed(1),
-                tasksAnalyzed: flattenedTasks.length
+                // OMN-290: the analyzed (non-root) population, counted in the
+                // loop after the root skip — the OMN-270 lesson: report what
+                // was analyzed, not the raw collection length.
+                tasksAnalyzed: tasksAnalyzed
               },
               projections: {
                 tasksPerDay: velocity.toFixed(2),

--- a/src/omnifocus/scripts/analytics/task-velocity-v3.ts
+++ b/src/omnifocus/scripts/analytics/task-velocity-v3.ts
@@ -11,6 +11,8 @@
  * Pattern based on: list-tasks-omnijs.ts
  */
 
+import { IS_PROJECT_ROOT_ROW_SNIPPET } from '../../../contracts/ast/types.js';
+
 export const TASK_VELOCITY_SCRIPT_V3 = `
   (() => {
     const app = Application('OmniFocus');
@@ -31,6 +33,8 @@ export const TASK_VELOCITY_SCRIPT_V3 = `
 
       const velocityScript = \`
         (() => {
+          ${IS_PROJECT_ROOT_ROW_SNIPPET}
+
           // Parse date range from options
           const rangeStart = new Date('$\{startDateStr}T00:00:00');
           const rangeEnd = new Date('$\{endDateStr}T23:59:59');
@@ -70,14 +74,15 @@ export const TASK_VELOCITY_SCRIPT_V3 = `
           flattenedTasks.forEach(task => {
             // OMN-290 (OMN-148 D11/D15): project ROOT rows are never tasks in
             // analytics — a completed project's root row otherwise counts as a
-            // completed task. Non-null task.project is the live root marker
-            // (PR #227). Own try so a corrupted row skips (per-task swallow
-            // convention) instead of aborting the forEach.
-            try {
-              if (task.project) return;
-            } catch (e) {
-              return;
-            }
+            // completed task. isProjectRootRow (IS_PROJECT_ROOT_ROW_SNIPPET,
+            // contracts/ast/types) fails OPEN on a throw — a task whose
+            // task.project read itself errors is still counted below, matching
+            // this script's pre-OMN-290 behavior, instead of silently
+            // vanishing from tasksAnalyzed/totalCompleted/totalCreated all at
+            // once (/code-review of the OMN-290 PR: the original per-task
+            // try/catch here returned on ANY error, gating every metric on a
+            // property read none of them actually need).
+            if (isProjectRootRow(task)) return;
             tasksAnalyzed++;
 
             try {

--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -24,6 +24,7 @@
  */
 
 import { ROUND1_HELPER } from '../shared/helpers.js';
+import { IS_PROJECT_ROOT_ROW_SNIPPET } from '../../../contracts/ast/types.js';
 
 export const WORKFLOW_ANALYSIS_V3 = `
   (() => {
@@ -47,6 +48,7 @@ export const WORKFLOW_ANALYSIS_V3 = `
       const analysisScript = \`
         (() => {
           ${ROUND1_HELPER}
+          ${IS_PROJECT_ROOT_ROW_SNIPPET}
           const nowTime = \${nowTime};
           const analysisDepth = "\${analysisDepth}";
           const focusAreas = \${JSON.stringify(focusAreas)};
@@ -176,8 +178,10 @@ export const WORKFLOW_ANALYSIS_V3 = `
               // project.flattenedTasks. OMN-270: the old gate read the
               // JXA-only child-count property — undefined in OmniJS — so it
               // never fired and every root polluted the task-level metrics.
-              // A non-null task.project is the live root-task marker (PR #227).
-              if (task.project) {
+              // isProjectRootRow (IS_PROJECT_ROOT_ROW_SNIPPET, contracts/ast/
+              // types) is the shared root-row predicate every root-skip site
+              // splices (OMN-290).
+              if (isProjectRootRow(task)) {
                 continue;
               }
 

--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -24,7 +24,6 @@
  */
 
 import { ROUND1_HELPER } from '../shared/helpers.js';
-import { IS_PROJECT_ROOT_ROW_SNIPPET } from '../../../contracts/ast/types.js';
 
 export const WORKFLOW_ANALYSIS_V3 = `
   (() => {
@@ -48,7 +47,6 @@ export const WORKFLOW_ANALYSIS_V3 = `
       const analysisScript = \`
         (() => {
           ${ROUND1_HELPER}
-          ${IS_PROJECT_ROOT_ROW_SNIPPET}
           const nowTime = \${nowTime};
           const analysisDepth = "\${analysisDepth}";
           const focusAreas = \${JSON.stringify(focusAreas)};
@@ -178,10 +176,18 @@ export const WORKFLOW_ANALYSIS_V3 = `
               // project.flattenedTasks. OMN-270: the old gate read the
               // JXA-only child-count property — undefined in OmniJS — so it
               // never fired and every root polluted the task-level metrics.
-              // isProjectRootRow (IS_PROJECT_ROOT_ROW_SNIPPET, contracts/ast/
-              // types) is the shared root-row predicate every root-skip site
-              // splices (OMN-290).
-              if (isProjectRootRow(task)) {
+              // A non-null task.project is the live root-task marker (PR
+              // #227). Deliberately NOT the shared isProjectRootRow()
+              // (IS_PROJECT_ROOT_ROW_SNIPPET, contracts/ast/types) here —
+              // that predicate fails OPEN (treats a throw as "not root," so
+              // the task IS counted), but this loop's whole per-task body
+              // already lives in its own try/catch (this one), which has
+              // always failed CLOSED: a task.project read that throws drops
+              // the task from totalTasks and every derived metric, same as
+              // any other per-task read failure. Using the shared predicate
+              // here would silently flip that to fail-open (/code-review
+              // regression, OMN-290 PR).
+              if (task.project) {
                 continue;
               }
 

--- a/tests/unit/omnifocus/scripts/analytics/nonroot-population.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/nonroot-population.test.ts
@@ -1,0 +1,121 @@
+// tests/unit/omnifocus/scripts/analytics/nonroot-population.test.ts
+// OMN-290 (OMN-148 D11/D15) — "project root rows are never tasks in analytics."
+// flattenedTasks includes each project's ROOT task; a non-null task.project is
+// the live root marker (PR #227). Pre-fix, overdue_analysis counted roots in
+// BOTH totalActive and the overdue numerator, productivity counted them in
+// every summary census field, and task_velocity counted a completed project's
+// root as a completed task. workflow_analysis already skips roots (OMN-270) —
+// these tests bring the other three ops onto the same population rule.
+import { describe, it, expect } from 'vitest';
+import { PRODUCTIVITY_STATS_SCRIPT_V3 } from '../../../../../src/omnifocus/scripts/analytics/productivity-stats-v3.js';
+import { TASK_VELOCITY_SCRIPT_V3 } from '../../../../../src/omnifocus/scripts/analytics/task-velocity-v3.js';
+import { ANALYZE_OVERDUE_V3 } from '../../../../../src/omnifocus/scripts/analytics/analyze-overdue-v3.js';
+import {
+  PRODUCTIVITY_STATS_V3_SCHEMA,
+  TASK_VELOCITY_V3_SCHEMA,
+  OVERDUE_ANALYSIS_V3_SCHEMA,
+} from '../../../../../src/omnifocus/response-schemas/analyze.js';
+import { stubTask } from '../../../contracts/ast/omnijs-vm-fixture.js';
+import { runAnalyticsScript } from './run-analytics-script.js';
+
+const DAY_MS = 86400000;
+const now = Date.now();
+
+/** A project ROOT row as it appears in flattenedTasks: task.project non-null.
+ * Deliberately given "polluting" attributes (overdue due date, in-range
+ * completion) so inclusion in any counter makes a test fail. */
+function rootRow(name: string, extra: Record<string, unknown> = {}): unknown {
+  return {
+    ...stubTask(name),
+    project: { name },
+    dueDate: new Date(now - 10 * DAY_MS),
+    ...extra,
+  };
+}
+
+function child(name: string, extra: Record<string, unknown> = {}): unknown {
+  return { ...stubTask(name), ...extra };
+}
+
+function isoDay(offsetDays: number): string {
+  return new Date(now + offsetDays * DAY_MS).toISOString().slice(0, 10);
+}
+
+describe('OMN-290 — non-root population everywhere', () => {
+  it('productivity_stats: summary census fields exclude project root rows', () => {
+    const db = {
+      flattenedTasks: [
+        // Root: not completed, overdue, available-looking — would pollute
+        // totalTasks, availableTasks AND overdueCount if counted.
+        rootRow('Project Alpha'),
+        child('done in period', { completed: true, completionDate: new Date(now - DAY_MS) }),
+        child('overdue leaf', { dueDate: new Date(now - 2 * DAY_MS) }),
+      ],
+    };
+    const parsed = runAnalyticsScript(
+      PRODUCTIVITY_STATS_SCRIPT_V3,
+      { period: 'week', includeProjectStats: false, includeTagStats: false },
+      db,
+    ) as {
+      ok: boolean;
+      data: {
+        summary: {
+          totalTasks: number;
+          completedTasks: number;
+          completedInPeriod: number;
+          availableTasks: number;
+          overdueCount: number;
+        };
+      };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(PRODUCTIVITY_STATS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    expect(parsed.data.summary.totalTasks).toBe(2); // root excluded
+    expect(parsed.data.summary.completedTasks).toBe(1);
+    expect(parsed.data.summary.completedInPeriod).toBe(1);
+    expect(parsed.data.summary.overdueCount).toBe(1); // root's overdue dueDate NOT counted
+    expect(parsed.data.summary.availableTasks).toBe(1); // the open leaf only; root NOT counted
+  });
+
+  it('overdue_analysis: totalActive and the overdue numerator exclude root rows', () => {
+    const db = {
+      flattenedTasks: [
+        rootRow('Project Beta'), // active + overdue-looking root
+        child('overdue leaf', { dueDate: new Date(now - 3 * DAY_MS) }),
+        child('future leaf', { dueDate: new Date(now + 3 * DAY_MS) }),
+      ],
+    };
+    const parsed = runAnalyticsScript(ANALYZE_OVERDUE_V3, { limit: 100 }, db) as {
+      ok: boolean;
+      data: { summary: { totalOverdue: number; totalActive: number; overduePercentage: number } };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(OVERDUE_ANALYSIS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    expect(parsed.data.summary.totalActive).toBe(2); // root excluded from denominator
+    expect(parsed.data.summary.totalOverdue).toBe(1); // root's past due date NOT an overdue task
+    expect(parsed.data.summary.overduePercentage).toBe(50);
+  });
+
+  it('task_velocity: completed roots are not throughput; tasksAnalyzed is the non-root population', () => {
+    const db = {
+      flattenedTasks: [
+        // Completed project: its root row carries an in-range completionDate.
+        rootRow('Project Gamma', { completed: true, completionDate: new Date(now - DAY_MS) }),
+        child('completed leaf', { completed: true, completionDate: new Date(now - DAY_MS) }),
+        child('open leaf'),
+      ],
+    };
+    const parsed = runAnalyticsScript(
+      TASK_VELOCITY_SCRIPT_V3,
+      { period: 'day', startDate: isoDay(-7), endDate: isoDay(0) },
+      db,
+    ) as {
+      ok: boolean;
+      data: { throughput: { totalCompleted: number }; breakdown: { tasksAnalyzed: number } };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(TASK_VELOCITY_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+    expect(parsed.data.throughput.totalCompleted).toBe(1); // root's completion excluded
+    expect(parsed.data.breakdown.tasksAnalyzed).toBe(2); // analyzed population, not collection length
+  });
+});


### PR DESCRIPTION
## What

OMN-148 walk-through decision 3 (D11/D15, 2026-07-21): **"project root rows are never tasks in analytics."** workflow_analysis already skips roots (OMN-270/#228); this brings the other three script-backed ops onto the same population rule using the same live root marker (non-null `task.project`, PR #227).

- **overdue_analysis**: roots leave BOTH `totalActive` and the overdue numerator — pre-fix every project inflated the denominator by one phantom row, and an overdue project's root counted as an overdue task.
- **productivity_stats**: the summary census loop skips roots (totalTasks / completedTasks / completedInPeriod / availableTasks / overdueCount).
- **task_velocity**: a completed project's root no longer counts in throughput; `breakdown.tasksAnalyzed` becomes the analyzed (non-root) population counted in-loop after the skip, not `flattenedTasks.length`.

## Why

Pre-capture fix wave 2 (OMN-148 spec draft §11): the population decision must land before golden capture so cross-op parity goldens can assert equality with the read side instead of pinning a root delta. Spec: vault `Technical/specs/OMN-148-analytics-spec-draft.md` §11 row 3.

## Approach

TDD via the shared vm harness (`run-analytics-script.ts`): each op gets a fixture whose root row carries deliberately polluting attributes (overdue due date / in-range completion), so root inclusion in any counter fails the test. All three tests watched RED first (each failing on exactly the root-inclusion assertion), then GREEN with the three script edits.

## Vertical Contract Matrix

| Layer | Disposition |
|---|---|
| 1 Schema (both) | N/A — no input change |
| 2 Normalization | N/A — output values only |
| 3 Single path | ✅ the script edits |
| 4 Batch path | N/A — no batch analytics route |
| 5 Script lowering | N/A — legacy analytics scripts, not AST-lowered |
| 6 Live bridge | post-merge `/verify`: overdue totalActive should drop by ~active-project-count vs pre-deploy |
| 7 Response validation | schemas unchanged; envelope shape identical (all three `*_V3_SCHEMA` asserted in tests) |
| 8 Cache key | N/A — no input change (values change on natural TTL expiry after deploy) |

Local: `npm run build` ✅ · `npm run test:unit` 4016/4016 ✅ · `npm run lint --max-warnings=0` ✅

Closes OMN-290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbUwQuQuFCytnxfAZB7tc1