### PR TITLE
feat(OMN-292): rename productivity_stats.healthScore to completionPercent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **BREAKING (analyze-response field): `productivity_stats.healthScore` is renamed to `completionPercent`** (OMN-292) —
+  the field was never a health composite: it is `round(completionRate * 100)`, the all-time completion rate, and the
+  name now says so. The graded key finding `GTD Health Score: N/100 (Excellent/Good/Fair/Needs attention)` becomes the
+  plain fact `All-time completion rate: N%`; the four grade bands were invented at the tool layer (the script grades
+  nothing) and are deleted. **No alias period** — carrying both names would advertise two names for one number and
+  re-create the collision this change exists to end. `pattern_analysis.health_score`/`health_rating` is a genuine
+  multi-factor composite and is untouched; after this change it is the only "health" surface in the analyze tool. The
+  productivity cache key is version-bumped (`productivity_v2_*` → `productivity_v3_*`) because that cache stores the
+  reshaped response, so stale entries would otherwise keep serving `healthScore` until TTL expiry after deploy. Also
+  removed: an unreachable "contradiction filter" that dropped script insights containing `excellent` below a score of 60
+  and `low completion`/`needs attention` at or above it. Against real script output it could never fire — the script
+  emits `Excellent completion rate` only above 0.80 and `Low completion rate` only below 0.30, and emits no string
+  containing `needs attention` — and its threshold of 60 belonged to neither scale. The script's own first insight now
+  passes through unchanged.
+
 - **BREAKING (read-response value): `omnifocus_read` project status is now `"onHold"`, was `"on-hold"`** (OMN-274) —
   script-builder's three inline Project.Status maps (filtered projects, project-by-id, folder listing's project rows)
   now splice the canonical `PROJECT_STATUS_STRING_SNIPPET`, converging the read path on the OMN-272 wire vocabulary

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -316,7 +316,7 @@ export class OmniFocusAnalyzeTool extends BaseTool<typeof AnalyzeSchema, unknown
   description = `Analyze OmniFocus data for insights, patterns, and specialized operations.
 
 ANALYSIS TYPES:
-- productivity_stats: GTD health metrics (completion rates, velocity)
+- productivity_stats: completion counts and rates (incl. completionPercent, the all-time completion rate)
 - task_velocity: Completion trends over time
 - overdue_analysis: Bottleneck identification
 - pattern_analysis: Database-wide patterns (tags, projects, stale items, missing next actions).
@@ -479,9 +479,12 @@ SCOPE FILTERING:
       const includeTagStats = true;
 
       // Cache key
-      const cacheKey = `productivity_v2_${period}_${includeProjectStats}_${includeTagStats}`;
+      // OMN-292: version-bumped v2 -> v3. This cache stores the RESHAPED response
+      // object, so entries written before the healthScore -> completionPercent rename
+      // would keep serving the old field name until TTL expiry after deploy.
+      const cacheKey = `productivity_v3_${period}_${includeProjectStats}_${includeTagStats}`;
 
-      const cached = this.cache.get<{ period?: string; stats?: Record<string, unknown>; healthScore?: number }>(
+      const cached = this.cache.get<{ period?: string; stats?: Record<string, unknown>; completionPercent?: number }>(
         'analytics',
         cacheKey,
       );
@@ -492,7 +495,7 @@ SCOPE FILTERING:
           cached,
           'Productivity Analysis',
           this.extractProductivityKeyFindings(
-            cached as { period?: string; stats?: Record<string, unknown>; healthScore?: number },
+            cached as { period?: string; stats?: Record<string, unknown>; completionPercent?: number },
           ),
           { from_cache: true, period, ...timer.toMetadata() },
         );
@@ -540,7 +543,11 @@ SCOPE FILTERING:
           tagStats: tagStatsArray,
         },
         insights: { recommendations: insights },
-        healthScore: Math.max(0, Math.min(100, Math.round((overview.completionRate || 0) * 100))),
+        // OMN-292: named `healthScore` until this rename, but the formula is literally
+        // the all-time completion rate as a percentage — no health composite involved.
+        // The name now states what is computed. (pattern_analysis.health_score is a
+        // real multi-factor composite and is deliberately untouched.)
+        completionPercent: Math.max(0, Math.min(100, Math.round((overview.completionRate || 0) * 100))),
       };
 
       this.cache.set('analytics', cacheKey, responseData);
@@ -655,7 +662,7 @@ SCOPE FILTERING:
       };
       projectStats?: Array<{ name: string; completedCount: number }>;
     };
-    healthScore?: number;
+    completionPercent?: number;
     insights?: { recommendations?: string[] };
   }): string[] {
     const findings: string[] = [];
@@ -668,13 +675,11 @@ SCOPE FILTERING:
       }
     }
 
-    if (typeof data.healthScore === 'number') {
-      const score = Math.round(data.healthScore);
-      let assessment = 'Needs attention';
-      if (score >= 80) assessment = 'Excellent';
-      else if (score >= 60) assessment = 'Good';
-      else if (score >= 40) assessment = 'Fair';
-      findings.push(`GTD Health Score: ${score}/100 (${assessment})`);
+    // OMN-292: was `GTD Health Score: N/100 (Excellent/Good/Fair/Needs attention)`.
+    // The number is the all-time completion rate, and the four grade bands were
+    // invented here — the script grades nothing. Report the fact; let the caller judge.
+    if (typeof data.completionPercent === 'number') {
+      findings.push(`All-time completion rate: ${Math.round(data.completionPercent)}%`);
     }
 
     if (data.stats?.projectStats && data.stats.projectStats.length > 0) {
@@ -687,20 +692,15 @@ SCOPE FILTERING:
       }
     }
 
+    // OMN-292: a "contradiction filter" used to arbitrate here, dropping script insights
+    // containing "excellent" when the score was < 60 and "low completion"/"needs attention"
+    // when it was >= 60. It was unreachable against real script output: the script emits
+    // "Excellent completion rate" only above 0.80 (score >= 81, never < 60) and "Low
+    // completion rate" only below 0.30 (score <= 29, never >= 60), and never emits any
+    // string containing "needs attention". Its 60 threshold belonged to neither scale —
+    // a third, invented grade band. Deleted; the script's own insight passes through.
     if (data.insights && Array.isArray(data.insights.recommendations) && data.insights.recommendations.length > 0) {
-      // Cross-check: filter out recommendations that contradict the data
-      const score = data.healthScore ?? 0;
-      const filteredRecs = data.insights.recommendations.filter((rec) => {
-        const recLower = rec.toLowerCase();
-        // Don't say "excellent" if health score is low
-        if (recLower.includes('excellent') && score < 60) return false;
-        // Don't say "low" or "needs attention" if health score is high
-        if ((recLower.includes('low completion') || recLower.includes('needs attention')) && score >= 60) return false;
-        return true;
-      });
-      if (filteredRecs.length > 0) {
-        findings.push(filteredRecs[0]);
-      }
+      findings.push(data.insights.recommendations[0]);
     }
 
     return findings.length > 0 ? findings : ['No productivity data available for this period'];

--- a/tests/integration/validation/analytics-validation.test.ts
+++ b/tests/integration/validation/analytics-validation.test.ts
@@ -128,10 +128,17 @@ describe('Analytics Validation - Actual Calculations', () => {
       expect(statsData.stats.overview.completionRate).toBeGreaterThanOrEqual(0);
       expect(statsData.stats.overview.completionRate).toBeLessThanOrEqual(100);
 
-      // Validate healthScore is calculated
-      expect(typeof statsData.healthScore).toBe('number');
-      expect(statsData.healthScore).toBeGreaterThanOrEqual(0);
-      expect(statsData.healthScore).toBeLessThanOrEqual(100);
+      // Validate completionPercent is calculated (OMN-292: renamed from
+      // `healthScore`, no alias — the old name is gone, not deprecated).
+      expect(typeof statsData.completionPercent).toBe('number');
+      expect(statsData.completionPercent).toBeGreaterThanOrEqual(0);
+      expect(statsData.completionPercent).toBeLessThanOrEqual(100);
+
+      // Negative pin for the rename: CI skips this suite, so a stale `healthScore`
+      // assertion here would only surface during the post-merge live verify it is
+      // meant to support. Assert the old name is absent so a partial revert or a
+      // cache entry written before the key bump fails loudly here instead.
+      expect(statsData).not.toHaveProperty('healthScore');
 
       // Also validate non-zero stats (regression test for bug where all stats were 0)
       expect(statsData.stats.overview.totalTasks).toBeGreaterThan(0);

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -54,7 +54,7 @@ describe('OmniFocusAnalyzeTool', () => {
       const cached = {
         period: 'week',
         stats: { overview: { totalTasks: 100, completedTasks: 75, completionRate: 0.75 } },
-        healthScore: 85,
+        completionPercent: 85,
       };
       mockCache.get.mockReturnValue(cached);
 
@@ -105,9 +105,40 @@ describe('OmniFocusAnalyzeTool', () => {
 
       expect(res.success).toBe(true);
       expect(res.data.period).toBe('week');
-      expect(res.data.healthScore).toBe(75);
+      // OMN-292: healthScore renamed to completionPercent — the field is literally
+      // round(completionRate * 100), so the name now says what the formula computes.
+      expect(res.data.completionPercent).toBe(75);
+      expect(res.data).not.toHaveProperty('healthScore');
       expect(res.data.stats.overview.totalTasks).toBe(200);
       expect(Array.isArray(res.summary.key_findings)).toBe(true);
+    });
+
+    // OMN-292: the graded "GTD Health Score: N/100 (Excellent…)" finding is replaced
+    // by a plain fact. No grade bands, no "GTD Health" framing anywhere in findings.
+    it('reports completion rate as a plain fact, with no grade language', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue({
+        summary: {
+          totalTasks: 200,
+          completedTasks: 150,
+          completionRate: 0.75,
+          activeProjects: 12,
+          overdueCount: 5,
+        },
+        insights: [],
+      });
+
+      const res: any = await tool.execute({ analysis: { type: 'productivity_stats' } });
+
+      expect(res.success).toBe(true);
+      const keyFindings: string[] = res.summary.key_findings;
+      expect(keyFindings).toEqual(expect.arrayContaining(['All-time completion rate: 75%']));
+
+      const graded = keyFindings.filter((f) =>
+        /GTD Health|Health Score|Excellent|Needs attention|\bFair\b|\/100/i.test(f),
+      );
+      expect(graded).toEqual([]);
     });
 
     it('surfaces the most productive project from the script map (OMN-252)', async () => {
@@ -156,7 +187,7 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(mockCache.set.mock.calls[0][0]).toBe('analytics');
     });
 
-    it('calculates healthScore correctly from decimal completionRate', async () => {
+    it('calculates completionPercent correctly from decimal completionRate', async () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       mockOmni.executeJson.mockResolvedValue({
@@ -176,9 +207,9 @@ describe('OmniFocusAnalyzeTool', () => {
 
       expect(res.success).toBe(true);
       // completionRate 0.151 * 100 = 15.1, rounded = 15
-      expect(res.data.healthScore).toBe(15);
+      expect(res.data.completionPercent).toBe(15);
       // Should NOT be 100 (the old bug where 15.1 * 100 = 1510 clamped to 100)
-      expect(res.data.healthScore).not.toBe(100);
+      expect(res.data.completionPercent).not.toBe(100);
     });
 
     it('includes overdueCount in response when script returns it', async () => {
@@ -251,7 +282,20 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(res.data.stats.overview.availableTasks).toBe(15);
     });
 
-    it('does not produce contradictory recommendations', async () => {
+    // OMN-292: replaces 'does not produce contradictory recommendations'.
+    //
+    // That test fed the reshape a combination the script CANNOT emit — completionRate
+    // 0.15 alongside an "Excellent completion rate" insight — to prove the contradiction
+    // filter fired. Against real script output the filter was unreachable: the script
+    // emits "Excellent completion rate" only above 0.80 (score >= 81, never < 60) and
+    // "Low completion rate" only below 0.30 (score <= 29, never >= 60), and emits no
+    // string containing "needs attention" at all. The filter also keyed off a THIRD
+    // threshold (60) belonging to neither scale — an invented grade band, which is the
+    // dishonesty this ticket exists to remove.
+    //
+    // The filter is deleted. This test pins what replaces it: the script's first insight
+    // reaches key findings unchanged, with no arbitration applied.
+    it("passes the script's first insight through to key findings unchanged", async () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       mockOmni.executeJson.mockResolvedValue({
@@ -262,8 +306,7 @@ describe('OmniFocusAnalyzeTool', () => {
           activeProjects: 3,
           overdueCount: 10,
         },
-        // Script says "Excellent" but completionRate is only 15% — contradictory
-        insights: ['Excellent completion rate: 85.0%'],
+        insights: ['Low completion rate - many tasks remain incomplete'],
       });
 
       const res: any = await tool.execute({
@@ -271,17 +314,14 @@ describe('OmniFocusAnalyzeTool', () => {
       });
 
       expect(res.success).toBe(true);
-      // healthScore = 0.15 * 100 = 15
-      expect(res.data.healthScore).toBe(15);
-      // The "Excellent" recommendation should be filtered out since healthScore < 60
+      expect(res.data.completionPercent).toBe(15);
+
       const keyFindings: string[] = res.summary.key_findings;
-      const hasExcellentWithLowScore = keyFindings.some(
-        (f: string) => f.toLowerCase().includes('excellent') && !f.includes('Health Score'),
-      );
-      expect(hasExcellentWithLowScore).toBe(false);
+      expect(keyFindings).toEqual(expect.arrayContaining(['Low completion rate - many tasks remain incomplete']));
+      expect(keyFindings).toEqual(expect.arrayContaining(['All-time completion rate: 15%']));
     });
 
-    it('healthScore is 0 when no tasks exist', async () => {
+    it('completionPercent is 0 when no tasks exist', async () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
       mockOmni.executeJson.mockResolvedValue({
@@ -300,10 +340,10 @@ describe('OmniFocusAnalyzeTool', () => {
       });
 
       expect(res.success).toBe(true);
-      expect(res.data.healthScore).toBe(0);
-      // Verify the health score finding is included even when score is 0
+      expect(res.data.completionPercent).toBe(0);
+      // The completion-rate fact is still reported at 0 (it is a fact, not a grade).
       const keyFindings: string[] = res.summary.key_findings;
-      expect(keyFindings).toEqual(expect.arrayContaining([expect.stringContaining('GTD Health Score: 0/100')]));
+      expect(keyFindings).toEqual(expect.arrayContaining(['All-time completion rate: 0%']));
     });
   });
 


### PR DESCRIPTION
## What

Renames the `productivity_stats` response field `healthScore` → **`completionPercent`**, and replaces the graded key finding with a plain fact.

The field was never a health composite. It is literally `round(completionRate * 100)` — the all-time completion rate — wearing a name that implied a multi-factor score. `pattern_analysis.health_score`/`health_rating` *is* a genuine composite, so the two collided in the same tool. After this change (and OMN-291, which deletes workflow's per-project `healthScore`), pattern_analysis is the only "health" surface left.

## Why

OMN-148 walk-through decision 6 / OMN-257 item 2 — option (a): rename pre-capture, field and finding string together. Pre-golden-capture is the designated window for the break.

## Changes

| Surface | Before | After |
|---|---|---|
| Response field | `healthScore` | `completionPercent` |
| Key finding | `GTD Health Score: N/100 (Excellent/Good/Fair/Needs attention)` | `All-time completion rate: N%` |
| Contradiction filter | arbitrated script insights against an invented 60 threshold | **deleted** (unreachable — see below) |
| Cache key | `productivity_v2_*` | `productivity_v3_*` |
| Tool description | "GTD health metrics" | "completion counts and rates (incl. completionPercent…)" |

**No alias period.** Carrying both names would advertise two names for one number and re-create the collision this change exists to end.

**Cache key bump is load-bearing:** that cache stores the *reshaped response object*, so without the bump, warm entries would keep serving `healthScore` until TTL expiry after deploy.

## The deleted contradiction filter

The filter dropped script insights containing `excellent` when the score was `< 60`, and `low completion`/`needs attention` when `>= 60`. It was **unreachable against real script output**. `score` is the same number the script thresholds on:

| Script string | Emitted when | Filter drops it when | Can fire? |
|---|---|---|---|
| `"Excellent completion rate: N%"` | `rate > 0.80` → score ≥ 81 | score < 60 | **Never** |
| `"Low completion rate…"` | `rate < 0.30` → score ≤ 29 | score ≥ 60 | **Never** |
| `"needs attention"` | — | score ≥ 60 | **No such string exists** |

All seven `insights.push` sites in `productivity-stats-v3.ts` were enumerated. Its threshold of 60 belonged to neither scale — a third, invented grade band, i.e. the same class of dishonesty this ticket removes.

⚠️ **Reviewer note:** the existing test `does not produce contradictory recommendations` fed the reshape `completionRate: 0.15` alongside an `"Excellent completion rate: 85.0%"` insight — a combination the script **cannot** emit. It proved the filter worked on adversarial input, not that it was reachable. It is replaced by a test pinning the passthrough. If you'd rather keep the filter as a defensive guard against a future script-threshold change, that's the one judgment call here worth revisiting.

## Vertical Contract Matrix

| # | Layer | Disposition |
|---|---|---|
| 1 | Schema (both) | Zod input **unchanged**; tool description edited (dual-schema rule covers the description string) |
| 2 | Normalization | **N/A** — output-side only |
| 3 | Single-item path | ✅ reshape + finding + filter edits |
| 4 | Batch path | **N/A** — no batch analytics route |
| 5 | Script lowering | **N/A** — script untouched |
| 6 | Live bridge | ⏳ **owed post-merge** (see below) |
| 7 | Response validation | script envelope schema unchanged; outward TS interfaces renamed |
| 8 | Cache key | ✅ version-bumped `productivity_v2_` → `productivity_v3_` |
| — | CHANGELOG | ✅ entry added (user-visible rename) |

## Verification

- `npm run build` ✅
- `npm run lint` (`--max-warnings=0`) ✅
- `npm run test:unit` ✅ **3912 passed / 183 files**
- `grep -rn 'console\.log' src/` → only the known `utils/cli.ts` `--help` printer ✅

**Live `/verify` owed after merge + redeploy** (layer 6): `productivity_stats` default call → response carries `completionPercent`, no `healthScore`; key finding reads `All-time completion rate: N%` with no grade words; version probe `buildId` == merged SHA and `stale: false`.

Spec: `Technical/specs/OMN-292-healthscore-rename.md` (§7 addendum records the dead-filter verification).

Closes OMN-292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mBfHxX9RXQxU4ZPSACQVF