### PR TITLE
feat(OMN-288): shrink analyze scope/metrics surface to what is honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **BREAKING (analyze input surface): `omnifocus_analyze` no longer accepts `scope` except on `task_velocity`, and no
+  longer accepts `params.metrics` at all** (OMN-288) — six analysis types advertised a full `scope` object
+  (`dateRange`/`tags`/`projects`/`includeCompleted`/`includeDropped`), but exactly one field on one op was ever read:
+  `task_velocity`'s `scope.dateRange`. Every other combination was accepted and silently ignored, so a caller scoping by
+  tag received a whole-database answer that reported success. Per OMN-273, inputs the platform does not honor are
+  deleted from the schema so they reject loudly (`VALIDATION_ERROR` naming the key) and the diagnose-failures pipeline
+  records the mismatch, rather than returning a confidently wrong answer. `productivity_stats`, `overdue_analysis`,
+  `workflow_analysis`, `pattern_analysis`, and `recurring_tasks` now take no `scope`; `task_velocity` accepts
+  `scope.dateRange` only. The shared `AnalysisScopeSchema` is renamed `VelocityScopeSchema` to say where it applies. The
+  `inputSchema` advertisement and the tool description move with it (the old "SCOPE FILTERING — use tags/projects to
+  focus analysis" paragraph described behavior that never existed). Actual scope _filtering_ remains future work
+  (OMN-293). Also removes dead plumbing (D3): the overdue handler passed `includeRecentlyCompleted`/`groupBy` into the
+  script, which bound them into OmniJS consts nothing ever read. Response shape, response metadata, and the overdue
+  cache key are unchanged.
+
 - **BREAKING (read-response value): `omnifocus_read` project status is now `"onHold"`, was `"on-hold"`** (OMN-274) —
   script-builder's three inline Project.Status maps (filtered projects, project-by-id, folder listing's project rows)
   now splice the canonical `PROJECT_STATUS_STRING_SNIPPET`, converging the read path on the OMN-272 wire vocabulary

--- a/src/omnifocus/scripts/analytics/analyze-overdue-v3.ts
+++ b/src/omnifocus/scripts/analytics/analyze-overdue-v3.ts
@@ -37,9 +37,11 @@ export const ANALYZE_OVERDUE_V3 = `
       const nowTime = now.getTime();
 
       // Extract options in JXA context to pass to OmniJS
+      // OMN-288 (D3): includeRecentlyCompleted and groupBy were extracted here and
+      // bound into the OmniJS program below as consts that nothing ever read — dead
+      // plumbing the caller had no way to detect. Removed. The limit option IS real.
+      // (No backticks in this comment: it sits inside a template literal.)
       const maxTasks = options.limit || 100;
-      const includeRecentlyCompleted = options.includeRecentlyCompleted || false;
-      const groupBy = options.groupBy || 'project';
 
       // Build comprehensive OmniJS script for ALL overdue analysis in one bridge call
       const analysisScript = \`
@@ -49,8 +51,6 @@ export const ANALYZE_OVERDUE_V3 = `
           ${IS_PROJECT_ROOT_ROW_SNIPPET}
           const nowTime = \${nowTime};
           const maxTasks = \${maxTasks};
-          const includeRecentlyCompleted = \${includeRecentlyCompleted};
-          const groupBy = "\${groupBy}";
 
           const now = new Date(nowTime);
           const overdueTasks = [];

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -353,9 +353,10 @@ PERFORMANCE WARNINGS:
 - workflow_analysis: ~20-45s — scans the ENTIRE task database (no cap); scales with DB size
 - Most others: <1 second with caching
 
-SCOPE FILTERING:
-- Use dateRange for time-based analysis
-- Use tags/projects to focus analysis`;
+TIME-WINDOW SCOPING:
+- task_velocity accepts scope.dateRange ({ start, end }) — the only honored scope input.
+- All other analysis types take no scope and run against the whole database.
+- Passing scope elsewhere (or scope.tags/projects anywhere) is rejected, not ignored.`;
 
   schema = AnalyzeSchema;
 
@@ -387,7 +388,21 @@ SCOPE FILTERING:
                 'manage_reviews',
               ],
             },
-            scope: { type: 'object' },
+            // OMN-288: `scope` is task_velocity-only and dateRange-only. Every
+            // other op rejects it (it was accepted-and-ignored before). Advertised
+            // with its real shape rather than the old generic `{ type: 'object' }`,
+            // which implied a tags/projects filter that never existed.
+            scope: {
+              type: 'object',
+              description:
+                'task_velocity ONLY. Time window: { dateRange: { start, end } }. Other analysis types accept no scope.',
+              properties: {
+                dateRange: {
+                  type: 'object',
+                  properties: { start: { type: 'string' }, end: { type: 'string' } },
+                },
+              },
+            },
             params: { type: 'object' },
           },
           required: ['type'],
@@ -930,6 +945,10 @@ SCOPE FILTERING:
     const timer = new OperationTimerV2();
 
     try {
+      // OMN-288 (D3): these two are no longer passed to the script — it bound them
+      // into consts it never read. They remain here only as the cache-key and
+      // response-metadata values they have always reported, so neither the cache
+      // key nor the response shape changes. `limit` IS read by the script.
       const includeRecentlyCompleted = true;
       const groupBy = 'project';
       const limit = 100;
@@ -949,7 +968,7 @@ SCOPE FILTERING:
       }
 
       const script = this.omniAutomation.buildScript(ANALYZE_OVERDUE_SCRIPT, {
-        options: { includeRecentlyCompleted, groupBy, limit },
+        options: { limit },
       });
       const result = await this.execJson(script, OVERDUE_ANALYSIS_V3_SCHEMA);
 

--- a/src/tools/unified/schemas/analyze-schema.ts
+++ b/src/tools/unified/schemas/analyze-schema.ts
@@ -10,8 +10,18 @@ import { coerceObject } from '../../schemas/coercion-helpers.js';
 // failures pipeline never records the LLM↔schema mismatch, and the same
 // blind spot OMN-76 closed for create/update would persist for analyze.
 
-// Scope schema for filtering analysis (shared across most analysis types)
-const AnalysisScopeSchema = z
+// OMN-288: this was `AnalysisScopeSchema`, shared by six analysis types and
+// carrying dateRange/tags/projects/includeCompleted/includeDropped. Exactly ONE
+// field on ONE op was ever read: task_velocity's `scope.dateRange`. Every other
+// combination was accepted and silently ignored, so a caller scoping by tag got
+// a whole-database answer that reported success.
+//
+// Per OMN-273, an input the platform does not honor is DELETED from the schema
+// rather than accepted-and-ignored, so it rejects loudly and the diagnose-
+// failures pipeline records the mismatch (the OMN-90 rationale above).
+//
+// Renamed to say where it applies. Real scope FILTERING is OMN-293, post-migration.
+const VelocityScopeSchema = z
   .object({
     dateRange: z
       .object({
@@ -20,10 +30,6 @@ const AnalysisScopeSchema = z
       })
       .strict()
       .optional(),
-    tags: z.array(z.string()).optional(),
-    projects: z.array(z.string()).optional(),
-    includeCompleted: z.boolean().optional(),
-    includeDropped: z.boolean().optional(),
   })
   .strict();
 
@@ -58,25 +64,24 @@ const AnalysisSchema = z.discriminatedUnion('type', [
   z
     .object({
       type: z.literal('productivity_stats'),
-      scope: AnalysisScopeSchema.optional(),
+      // OMN-288: no `scope` (never read) and no `params.metrics` (never read).
       params: z
         .object({
           groupBy: z.enum(['day', 'week', 'month']).optional(),
-          metrics: z.array(z.string()).optional(),
         })
         .strict()
         .optional(),
     })
     .strict(),
-  // Task velocity
+  // Task velocity — the ONLY op that reads any scope (dateRange).
   z
     .object({
       type: z.literal('task_velocity'),
-      scope: AnalysisScopeSchema.optional(),
+      scope: VelocityScopeSchema.optional(),
+      // OMN-288: `metrics` removed here too — accepted and ignored.
       params: z
         .object({
           groupBy: z.enum(['day', 'week', 'month']).optional(),
-          metrics: z.array(z.string()).optional(),
         })
         .strict()
         .optional(),
@@ -86,7 +91,7 @@ const AnalysisSchema = z.discriminatedUnion('type', [
   z
     .object({
       type: z.literal('overdue_analysis'),
-      scope: AnalysisScopeSchema.optional(),
+      // OMN-288: no `scope` — whole-database by construction.
       params: z.object({}).strict().optional(),
     })
     .strict(),
@@ -94,7 +99,8 @@ const AnalysisSchema = z.discriminatedUnion('type', [
   z
     .object({
       type: z.literal('pattern_analysis'),
-      scope: AnalysisScopeSchema.optional(),
+      // OMN-288 (Kip decision D-1, 2026-07-27): outside the original decided set,
+      // but the same accept-then-ignore class — shrunk in the same pass.
       params: z
         .object({
           insights: z.array(z.string()).optional(),
@@ -107,7 +113,7 @@ const AnalysisSchema = z.discriminatedUnion('type', [
   z
     .object({
       type: z.literal('workflow_analysis'),
-      scope: AnalysisScopeSchema.optional(),
+      // OMN-288: no `scope` — whole-database by construction.
       params: z.object({}).strict().optional(),
     })
     .strict(),
@@ -115,7 +121,7 @@ const AnalysisSchema = z.discriminatedUnion('type', [
   z
     .object({
       type: z.literal('recurring_tasks'),
-      scope: AnalysisScopeSchema.optional(),
+      // OMN-288 (Kip decision D-1): same accept-then-ignore class as pattern_analysis.
       params: z
         .object({
           operation: z.enum(['analyze', 'patterns']).optional(),

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -2062,10 +2062,16 @@ describe('OmniFocusAnalyzeTool', () => {
       const analysis = (schema as any).properties?.analysis;
       expect(analysis).toBeDefined();
 
-      // Should have type enum and loose scope/params objects
+      // Should have type enum and a loose params object
       expect(analysis.properties.type).toBeDefined();
-      expect(analysis.properties.scope).toEqual({ type: 'object' });
       expect(analysis.properties.params).toEqual({ type: 'object' });
+
+      // OMN-288: scope is no longer advertised as a generic `{ type: 'object' }`.
+      // It is task_velocity-only and dateRange-only, and says so — the old generic
+      // form implied a tags/projects filter that was never honored anywhere.
+      expect(analysis.properties.scope.type).toBe('object');
+      expect(analysis.properties.scope.description).toMatch(/task_velocity ONLY/);
+      expect(Object.keys(analysis.properties.scope.properties)).toEqual(['dateRange']);
 
       // Should NOT have oneOf (which duplicates scope across 8 branches)
       expect(analysis.oneOf).toBeUndefined();

--- a/tests/unit/tools/unified/compilers/AnalysisCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/AnalysisCompiler.test.ts
@@ -6,6 +6,7 @@ import {
 import type { AnalyzeInput } from '../../../../../src/tools/unified/schemas/analyze-schema.js';
 
 type CompiledProductivityStats = Extract<CompiledAnalysis, { type: 'productivity_stats' }>;
+type CompiledTaskVelocity = Extract<CompiledAnalysis, { type: 'task_velocity' }>;
 type CompiledParseMeetingNotes = Extract<CompiledAnalysis, { type: 'parse_meeting_notes' }>;
 type CompiledManageReviews = Extract<CompiledAnalysis, { type: 'manage_reviews' }>;
 
@@ -13,9 +14,31 @@ describe('AnalysisCompiler', () => {
   const compiler = new AnalysisCompiler();
 
   it('should compile productivity stats analysis', () => {
+    // OMN-288: productivity_stats no longer accepts `scope` — it was accepted
+    // and never read. The surviving scope read is task_velocity's, covered below.
     const input: AnalyzeInput = {
       analysis: {
         type: 'productivity_stats',
+        params: {
+          groupBy: 'week',
+        },
+      },
+    };
+
+    const compiled = compiler.compile(input) as CompiledProductivityStats;
+
+    expect(compiled.type).toBe('productivity_stats');
+    expect(compiled.params?.groupBy).toBe('week');
+  });
+
+  // OMN-288: task_velocity is the ONE op whose `scope.dateRange` is actually read.
+  // The compiler union is a distinct layer from the Zod schema (see the OMN-256 note
+  // below) — a scope the schema accepts can still be dropped on the way through here,
+  // so the surviving read needs its own compiler-layer pin, not just a schema test.
+  it('should compile task_velocity with the one surviving scope read intact', () => {
+    const input: AnalyzeInput = {
+      analysis: {
+        type: 'task_velocity',
         scope: {
           dateRange: {
             start: '2025-01-01',
@@ -28,10 +51,11 @@ describe('AnalysisCompiler', () => {
       },
     };
 
-    const compiled = compiler.compile(input) as CompiledProductivityStats;
+    const compiled = compiler.compile(input) as CompiledTaskVelocity;
 
-    expect(compiled.type).toBe('productivity_stats');
+    expect(compiled.type).toBe('task_velocity');
     expect(compiled.scope?.dateRange?.start).toBe('2025-01-01');
+    expect(compiled.scope?.dateRange?.end).toBe('2025-01-31');
     expect(compiled.params?.groupBy).toBe('week');
   });
 

--- a/tests/unit/tools/unified/schemas/analyze-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/analyze-schema.test.ts
@@ -3,24 +3,86 @@ import { AnalyzeSchema } from '../../../../../src/tools/unified/schemas/analyze-
 
 describe('AnalyzeSchema', () => {
   it('should validate productivity stats analysis', () => {
+    // OMN-288: productivity_stats no longer accepts `scope` or `params.metrics` —
+    // neither was ever honored. `params.groupBy` is the whole input surface.
     const input = {
       analysis: {
         type: 'productivity_stats',
-        scope: {
-          dateRange: {
-            start: '2025-01-01',
-            end: '2025-01-31',
-          },
-        },
         params: {
           groupBy: 'week',
-          metrics: ['completed', 'velocity'],
         },
       },
     };
 
     const result = AnalyzeSchema.safeParse(input);
     expect(result.success).toBe(true);
+  });
+
+  // ==========================================================================
+  // OMN-288: shrink the advertised surface to what is actually honored.
+  //
+  // Six analyze ops accepted a full `scope` object. Exactly one read any of it:
+  // task_velocity reads `scope.dateRange`. Everything else was accepted and
+  // silently ignored, so a caller filtering by tag got a whole-database answer
+  // that looked successful. Per OMN-273, inputs the platform does not honor are
+  // DELETED from the schema so they reject loudly instead.
+  // ==========================================================================
+  describe('OMN-288 scope/metrics shrink', () => {
+    const parse = (analysis: Record<string, unknown>) => AnalyzeSchema.safeParse({ analysis });
+
+    const errorKeys = (result: ReturnType<typeof parse>) => (result.success ? '' : JSON.stringify(result.error.issues));
+
+    describe('scope is rejected on every op that never honored it', () => {
+      // pattern_analysis and recurring_tasks are included per Kip's decision D-1
+      // (2026-07-27): same accept-then-ignore class, same PR, no golden interaction.
+      for (const type of [
+        'productivity_stats',
+        'overdue_analysis',
+        'workflow_analysis',
+        'pattern_analysis',
+        'recurring_tasks',
+      ]) {
+        it(`rejects scope on ${type}`, () => {
+          const result = parse({ type, scope: { tags: ['work'] } });
+          expect(result.success).toBe(false);
+          expect(errorKeys(result)).toContain('scope');
+        });
+      }
+    });
+
+    describe('task_velocity keeps dateRange only — the one honored scope read', () => {
+      it('accepts scope.dateRange', () => {
+        const result = parse({
+          type: 'task_velocity',
+          scope: { dateRange: { start: '2025-01-01', end: '2025-01-31' } },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      for (const key of ['tags', 'projects', 'includeCompleted', 'includeDropped']) {
+        it(`rejects scope.${key} (never honored, even on velocity)`, () => {
+          const value = key === 'tags' || key === 'projects' ? ['x'] : true;
+          const result = parse({ type: 'task_velocity', scope: { [key]: value } });
+          expect(result.success).toBe(false);
+          expect(errorKeys(result)).toContain(key);
+        });
+      }
+    });
+
+    describe('params.metrics is rejected — it was accepted and ignored on both ops', () => {
+      for (const type of ['productivity_stats', 'task_velocity']) {
+        it(`rejects params.metrics on ${type}`, () => {
+          const result = parse({ type, params: { metrics: ['completed'] } });
+          expect(result.success).toBe(false);
+          expect(errorKeys(result)).toContain('metrics');
+        });
+      }
+    });
+
+    it('still accepts params.groupBy on both ops (the honored input)', () => {
+      expect(parse({ type: 'productivity_stats', params: { groupBy: 'week' } }).success).toBe(true);
+      expect(parse({ type: 'task_velocity', params: { groupBy: 'day' } }).success).toBe(true);
+    });
   });
 
   it('should validate parse meeting notes', () => {
@@ -486,16 +548,27 @@ describe('AnalyzeSchema', () => {
       expect(result.success).toBe(false);
     });
 
+    // OMN-288: this test used to pin scope.tags/includeCompleted + params.metrics on
+    // productivity_stats as "the documented surface". That surface was the defect —
+    // documented, accepted, and never honored. It now pins the honest surface, and
+    // task_velocity carries the one scope read that survives.
     it('still accepts the documented analyze surface (no regression — productivity_stats)', () => {
       const input = {
         analysis: {
           type: 'productivity_stats',
-          scope: {
-            dateRange: { start: '2026-01-01', end: '2026-01-31' },
-            tags: ['work'],
-            includeCompleted: true,
-          },
-          params: { groupBy: 'week', metrics: ['completed', 'velocity'] },
+          params: { groupBy: 'week' },
+        },
+      };
+      const result = AnalyzeSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('still accepts the documented analyze surface (no regression — task_velocity dateRange)', () => {
+      const input = {
+        analysis: {
+          type: 'task_velocity',
+          scope: { dateRange: { start: '2026-01-01', end: '2026-01-31' } },
+          params: { groupBy: 'week' },
         },
       };
       const result = AnalyzeSchema.safeParse(input);


### PR DESCRIPTION
## What

Six `omnifocus_analyze` types advertised a full `scope` object (`dateRange`, `tags`, `projects`, `includeCompleted`, `includeDropped`). **Exactly one field on one op was ever read:** `task_velocity`'s `scope.dateRange`. Everything else was accepted and silently ignored — a caller scoping by tag got a whole-database answer that reported success.

Per OMN-273, an input the platform does not honor is **deleted** from the schema so it rejects loudly, instead of being accepted-and-ignored. The diagnose-failures pipeline then records the mismatch rather than a confidently wrong answer reaching the caller.

## Post-shrink input surface

| Op | Accepts now |
|---|---|
| `productivity_stats` | `params.groupBy` — **no scope, no metrics** |
| `task_velocity` | `scope.dateRange` + `params.groupBy` — **no metrics** |
| `overdue_analysis` | `params: {}` |
| `workflow_analysis` | `params: {}` |
| `pattern_analysis` | `params.insights` |
| `recurring_tasks` | `params.operation` / `params.sortBy` |

`pattern_analysis` and `recurring_tasks` were outside the OMN-148 walk-through's decided set but carry the identical accept-then-ignore defect — included per **Kip's decision D-1 (2026-07-27)**: same class, same PR, no golden interaction.

`AnalysisScopeSchema` → **`VelocityScopeSchema`**, so the name says where it applies. Real scope *filtering* stays future work (**OMN-293**).

## Dual-schema rule

The Zod change, the `inputSchema` advertisement, and the tool description all move together:

- `inputSchema`: `scope` was a generic `{ type: 'object' }` implying a tags/projects filter that never existed. Now advertised with its real shape and a `task_velocity ONLY` description.
- Tool description: the `SCOPE FILTERING — use tags/projects to focus analysis` paragraph described behavior that has never existed. Replaced with `TIME-WINDOW SCOPING`, which states that passing scope elsewhere is rejected rather than ignored.

## Also: D3 dead plumbing

The overdue handler passed `includeRecentlyCompleted`/`groupBy` into the script, which bound them into OmniJS consts **nothing ever read**. Removed from the script. They remain handler-local so the **cache key and response metadata are byte-identical** — no response-shape change.

## Vertical Contract Matrix

| # | Layer | Disposition |
|---|---|---|
| 1 | Schema (both) | ✅ Zod + `inputSchema` + description, moved together |
| 2 | Normalization | ✅ **checked, clear** — `grep` of `src/tools/normalization/` finds no scope/metrics references in `WRAPPER_HINTS` |
| 3 | Single-item path | **N/A** — input-side removal; handlers already ignored these keys |
| 4 | Batch path | **N/A** — no batch analytics route |
| 5 | Script lowering | ✅ D3 dead-const removal only (no behavioral lowering change) |
| 6 | Live bridge | ⏳ **owed post-merge** (see below) |
| 7 | Response validation | **N/A** — responses untouched (metadata deliberately preserved) |
| 8 | Cache key | **N/A** — removed inputs never influenced script output; overdue key unchanged by construction |

## Verification

- `npm run build` ✅
- `npm run lint` (`--max-warnings=0`) ✅
- `npm run test:unit` ✅ **3925 passed / 183 files**
- `grep -rn 'console\.log' src/` → only the known `utils/cli.ts` `--help` printer ✅

**Live `/verify` owed after merge + redeploy** (layer 6):
1. `omnifocus_analyze { analysis: { type: 'productivity_stats', scope: { tags: ['x'] } } }` → `VALIDATION_ERROR` naming `scope` (was: a silent whole-DB answer)
2. `task_velocity` with an explicit `scope.dateRange` → same numbers as before the change
3. Version probe: `buildId` == merged SHA, `stale: false`

## Reviewer notes

⚠️ **One existing test changed meaning.** `still accepts the documented analyze surface (no regression — productivity_stats)` pinned `scope.tags` + `includeCompleted` + `params.metrics` as the documented surface. That surface *was* the defect — documented, accepted, never honored. It now pins the honest surface, and a sibling test covers `task_velocity`'s surviving `dateRange`.

📋 **Conformance re-baseline flag (carried from the spec, not actioned here):** OMN-168's baseline may count previously-"successful" scope-bearing calls differently after this shrink. Flag for the next re-baseline; deliberately **not** re-baselined in this PR.

Spec: `Technical/specs/OMN-288-analytics-scope-shrink.md`

Closes OMN-288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mBfHxX9RXQxU4ZPSACQVF