### PR TITLE
feat(OMN-291): demote workflow_analysis to an evidence bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **BREAKING (analyze response): `workflow_analysis` is demoted to an evidence bundle** (OMN-291) — it screens and
+  counts; it no longer scores, ranks, or recommends. Per OMN-258's contract the server produces evidence and the caller
+  judges, and that now explicitly includes numeric weight-composites, not just prose. **Removed:** `insights[]` and
+  `recommendations[]` (with all their priority labels and the invented "N × 1.5 dependent tasks" multiplier), the
+  per-project `healthScore` (100 minus a hand-tuned 25/20/15/15/−10/+5 weight stack — the weights encode what matters
+  and by how much, which is the caller's call) and `momentumScore` (which additionally _subtracted_ availableRate, so
+  more available work scored _lower_ momentum, contradicting its own prose), the healthy/unhealthy project rollups, and
+  the `analysisDepth`/`focusAreas`/`maxInsights` machinery including three focus-area branches that could never fire.
+  **Kept/added:** whole-DB counters, `workflowMetrics` percentages, `timeBuckets`, per-tag stats, and per-project rows
+  that are purely mechanical — `total`, `completed`, `available`, `overdue`, `blocked`, `estimatedHours`, `overdueRate`,
+  `availableRate`, `avgAge`, and `deferrals { total, over90Days, keywordMatched }`. **Deferral honesty:** the
+  strategic/problematic _verdict_ split (`deferDays <= 90 || nameMatchesKeyword` → good/bad) becomes two **independent**
+  screen counts, `over90Days` and `keywordMatched`. A deferral can be in both, one, or neither — they do not sum to
+  `totalDeferred`, unlike the labels they replace. The keyword list survives only as an explicitly-labelled recall
+  screen (one personal database, English-only), and per-task rows carry `keywordMatched` as a candidate marker rather
+  than a conclusion. Key findings become at most three mechanical restatements of numbers already in the response. The
+  response schema is strict, so a re-introduced `insights`/`recommendations` key is a validation failure — the removal
+  is pinned, not just performed. The cache key is version-bumped to `workflow_analysis_v4` (the old key literally named
+  the deleted machinery), so stale pre-demote entries cannot serve the old shape after deploy.
+
 - **BREAKING (read-response value): `omnifocus_read` project status is now `"onHold"`, was `"on-hold"`** (OMN-274) —
   script-builder's three inline Project.Status maps (filtered projects, project-by-id, folder listing's project rows)
   now splice the canonical `PROJECT_STATUS_STRING_SNIPPET`, converging the read path on the OMN-272 wire vocabulary

--- a/src/omnifocus/response-schemas/analyze.ts
+++ b/src/omnifocus/response-schemas/analyze.ts
@@ -250,22 +250,17 @@ export const OVERDUE_ANALYSIS_V3_SCHEMA = v3EnvelopeSchema(OverdueAnalysisDataSc
 export type OverdueAnalysisV3Data = z.infer<typeof OverdueAnalysisDataSchema>;
 
 /**
- * Workflow analysis insight row.
- * Source: analyze-overdue-v3.ts insights.push({category, insight, priority}).
- */
-const WorkflowInsightSchema = z.object({ category: z.string(), insight: z.string(), priority: z.string() }).strict();
-
-/**
- * Workflow analysis recommendation row.
- * Source: workflow-analysis-v3.ts recommendations.push({category, recommendation, priority}).
- */
-const WorkflowRecommendationSchema = z
-  .object({ category: z.string(), recommendation: z.string(), priority: z.string() })
-  .strict();
-
-/**
  * Workflow analysis data payload — emitted by WORKFLOW_ANALYSIS_V3 data block.
  * Source: workflow-analysis-v3.ts outer return JSON.stringify({ok:true, v:'3', data:{…}}).
+ *
+ * OMN-291: `insights` and `recommendations` are GONE, along with the per-project
+ * healthScore/momentumScore composites and the analysisDepth/focusAreas/maxInsights
+ * metadata echo. workflow_analysis is an evidence bundle: it screens and counts,
+ * and the caller judges (OMN-258's contract, extended to numeric composites).
+ *
+ * This schema is `.strict()` at every level, so a re-introduced `insights` or
+ * `recommendations` key is a VALIDATION FAILURE, not a silently-passed extra —
+ * the removal is pinned, not merely performed.
  *
  * patterns: NOT a name-keyed map. The script always emits exactly three named keys
  *   (workloadDistribution, workflowMetrics, deferralAnalysis) with heterogeneous shapes.
@@ -274,12 +269,9 @@ const WorkflowRecommendationSchema = z
  *
  * data: passthrough of raw task/project/workload data when includeRawData=true;
  *   undefined-dropped (JSON.stringify(undefined)) when false → z.unknown().optional().
- *
- * metadata.note: present from the outer spread. metadata.focusAreas: string[] (from options).
  */
 export const WorkflowAnalysisDataSchema = z
   .object({
-    insights: z.array(WorkflowInsightSchema),
     patterns: z
       .object({
         workloadDistribution: z.unknown(),
@@ -287,7 +279,6 @@ export const WorkflowAnalysisDataSchema = z
         deferralAnalysis: z.unknown(),
       })
       .strict(),
-    recommendations: z.array(WorkflowRecommendationSchema),
     // passthrough: includeRawData echo — raw task/project/workload data; undefined-dropped when false
     data: z.unknown().optional(),
     totalTasks: z.number(),
@@ -296,9 +287,6 @@ export const WorkflowAnalysisDataSchema = z
     dataPoints: z.number(),
     metadata: z
       .object({
-        analysisDepth: z.string(),
-        focusAreas: z.array(z.string()),
-        maxInsights: z.number(),
         method: z.string(),
         optimization: z.string(),
         query_time_ms: z.number(),

--- a/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
+++ b/src/omnifocus/scripts/analytics/workflow-analysis-v3.ts
@@ -11,16 +11,18 @@
  *
  * Converted from helper-based to pure OmniJS following v3 pattern.
  *
- * Original script features (ALL PRESERVED):
- * - Cross-project pattern analysis
- * - Workload distribution analysis
- * - Time pattern discovery
- * - Bottleneck identification
- * - Productivity insights
- * - Project health assessment
- * - Strategic vs problematic deferral analysis
- * - Tag bottleneck tracking
- * - Multiple focus areas (productivity, workload, bottlenecks, project_health, time_patterns, opportunities)
+ * OMN-291: demoted to an EVIDENCE BUNDLE. This script screens and counts; it no
+ * longer judges. The insight/recommendation generators, the per-project
+ * healthScore/momentumScore composites, and the focus-area machinery are deleted
+ * — per OMN-258's contract the server screens and evidences, and the caller
+ * applies judgment. That now includes numeric weight-composites, not just prose.
+ *
+ * What it emits:
+ * - Whole-DB counters (overdue/flagged/blocked/available/inbox/estimated time)
+ * - workflowMetrics percentages, timeBuckets, per-tag stats
+ * - Per-project mechanical rows: counts, rates, avgAge, deferral screen counts
+ * - deferralAnalysis: totals plus two INDEPENDENT screen counts (over90Days,
+ *   keywordMatched) and a top-10 detail list carrying a keywordMatched marker
  */
 
 import { ROUND1_HELPER } from '../shared/helpers.js';
@@ -38,9 +40,9 @@ export const WORKFLOW_ANALYSIS_V3 = `
       const nowTime = now.getTime();
 
       // Extract options in JXA context to pass to OmniJS
-      const analysisDepth = options.analysisDepth || 'full'; // OMN-200: full-DB is the only mode now
-      const focusAreas = options.focusAreas || ['productivity', 'workload', 'bottlenecks'];
-      const maxInsights = options.maxInsights || 15;
+      // OMN-291: analysisDepth / focusAreas / maxInsights are gone. They only ever
+      // gated and capped the insight+recommendation generators, which this ticket
+      // deletes — workflow_analysis is an evidence bundle now, not a verdict source.
       const includeRawData = options.includeRawData || false;
 
       // Build comprehensive OmniJS script for ALL workflow analysis in one bridge call
@@ -48,17 +50,27 @@ export const WORKFLOW_ANALYSIS_V3 = `
         (() => {
           ${ROUND1_HELPER}
           const nowTime = \${nowTime};
-          const analysisDepth = "\${analysisDepth}";
-          const focusAreas = \${JSON.stringify(focusAreas)};
-          const maxInsights = \${maxInsights};
           const includeRawData = \${includeRawData};
+
+          // OMN-291: a RECALL SCREEN, not a classifier. These substrings were derived
+          // from one personal database and are locale-bound (English-only), so a hit
+          // means "worth a look", never "this deferral is strategic". Rows report
+          // keywordMatched as a candidate marker and the caller judges. Kept as one
+          // shared const so the two loops below cannot drift apart.
+          const DEFERRAL_KEYWORD_SCREEN = ['renewal', 'movie', 'annual', 'seasonal', 'quarterly', 'monthly'];
+          const matchesDeferralKeyword = function (lowerName) {
+            for (let k = 0; k < DEFERRAL_KEYWORD_SCREEN.length; k++) {
+              if (lowerName.indexOf(DEFERRAL_KEYWORD_SCREEN[k]) !== -1) return true;
+            }
+            return false;
+          };
 
           const now = new Date(nowTime);
 
           // Initialize analysis structures
-          const insights = [];
+          // OMN-291: the insights[] and recommendations[] accumulators are gone
+          // along with the generators that filled them.
           const patterns = {};
-          const recommendations = [];
           // OMN-208: data.tasks is capped independently of the full-population
           // metrics loop below (maxTasksToProcess stays = totalTasks). This cap
           // only protects the raw-record echo (currently unreachable in prod —
@@ -118,8 +130,11 @@ export const WORKFLOW_ANALYSIS_V3 = `
           let totalInboxTasks = 0;
 
           // Deferral analysis - distinguish good vs. problematic deferrals
-          let strategicDeferrals = 0;
-          let problematicDeferrals = 0;
+          // OMN-291 (D16): the old strategic/problematic VERDICT split becomes two
+          // independent, honestly-named screen counts. A deferral can match both,
+          // or neither — they are not complements, unlike the labels they replace.
+          let deferralsOver90Days = 0;
+          let deferralsKeywordMatched = 0;
           const deferredTaskDetails = [];
 
           // Project analysis - focus on momentum and health
@@ -241,31 +256,22 @@ export const WORKFLOW_ANALYSIS_V3 = `
               if (deferDate && deferDate.getTime() > nowTime) {
                 totalDeferredTasks++;
 
-                // Analyze if this is a strategic deferral or problematic
+                // OMN-291 (D16): measure, do not conclude. Two independent facts —
+                // how far out the deferral reaches, and whether its name hit the
+                // recall screen. The old isStrategic collapsed both into a verdict.
                 const deferDays = Math.floor((deferDate.getTime() - nowTime) / (1000 * 60 * 60 * 24));
                 const taskName = task.name || 'Unnamed Task';
-                const taskNameLower = taskName.toLowerCase();
+                const keywordMatched = matchesDeferralKeyword(taskName.toLowerCase());
+                const over90Days = deferDays > 90;
 
-                // Strategic deferrals: time-based, seasonal, or dependency-based
-                const isStrategic = deferDays <= 90 || // Within 3 months (reasonable planning horizon)
-                                   taskNameLower.includes('renewal') ||
-                                   taskNameLower.includes('movie') ||
-                                   taskNameLower.includes('annual') ||
-                                   taskNameLower.includes('seasonal') ||
-                                   taskNameLower.includes('quarterly') ||
-                                   taskNameLower.includes('monthly');
-
-                if (isStrategic) {
-                  strategicDeferrals++;
-                } else {
-                  problematicDeferrals++;
-                }
+                if (over90Days) deferralsOver90Days++;
+                if (keywordMatched) deferralsKeywordMatched++;
 
                 // Store deferral details for pattern analysis
                 deferredTaskDetails.push({
                   name: taskName,
                   deferDays: deferDays,
-                  isStrategic: isStrategic,
+                  keywordMatched: keywordMatched,
                   project: projectName
                 });
               }
@@ -288,13 +294,16 @@ export const WORKFLOW_ANALYSIS_V3 = `
                 if (!projectStats[projectName]) {
                   projectStats[projectName] = {
                     total: 0,
+                    completed: 0,
                     overdue: 0,
                     flagged: 0,
                     blocked: 0,
                     available: 0,
                     deferred: 0,
-                    strategicDeferred: 0,
-                    problematicDeferred: 0,
+                    // OMN-291 (D16): honest screen counts, replacing the
+                    // strategicDeferred/problematicDeferred verdict split.
+                    deferredOver90Days: 0,
+                    deferredKeywordMatched: 0,
                     estimatedTime: 0,
                     avgAge: 0,
                     totalAge: 0
@@ -302,6 +311,7 @@ export const WORKFLOW_ANALYSIS_V3 = `
                 }
 
                 projectStats[projectName].total++;
+                if (completed) projectStats[projectName].completed++;
                 if (overdueDays > 0) projectStats[projectName].overdue++;
                 if (flagged) projectStats[projectName].flagged++;
                 if (blocked) projectStats[projectName].blocked++;
@@ -311,21 +321,14 @@ export const WORKFLOW_ANALYSIS_V3 = `
                 if (deferDate && deferDate.getTime() > nowTime) {
                   projectStats[projectName].deferred++;
 
+                  // OMN-291 (D16): same two independent facts as the global pass,
+                  // computed through the same shared screen so they cannot drift.
                   const deferDays = Math.floor((deferDate.getTime() - nowTime) / (1000 * 60 * 60 * 24));
                   const taskName = task.name || 'Unnamed Task';
-                  const taskNameLower = taskName.toLowerCase();
-                  const isStrategic = deferDays <= 90 ||
-                                     taskNameLower.includes('renewal') ||
-                                     taskNameLower.includes('movie') ||
-                                     taskNameLower.includes('annual') ||
-                                     taskNameLower.includes('seasonal') ||
-                                     taskNameLower.includes('quarterly') ||
-                                     taskNameLower.includes('monthly');
 
-                  if (isStrategic) {
-                    projectStats[projectName].strategicDeferred++;
-                  } else {
-                    projectStats[projectName].problematicDeferred++;
+                  if (deferDays > 90) projectStats[projectName].deferredOver90Days++;
+                  if (matchesDeferralKeyword(taskName.toLowerCase())) {
+                    projectStats[projectName].deferredKeywordMatched++;
                   }
                 }
 
@@ -420,390 +423,59 @@ export const WORKFLOW_ANALYSIS_V3 = `
             stats.availableRate = availableRate;
             stats.overdueRate = overdueRate;
 
-            // Project workflow health scoring - focus on system efficiency
-            let healthScore = 100;
-
-            // Overdue tasks hurt workflow health
-            if (stats.overdue > 0) healthScore -= (stats.overdue / stats.total) * 25;
-
-            // Blocked tasks slow down the system
-            if (stats.blocked > 0) healthScore -= (stats.blocked / stats.total) * 20;
-
-            // Very old projects may be stale
-            if (avgAge > 120) healthScore -= 15;
-
-            // Smart deferral analysis - only penalize problematic deferrals
-            if (stats.problematicDeferred > 0) {
-              const problematicDeferralRate = stats.problematicDeferred / stats.total;
-              if (problematicDeferralRate > 0.2) healthScore -= 15; // High problematic deferral rate
-            }
-
-            // Strategic deferrals are actually GOOD - don't penalize
-            if (stats.strategicDeferred > 0) {
-              // This might actually improve the score slightly
-              healthScore = Math.min(100, healthScore + 5);
-            }
-
-            // Low available tasks suggest project may be stalled
-            if (availableRate < 20) healthScore -= 10;
-
-            stats.healthScore = Math.max(0, healthScore);
-
-            // Calculate momentum (how much forward progress is possible)
-            const momentumScore = Math.max(0, 100 - (overdueRate * 0.5) - (availableRate * 0.3));
-            stats.momentumScore = momentumScore;
+            // OMN-291 (D19): healthScore and momentumScore are DELETED here.
+            //
+            // healthScore was 100 minus a hand-tuned weight stack (overdue 25,
+            // blocked 20, stale-age 15, problematic-deferral 15, low-available 10,
+            // +5 strategic bonus). A weighted composite IS a verdict — the weights
+            // encode what matters and by how much, which is the caller's judgment
+            // to make, not the server's. Its components all survive as separate
+            // facts below (overdue, blocked, avgAge, availableRate, deferrals).
+            //
+            // momentumScore additionally had a direction bug: it SUBTRACTED
+            // availableRate, so a project with more available work scored LOWER
+            // momentum, contradicting the prose that shipped alongside it.
+            // Deleting it makes that bug historical rather than something to fix.
           });
 
-          // PHASE 5: Generate insights based on focus areas
-          if (focusAreas.includes('productivity')) {
-            const availableRate = totalTasks > 0 ? round1(availableTasks / totalTasks * 100) : 0;
-            insights.push({
-              category: 'productivity',
-              insight: availableRate + '% of tasks are ready to work on (' + availableTasks + ' of ' + totalTasks + ' tasks)',
-              priority: 'medium'
-            });
-
-            if (overdueTasks > 0) {
-              const avgOverdue = Math.round(totalOverdueDays / overdueTasks);
-              insights.push({
-                category: 'productivity',
-                insight: overdueTasks + ' tasks are overdue, averaging ' + avgOverdue + ' days late',
-                priority: 'high'
-              });
-            }
-
-            if (totalDeferredTasks > 0) {
-              const deferredRate = totalTasks > 0 ? round1(totalDeferredTasks / totalTasks * 100) : 0;
-              const strategicRate = totalTasks > 0 ? round1(strategicDeferrals / totalTasks * 100) : 0;
-              const problematicRate = totalTasks > 0 ? round1(problematicDeferrals / totalTasks * 100) : 0;
-
-              insights.push({
-                category: 'productivity',
-                insight: deferredRate + '% of tasks are deferred (' + totalDeferredTasks + ' total)',
-                priority: 'medium'
-              });
-
-              if (strategicDeferrals > 0) {
-                insights.push({
-                  category: 'productivity',
-                  insight: strategicRate + '% are strategic deferrals (' + strategicDeferrals + ' tasks) - Good GTD practice!',
-                  priority: 'low'
-                });
-              }
-
-              if (problematicDeferrals > 0) {
-                insights.push({
-                  category: 'productivity',
-                  insight: problematicRate + '% are problematic deferrals (' + problematicDeferrals + ' tasks) - May need attention',
-                  priority: 'medium'
-                });
-              }
-            }
-          }
-
-          if (focusAreas.includes('workload')) {
-            const totalHours = Math.round(totalEstimatedTime / 60);
-            insights.push({
-              category: 'workload',
-              insight: 'Total estimated workload: ' + totalHours + ' hours across ' + totalProjects + ' projects',
-              priority: 'medium'
-            });
-
-            // Find projects with high momentum (many available tasks)
-            const highMomentumProjects = [];
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.available > 0 && (stats.available / stats.total) > 0.3) {
-                highMomentumProjects.push({ name, stats });
-              }
-            });
-            highMomentumProjects.sort((a, b) => (b.stats.available / b.stats.total) - (a.stats.available / a.stats.total));
-
-            if (highMomentumProjects.length > 0) {
-              const top3 = highMomentumProjects.slice(0, 3);
-              const projectList = top3.map(p => p.name + ' (' + p.stats.available + ' available tasks)').join(', ');
-              insights.push({
-                category: 'workload',
-                insight: 'High-momentum projects: ' + projectList,
-                priority: 'medium'
-              });
-            }
-
-            // Find projects with problematic deferral patterns
-            const problematicDeferralProjects = [];
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.problematicDeferred > 0 && (stats.problematicDeferred / stats.total) > 0.3) {
-                problematicDeferralProjects.push({ name, stats });
-              }
-            });
-            problematicDeferralProjects.sort((a, b) =>
-              (b.stats.problematicDeferred / b.stats.total) - (a.stats.problematicDeferred / a.stats.total)
-            );
-
-            if (problematicDeferralProjects.length > 0) {
-              const top3 = problematicDeferralProjects.slice(0, 3);
-              const projectList = top3.map(p =>
-                p.name + ' (' + Math.round((p.stats.problematicDeferred / p.stats.total) * 100) + '% problematic deferrals)'
-              ).join(', ');
-              insights.push({
-                category: 'workload',
-                insight: 'Projects with high problematic deferral rates: ' + projectList,
-                priority: 'high'
-              });
-            }
-
-            // Celebrate projects with good strategic deferral practices
-            const strategicDeferralProjects = [];
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.strategicDeferred > 0 && stats.problematicDeferred === 0) {
-                strategicDeferralProjects.push({ name, stats });
-              }
-            });
-            strategicDeferralProjects.sort((a, b) =>
-              (b.stats.strategicDeferred / b.stats.total) - (a.stats.strategicDeferred / a.stats.total)
-            );
-
-            if (strategicDeferralProjects.length > 0) {
-              const top3 = strategicDeferralProjects.slice(0, 3);
-              const projectList = top3.map(p =>
-                p.name + ' (' + Math.round((p.stats.strategicDeferred / p.stats.total) * 100) + '% strategic deferrals)'
-              ).join(', ');
-              insights.push({
-                category: 'workload',
-                insight: 'Projects with good deferral practices: ' + projectList,
-                priority: 'low'
-              });
-            }
-          }
-
-          if (focusAreas.includes('bottlenecks')) {
-            if (blockedTasks > 0) {
-              insights.push({
-                category: 'bottlenecks',
-                insight: blockedTasks + ' tasks are blocked, potentially slowing down ' + Math.round(blockedTasks * 1.5) + ' dependent tasks',
-                priority: 'high'
-              });
-            }
-
-            // Find projects with high overdue rates
-            const problematicProjects = [];
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.overdue > 0 && (stats.overdue / stats.total) > 0.3) {
-                problematicProjects.push({ name, stats });
-              }
-            });
-            problematicProjects.sort((a, b) =>
-              (b.stats.overdue / b.stats.total) - (a.stats.overdue / a.stats.total)
-            );
-
-            if (problematicProjects.length > 0) {
-              const top3 = problematicProjects.slice(0, 3);
-              const projectList = top3.map(p =>
-                p.name + ' (' + Math.round((p.stats.overdue / p.stats.total) * 100) + '%)'
-              ).join(', ');
-              insights.push({
-                category: 'bottlenecks',
-                insight: 'Projects with high overdue rates: ' + projectList,
-                priority: 'high'
-              });
-            }
-          }
-
-          if (focusAreas.includes('project_health')) {
-            let healthyProjects = 0;
-            let unhealthyProjects = 0;
-            let highMomentumProjects = 0;
-
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.healthScore >= 80) healthyProjects++;
-              if (stats.healthScore < 50) unhealthyProjects++;
-              if (stats.momentumScore >= 80) highMomentumProjects++;
-            });
-
-            insights.push({
-              category: 'project_health',
-              insight: 'Workflow health: ' + healthyProjects + ' healthy projects, ' + unhealthyProjects + ' need attention',
-              priority: 'medium'
-            });
-
-            insights.push({
-              category: 'project_health',
-              insight: highMomentumProjects + ' projects have high momentum (ready for progress)',
-              priority: 'medium'
-            });
-          }
-
-          if (focusAreas.includes('time_patterns')) {
-            let mostOverdueBucket = null;
-            let maxCount = 0;
-
-            Object.keys(timeBuckets).forEach(bucket => {
-              if (timeBuckets[bucket] > maxCount) {
-                maxCount = timeBuckets[bucket];
-                mostOverdueBucket = bucket;
-              }
-            });
-
-            if (mostOverdueBucket && maxCount > 0) {
-              insights.push({
-                category: 'time_patterns',
-                insight: 'Most overdue tasks cluster in: ' + mostOverdueBucket + ' (' + maxCount + ' tasks)',
-                priority: 'medium'
-              });
-            }
-          }
-
-          if (focusAreas.includes('opportunities')) {
-            if (availableTasks > 0) {
-              insights.push({
-                category: 'opportunities',
-                insight: availableTasks + ' tasks are ready to work on now',
-                priority: 'low'
-              });
-            }
-
-            // Find projects with high momentum
-            const momentumProjects = [];
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.momentumScore >= 75) {
-                momentumProjects.push({ name, stats });
-              }
-            });
-            momentumProjects.sort((a, b) => b.stats.momentumScore - a.stats.momentumScore);
-
-            if (momentumProjects.length > 0) {
-              const top3 = momentumProjects.slice(0, 3);
-              const projectList = top3.map(p =>
-                p.name + ' (momentum: ' + Math.round(p.stats.momentumScore) + ')'
-              ).join(', ');
-              insights.push({
-                category: 'opportunities',
-                insight: 'High-momentum projects ready for focus: ' + projectList,
-                priority: 'low'
-              });
-            }
-
-            // Find projects that could benefit from attention
-            const attentionProjects = [];
-            Object.keys(projectStats).forEach(name => {
-              const stats = projectStats[name];
-              if (stats.momentumScore < 50 && stats.blocked === 0) {
-                attentionProjects.push({ name, stats });
-              }
-            });
-            attentionProjects.sort((a, b) => a.stats.momentumScore - b.stats.momentumScore);
-
-            if (attentionProjects.length > 0) {
-              const top3 = attentionProjects.slice(0, 3);
-              const projectList = top3.map(p =>
-                p.name + ' (momentum: ' + Math.round(p.stats.momentumScore) + ')'
-              ).join(', ');
-              insights.push({
-                category: 'opportunities',
-                insight: 'Projects that could use attention: ' + projectList,
-                priority: 'medium'
-              });
-            }
-          }
-
-          // Generate recommendations focused on workflow health
-          if (overdueTasks > totalTasks * 0.15) {
-            recommendations.push({
-              category: 'workflow_management',
-              recommendation: 'High overdue rate suggests workflow bottlenecks - consider reviewing task flow and dependencies',
-              priority: 'high'
-            });
-          }
-
-          if (blockedTasks > 0) {
-            recommendations.push({
-              category: 'dependency_management',
-              recommendation: 'Review blocked tasks to identify and resolve dependencies that slow down your system',
-              priority: 'high'
-            });
-          }
-
-          // Smart deferral recommendations
-          if (problematicDeferrals > totalTasks * 0.15) {
-            recommendations.push({
-              category: 'deferral_optimization',
-              recommendation: 'High problematic deferral rate suggests avoidance or overwhelm - review if these tasks are truly necessary or if you need to break them down',
-              priority: 'high'
-            });
-          }
-
-          if (strategicDeferrals > 0 && strategicDeferrals > problematicDeferrals * 2) {
-            recommendations.push({
-              category: 'deferral_practice',
-              recommendation: 'Your strategic deferral practices are excellent! You are using deferrals appropriately for time-based and seasonal tasks',
-              priority: 'low'
-            });
-          }
-
-          if (totalInboxTasks > 50) {
-            recommendations.push({
-              category: 'inbox_management',
-              recommendation: 'Large inbox suggests processing backlog - consider batch processing to clear the way',
-              priority: 'medium'
-            });
-          }
-
-          // Calculate average project health
-          let totalHealthScore = 0;
-          let projectCount = 0;
-          Object.keys(projectStats).forEach(name => {
-            totalHealthScore += projectStats[name].healthScore;
-            projectCount++;
-          });
-          const avgProjectHealth = projectCount > 0 ? totalHealthScore / projectCount : 0;
-
-          if (avgProjectHealth < 70) {
-            recommendations.push({
-              category: 'workflow_optimization',
-              recommendation: 'Overall workflow health is low - consider reviewing project portfolio and task flow',
-              priority: 'medium'
-            });
-          }
-
-          // Calculate average momentum
-          let totalMomentum = 0;
-          Object.keys(projectStats).forEach(name => {
-            totalMomentum += projectStats[name].momentumScore;
-          });
-          const avgMomentum = projectCount > 0 ? totalMomentum / projectCount : 0;
-
-          if (avgMomentum < 60) {
-            recommendations.push({
-              category: 'momentum_building',
-              recommendation: 'Low project momentum suggests focus issues - consider concentrating on fewer, high-impact projects',
-              priority: 'medium'
-            });
-          }
-
-          // Limit insights to requested maximum
-          if (insights.length > maxInsights) {
-            insights.splice(maxInsights);
-          }
-          // Cap recommendations at 10
-          if (recommendations.length > 10) {
-            recommendations.splice(10);
-          }
-
+          // OMN-291 (D-GTD + D20 + D21): PHASE 5 (the productivity / workload /
+          // bottlenecks / project_health / time_patterns / opportunities insight
+          // generators) and the recommendation block that followed it are DELETED,
+          // live branches and dead ones alike.
+          //
+          // Per OMN-258's contract the server SCREENS and EVIDENCES; it does not
+          // rank by embedded judgment. That now explicitly includes numeric
+          // weight-composites, not just prose. Everything these blocks emitted was
+          // a verdict wearing a data shape: priority labels the caller never chose,
+          // an invented "N x 1.5 dependent tasks" multiplier with no basis (D21),
+          // and three focus-area branches (project_health, time_patterns,
+          // opportunities) that could never fire because the handler only ever
+          // passed productivity/workload/bottlenecks (D20).
+          //
+          // The facts they were computed FROM all survive in the evidence bundle
+          // below. The caller applies its own thresholds and priorities.
           // Build patterns object focused on workflow health
+          // OMN-291: mechanical rows only. Every field is a count, a rate, or a mean
+          // — no composite, no grade, no label. avgAge is the mean of day-ages (live
+          // since OMN-251) and is a FACT; the caller applies any staleness threshold.
           const workloadByProject = {};
           Object.keys(projectStats).forEach(name => {
             const stats = projectStats[name];
             workloadByProject[name] = {
-              totalTasks: stats.total,
+              total: stats.total,
+              completed: stats.completed,
+              available: stats.available,
+              overdue: stats.overdue,
+              blocked: stats.blocked,
               estimatedHours: Math.round(stats.estimatedTime / 60),
+              overdueRate: stats.overdueRate,
               availableRate: stats.availableRate,
-              momentumScore: stats.momentumScore,
-              healthScore: stats.healthScore
+              avgAge: stats.avgAge,
+              deferrals: {
+                total: stats.deferred,
+                over90Days: stats.deferredOver90Days,
+                keywordMatched: stats.deferredKeywordMatched
+              }
             };
           });
 
@@ -819,18 +491,22 @@ export const WORKFLOW_ANALYSIS_V3 = `
             flaggedPercentage: totalTasks > 0 ? round1(flaggedTasks / totalTasks * 100) : 0,
             blockedPercentage: totalTasks > 0 ? round1(blockedTasks / totalTasks * 100) : 0,
             deferredPercentage: totalTasks > 0 ? round1(totalDeferredTasks / totalTasks * 100) : 0,
-            strategicDeferredPercentage: totalTasks > 0 ? round1(strategicDeferrals / totalTasks * 100) : 0,
-            problematicDeferredPercentage: totalTasks > 0 ? round1(problematicDeferrals / totalTasks * 100) : 0,
+            // OMN-291 (D16): screen counts, not the old strategic/problematic verdict.
+            deferredOver90DaysPercentage: totalTasks > 0 ? round1(deferralsOver90Days / totalTasks * 100) : 0,
+            deferredKeywordMatchedPercentage: totalTasks > 0 ? round1(deferralsKeywordMatched / totalTasks * 100) : 0,
             inboxPercentage: totalTasks > 0 ? round1(totalInboxTasks / totalTasks * 100) : 0
           };
 
           // Add deferral pattern analysis
           patterns.deferralAnalysis = {
             totalDeferred: totalDeferredTasks,
-            strategicDeferrals: strategicDeferrals,
-            problematicDeferrals: problematicDeferrals,
-            strategicRate: totalTasks > 0 ? round1(strategicDeferrals / totalTasks * 100) : 0,
-            problematicRate: totalTasks > 0 ? round1(problematicDeferrals / totalTasks * 100) : 0,
+            // OMN-291 (D16): two independent screen counts. A deferral can be in
+            // both, or neither — they do NOT sum to totalDeferred, unlike the
+            // strategic/problematic split they replace.
+            over90Days: deferralsOver90Days,
+            keywordMatched: deferralsKeywordMatched,
+            over90DaysRate: totalTasks > 0 ? round1(deferralsOver90Days / totalTasks * 100) : 0,
+            keywordMatchedRate: totalTasks > 0 ? round1(deferralsKeywordMatched / totalTasks * 100) : 0,
             // True "Top 10": rank by deferral magnitude (longest defer first), not DB iteration order
             deferralDetails: deferredTaskDetails.slice().sort(function(a, b) { return b.deferDays - a.deferDays; }).slice(0, 10)
           };
@@ -845,19 +521,13 @@ export const WORKFLOW_ANALYSIS_V3 = `
             ? rawDataTaskCount - data.tasks.length
             : 0;
 
+          // OMN-291: insights and recommendations are gone from the payload.
           return JSON.stringify({
-            insights: insights,
             patterns: patterns,
-            recommendations: recommendations,
             data: includeRawData ? data : undefined,
             totalTasks: totalTasks,
             totalProjects: totalProjects,
-            dataPoints: maxTasksToProcess,
-            metadata: {
-              analysisDepth: analysisDepth,
-              focusAreas: focusAreas,
-              maxInsights: maxInsights
-            }
+            dataPoints: maxTasksToProcess
           });
         })()
       \`;
@@ -874,16 +544,13 @@ export const WORKFLOW_ANALYSIS_V3 = `
         ok: true,
         v: '3',
         data: {
-          insights: analysis.insights,
           patterns: analysis.patterns,
-          recommendations: analysis.recommendations,
           data: analysis.data,
           totalTasks: analysis.totalTasks,
           totalProjects: analysis.totalProjects,
           analysisTime: analysisTime,
           dataPoints: analysis.dataPoints,
           metadata: {
-            ...analysis.metadata,
             method: 'omnijs_v3_single_bridge',
             optimization: 'omnijs_v3',
             query_time_ms: analysisTime,

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -323,7 +323,9 @@ ANALYSIS TYPES:
   The judgment detectors (clarify_candidates, waiting_for, estimation_bias) run a heuristic
   SCREEN and return per-candidate evidence bundles (id, name, note head, placement, dates) —
   the screen does not judge; YOU judge each candidate from its evidence and act by id.
-- workflow_analysis: Deep workflow analysis
+- workflow_analysis: Workflow EVIDENCE — whole-DB counters, per-project counts/rates/avgAge, and
+  deferral facts (incl. two independent screen counts: over90Days, keywordMatched). It reports
+  measurements only; it does not score, rank, or recommend. YOU draw the conclusions.
 - recurring_tasks: Recurring task patterns and frequencies
 - parse_meeting_notes: Structure meeting action items into OmniFocus.
   PREFERRED: extract the action items YOURSELF, then pass params.items[] —
@@ -2177,22 +2179,19 @@ SCOPE FILTERING:
     const wfLogger = createLogger('workflow_analysis');
 
     try {
-      // OMN-200: 'full' — workflow_analysis always scans the entire task DB (the
-      // 1000-task cap and its unreachable 'deep' branch were removed). The label is
-      // informational only; it no longer gates any behavior.
-      const analysisDepth = 'full';
-      const focusAreas = ['productivity', 'workload', 'bottlenecks'];
-      const maxInsights = 15;
       const includeRawData = false;
 
-      wfLogger.info(`Starting workflow analysis with depth: ${analysisDepth}, focus: ${focusAreas.join(', ')}`);
+      wfLogger.info('Starting workflow analysis (whole-database evidence bundle)');
 
-      const cacheKey = `workflow_analysis_${analysisDepth}_${[...focusAreas].sort((a, b) => a.localeCompare(b)).join('_')}_${maxInsights}`;
+      // OMN-291: the old key was
+      // `workflow_analysis_full_bottlenecks_productivity_workload_15` — every
+      // component named machinery this ticket deletes. Version-bumped to v4 so
+      // entries written before the demote can never serve the old shape after
+      // deploy; the stale v3 entries simply age out by TTL.
+      const cacheKey = 'workflow_analysis_v4';
 
       const cached = this.cache.get<{
-        insights?: Array<string | { insight?: string; message?: string }>;
-        recommendations?: Array<string | { recommendation?: string; message?: string }>;
-        patterns?: unknown[];
+        patterns?: Record<string, unknown>;
         metadata?: Record<string, unknown>;
       }>('analytics', cacheKey);
       if (cached) {
@@ -2204,15 +2203,13 @@ SCOPE FILTERING:
           this.extractWorkflowKeyFindings(cached),
           {
             from_cache: true,
-            analysis_depth: analysisDepth,
-            focus_areas: focusAreas,
             ...timer.toMetadata(),
           },
         );
       }
 
       const script = this.omniAutomation.buildScript(WORKFLOW_ANALYSIS_V3, {
-        options: { analysisDepth, focusAreas, maxInsights, includeRawData },
+        options: { includeRawData },
       });
 
       const result = await this.execJson(script, WORKFLOW_ANALYSIS_V3_SCHEMA);
@@ -2242,15 +2239,14 @@ SCOPE FILTERING:
         );
       }
 
+      // OMN-291: `insights`, `recommendations`, and the analysis.depth/focusAreas
+      // echo are DELETED from the response — not emptied, absent. Tests assert
+      // absence, and the strict response schema rejects their reappearance.
       const responseData = {
         analysis: {
-          depth: analysisDepth,
-          focusAreas,
           timestamp: new Date().toISOString(),
         },
-        insights: v3Data.insights || [],
         patterns: v3Data.patterns || {},
-        recommendations: v3Data.recommendations || [],
         data: includeRawData ? v3Data.data : undefined,
         metadata: {
           totalTasks: v3Data.totalTasks || 0,
@@ -2267,8 +2263,6 @@ SCOPE FILTERING:
       const keyFindings = this.extractWorkflowKeyFindings(responseData);
 
       return createAnalyticsResponseV2('workflow_analysis', responseData, 'Workflow Analysis Results', keyFindings, {
-        analysis_depth: analysisDepth,
-        focus_areas: focusAreas,
         include_raw_data: includeRawData,
         ...timer.toMetadata(),
       });
@@ -2308,55 +2302,46 @@ SCOPE FILTERING:
     }
   }
 
+  /**
+   * OMN-291: mechanical restatements only.
+   *
+   * Was: the first 3 insights + first 2 recommendations (verdict prose the
+   * generators produced) + "Found N pattern categories in your workflow".
+   * Those generators are deleted, so key findings become at most three plain
+   * restatements of numbers the response already carries. No advice verbs, no
+   * grades, no priorities — the caller reads the evidence and judges.
+   */
   private extractWorkflowKeyFindings(data: {
-    insights?: Array<string | { category?: string; insight?: string; message?: string; priority?: string }>;
-    recommendations?: Array<
-      string | { category?: string; recommendation?: string; message?: string; priority?: string }
-    >;
     patterns?: unknown;
-    metadata?: { score?: number; totalTasks?: number; totalProjects?: number };
+    metadata?: { totalTasks?: number; totalProjects?: number };
   }): string[] {
     const findings: string[] = [];
 
-    if (data.insights && Array.isArray(data.insights)) {
+    const metrics = (data.patterns as { workflowMetrics?: Record<string, unknown> } | undefined)?.workflowMetrics;
+    const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
+
+    const total = data.metadata?.totalTasks ?? 0;
+    const availablePct = num(metrics?.availablePercentage);
+    const overduePct = num(metrics?.overduePercentage);
+    const blockedPct = num(metrics?.blockedPercentage);
+
+    if (total > 0 && availablePct !== undefined) {
+      findings.push(`${Math.round((availablePct / 100) * total)} of ${total} tasks available (${availablePct}%)`);
+    }
+
+    if (total > 0 && overduePct !== undefined) {
+      const overdueCount = Math.round((overduePct / 100) * total);
+      const deferral = (data.patterns as { deferralAnalysis?: { totalDeferred?: number } } | undefined)
+        ?.deferralAnalysis;
       findings.push(
-        ...(data.insights as unknown[]).slice(0, 3).map((i) => {
-          if (typeof i === 'string') return i;
-          if (typeof i === 'object' && i !== null) {
-            const insight =
-              (i as { insight?: string; message?: string }).insight ||
-              (i as { insight?: string; message?: string }).message;
-            return insight || JSON.stringify(i);
-          }
-          return JSON.stringify(i);
-        }),
+        deferral?.totalDeferred !== undefined
+          ? `${overdueCount} overdue (${overduePct}%), ${deferral.totalDeferred} deferred`
+          : `${overdueCount} overdue (${overduePct}%)`,
       );
     }
 
-    if (data.recommendations && Array.isArray(data.recommendations)) {
-      findings.push(
-        ...(data.recommendations as unknown[]).slice(0, 2).map((r) => {
-          if (typeof r === 'string') return r;
-          if (typeof r === 'object' && r !== null) {
-            const rec =
-              (r as { recommendation?: string; message?: string }).recommendation ||
-              (r as { recommendation?: string; message?: string }).message;
-            return rec || JSON.stringify(r);
-          }
-          return JSON.stringify(r);
-        }),
-      );
-    }
-
-    if (data.patterns && typeof data.patterns === 'object') {
-      const patternCount = Object.keys(data.patterns).length;
-      if (patternCount > 0) {
-        findings.push(`Found ${patternCount} pattern categories in your workflow`);
-      }
-    }
-
-    if (data.metadata?.totalTasks && data.metadata.totalTasks > 0) {
-      findings.push(`Analyzed ${data.metadata.totalTasks} tasks across ${data.metadata.totalProjects || 0} projects`);
+    if (total > 0 && blockedPct !== undefined) {
+      findings.push(`${Math.round((blockedPct / 100) * total)} blocked (${blockedPct}%)`);
     }
 
     return findings.length > 0 ? findings : ['Analysis completed successfully'];

--- a/tests/unit/omnifocus/script-response-schemas.test.ts
+++ b/tests/unit/omnifocus/script-response-schemas.test.ts
@@ -2432,24 +2432,19 @@ describe('WORKFLOW_ANALYSIS_V3_SCHEMA', () => {
   const minimalPayload = {
     ok: true,
     v: '3',
+    // OMN-291: the evidence-bundle shape. No insights, no recommendations, and
+    // no analysisDepth/focusAreas/maxInsights metadata echo.
     data: {
-      insights: [{ category: 'productivity', insight: '75% of tasks are ready', priority: 'medium' }],
       patterns: {
         workloadDistribution: { byProject: {}, byTag: {}, timeBuckets: {} },
         workflowMetrics: { availablePercentage: '75.0', overduePercentage: '5.0' },
-        deferralAnalysis: { totalDeferred: 10, strategicDeferrals: 8, problematicDeferrals: 2 },
+        deferralAnalysis: { totalDeferred: 10, over90Days: 2, keywordMatched: 8 },
       },
-      recommendations: [
-        { category: 'dependency_management', recommendation: 'Review blocked tasks', priority: 'high' },
-      ],
       totalTasks: 200,
       totalProjects: 15,
       analysisTime: 1200,
       dataPoints: 200,
       metadata: {
-        analysisDepth: 'full', // OMN-200: full-DB scan is the only mode now
-        focusAreas: ['productivity', 'workload'],
-        maxInsights: 15,
         method: 'omnijs_v3_single_bridge',
         optimization: 'omnijs_v3',
         query_time_ms: 1200,
@@ -2473,12 +2468,37 @@ describe('WORKFLOW_ANALYSIS_V3_SCHEMA', () => {
     expect(result.success).toBe(true);
   });
 
-  it('(b) rejects wrong-typed insight (priority not string)', () => {
+  // OMN-291: the demote is PINNED, not merely performed. A re-introduced
+  // insights/recommendations key is a schema VIOLATION, so a future change that
+  // quietly restores verdict prose fails here instead of shipping.
+  it('(b) rejects a re-introduced insights key (the demote is pinned)', () => {
     const result = WORKFLOW_ANALYSIS_V3_SCHEMA.safeParse({
       ...minimalPayload,
       data: {
         ...minimalPayload.data,
-        insights: [{ category: 'productivity', insight: 'x', priority: 5 }],
+        insights: [{ category: 'productivity', insight: 'x', priority: 'high' }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('(b) rejects a re-introduced recommendations key (the demote is pinned)', () => {
+    const result = WORKFLOW_ANALYSIS_V3_SCHEMA.safeParse({
+      ...minimalPayload,
+      data: {
+        ...minimalPayload.data,
+        recommendations: [{ category: 'x', recommendation: 'y', priority: 'high' }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('(b) rejects the old analysisDepth/focusAreas/maxInsights metadata echo', () => {
+    const result = WORKFLOW_ANALYSIS_V3_SCHEMA.safeParse({
+      ...minimalPayload,
+      data: {
+        ...minimalPayload.data,
+        metadata: { ...minimalPayload.data.metadata, analysisDepth: 'full' },
       },
     });
     expect(result.success).toBe(false);

--- a/tests/unit/omnifocus/scripts/analytics/workflow-deferral-screens.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/workflow-deferral-screens.test.ts
@@ -1,0 +1,149 @@
+// OMN-291 (D16) — the strategic/problematic deferral VERDICT split is replaced by
+// two INDEPENDENT, honestly-named screen counts.
+//
+// The old rule was `isStrategic = deferDays <= 90 || nameMatchesKeyword`, and
+// every deferral was then labelled strategic (good) or problematic (bad). Two
+// separate dishonesties: it concluded rather than measured, and it made the two
+// signals mutually exclusive when they are orthogonal.
+//
+// Now: `over90Days` counts how far the deferral reaches, `keywordMatched` counts
+// recall-screen hits, and a deferral can be in both, one, or neither. They do NOT
+// sum to totalDeferred — this file pins exactly that.
+import { describe, it, expect } from 'vitest';
+import { WORKFLOW_ANALYSIS_V3 } from '../../../../../src/omnifocus/scripts/analytics/workflow-analysis-v3.js';
+import { WORKFLOW_ANALYSIS_V3_SCHEMA } from '../../../../../src/omnifocus/response-schemas/analyze.js';
+import { runAnalyticsScript, FAKE_TASK_STATUS } from './run-analytics-script.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface FakeTask {
+  completed: boolean;
+  flagged: boolean;
+  taskStatus: unknown;
+  dueDate: Date | null;
+  deferDate: Date | null;
+  added: Date | null;
+  modified: Date | null;
+  estimatedMinutes: number;
+  inInbox: boolean;
+  containingProject: { name: string } | null;
+  tags: Array<{ name: string }>;
+  name: string;
+  id: { primaryKey: string };
+}
+
+function deferredTask(name: string, deferInDays: number, id: string): FakeTask {
+  return {
+    completed: false,
+    flagged: false,
+    taskStatus: FAKE_TASK_STATUS.Available,
+    dueDate: null,
+    deferDate: new Date(Date.now() + deferInDays * DAY),
+    added: new Date(Date.now() - DAY),
+    modified: null,
+    estimatedMinutes: 0,
+    inInbox: false,
+    containingProject: { name: 'P' },
+    tags: [],
+    name,
+    id: { primaryKey: id },
+  };
+}
+
+interface Parsed {
+  ok: boolean;
+  data: {
+    patterns: {
+      deferralAnalysis: {
+        totalDeferred: number;
+        over90Days: number;
+        keywordMatched: number;
+        deferralDetails: Array<{ name: string; deferDays: number; keywordMatched: boolean }>;
+      };
+      workloadDistribution: {
+        byProject: Record<string, { deferrals: { total: number; over90Days: number; keywordMatched: number } }>;
+      };
+    };
+  };
+}
+
+function runScript(tasks: FakeTask[]): Parsed {
+  return runAnalyticsScript(
+    WORKFLOW_ANALYSIS_V3,
+    { includeRawData: false },
+    { flattenedTasks: tasks, flattenedProjects: [{ name: 'P' }] },
+  ) as Parsed;
+}
+
+describe('OMN-291 (D16) — deferral screens are independent counts, not a verdict split', () => {
+  // One task per quadrant of (over90Days x keywordMatched), plus a second
+  // "neither" so the arithmetic below is a real property and not a coincidence
+  // of a 4-task fixture where 2 + 2 happens to equal the total.
+  const tasks = [
+    deferredTask('Renewal of domain', 200, 'both'), // keyword AND >90d
+    deferredTask('Quiet long defer', 200, 'longOnly'), // >90d only
+    deferredTask('Annual checkup', 10, 'kwOnly'), // keyword only
+    deferredTask('Ordinary short defer', 10, 'neither1'), // neither
+    deferredTask('Another plain defer', 5, 'neither2'), // neither
+  ];
+
+  it('counts both dimensions independently — a deferral can match both or neither', () => {
+    const parsed = runScript(tasks);
+    expect(parsed.ok).toBe(true);
+    expect(WORKFLOW_ANALYSIS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
+
+    const d = parsed.data.patterns.deferralAnalysis;
+    expect(d.totalDeferred).toBe(5);
+    expect(d.over90Days).toBe(2); // 'both' + 'longOnly'
+    expect(d.keywordMatched).toBe(2); // 'both' + 'kwOnly'
+
+    // The decisive property: the screens OVERLAP (one task is in both) and leave
+    // a REMAINDER (two tasks are in neither), so they cannot be a partition the
+    // way strategic/problematic claimed to be. Under the old rule all 5 would
+    // have been forced into exactly one of two buckets summing to 5.
+    expect(d.over90Days + d.keywordMatched).toBeLessThan(d.totalDeferred);
+  });
+
+  it('the quadrants are directly observable in the per-task detail rows', () => {
+    const details = runScript(tasks).data.patterns.deferralAnalysis.deferralDetails;
+    const byName = Object.fromEntries(details.map((r) => [r.name, r]));
+
+    // both
+    expect(byName['Renewal of domain'].keywordMatched).toBe(true);
+    expect(byName['Renewal of domain'].deferDays).toBeGreaterThan(90);
+    // >90d only
+    expect(byName['Quiet long defer'].keywordMatched).toBe(false);
+    expect(byName['Quiet long defer'].deferDays).toBeGreaterThan(90);
+    // keyword only
+    expect(byName['Annual checkup'].keywordMatched).toBe(true);
+    expect(byName['Annual checkup'].deferDays).toBeLessThanOrEqual(90);
+    // neither
+    expect(byName['Ordinary short defer'].keywordMatched).toBe(false);
+    expect(byName['Ordinary short defer'].deferDays).toBeLessThanOrEqual(90);
+  });
+
+  it('per-project rows carry the same two screen counts', () => {
+    const row = runScript(tasks).data.patterns.workloadDistribution.byProject['P'];
+    expect(row.deferrals).toEqual({ total: 5, over90Days: 2, keywordMatched: 2 });
+  });
+
+  it('per-task detail rows carry keywordMatched as a candidate marker, never a verdict', () => {
+    const details = runScript(tasks).data.patterns.deferralAnalysis.deferralDetails;
+    const byName = Object.fromEntries(details.map((r) => [r.name, r]));
+
+    expect(byName['Renewal of domain'].keywordMatched).toBe(true);
+    expect(byName['Annual checkup'].keywordMatched).toBe(true);
+    expect(byName['Quiet long defer'].keywordMatched).toBe(false);
+    expect(byName['Ordinary short defer'].keywordMatched).toBe(false);
+
+    // The old verdict field is gone.
+    for (const row of details) {
+      expect(row).not.toHaveProperty('isStrategic');
+    }
+  });
+
+  it('the 90-day boundary is exclusive (>90, not >=90)', () => {
+    expect(runScript([deferredTask('x', 90, 'a')]).data.patterns.deferralAnalysis.over90Days).toBe(0);
+    expect(runScript([deferredTask('x', 91, 'a')]).data.patterns.deferralAnalysis.over90Days).toBe(1);
+  });
+});

--- a/tests/unit/omnifocus/scripts/analytics/workflow-deferral-screens.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/workflow-deferral-screens.test.ts
@@ -32,13 +32,22 @@ interface FakeTask {
   id: { primaryKey: string };
 }
 
+// The script recomputes `nowTime` when it runs, which is strictly AFTER this
+// helper reads Date.now(). A bare `Date.now() + deferInDays * DAY` therefore
+// arrives as `deferInDays * DAY - ε`, and the script's
+// `Math.floor((deferDate - nowTime) / DAY)` yields deferInDays - 1. Invisible
+// for the 200/10/5 fixtures, fatal exactly on the 90/91 boundary case.
+// The cushion makes the helper's contract exact: the script floors to
+// deferInDays for any start delay under a minute.
+const CLOCK_SKEW_CUSHION = 60 * 1000;
+
 function deferredTask(name: string, deferInDays: number, id: string): FakeTask {
   return {
     completed: false,
     flagged: false,
     taskStatus: FAKE_TASK_STATUS.Available,
     dueDate: null,
-    deferDate: new Date(Date.now() + deferInDays * DAY),
+    deferDate: new Date(Date.now() + deferInDays * DAY + CLOCK_SKEW_CUSHION),
     added: new Date(Date.now() - DAY),
     modified: null,
     estimatedMinutes: 0,

--- a/tests/unit/omnifocus/scripts/analytics/workflow-root-skip.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/workflow-root-skip.test.ts
@@ -58,15 +58,14 @@ function runScript(tasks: FakeTask[]): {
   data: {
     totalTasks: number;
     patterns: {
-      workloadDistribution: { byProject: Record<string, { totalTasks: number }> };
+      // OMN-291: the byProject row's task count is `total` now (mechanical row).
+      workloadDistribution: { byProject: Record<string, { total: number }> };
       workflowMetrics: { availablePercentage: number };
     };
   };
 } {
+  // OMN-291: analysisDepth/focusAreas/maxInsights are gone with the generators.
   const options = {
-    analysisDepth: 'full',
-    focusAreas: ['productivity', 'workload', 'bottlenecks'],
-    maxInsights: 15,
     includeRawData: false,
   };
   return runAnalyticsScript(WORKFLOW_ANALYSIS_V3, options, { flattenedTasks: tasks }) as ReturnType<typeof runScript>;
@@ -83,7 +82,7 @@ describe('OMN-270 — workflow_analysis skips project root tasks in task-level m
 
     // Pre-fix: the root was processed as a task → per-project total 3 and
     // availablePercentage 66.7 (root + available leaf, over 3).
-    expect(parsed.data.patterns.workloadDistribution.byProject['P'].totalTasks).toBe(2);
+    expect(parsed.data.patterns.workloadDistribution.byProject['P'].total).toBe(2);
     // /code-review of this PR (round 1): the denominator must move WITH the
     // numerators — skipping roots only in the counters while totalTasks kept
     // counting them understated every workflowMetrics percentage (the OMN-200

--- a/tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
+++ b/tests/unit/omnifocus/scripts/analytics/workflow-taskage.test.ts
@@ -48,12 +48,10 @@ function makeLeafTask(overrides: Partial<FakeTask>): FakeTask {
 
 function runScript(tasks: FakeTask[]): {
   ok: boolean;
-  data: { patterns: { workloadDistribution: { byProject: Record<string, { healthScore: number }> } } };
+  data: { patterns: { workloadDistribution: { byProject: Record<string, { avgAge: number }> } } };
 } {
+  // OMN-291: analysisDepth/focusAreas/maxInsights are gone with the generators.
   const options = {
-    analysisDepth: 'full',
-    focusAreas: ['productivity', 'workload', 'bottlenecks'],
-    maxInsights: 15,
     includeRawData: false,
   };
   return runAnalyticsScript(WORKFLOW_ANALYSIS_V3, options, {
@@ -65,23 +63,27 @@ function runScript(tasks: FakeTask[]): {
   }) as ReturnType<typeof runScript>;
 }
 
+// OMN-291 migration: these pins previously asserted a healthScore DELTA
+// (100 → 85, i.e. "the avgAge>120 penalty fired"). healthScore is deleted, so
+// they now assert the underlying FACT that delta was only ever evidence of —
+// the raw avgAge on the byProject row. Same defect coverage: if taskAge went
+// back to reading the JXA-only names, avgAge would read 0 and these fail.
 describe('OMN-251 — taskAge reads the real OmniJS date properties', () => {
-  it('a 200-day-old task (via `added`) finally triggers the avgAge>120 health penalty', () => {
+  it('a 200-day-old task (via `added`) is reflected in the project avgAge', () => {
     const parsed = runScript([makeLeafTask({ added: new Date(Date.now() - 200 * DAY) })]);
     expect(parsed.ok).toBe(true);
     expect(WORKFLOW_ANALYSIS_V3_SCHEMA.safeParse(parsed).success).toBe(true);
-    // Otherwise-healthy project: 100 minus ONLY the stale-age penalty (15).
-    // Pre-fix the read was undefined → taskAge 0 → healthScore stayed 100.
-    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].healthScore).toBe(85);
+    // Pre-fix the read was undefined → taskAge 0 → avgAge 0.
+    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].avgAge).toBe(200);
   });
 
   it('falls back to `modified` when `added` is absent (the || fallback, real names)', () => {
     const parsed = runScript([makeLeafTask({ modified: new Date(Date.now() - 200 * DAY) })]);
-    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].healthScore).toBe(85);
+    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].avgAge).toBe(200);
   });
 
-  it('a fresh task keeps the project unpenalized (no age → no penalty)', () => {
+  it('a fresh task reports a small avgAge, not a stale one', () => {
     const parsed = runScript([makeLeafTask({ added: new Date(Date.now() - 3 * DAY) })]);
-    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].healthScore).toBe(100);
+    expect(parsed.data.patterns.workloadDistribution.byProject['Aged Project'].avgAge).toBe(3);
   });
 });

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -637,7 +637,7 @@ describe('OmniFocusAnalyzeTool', () => {
   // ==========================================================================
   describe('workflow_analysis', () => {
     it('returns cached results when available', async () => {
-      const cached = { insights: [{ insight: 'Cache' }], recommendations: [], patterns: {} };
+      const cached = { patterns: {}, metadata: { totalTasks: 0 } };
       mockCache.get.mockReturnValue(cached);
 
       const res: any = await tool.execute({
@@ -659,22 +659,26 @@ describe('OmniFocusAnalyzeTool', () => {
       expect(res.error?.code).toBe('ANALYSIS_FAILED');
     });
 
-    it('returns analytics response with key findings', async () => {
+    // OMN-291: workflow_analysis is an evidence bundle. The response carries
+    // measurements only — insights/recommendations/data and the analysis.depth +
+    // focusAreas echo are ABSENT (asserted as absence, not as empty).
+    it('returns an evidence bundle with mechanical key findings only', async () => {
       mockCache.get.mockReturnValue(null);
       mockOmni.buildScript.mockReturnValue('script');
-      // OMN-139: executeJson returns ScriptResult; wrap V3 envelope
       mockOmni.executeJson.mockResolvedValue(
         createScriptSuccess({
           ok: true,
           v: '3',
           data: {
-            insights: [{ insight: 'Focus on review cadence' }, { message: 'Reduce WIP' }],
-            patterns: { bottlenecks: 3, projects: 2 },
-            recommendations: [{ recommendation: 'Batch similar tasks' }],
-            totalTasks: 123,
+            patterns: {
+              workloadDistribution: { byProject: {}, byTag: {}, timeBuckets: {} },
+              workflowMetrics: { availablePercentage: 50, overduePercentage: 10, blockedPercentage: 5 },
+              deferralAnalysis: { totalDeferred: 7, over90Days: 2, keywordMatched: 3 },
+            },
+            totalTasks: 200,
             totalProjects: 12,
             analysisTime: 250,
-            dataPoints: 4000,
+            dataPoints: 200,
           },
         }),
       );
@@ -683,10 +687,67 @@ describe('OmniFocusAnalyzeTool', () => {
         analysis: { type: 'workflow_analysis' },
       });
       expect(res.success).toBe(true);
-      // OMN-200: depth is now reported as 'full' — the analysis always scans the
-      // entire task DB (the 1000-cap + its dead 'deep' escape hatch were removed).
-      expect(res.data.analysis.depth).toBe('full');
-      expect(Array.isArray(res.summary.key_findings)).toBe(true);
+
+      // Verdict surfaces are gone, not emptied.
+      expect(res.data).not.toHaveProperty('insights');
+      expect(res.data).not.toHaveProperty('recommendations');
+      expect(res.data.analysis).not.toHaveProperty('depth');
+      expect(res.data.analysis).not.toHaveProperty('focusAreas');
+
+      // Key findings are <=3 mechanical restatements of numbers already present.
+      const findings: string[] = res.summary.key_findings;
+      expect(findings.length).toBeLessThanOrEqual(3);
+      expect(findings).toEqual(
+        expect.arrayContaining(['100 of 200 tasks available (50%)', '20 overdue (10%), 7 deferred', '10 blocked (5%)']),
+      );
+      // No advice verbs or grades anywhere in the findings.
+      expect(findings.some((f) => /consider|should|review |recommend|excellent|health/i.test(f))).toBe(false);
+    });
+
+    it('does not leak per-project healthScore/momentumScore anywhere in the response', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: {
+            patterns: {
+              workloadDistribution: {
+                byProject: {
+                  P: {
+                    total: 4,
+                    completed: 1,
+                    available: 2,
+                    overdue: 1,
+                    blocked: 0,
+                    estimatedHours: 3,
+                    overdueRate: 25,
+                    availableRate: 50,
+                    avgAge: 12,
+                    deferrals: { total: 1, over90Days: 1, keywordMatched: 0 },
+                  },
+                },
+                byTag: {},
+                timeBuckets: {},
+              },
+              workflowMetrics: { availablePercentage: 50, overduePercentage: 25, blockedPercentage: 0 },
+              deferralAnalysis: { totalDeferred: 1, over90Days: 1, keywordMatched: 0 },
+            },
+            totalTasks: 4,
+            totalProjects: 1,
+            analysisTime: 10,
+            dataPoints: 4,
+          },
+        }),
+      );
+
+      const res: any = await tool.execute({ analysis: { type: 'workflow_analysis' } });
+      const raw = JSON.stringify(res);
+      expect(raw).not.toMatch(/healthScore/);
+      expect(raw).not.toMatch(/momentumScore/);
+      expect(raw).not.toMatch(/strategicDefer/);
+      expect(raw).not.toMatch(/problematicDefer/);
     });
 
     it('extractKeyFindings falls back to default message', async () => {


### PR DESCRIPTION
## What

`workflow_analysis` screens and counts; it no longer scores, ranks, or recommends. Per **OMN-258's contract** the server produces evidence and the caller judges — this ticket extends that from prose to **numeric weight-composites**, on the grounds that a score is a verdict whose weights encode what matters and by how much.

Net: **−563 / +289** lines.

## What leaves

| Surface | Why |
|---|---|
| `insights[]` / `recommendations[]` | Verdict prose with priority labels the caller never chose. Includes the invented "N × 1.5 dependent tasks" multiplier (D21). |
| per-project `healthScore` | 100 minus a hand-tuned stack (overdue 25, blocked 20, stale-age 15, problematic-deferral 15, low-available 10, +5 bonus). Every component survives as a separate fact. |
| per-project `momentumScore` | D19. It **subtracted** `availableRate` — a project with more available work scored *lower* momentum, contradicting its own prose. Deleting makes the direction bug historical rather than something to fix. |
| healthy/unhealthy rollups, `avgProjectHealth`, `avgMomentum` | Score-derived. |
| `analysisDepth` / `focusAreas` / `maxInsights` + `insights.splice` cap | Nothing left to gate or cap. Three focus-area branches (`project_health`, `time_patterns`, `opportunities`) could never fire — the handler only ever passed the other three (D20). |

## What stays — the evidence bundle

Whole-DB counters, `workflowMetrics` percentages, `timeBuckets`, per-tag stats, and per-project rows that are purely mechanical:

```
{ total, completed, available, overdue, blocked, estimatedHours,
  overdueRate, availableRate, avgAge,
  deferrals: { total, over90Days, keywordMatched } }
```

`avgAge` is a mean of day-ages (live since OMN-251) — a fact. The caller applies any staleness threshold.

## Deferral honesty (D16) — the subtlest change

The old rule was `isStrategic = deferDays <= 90 || nameMatchesKeyword`, then every deferral was labelled **strategic** (good) or **problematic** (bad). Two separate dishonesties: it *concluded* rather than measured, and it made two **orthogonal** signals mutually exclusive.

Now `over90Days` and `keywordMatched` are counted independently. A deferral can be in both, one, or neither, and **they do not sum to `totalDeferred`** — `workflow-deferral-screens.test.ts` pins exactly that with one task per quadrant.

The keyword list survives as **one shared const explicitly labelled a recall screen** — derived from a single personal database and English-only, so a hit means "worth a look", never "this is strategic". Per-task rows carry `keywordMatched` as a candidate marker per OMN-258's screens-as-candidates convention.

## Tool layer

- **Key findings** → ≤3 mechanical restatements of numbers already in the response (`N of M tasks available (X%)`, `N overdue (X%), M deferred`, `N blocked (X%)`). No advice verbs, no grades — asserted by a regex sweep.
- **Response**: `insights` / `recommendations` / `data` and the `analysis.depth` + `focusAreas` echo are **absent**, asserted as absence rather than emptiness.
- **Cache key** → `workflow_analysis_v4`. The old key was literally `workflow_analysis_full_bottlenecks_productivity_workload_15` — every component named deleted machinery. Version-bumped so stale pre-demote entries can't serve the old shape after deploy.
- **Response schema** rewritten `.strict()`: a re-introduced `insights`/`recommendations` key is a **validation failure**. The removal is pinned, not merely performed.

## ⚠️ Preserved verbatim: the OMN-290 root-row check

`workflow-analysis-v3.ts` uses a bare `task.project` check and **must not** be consolidated onto the shared `isProjectRootRow()` predicate, even though the three sibling analytics scripts do. The shared predicate fails **OPEN**; this file's per-task try/catch has always failed **CLOSED**. `/code-review` caught that exact regression **twice** during PR #248.

This PR rewrites ~200 lines of this very file, so it was the obvious place to slip. **Verified unchanged** — `git diff origin/main` shows zero `+`/`-` lines touching `task.project` or `isProjectRootRow`.

## Test migration

OMN-251's `taskAge` pin moved from a **healthScore delta** (100 → 85, "the avgAge>120 penalty fired") to asserting the **raw `avgAge`** on the byProject row — the underlying fact the old pin was only ever evidence of. Same defect coverage: if `taskAge` regressed to the JXA-only property names, `avgAge` would read 0 and the test fails.

## Vertical Contract Matrix

| # | Layer | Disposition |
|---|---|---|
| 1 | Schema (both) | Zod **input** unchanged (`params: {}`); tool **description** rewritten to evidence language (dual-schema rule covers the description) |
| 2 | Normalization | **N/A** — input surface unchanged |
| 3 | Single-item path | ✅ script + reshape rewrite |
| 4 | Batch path | **N/A** |
| 5 | Script lowering | **N/A** — legacy analytics script, stays legacy by design |
| 6 | Live bridge | ⏳ **owed post-merge** (see below) |
| 7 | Response validation | ✅ strict schema rewrite; projection N/A |
| 8 | Cache key | ✅ version-bumped `workflow_analysis_v4` |

## Verification

- `npm run build` ✅ · `npm run typecheck` ✅
- `npm run lint` (`--max-warnings=0`) ✅
- `npm run test:unit` ✅ **3919 passed / 184 files**
- `grep -rn 'console\.log' src/` → only the known `utils/cli.ts` `--help` printer ✅

**Live `/verify` owed after merge + redeploy** (layer 6):
1. `workflow_analysis` → `patterns.byProject` rows carry the mechanical fields; grep raw JSON for `insights` / `recommendations` / `healthScore` / `momentumScore` → **zero hits**
2. A real stale project shows a plausible nonzero `avgAge`
3. Version probe `buildId` + `stale:false`; first post-deploy call misses cache (new key), then caches

## Sizing honesty

The spec flagged this as the wave's largest slice and expected multiple review rounds. Reviewing the script diff whole rather than hunk-by-hunk will read more easily — most of it is contiguous deletion.

Spec: `Technical/specs/OMN-291-workflow-demote.md` (§8 addendum records the root-check hazard).

Closes OMN-291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mBfHxX9RXQxU4ZPSACQVF