### PR TITLE
feat(OMN-289): surface computed fields, delete fabricated placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **BREAKING (analyze response): `task_velocity` drops four fabricated fields and gains four real ones;
+  `productivity_stats` surfaces three computed fields it was discarding** (OMN-289) — the response now contains exactly
+  what was actually computed: nothing real hidden, nothing fake shipped. **Added to `velocity`:** `averageCreated`,
+  `backlogGrowthRate` (negative means a shrinking backlog), `medianCompletionHours`, `tasksAnalyzed` — all four were
+  computed by the script and discarded by the tool-layer reshape. Parsed from the script's `toFixed` strings to numbers,
+  matching the existing `averagePerDay`/ `predictedCapacity` convention. **Added to `stats.overview`:**
+  `completedInPeriod`, `dailyAverage`, `daysInPeriod` (same silent-omission class as the OMN-254 `availableTasks`
+  rescue). **Removed:** `velocity.peakDay` (always `{date:null,count:0}`), `velocity.trend` (always `'stable'`), the
+  `patterns` block (always three empty containers), and `insights` (always `[]`). Every one was a hardcoded constant
+  that advertised analysis which did not exist — the OMN-273 acceptable-break class, since no client can have derived
+  value from a field that only ever held one constant. The dead code riding on them goes too: the peak-day and
+  most-productive-day collectors (whose guards could never pass), the top-project collector, and the
+  `increasing`/`decreasing` trend labels (only the `'stable'` fallback was reachable). The velocity cache key is
+  version-bumped (`velocity_v2_*` → `velocity_v3_*`) because that cache stores the reshaped response object, so stale
+  entries would otherwise serve the old shape until TTL expiry after deploy.
+
 - **BREAKING (read-response value): `omnifocus_read` project status is now `"onHold"`, was `"on-hold"`** (OMN-274) —
   script-builder's three inline Project.Status maps (filtered projects, project-by-id, folder listing's project rows)
   now splice the canonical `PROJECT_STATUS_STRING_SNIPPET`, converging the read path on the OMN-272 wire vocabulary

--- a/src/tools/unified/OmniFocusAnalyzeTool.ts
+++ b/src/tools/unified/OmniFocusAnalyzeTool.ts
@@ -581,6 +581,10 @@ SCOPE FILTERING:
       completionRate: number;
       activeProjects: number;
       overdueCount: number;
+      // OMN-289 (D7): computed by the script's summary, previously dropped here.
+      completedInPeriod: number;
+      dailyAverage: number;
+      daysInPeriod: number;
     };
     projectStatsArray: Array<{ name: string; completedCount: number }> | Record<string, unknown>;
     tagStatsArray: Record<string, unknown>;
@@ -593,6 +597,9 @@ SCOPE FILTERING:
       completionRate?: number;
       activeProjects?: number;
       overdueCount?: number;
+      completedInPeriod?: number;
+      dailyAverage?: number;
+      daysInPeriod?: number;
     }
     interface ScriptData {
       summary?: ScriptOverview;
@@ -618,6 +625,9 @@ SCOPE FILTERING:
       completionRate: 0,
       activeProjects: 0,
       overdueCount: 0,
+      completedInPeriod: 0,
+      dailyAverage: 0,
+      daysInPeriod: 0,
     };
     if (!actualData || typeof actualData !== 'object' || !('summary' in actualData)) {
       return { overview: empty, projectStatsArray: [], tagStatsArray: {}, insights: [] };
@@ -636,6 +646,12 @@ SCOPE FILTERING:
         completionRate: summary.completionRate || 0,
         activeProjects: summary.activeProjects || 0,
         overdueCount: summary.overdueCount || 0,
+        // OMN-289 (D7): the script computed all three and the reshape dropped
+        // them — the same silent-omission class as the OMN-254 availableTasks
+        // rescue directly above, whose `|| 0` guard style this mirrors.
+        completedInPeriod: summary.completedInPeriod || 0,
+        dailyAverage: summary.dailyAverage || 0,
+        daysInPeriod: summary.daysInPeriod || 0,
       },
       projectStatsArray: includeProjectStats ? typedScriptData.projectStats || [] : [],
       tagStatsArray: includeTagStats ? typedScriptData.tagStats || {} : {},
@@ -733,12 +749,15 @@ SCOPE FILTERING:
         rangeEnd = now.toISOString().split('T')[0];
       }
 
-      const cacheKey = `velocity_v2_${rangeStart}_${rangeEnd}_${groupBy}_${includeWeekends}`;
+      // OMN-289: version-bumped v2 -> v3. This cache stores the RESHAPED response
+      // object (see `cache.set(..., responseData)` below), NOT the script envelope,
+      // so entries written before this change would keep serving the old shape —
+      // peakDay/trend/patterns/insights present, the four real numbers missing —
+      // until TTL expiry after deploy. Same class as OMN-292's productivity bump.
+      const cacheKey = `velocity_v3_${rangeStart}_${rangeEnd}_${groupBy}_${includeWeekends}`;
 
       const cached = this.cache.get<{
         velocity?: { period?: string; tasksCompleted?: number; averagePerDay?: number };
-        patterns?: unknown;
-        insights?: string[];
       }>('analytics', cacheKey);
       if (cached) {
         this.logger.debug('Returning cached task velocity');
@@ -782,22 +801,34 @@ SCOPE FILTERING:
       const averagePerDay = parseFloat(scriptData?.velocity?.dailyVelocity || '0');
       const predictedCapacity = parseFloat(scriptData?.projections?.tasksPerWeek || '0');
 
-      const peak = { date: null, count: 0 };
-      const trend = 'stable' as const;
       const daily = scriptData?.throughput?.intervals || [];
+
+      // OMN-289 (D10): the script emits these as toFixed strings; the tool layer
+      // parses them to numbers, matching the averagePerDay/predictedCapacity
+      // convention directly above. All four were computed and then discarded.
+      const averageCreated = parseFloat(scriptData?.velocity?.averageCreated || '0');
+      const backlogGrowthRate = parseFloat(scriptData?.velocity?.backlogGrowthRate || '0');
+      const medianCompletionHours = parseFloat(scriptData?.breakdown?.medianCompletionHours || '0');
 
       const responseData = {
         velocity: {
           period: groupBy,
           tasksCompleted,
           averagePerDay: typeof averagePerDay === 'number' ? averagePerDay : Number(averagePerDay) || 0,
-          peakDay: peak,
-          trend,
           predictedCapacity: typeof predictedCapacity === 'number' ? predictedCapacity : Number(predictedCapacity) || 0,
+          averageCreated,
+          // Negative means the backlog is shrinking — completed outpaces created.
+          backlogGrowthRate,
+          medianCompletionHours,
+          tasksAnalyzed: scriptData?.breakdown?.tasksAnalyzed ?? 0,
         },
         daily,
-        patterns: { byDayOfWeek: {}, byTimeOfDay: {}, byProject: [] },
-        insights: [],
+        // OMN-289 (D10): `peakDay` ({date:null,count:0}), `trend` ('stable'),
+        // `patterns` (three empty containers) and `insights` ([]) are DELETED.
+        // Every one was a hardcoded constant — never computed from anything — so
+        // they advertised analysis that did not exist. This is the OMN-273
+        // acceptable-break class: no client can have derived value from a field
+        // that only ever held the same constant.
       };
 
       this.cache.set('analytics', cacheKey, responseData);
@@ -825,20 +856,28 @@ SCOPE FILTERING:
     }
   }
 
+  /**
+   * OMN-289 (D10): trimmed to findings that can actually fire.
+   *
+   * Removed with the fabricated fields they read:
+   * - collectPeakDayFinding — `peakDay` was the constant {date:null,count:0},
+   *   so the `peakDay?.date &&` guard could never pass.
+   * - collectMostProductiveDayFinding — `patterns.byDayOfWeek` was always {},
+   *   so `days.length > 0` could never pass.
+   * - collectTopProjectFinding — `patterns.byProject` was always [], same.
+   * - The TREND_LABELS map's increasing/decreasing entries — `trend` was
+   *   hardcoded 'stable', so only the 'Velocity stable' fallback was reachable.
+   *   With trend deleted there is no trend claim to make at all.
+   * - The `insights[0]` push — velocity's insights array was always [].
+   */
   private extractVelocityKeyFindings(data: {
     velocity?: {
       period?: string;
       tasksCompleted?: number;
       averagePerDay?: number;
-      peakDay?: { date: string | null; count: number };
-      trend?: string;
       predictedCapacity?: number;
+      backlogGrowthRate?: number;
     };
-    patterns?: {
-      byDayOfWeek?: Record<string, number>;
-      byProject?: Array<{ name: string; completed: number }>;
-    };
-    insights?: string[];
   }): string[] {
     const findings: string[] = [];
 
@@ -846,77 +885,26 @@ SCOPE FILTERING:
       this.collectVelocityFindings(data.velocity, findings);
     }
 
-    this.collectPeakDayFinding(data.velocity?.peakDay, findings);
-    this.collectMostProductiveDayFinding(data.patterns?.byDayOfWeek, findings);
-    this.collectTopProjectFinding(data.patterns?.byProject, findings);
-
-    if (data.insights && Array.isArray(data.insights) && data.insights.length > 0) {
-      findings.push(data.insights[0]);
-    }
-
     return findings.length > 0 ? findings : ['No velocity data available for this period'];
   }
-
-  private static readonly TREND_LABELS: Record<string, string> = {
-    increasing: 'Velocity trending upward',
-    decreasing: 'Velocity trending downward',
-  };
 
   private collectVelocityFindings(
     velocity: {
       tasksCompleted?: number;
       averagePerDay?: number;
-      trend?: string;
       predictedCapacity?: number;
     },
     findings: string[],
   ): void {
-    const { tasksCompleted, averagePerDay, trend, predictedCapacity } = velocity;
+    const { tasksCompleted, averagePerDay, predictedCapacity } = velocity;
 
     if (tasksCompleted && tasksCompleted > 0) {
       const avgPerDay = averagePerDay || 0;
       findings.push(`Completed ${tasksCompleted} tasks (avg ${avgPerDay.toFixed(1)}/day)`);
     }
 
-    findings.push(OmniFocusAnalyzeTool.TREND_LABELS[trend ?? ''] ?? 'Velocity stable');
-
     if (predictedCapacity && predictedCapacity > 0) {
       findings.push(`Predicted capacity: ${Math.round(predictedCapacity)} tasks/week`);
-    }
-  }
-
-  private collectPeakDayFinding(peakDay: { date: string | null; count: number } | undefined, findings: string[]): void {
-    if (peakDay?.date && peakDay.count > 0) {
-      findings.push(`Peak day: ${peakDay.date} (${peakDay.count} tasks)`);
-    }
-  }
-
-  private collectMostProductiveDayFinding(byDayOfWeek: Record<string, number> | undefined, findings: string[]): void {
-    if (!byDayOfWeek) return;
-
-    const days = Object.entries(byDayOfWeek).sort((a, b) => {
-      const aVal = typeof a[1] === 'number' ? a[1] : 0;
-      const bVal = typeof b[1] === 'number' ? b[1] : 0;
-      return bVal - aVal;
-    });
-
-    if (days.length > 0) {
-      const dayCount = typeof days[0][1] === 'number' ? days[0][1] : 0;
-      if (dayCount > 0) {
-        findings.push(`Most productive: ${days[0][0]}s`);
-      }
-    }
-  }
-
-  private collectTopProjectFinding(
-    byProject: Array<{ name: string; completed: number }> | undefined,
-    findings: string[],
-  ): void {
-    if (!Array.isArray(byProject) || byProject.length === 0) return;
-
-    const topProject = byProject[0];
-    if (topProject && topProject.completed > 0) {
-      findings.push(`Fastest moving project: ${topProject.name}`);
     }
   }
 

--- a/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
+++ b/tests/unit/tools/unified/OmniFocusAnalyzeTool.test.ts
@@ -310,6 +310,103 @@ describe('OmniFocusAnalyzeTool', () => {
   // ==========================================================================
   // Task Velocity
   // ==========================================================================
+  // ==========================================================================
+  // OMN-289 (OMN-148 D7/D10): the response contains exactly what was actually
+  // computed — nothing real hidden, nothing fabricated shipped.
+  // ==========================================================================
+  describe('OMN-289 response completeness', () => {
+    it('productivity overview surfaces the period fields the script already computed', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue({
+        summary: {
+          totalTasks: 200,
+          completedTasks: 150,
+          availableTasks: 30,
+          completionRate: 0.75,
+          activeProjects: 12,
+          overdueCount: 5,
+          completedInPeriod: 42,
+          dailyAverage: 6,
+          daysInPeriod: 7,
+        },
+        insights: [],
+      });
+
+      const res: any = await tool.execute({ analysis: { type: 'productivity_stats' } });
+
+      expect(res.success).toBe(true);
+      const overview = res.data.stats.overview;
+      // Computed by the script, dropped by the reshape until now.
+      expect(overview.completedInPeriod).toBe(42);
+      expect(overview.dailyAverage).toBe(6);
+      expect(overview.daysInPeriod).toBe(7);
+    });
+
+    it('velocity surfaces the four computed numbers, parsed from the script strings', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: {
+            throughput: { totalCompleted: 90, intervals: [] },
+            velocity: {
+              dailyVelocity: '3.0',
+              averageCreated: '4.5',
+              backlogGrowthRate: '-1.5',
+            },
+            breakdown: { medianCompletionHours: '18.2', tasksAnalyzed: 300 },
+            projections: { tasksPerWeek: '21.0' },
+          },
+        }),
+      );
+
+      const res: any = await tool.execute({ analysis: { type: 'task_velocity' } });
+
+      expect(res.success).toBe(true);
+      const v = res.data.velocity;
+      // Script emits toFixed strings; the tool layer parses to numbers, matching
+      // the existing averagePerDay/predictedCapacity convention.
+      expect(v.averageCreated).toBe(4.5);
+      expect(v.backlogGrowthRate).toBe(-1.5); // may be negative: shrinking backlog
+      expect(v.medianCompletionHours).toBe(18.2);
+      expect(v.tasksAnalyzed).toBe(300);
+    });
+
+    it('velocity no longer ships the fabricated fields (absence, not emptiness)', async () => {
+      mockCache.get.mockReturnValue(null);
+      mockOmni.buildScript.mockReturnValue('script');
+      mockOmni.executeJson.mockResolvedValue(
+        createScriptSuccess({
+          ok: true,
+          v: '3',
+          data: {
+            throughput: { totalCompleted: 90, intervals: [] },
+            velocity: { dailyVelocity: '3.0', averageCreated: '4.5', backlogGrowthRate: '0.0' },
+            breakdown: { medianCompletionHours: '18.2', tasksAnalyzed: 300 },
+            projections: { tasksPerWeek: '21.0' },
+          },
+        }),
+      );
+
+      const res: any = await tool.execute({ analysis: { type: 'task_velocity' } });
+
+      // peakDay was always {date:null,count:0}; trend was always 'stable';
+      // patterns was always all-empty; insights was always []. Constants, never
+      // computed — deleted rather than left as decorative shapes.
+      expect(res.data.velocity).not.toHaveProperty('peakDay');
+      expect(res.data.velocity).not.toHaveProperty('trend');
+      expect(res.data).not.toHaveProperty('patterns');
+      expect(res.data).not.toHaveProperty('insights');
+
+      // And no finding invented from them.
+      const findings: string[] = res.summary.key_findings;
+      expect(findings.some((f) => /peak day|most productive day|trending/i.test(f))).toBe(false);
+    });
+  });
+
   describe('task_velocity', () => {
     it('returns cached results when available', async () => {
       const cached = {


### PR DESCRIPTION
## What

The response now contains exactly what was actually computed — **nothing real hidden, nothing fake shipped** (OMN-148 walk-through decision 2, D7/D10).

## Added — computed by the script, discarded by the reshape

| Field | Where | Note |
|---|---|---|
| `averageCreated` | `velocity` | parseFloat of the script's `toFixed` string |
| `backlogGrowthRate` | `velocity` | **may be negative** — a shrinking backlog |
| `medianCompletionHours` | `velocity` | from `breakdown` |
| `tasksAnalyzed` | `velocity` | the analyzed (non-root) population, post-OMN-290 |
| `completedInPeriod` / `dailyAverage` / `daysInPeriod` | `stats.overview` | same silent-omission class as the OMN-254 `availableTasks` rescue |

Numbers are parsed at the tool layer to match the existing `averagePerDay`/`predictedCapacity` convention. **The script envelope schema is untouched** — these fields were already validated at that seam; only the reshape was dropping them.

## Removed — fabrications

| Field | Actual value, always |
|---|---|
| `velocity.peakDay` | `{ date: null, count: 0 }` |
| `velocity.trend` | `'stable'` |
| `patterns` | `{ byDayOfWeek: {}, byTimeOfDay: {}, byProject: [] }` |
| `insights` | `[]` |

Hardcoded constants advertising analysis that did not exist. **OMN-273 acceptable-break class** — no client can have derived value from a field that only ever held one constant. Tests assert **absence**, not emptiness.

Dead code riding on them, also removed:
- `collectPeakDayFinding` — the `peakDay?.date &&` guard could never pass against a constant `null`
- `collectMostProductiveDayFinding` — `byDayOfWeek` was always `{}`
- `collectTopProjectFinding` — `byProject` was always `[]`
- `TREND_LABELS` `increasing`/`decreasing` — `trend` was hardcoded `'stable'`, so only the fallback was reachable; with `trend` deleted there is no trend claim to make
- the velocity `insights[0]` push — that array was always `[]`

## ⚠️ Corrects the spec's matrix: velocity cache key bumped

The spec marked **layer 8 N/A**, reasoning that "cached script envelopes already contain the fields, so post-deploy responses are correct even on warm cache."

The premise is wrong. This cache stores the **reshaped response object** (`cache.set('analytics', cacheKey, responseData)`), not the script envelope. A warm `velocity_v2_*` entry written before deploy would keep serving the **old shape** — fabrications present, the four real numbers missing — until TTL expiry.

Bumped `velocity_v2_*` → `velocity_v3_*`. This is the same class as OMN-292's productivity bump, which the sibling spec *did* catch — worth a look at review since it's a deviation from the approved plan.

## Decision D-2 honored

Per Kip's decision (2026-07-27), the proposed `backlogGrowthRate` key finding is **not** added here — deferred to **OMN-295**. `backlogGrowthRate` is still surfaced as a raw number, which is what makes that follow-up purely a narration string with no script, schema, or computation change.

## Vertical Contract Matrix

| # | Layer | Disposition |
|---|---|---|
| 1 | Schema (both) | **N/A** — no input-schema change; description's `task_velocity` blurb ("Completion trends over time") stays accurate (intervals remain) |
| 2 | Normalization | **N/A** — output-side only |
| 3 | Single-item path | ✅ the reshape edits |
| 4 | Batch path | **N/A** |
| 5 | Script lowering | **N/A** — scripts untouched |
| 6 | Live bridge | ⏳ **owed post-merge** (see below) |
| 7 | Response validation | script schemas unchanged (fields already present); outward TS interfaces updated |
| 8 | Cache key | ✅ **bumped** `velocity_v3_` — see the correction above |

## Verification

- `npm run build` ✅ · `npm run typecheck` ✅
- `npm run lint` (`--max-warnings=0`) ✅
- `npm run test:unit` ✅ **3914 passed / 183 files**
- `grep -rn 'console\.log' src/` → only the known `utils/cli.ts` `--help` printer ✅

**Live `/verify` owed after merge + redeploy** (layer 6):
1. `task_velocity` default → response has `averageCreated`/`backlogGrowthRate`/`medianCompletionHours`/`tasksAnalyzed`, and **no** `peakDay`/`trend`/`patterns`/`insights`
2. `productivity_stats` default → overview has the three period fields; `dailyAverage` ≈ `completedInPeriod / daysInPeriod`
3. Version probe `buildId` + `stale:false`; first post-deploy velocity call misses cache (new key)

## Rebase note

This is the last of the four wave-2 PRs by design. It edits the productivity reshape region adjacent to **#251** (OMN-292's `healthScore` → `completionPercent`) — adjacent but disjoint field-set edits, so whichever lands second rebases trivially.

Spec: `Technical/specs/OMN-289-analytics-response-completeness.md`

Closes OMN-289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mBfHxX9RXQxU4ZPSACQVF