### PR TITLE
docs: one term per concept — add the rule, apply it to docs/dev/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,13 +169,17 @@ pipeline — other docs should link here rather than restate it.
 ## Code & Writing Standards
 
 - **TypeScript only** - Never create `.js` files. Follow existing patterns in the codebase.
-- **Markdown for documentation** - Apply Elements of Style: tables over prose, omit needless words, active voice.
+- **Markdown for documentation** - Apply Elements of Style: tables over prose, omit needless words, active voice. This
+  is the single authoritative statement of prose style — other sections link here rather than restate it.
+- **One term per concept** - Never alternate synonyms for the same thing. The OmniJS escape hatch is the _bridge_
+  everywhere; not "the shim", not "the `evaluateJavascript` call". Reuse the term this doc already uses, verbatim.
+  JXA/OmniJS/bridge terminology drift is a recurring source of confusion in reviews and generated scripts.
 - **Run integration tests** before considering features complete
 
 ## Documentation
 
 - Archive obsolete docs to `.archive/` → push to https://github.com/kip-d/omnifocus-mcp-archive
-- Follow Strunk's Elements of Style (tables > prose, omit needless words, active voice)
+- Prose style: see **Code & Writing Standards** above.
 - **Don't hardcode the current version in prose.** `package.json` and `CHANGELOG.md` are the single source of truth.
   Historical references like "introduced in v3.0.0" are fine — descriptive labels like "(current v4.1.0)" go stale on
   every release.

--- a/docs/dev/AST_ARCHITECTURE.md
+++ b/docs/dev/AST_ARCHITECTURE.md
@@ -97,7 +97,7 @@ function buildAST(filter: TaskFilter): FilterNode {
 }
 ```
 
-### Step 3: OmniJS Code Generation
+### Step 3: OmniJS Emission
 
 ```typescript
 // Emit OmniJS code from AST

--- a/docs/dev/FILTER_PIPELINE.md
+++ b/docs/dev/FILTER_PIPELINE.md
@@ -150,7 +150,7 @@ QueryTasksTool remains for CacheWarmer and internal use, but the public path byp
 
 ## Related Documentation
 
-- **[AST_ARCHITECTURE.md](AST_ARCHITECTURE.md)** — Deep dive on layers 3-4 (AST construction and code generation)
+- **[AST_ARCHITECTURE.md](AST_ARCHITECTURE.md)** — Deep dive on layers 3-4 (AST construction and emission)
 - **[API-COMPACT-UNIFIED.md](../api/API-COMPACT-UNIFIED.md)** — API schema reference (layer 1)
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — JXA/OmniJS execution model (what runs after the emitter)
 - **[PATTERNS.md](PATTERNS.md)** — Symptom-based debugging guide

--- a/docs/dev/PERFORMANCE-BOTTLENECK-ANALYSIS.md
+++ b/docs/dev/PERFORMANCE-BOTTLENECK-ANALYSIS.md
@@ -122,7 +122,7 @@ const tasks = JSON.parse(resultJson);
 
 1. **Fixed script size**: Script doesn't embed task IDs (avoids Issue #27)
 2. **Massive speed boost**: Property access ~16,000x faster
-3. **Single bridge call**: One `evaluateJavascript()` call replaces all 450 Apple Event round trips
+3. **Single bridge call**: One bridge call (`app.evaluateJavascript()`) replaces all 450 Apple Event round trips
 4. **Simpler code**: No complex JXA iteration and error handling
 
 ### Available OmniJS Global Collections

--- a/docs/dev/PERFORMANCE-BOTTLENECK-ANALYSIS.md
+++ b/docs/dev/PERFORMANCE-BOTTLENECK-ANALYSIS.md
@@ -75,8 +75,8 @@ for (let i = 0; i < allTasks.length; i++) {
 
 ### Why This Is Slow
 
-1. **JXA bridge overhead**: Each `task.property()` call crosses the JXA/OmniFocus bridge
-2. **Accumulation**: 45 tasks × 10 properties = 450 bridge crossings
+1. **Apple Events overhead**: Each `task.property()` call is a separate Apple Event round trip to OmniFocus
+2. **Accumulation**: 45 tasks × 10 properties = 450 Apple Event round trips
 3. **JavaScript processing**: Complex plugin system for recurring task analysis adds 85% overhead
 
 ## Solution: OmniJS-First Architecture
@@ -122,7 +122,7 @@ const tasks = JSON.parse(resultJson);
 
 1. **Fixed script size**: Script doesn't embed task IDs (avoids Issue #27)
 2. **Massive speed boost**: Property access ~16,000x faster
-3. **Single bridge crossing**: One `evaluateJavascript()` call instead of 450
+3. **Single bridge call**: One `evaluateJavascript()` call replaces all 450 Apple Event round trips
 4. **Simpler code**: No complex JXA iteration and error handling
 
 ### Available OmniJS Global Collections
@@ -152,7 +152,7 @@ const allTasks = doc.flattenedTasks();
 for (let i = 0; i < allTasks.length; i++) {
   if (matchesFilter(task, filter)) {
     // 3. Access properties via JXA (SLOW!)
-    const taskObj = buildTaskObject(task); // 450 bridge crossings!
+    const taskObj = buildTaskObject(task); // 450 Apple Event round trips!
     tasks.push(taskObj);
   }
 }


### PR DESCRIPTION
Two commits: the rule, then its first enforcement.

## 1. CLAUDE.md — dedupe + add the rule

CLAUDE.md stated the same prose-style rule twice (**Code & Writing Standards** and **Documentation**). Consolidated into the section that owns the topic, with a one-clause pointer left behind so the duplicate isn't re-added.

Added a **One term per concept** rule. This came out of evaluating whether to instruct the model to write per **ASD-STE100** or **ISO 24495-1**. Both were rejected:

| Standard | Finding |
| --- | --- |
| ASD-STE100 (Issue 9, Jan 2025) | 53 writing rules **plus a closed ~900-word approved dictionary**. The dictionary is the load-bearing half, isn't freely redistributable, and can't be verified against without a conformance checker — so naming it buys a style prior, not compliance, and invites unfalsifiable conformance claims. Its design target (translated safety-critical procedures) is also wrong for docs that explain rationale. |
| ISO 24495-1:2023 | Four governing principles (relevant, findable, understandable, usable). Nothing to look up, so it degrades gracefully — but vague enough that it mostly restates what Elements of Style already carries. |

"One term per concept" is the portable idea from STE: concrete, checkable, and directly relevant where JXA/OmniJS/bridge vocabulary drifts.

## 2. docs/dev/ — apply it

Swept all 43 files. **The corpus was already largely compliant**, and most grep candidates were false positives, deliberately left alone:

- `OmniAutomation` vs "Omni Automation" — a code identifier (`src/omnifocus/OmniAutomation.ts`) vs the official product name. Two referents, correctly distinguished.
- "tool layer" / "script layer" — two genuinely different layers, used consistently in `TAG_FILTERING_BUG_ANALYSIS.md`.
- "Code generation" in `COGNITIVE-COMPLEXITY-ASSESSMENT.md` — `describeFilter()` builds human-readable text (`tags AND [a, b]`), **not** emitted OmniJS. Different concept; renaming would have been wrong.
- `evaluateJavascript` casing — already 53/53 correct.

Two real violations fixed (6 lines, 3 files):

**`PERFORMANCE-BOTTLENECK-ANALYSIS.md`** used "bridge crossing" for *both* the Apple Events RPC boundary (the bottleneck, ~450) and the OmniJS `evaluateJavascript` bridge (the fix, 1). The doc's central argument read as "450 crossings → 1 crossing", framing a **change of mechanism** as a quantitative tweak. "Bridge" is now reserved for OmniJS; the JXA property boundary uses "Apple Events", matching the 9 existing uses in `JXA-VS-OMNIJS-PATTERNS.md` / `OMNIJS-FIRST-PATTERN.md`.

**`AST_ARCHITECTURE.md`** called the AST output step "OmniJS Code Generation" while CLAUDE.md, `PATTERN_INDEX.md` and `FILTER_PIPELINE.md` use lowering → emission. Renamed to "OmniJS Emission" (its own code is `emitOmniJS()`); the `FILTER_PIPELINE.md` cross-reference now matches the "emitter" wording two lines below it.

Dated artifacts (`SESSION_*`, `BENCHMARK_RESULTS`, `*TIMING*`) left untouched — normalizing vocabulary inside a historical record falsifies it. Unrelated to the ~36 known-rotted refs in docs/dev, which stay deferred.

## Verification

- `tests/unit/docs/claude-md-paths.test.ts` — 8/8
- `npm run lint` — exit 0
- Unit suite ran via pre-push hook — passed
- No stale heading anchors; no ambiguous "bridge" uses remain outside dated artifacts
- Prettier ran via lint-staged (reflowed wrapping, normalized emphasis)

## Vertical Contract Matrix

**N/A — documentation-only.** Zero source files touched; no public field or operation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MwgvjKASBn9hxBGuL6e87