### PR TITLE
fix(OMN-300, OMN-301): sweep two contract changes into the integration suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   now splice the canonical `PROJECT_STATUS_STRING_SNIPPET`, converging the read path on the OMN-272 wire vocabulary
   (`active`/`onHold`/`done`/`dropped`) used by every analytics endpoint. Unknown future statuses now fail OPEN
   (`String(s)`) instead of silently misreporting as `active`/`dropped`, and folder status gains the same treatment via
-  the new `FOLDER_STATUS_STRING_SNIPPET`. Filter INPUTS are unchanged (`status: "on_hold"` transport form), and the
-  write envelope's status read-back deliberately keeps the transport vocabulary (`on_hold`/`completed`) — adjudication
-  comment at `PROJECT_STATUS_READBACK`. The `generateProjectSummary` dual-key tolerance for the old hyphen form is
-  removed.
+  the new `FOLDER_STATUS_STRING_SNIPPET`. Filter INPUTS are unchanged (`status: "on_hold"` transport form). The write
+  envelope's status read-back **also speaks this canonical vocabulary** as of OMN-278 — write INPUTS still take the
+  transport enum (`on_hold`/`completed`), so input and echo are asymmetric by design; adjudication comment at
+  `PROJECT_STATUS_READBACK`. (This sentence previously said the write echo kept the transport vocabulary. That was true
+  when written and falsified by OMN-278 four days later; corrected under OMN-301.) The `generateProjectSummary` dual-key
+  tolerance for the old hyphen form is removed.
 
 ### Added
 

--- a/tests/integration/tools/unified/complete-delete-paths.test.ts
+++ b/tests/integration/tools/unified/complete-delete-paths.test.ts
@@ -2,42 +2,48 @@
  * OMN-138 (OMN-128 slice 5) — live complete/delete/bulk_delete coverage for the
  * OmniJS-native mutation AST: task complete (with completionDate), project
  * complete, task delete, project delete, bulk task delete (mixed real+bogus ids),
- * and guard-refused not-found single ops. All paths use the new AST lowerings
+ * and not-found single ops. All paths use the new AST lowerings
  * (buildCompleteScript / buildDeleteScript / buildBulkDeleteTasksScript) wired
  * in slice 5.
  *
  * CARDINAL RULE (the slice-3 vacuous-parentage lesson): every assertion reads
  * back the PERSISTED value via a follow-up omnifocus_read call — never the
  * write response's own echo. Single deliberate exceptions: the delete read-backs
- * are NOT_FOUND assertions (the object no longer exists), and the guard-refused
- * probes assert the refusal envelope shape.
+ * are NOT_FOUND assertions (the object no longer exists), and the not-found
+ * probes assert the error envelope shape.
  *
  * Coverage matrix:
  *   1. complete task with completionDate → read back completed:true + date-part
  *   2. complete project → read back status "done" (project id lookup)
  *   3. delete task → read back NOT_FOUND
  *   4. delete project → read back NOT_FOUND
- *   5. bulk_delete mixed real+bogus ids → whole-dispatch guard refusal (see below)
- *   6. not-found single ops (complete + delete bogus id) → TEST GUARD refusal
+ *   5. bulk_delete mixed real+bogus ids → batch PARTITIONS (see below)
+ *   6. not-found single ops (complete + delete bogus id) → script-level not-found
  *
- * GUARD INTERACTION on rows 5–6 (OMN-46 + OMN-120 fix):
+ * GUARD INTERACTION on rows 5–6 (OMN-46 + OMN-120, revised by OMN-286):
  *
- * Single ops (complete, delete): the sandbox guard's pre-flight
- * (validateTaskInSandbox → isTaskInSandbox → Task.byIdentifier) runs BEFORE the
- * mutation script. An unknown id resolves to nothing → "outside sandbox" → guard
- * REFUSES (success:false). Script-level "Task not found:" is unreachable on a
- * guarded server. Same pattern as update-paths row 6.
+ * OMN-286 replaced the guard's boolean with a tri-state —
+ * 'in_sandbox' | 'outside_sandbox' | 'not_found' — because collapsing the last
+ * two made a single bogus id abort an entire continue-on-error batch. Rows 5–6
+ * assert the post-OMN-286 contract; they asserted the collapsed one until
+ * OMN-300.
  *
- * Bulk delete (row 5): the bulk_delete/task guard runs Promise.all over ALL ids
- * (spec §2.1, MUTATION_DEFS 'bulk_delete/task') before any delete executes. One
- * bogus id causes the guard to throw → caught by handleBulkDeleteTasks' outer
- * catch → error ends up in data.errors[]. Response shape: success:true with
- * successCount:0 and errorCount:1. This differs from single-op guard refusals
- * (which return success:false) because the bulk handler collects all errors into
- * data.errors regardless of source — documented current behavior; envelope
- * follow-up tracked in OMN-144. Both real fixtures survive. The per-item
- * continue-on-error behavior (AST emitter) is reachable only in production mode;
- * unit tests cover that path.
+ * Single ops (complete, delete): these are ID-ADDRESSED, resolving strictly via
+ * Task.byIdentifier. A miss writes nothing, so 'not_found' is deliberately
+ * PASSED THROUGH and the script-level "Task not found:" envelope is the correct
+ * live result — not a guard escape. Same pattern as update-paths row 6.
+ *
+ * Bulk delete (row 5): the guard still pre-flights ALL ids (spec §2.1,
+ * MUTATION_DEFS 'bulk_delete/task'), but a bogus id now passes through instead
+ * of throwing, so the batch partitions: the real ids delete and the miss lands
+ * in errors[], with the response staying success:true (OMN-137 partial-success
+ * contract). Both real fixtures are therefore GONE, not surviving.
+ *
+ * Still fail-closed, and NOT covered here: an id resolving OUTSIDE the sandbox
+ * is 'outside_sandbox' and still refuses the whole dispatch (the OMN-120
+ * non-bypass contract). That case cannot be staged from this file — the guard
+ * forbids creating a fixture outside the sandbox — so it lives in unit coverage,
+ * as does the production-mode per-item continue-on-error unroll.
  *
  * Read-back idioms:
  *   - Completed task: filters { id, completed: true } — without 'completed:true'
@@ -372,15 +378,25 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
     expect(resText).not.toContain('TEST GUARD');
 
     // (b) Both real tasks are gone — the batch did NOT abort on the miss.
-    // Pin the error CODE: a transient SCRIPT_ERROR would also be success:false
-    // but must not false-green "deleted".
+    //
+    // Same idiom as the single delete rows above: an id lookup for a deleted
+    // task returns success:false with code NOT_FOUND (verified live — it does
+    // NOT return success:true with an empty array). Pin the CODE, not just the
+    // false: a transient SCRIPT_ERROR is also success:false and must not
+    // false-green "deleted" when the task may still exist.
     for (const [id, label] of [
       [idA, BULK_TASK_A_NAME],
       [idB, BULK_TASK_B_NAME],
     ] as const) {
       const readRes = await readTaskByIdRaw(id, ['name']);
-      const stillThere = readRes.success && tasksOf(readRes).some((t: any) => t.id === id);
-      expect(stillThere, `task ${label} (${id}) survived a bulk_delete that should have removed it`).toBe(false);
+      expect(
+        readRes.success,
+        `task ${label} (${id}) survived a bulk_delete that should have removed it: ${JSON.stringify(readRes).slice(0, 300)}`,
+      ).toBe(false);
+      expect(
+        readRes.error?.code,
+        `expected NOT_FOUND for deleted ${label}, got: ${JSON.stringify(readRes.error).slice(0, 300)}`,
+      ).toBe('NOT_FOUND');
     }
   }, 120000);
 

--- a/tests/integration/tools/unified/complete-delete-paths.test.ts
+++ b/tests/integration/tools/unified/complete-delete-paths.test.ts
@@ -153,6 +153,16 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
   }
 
   /**
+   * Read-back: task by id WITHOUT asserting presence. readTaskById above pins
+   * the task as found, which is wrong for rows that assert a task is gone.
+   */
+  async function readTaskByIdRaw(id: string, fields: string[]): Promise<any> {
+    return client.callTool('omnifocus_read', {
+      query: { type: 'tasks', filters: { id }, fields: ['id', ...fields] },
+    });
+  }
+
+  /**
    * Read-back: project by id. Project.byIdentifier is status-agnostic, so
    * completed projects are found without a special filter. Returns undefined
    * when the project does not exist (NOT_FOUND path).
@@ -315,38 +325,33 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
     );
   }, 120000);
 
-  // ── 5. bulk_delete mixed real+bogus ids → whole-dispatch guard refusal ─────
+  // ── 5. bulk_delete mixed real+bogus ids → the batch PARTITIONS ────────────
   //
-  // GUARD INTERACTION (LOAD-BEARING assertion, note carefully):
+  // GUARD INTERACTION (LOAD-BEARING assertion, note carefully). This row
+  // asserted whole-dispatch refusal before OMN-286; that is no longer the
+  // contract, and the change was the entire point of that ticket.
   //
-  // In test mode, MUTATION_DEFS['bulk_delete/task'].guard runs:
-  //   Promise.all(taskIds.map(id => validateTaskInSandbox(id, 'bulk delete')))
+  // In test mode, MUTATION_DEFS['bulk_delete/task'].guard pre-flights every id.
+  // Pre-OMN-286 the check returned a boolean, so a bogus id was
+  // indistinguishable from an out-of-sandbox one: the guard threw, Promise.all
+  // propagated, and the ENTIRE dispatch was refused with successCount:0 — even
+  // though the batch is a continue-on-error route. OMN-286 made the check a
+  // tri-state ('in_sandbox' | 'outside_sandbox' | 'not_found') so that a
+  // strictly-resolved miss PASSES THROUGH: it writes nothing, so it is safe,
+  // and the batch now partitions the way it does in production — real ids
+  // delete, the bogus one lands in errors[].
   //
-  // A bogus id resolves to not_found → isTaskInSandbox returns false → throws.
-  // Promise.all propagates the first rejection → the guard throw bubbles up
-  // through buildBulkDeleteTasksScript → is caught by handleBulkDeleteTasks'
-  // outer try/catch → error ends up in errors[] → ENTIRE dispatch refused
-  // with successCount:0.
-  //
-  // NOTE ON RESPONSE SHAPE (OMN-144): a fully-refused bulk delete now returns
-  // top-level success:false with error.code BULK_DELETE_FAILED — consistent
-  // with the single-op guard envelope for the same refusal. Per-item detail
-  // (successCount/errorCount/errors) rides error.details. Partial success
-  // remains success:true with loud data.errors[] (OMN-137 contract).
-  //
-  // This whole-dispatch refusal IS the OMN-120 non-bypass contract (guard must
-  // cover every id before any mutation executes). The unguarded per-item
-  // continue-on-error behavior (provided by the AST emitter's bulkDeleteItem
-  // try/continue-on-error unroll) is correct in production mode and is covered
-  // by unit tests; it is unreachable in test mode because the guard pre-flighted
-  // all ids.
+  // Still true, and NOT what this row covers: an id that resolves OUTSIDE the
+  // sandbox is 'outside_sandbox', still fails closed, and still refuses the
+  // whole dispatch (the OMN-120 non-bypass contract). That case cannot be
+  // staged from here — the guard forbids creating a fixture outside the
+  // sandbox in the first place — so it lives in unit coverage.
   //
   // The test asserts:
-  //   (a) the write response is a top-level failure (success:false,
-  //       BULK_DELETE_FAILED) with the TEST GUARD error text in the error
-  //       and per-item detail in error.details (successCount:0)
-  //   (b) BOTH real task fixtures still exist (read-back succeeds for each)
-  it('bulk_delete with a bogus id in the list: whole-dispatch guard refusal is a top-level failure (OMN-144); both real fixtures survive', async () => {
+  //   (a) partial success: success:true with the bogus id loud in data.errors[]
+  //       (OMN-137 contract), NOT a top-level BULK_DELETE_FAILED
+  //   (b) BOTH real task fixtures are GONE — the batch proceeded past the miss
+  it('bulk_delete with a bogus id in the list: the batch partitions — real ids delete, the bogus one errors (OMN-286)', async () => {
     const idA = await createTask({ name: BULK_TASK_A_NAME });
     const idB = await createTask({ name: BULK_TASK_B_NAME });
 
@@ -358,83 +363,86 @@ describe('OMN-138: live complete/delete/bulk_delete paths (task + project, persi
       },
     });
 
-    // (a) Zero deletes + errors → top-level success:false, matching the
-    // single-op envelope for the same guard refusal (OMN-144).
-    expect(writeRes.success, `expected top-level failure, got: ${JSON.stringify(writeRes).slice(0, 400)}`).toBe(false);
-    expect(writeRes.error?.code, `expected BULK_DELETE_FAILED, got: ${writeRes.error?.code}`).toBe(
-      'BULK_DELETE_FAILED',
-    );
-    // Guard error text surfaces in the top-level error (message and/or details).
-    const errText = JSON.stringify(writeRes.error ?? {});
-    expect(errText, `guard error text not in error: ${errText.slice(0, 400)}`).toContain('TEST GUARD');
-    expect(errText).toContain('outside sandbox');
-    // Per-item detail preserved in error.details.
-    const details = writeRes.error?.details as { successCount?: number; errorCount?: number };
-    expect(details?.successCount, `expected zero deletes due to guard refusal, got: ${details?.successCount}`).toBe(0);
-    expect(
-      details?.errorCount,
-      `expected one guard error entry, got errorCount: ${details?.errorCount}`,
-    ).toBeGreaterThanOrEqual(1);
+    // (a) Partial success, not a whole-dispatch refusal.
+    expect(writeRes.success, `expected partial success, got: ${JSON.stringify(writeRes).slice(0, 400)}`).toBe(true);
+    const resText = JSON.stringify(writeRes);
+    // The miss is reported, not swallowed — silence here would be the real bug.
+    expect(resText, `bogus id not reported anywhere in response: ${resText.slice(0, 400)}`).toContain(BOGUS_TASK_ID);
+    // And it passed through the guard rather than being refused by it.
+    expect(resText).not.toContain('TEST GUARD');
 
-    // (b) Both real tasks survive — guard ran before any delete script.
-    const taskA = await readTaskById(idA, ['name']);
-    expect(taskA.name).toBe(BULK_TASK_A_NAME);
-    const taskB = await readTaskById(idB, ['name']);
-    expect(taskB.name).toBe(BULK_TASK_B_NAME);
+    // (b) Both real tasks are gone — the batch did NOT abort on the miss.
+    // Pin the error CODE: a transient SCRIPT_ERROR would also be success:false
+    // but must not false-green "deleted".
+    for (const [id, label] of [
+      [idA, BULK_TASK_A_NAME],
+      [idB, BULK_TASK_B_NAME],
+    ] as const) {
+      const readRes = await readTaskByIdRaw(id, ['name']);
+      const stillThere = readRes.success && tasksOf(readRes).some((t: any) => t.id === id);
+      expect(stillThere, `task ${label} (${id}) survived a bulk_delete that should have removed it`).toBe(false);
+    }
   }, 120000);
 
   // ── 6. not-found single ops: complete + delete with bogus ids ─────────────
   //
-  // GUARD INTERACTION: same as update-paths row 6. The guard's pre-flight
-  // (validateTaskInSandbox → isTaskInSandbox → Task.byIdentifier → null →
-  // "outside sandbox") fires BEFORE the mutation script. Script-level
-  // "Task not found:" / "Project not found:" are unreachable on the guarded
-  // server. The refusal IS the correct live behavior in test mode.
-  it('complete a non-existent task id is refused by the sandbox guard (not a script-level not-found)', async () => {
+  // GUARD INTERACTION (OMN-286 tri-state; these rows previously asserted the
+  // pre-OMN-286 collapsed boolean). The guard distinguishes three states, not
+  // two: 'in_sandbox' | 'outside_sandbox' | 'not_found'. For ID-ADDRESSED
+  // mutations the id resolves STRICTLY via byIdentifier, so a miss writes
+  // nothing and 'not_found' is deliberately PASSED THROUGH — the script-level
+  // "Task not found:" / "Project not found:" is the correct live behavior, not
+  // a guard escape. (Fail-closed is still required where a NAME fallback
+  // exists — e.g. create-with-project — because a not-found-by-id value could
+  // resolve by name to something outside the sandbox. That path is asserted in
+  // the create tests and in unit coverage.)
+  //
+  // These rows therefore assert the INVERSE of the guard refusal: the
+  // not-found surfaces, and TEST GUARD does NOT — which is what pins the
+  // pass-through half of the tri-state. See src/contracts/ast/
+  // mutation-script-builder.ts (SandboxCheck) for the adjudication.
+  it('complete a non-existent task id passes the guard and surfaces a script-level not-found (OMN-286)', async () => {
     const res = await client.callTool('omnifocus_write', {
       mutation: { operation: 'complete', target: 'task', id: BOGUS_TASK_ID },
     });
 
-    expect(res.success, `expected guard refusal, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+    expect(res.success, `expected failure, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
     const errText = JSON.stringify(res.error ?? res);
-    expect(errText).toContain('TEST GUARD');
-    expect(errText).toContain('outside sandbox');
-    expect(errText).not.toContain('Task not found');
+    expect(errText).toContain('Task not found');
+    // Pass-through, NOT a refusal — the discriminating half of the tri-state.
+    expect(errText).not.toContain('TEST GUARD');
   }, 120000);
 
-  it('delete a non-existent task id is refused by the sandbox guard (not a script-level not-found)', async () => {
+  it('delete a non-existent task id passes the guard and surfaces a script-level not-found (OMN-286)', async () => {
     const res = await client.callTool('omnifocus_write', {
       mutation: { operation: 'delete', target: 'task', id: BOGUS_TASK_ID },
     });
 
-    expect(res.success, `expected guard refusal, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+    expect(res.success, `expected failure, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
     const errText = JSON.stringify(res.error ?? res);
-    expect(errText).toContain('TEST GUARD');
-    expect(errText).toContain('outside sandbox');
-    expect(errText).not.toContain('Task not found');
+    expect(errText).toContain('Task not found');
+    expect(errText).not.toContain('TEST GUARD');
   }, 120000);
 
-  it('complete a non-existent project id is refused by the sandbox guard', async () => {
+  it('complete a non-existent project id passes the guard and surfaces a script-level not-found (OMN-286)', async () => {
     const res = await client.callTool('omnifocus_write', {
       mutation: { operation: 'complete', target: 'project', id: BOGUS_PROJ_ID },
     });
 
-    expect(res.success, `expected guard refusal, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+    expect(res.success, `expected failure, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
     const errText = JSON.stringify(res.error ?? res);
-    expect(errText).toContain('TEST GUARD');
-    expect(errText).toContain('outside sandbox');
-    expect(errText).not.toContain('Project not found');
+    expect(errText).toContain('Project not found');
+    expect(errText).not.toContain('TEST GUARD');
   }, 120000);
 
-  it('delete a non-existent project id is refused by the sandbox guard', async () => {
+  it('delete a non-existent project id passes the guard and surfaces a script-level not-found (OMN-286)', async () => {
     const res = await client.callTool('omnifocus_write', {
       mutation: { operation: 'delete', target: 'project', id: BOGUS_PROJ_ID },
     });
 
-    expect(res.success, `expected guard refusal, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+    expect(res.success, `expected failure, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
     const errText = JSON.stringify(res.error ?? res);
-    expect(errText).toContain('TEST GUARD');
-    expect(errText).toContain('outside sandbox');
-    expect(errText).not.toContain('Project not found');
+    expect(errText).toContain('Project not found');
+    expect(errText).not.toContain('TEST GUARD');
   }, 120000);
 });

--- a/tests/integration/tools/unified/update-paths.test.ts
+++ b/tests/integration/tools/unified/update-paths.test.ts
@@ -11,7 +11,10 @@
  * (`changes.status || 'active'`) with a LIVE status read-back inside the
  * mutation script, and that response-side contract is itself under test —
  * proven by an update that does NOT touch status still reporting the
- * persisted 'on_hold', which the legacy echo could never do.
+ * persisted on-hold state, which the legacy echo could never do. Since
+ * OMN-278 that read-back speaks the CANONICAL vocabulary ('onHold'), while
+ * write INPUT still takes the transport enum ('on_hold') — asymmetric by
+ * design; PROJECT_STATUS_READBACK is the authority.
  *
  * Coverage matrix (plan Task 10):
  *   1. rename + flag             → read shows new name + flagged true
@@ -20,18 +23,22 @@
  *   4. addTags then removeTags   → read shows union, then difference
  *   5. move to project / inbox   → read shows projectId == fixture project's
  *                                  ID (not name), then inInbox true
- *   6. not-found target (guarded)→ TEST GUARD refusal — see below
- *   7. project rename + on_hold  → read shows status persisted; §2.4 envelope
+ *   6. not-found target (guarded)→ script-level not-found — see below
+ *   7. project rename + on_hold  → read shows status persisted as canonical
+ *                                  'onHold'; §2.4 envelope
  *   8. project folder move       → read shows persisted parent folder (tied
  *                                  to the destination folder's ID)
  *
- * GUARD INTERACTION on row 6 (OMN-46): the sandbox guard's update pre-flight
- * is ID-only (`Task.byIdentifier`) and runs BEFORE the mutation script — an
- * unknown id resolves to nothing, is therefore "outside sandbox", and the
- * guard REFUSES it. The script-level loud `Task not found:` guard is
- * unreachable on a guarded server; this suite asserts the refusal. The
- * unguarded not-found probes (script-level `Task not found:` /
- * `Project not found:`) belong to Task 11's live /verify matrix.
+ * GUARD INTERACTION on row 6 (OMN-46, revised by OMN-286): the update
+ * pre-flight is ID-only (`Task.byIdentifier`) and runs BEFORE the mutation
+ * script. OMN-286 made the check a tri-state
+ * ('in_sandbox' | 'outside_sandbox' | 'not_found') rather than a boolean, so an
+ * unknown id is 'not_found' and is deliberately PASSED THROUGH — it resolves
+ * strictly and therefore writes nothing, making the script-level loud
+ * `Task not found:` envelope the correct live result on a guarded server. This
+ * row asserted a TEST GUARD refusal until OMN-300, back when the boolean
+ * collapsed 'not_found' into 'outside_sandbox'. An id that genuinely resolves
+ * outside the sandbox is still refused.
  *
  * SKIPPED matrix row (carried from the Task-7 review): "composed failure —
  * status apply fails while other changes succeed". Not reproducible against

--- a/tests/integration/tools/unified/update-paths.test.ts
+++ b/tests/integration/tools/unified/update-paths.test.ts
@@ -315,47 +315,57 @@ describe('OMN-138: live update paths (task + project, persisted read-backs)', ()
     expect(back.projectId).toBeNull();
   }, 120000);
 
-  // ── 6. not-found target on the guarded server: TEST GUARD refusal ────────
+  // ── 6. not-found target on the guarded server: guard PASSES THROUGH ──────
   //
-  // The guard's ID-only pre-flight (Task.byIdentifier) refuses unknown ids
-  // BEFORE the mutation script runs — the script-level 'Task not found:'
-  // envelope is unreachable here (it belongs to Task 11's unguarded /verify
-  // matrix). The refusal IS the guarded server's contract for this input.
-  it('update of an unknown task id is refused by the sandbox guard (not a script-level not-found)', async () => {
+  // Pre-OMN-286 this row asserted a TEST GUARD refusal, because the guard's
+  // boolean check collapsed "not found" into "outside sandbox". OMN-286 made
+  // it a tri-state: update is ID-ADDRESSED and resolves strictly via
+  // Task.byIdentifier, so a miss writes nothing and is safe to pass through —
+  // the script-level 'Task not found:' envelope is now the correct live
+  // behavior on the guarded server, not an escape. Fail-closed is retained
+  // only where a NAME fallback could reach outside the sandbox.
+  it('update of an unknown task id passes the guard and surfaces a script-level not-found (OMN-286)', async () => {
     const res = await client.callTool('omnifocus_write', {
       mutation: { operation: 'update', target: 'task', id: BOGUS_TASK_ID, changes: { flagged: true } },
     });
 
-    expect(res.success, `expected guard refusal, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
+    expect(res.success, `expected failure, got: ${JSON.stringify(res).slice(0, 300)}`).toBe(false);
     const errText = JSON.stringify(res.error);
-    expect(errText).toContain('TEST GUARD');
-    expect(errText).toContain('outside sandbox');
-    // And NOT the script-level envelope — the guard fired pre-script.
-    expect(errText).not.toContain('Task not found');
+    expect(errText).toContain('Task not found');
+    // Pass-through, NOT a refusal — the discriminating half of the tri-state.
+    expect(errText).not.toContain('TEST GUARD');
   }, 120000);
 
   // ── 7. update-project rename + status on_hold (incl. the §2.4 envelope) ──
   it('project rename + status on_hold persists; the response carries the LIVE status read-back, not an echo', async () => {
     const projId = await createProject(UPD_PROJECT_NAME);
 
+    // Input stays the TRANSPORT enum ('on_hold'); the echo comes back CANONICAL.
     const res = await updateProject(projId, { name: UPD_PROJECT_NEW_NAME, status: 'on_hold' });
-    // §2.4 deliberate response check: the envelope status is read back from
-    // the live object post-apply (transport vocab 'on_hold').
-    expect(res.data.status).toBe('on_hold');
+    // §2.4 deliberate response check: the envelope status is read back from the
+    // live object post-apply. Since OMN-278 that read-back speaks the canonical
+    // read/analytics vocabulary ('active'|'onHold'|'done'|'dropped'), matching
+    // what a subsequent read of the same project returns. Input and echo are
+    // asymmetric BY DESIGN — see the adjudication comment at
+    // PROJECT_STATUS_READBACK in src/contracts/ast/mutation/defs.ts, which is
+    // the authority here. Do not "restore" this to 'on_hold': that reintroduces
+    // the mixed-vocabulary hazard the OMN-274 spec's POST-BUILD REVERSAL warns of.
+    expect(res.data.status).toBe('onHold');
 
-    // Independent read-back — the persisted truth. Read projection vocab is
-    // canonical 'onHold' (OMN-274), distinct from the transport enum the
-    // write envelope echoes ('on_hold' — see PROJECT_STATUS_READBACK).
+    // Independent read-back — the persisted truth. Same canonical vocabulary as
+    // the envelope above; post-OMN-278 the two agree rather than differing.
     const project = await readProjectInFolder(projId, ['name', 'status'], SANDBOX_FOLDER_NAME);
     expect(project, `project ${projId} not found in sandbox on read-back`).toBeTruthy();
     expect(project.name).toBe(UPD_PROJECT_NEW_NAME);
     expect(project.status).toBe('onHold');
 
     // No-stale-echo proof: an update that does NOT touch status must still
-    // report the persisted 'on_hold'. The legacy envelope echoed
-    // `changes.status || 'active'` — it would say 'active' here.
+    // report the persisted on-hold state. The legacy envelope echoed
+    // `changes.status || 'active'` — it would say 'active' here. This assertion
+    // discriminates live-read-back from echo regardless of vocabulary; only the
+    // expected spelling moved with OMN-278.
     const res2 = await updateProject(projId, { note: `omn138u-note-${TS}` });
-    expect(res2.data.status, 'envelope status is a stale echo, not a live read-back').toBe('on_hold');
+    expect(res2.data.status, 'envelope status is a stale echo, not a live read-back').toBe('onHold');
   }, 120000);
 
   // ── 8. update-project folder move into a sandbox subfolder ───────────────


### PR DESCRIPTION
Fixes OMN-300 and OMN-301. **Corrects #246. Corrects #240.**

Two independent stale-expectation clusters, found by the first hand-run of `npm run test:integration` in ~2 weeks (7 failed / 177 passed on `62567d6f`). Both are **test-only — no `src/` change**, and neither underlying behaviour is a defect.

Filed as two tickets but shipped as one PR: they overlap in `update-paths.test.ts`, so splitting them would have made the two PRs conflict with each other.

## OMN-300 — 6 rows asserted the pre-OMN-286 collapsed boolean

OMN-286 made the sandbox check a tri-state — `'in_sandbox' | 'outside_sandbox' | 'not_found'`. For **id-addressed** mutations the id resolves strictly via `byIdentifier`, so a miss writes nothing and `not_found` is deliberately **passed through**: the script-level `Task not found:` is correct live behaviour, not a guard escape. Fail-closed is retained only where a **name** fallback could resolve outside the sandbox (create-with-project).

**This is not a guard bypass**, and I checked that specifically before writing anything — "guard stopped firing" would have meant tests could reach real data.

The five single-op rows now assert the inverse: the not-found surfaces **and** `TEST GUARD` does not. That negative is the point — it pins the pass-through half of the tri-state instead of accepting any failure.

The **bulk_delete row needed rework, not a find-and-replace**. It asserted `successCount: 0` and *both real fixtures survive*. Post-OMN-286 the batch partitions — which was the entire reason for that ticket, since the collapsed boolean aborted continue-on-error batches on a single bogus id — so the fixtures are now **deleted** and the correct assertion is the opposite. Added `readTaskByIdRaw` because the existing `readTaskById` asserts presence and therefore cannot express "is gone".

Two things preserved deliberately:

- **The OMN-120 non-bypass contract still holds** for a genuinely out-of-sandbox id: still fails closed, still refuses the whole dispatch. This row no longer covers it, and the comment says so plus why it can't be staged here — the guard forbids creating a fixture outside the sandbox — so it lives in unit coverage. Dropping that silently would read as the guard getting weaker.
- The row now asserts the bogus id is **reported** in the response. Partitioning that silently swallowed the miss would be a real bug, and `success: true` alone would not catch it.

## OMN-301 — write-echo vocabulary stale in three places

OMN-278 converged the write-envelope status read-back on the canonical vocabulary; write **input** still takes the transport enum, so input and echo are asymmetric by design (`PROJECT_STATUS_READBACK` is the authority). Three artifacts still said otherwise — and each cited that constant while asserting its opposite:

1. **Two** assertions in `update-paths.test.ts` (the failure output surfaced only one; the second is the no-stale-echo proof)
2. The inline comment claiming the envelope echoes `on_hold`
3. The **OMN-274 CHANGELOG entry** — which ships to users, so it misinforms beyond this repo

A reader trusting any of them would "fix" `onHold` back to `on_hold` and reintroduce the mixed-vocabulary hazard the OMN-274 spec's POST-BUILD REVERSAL section warns about. The CHANGELOG now records that the old sentence was true when written and falsified by OMN-278 four days later.

## Vertical Contract Matrix

Test + docs only; no public field or operation changes.

| # | Layer | Status |
|---|---|---|
| 1 | Schema (both) | **N/A** |
| 2 | Normalization | **N/A** |
| 3 | Single-item path | **N/A** — behaviour unchanged; the tests were wrong about it |
| 4 | Batch path | **N/A** — same; bulk_delete partitioning is OMN-286's shipped behaviour |
| 5 | Script lowering | **N/A** |
| 6 | Live bridge | **DONE** — both files run live, 17/17 |
| 7 | Response validation | **N/A** |
| 8 | Cache key | **N/A** |

## Verification

- **Live run against OmniFocus: 17/17 pass** across both files. The bulk-partition assertions were *inferred* from the tri-state contract and then **confirmed by that run**, not assumed.
- `npm run build` and `typecheck:test` clean.
- **No test data leaked** — inbox back at its 166 pre-run baseline, no `__TEST__` strays, no `__MCP_TEST_SANDBOX__` folder.
- Neither cluster came from the OMN-288/289/291/292 wave: `git diff a2ee0706..62567d6f` over non-test source touches five files, all analyze-path, and every failure here is write-path.

Root cause of the two-week gap is **OMN-302** — nothing triggers this suite, so contract changes rot in it silently. This PR clears the current red; it does not prevent the fourth occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaoJtr3bEKwT6nG2C18rKp
