### PR TITLE
feat(OMN-302): weekly launchd job so the integration suite actually runs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,18 @@
 #!/bin/sh
 
-# Pre-push: run typecheck, lint, and unit tests before pushing
+# Pre-push: run typecheck, format check, lint, and unit tests before pushing
 # This ensures no broken code reaches the remote
 echo "Running pre-push checks..."
 
 # Typecheck first (catches type errors that tests might miss)
 npm run typecheck || exit 1
+
+# Formatting. CI runs this over **/*.{ts,js,json,md}, so it covers markdown and
+# JSON that `npm run lint` (eslint over src/ only) never sees. Added 2026-08-06
+# after a docs-only change passed build + lint + typecheck + the whole unit suite
+# locally and still failed CI on Prettier — the local gate simply did not check
+# the file type that changed. ~7s, comparable to lint.
+npm run format:check || exit 1
 
 # Lint and test
 npm run lint && npm run test:unit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,15 @@ here.)_
 - **Public field/operation changes** walk the Vertical Contract Matrix below — every layer done or explicitly N/A.
 - **Measure before optimizing;** bulk operations are NOT the same as multiple single queries — check how the batch route
   actually lowers before assuming equivalence.
-- **Before declaring a task complete:** `npm run build`, `npm run lint` (`--max-warnings=0` — warnings fail), and
-  `npm run test:unit` pass locally; `grep -rn 'console\.log' src/` shows no hits beyond the known `--help` printer in
-  `src/utils/cli.ts` (runs and exits before stdio mode) — ESLint's `no-console` is deliberately off here, and a stray
-  `console.log` on a stdio MCP server corrupts JSON-RPC framing for every client (`console.error`/`console.warn` write
-  to stderr and are safe); TODO comments you touched still reflect reality. Features additionally need integration tests
-  before they're considered complete (long-running — see `tests/integration/PERFORMANCE.md`; run in the background,
-  never inside fleet builds).
+- **Before declaring a task complete:** `npm run build`, `npm run lint` (`--max-warnings=0` — warnings fail),
+  `npm run format:check`, and `npm run test:unit` pass locally — `format:check` covers `**/*.{ts,js,json,md}`, so it is
+  the ONLY one of these that sees markdown and JSON (`lint` is eslint over `src/` alone); a docs-only change can pass
+  every other check here and still fail CI without it. `npm run ci:local` runs the whole set;
+  `grep -rn 'console\.log' src/` shows no hits beyond the known `--help` printer in `src/utils/cli.ts` (runs and exits
+  before stdio mode) — ESLint's `no-console` is deliberately off here, and a stray `console.log` on a stdio MCP server
+  corrupts JSON-RPC framing for every client (`console.error`/`console.warn` write to stderr and are safe); TODO
+  comments you touched still reflect reality. Features additionally need integration tests before they're considered
+  complete (long-running — see `tests/integration/PERFORMANCE.md`; run in the background, never inside fleet builds).
 - **Changes spanning >10 files:** STOP and get explicit approval of the blast radius before proceeding.
 
 **Full docs:** [docs/DOCS_MAP.md](docs/DOCS_MAP.md)

--- a/docs/dev/integration-scheduling.md
+++ b/docs/dev/integration-scheduling.md
@@ -56,10 +56,21 @@ that exact mistake made a 7-failure run report exit 0 — the wrapper would have
 starts. An unbounded wedge mid-suite is this job's worst failure: the wrapper blocks forever, never writes a `STATUS:`
 line, and stays alive under launchd — which will not start a new instance of a `StartCalendarInterval` job while the
 previous one is still running, so **every subsequent Saturday is silently skipped, indefinitely**. That recreates the
-exact blind spot this job exists to close. Build, suite, and cleanup each run under a timeout (`OF_MCP_SUITE_TIMEOUT`,
-default 2700s; `OF_MCP_CLEANUP_TIMEOUT`, default 600s — hang-breakers, not performance budgets). A timeout reports
-`WEDGED`, not `FAILED`, and still attempts the leak scan, since a suite killed mid-flight is _more_ likely to have left
-fixtures behind.
+exact blind spot this job exists to close. Each step has its **own** timeout — sharing one knob means tuning the leak
+scan silently retunes the build:
+
+| Env override               | Default | Bounds                     |
+| -------------------------- | ------- | -------------------------- |
+| `OF_MCP_PREFLIGHT_TIMEOUT` | 30s     | the AppleEvent round-trip  |
+| `OF_MCP_BUILD_TIMEOUT`     | 600s    | `npm run build`            |
+| `OF_MCP_SUITE_TIMEOUT`     | 2700s   | `npm run test:integration` |
+| `OF_MCP_CLEANUP_TIMEOUT`   | 600s    | `npm run test:cleanup`     |
+
+These are hang-breakers, not performance budgets. A timeout reports `WEDGED`, not `FAILED`, and still attempts the leak
+scan, since a suite killed mid-flight is _more_ likely to have left fixtures behind. The kill targets the whole process
+group: `npm` forks vitest, which forks node, and killing only the top-level process would leave workers writing to the
+live database after the wrapper had already logged its verdict and exited. (`--verify` derives its own wait from these
+values, so raising one cannot leave the installer reporting a false failure.)
 
 **Leaks are detected, not auto-deleted.** The suite's cleanup is folder-scoped and has left `__TEST__` inbox tasks
 behind. `npm run test:cleanup` is dry-run by default _because loose substring matching once deleted real user tasks_

--- a/docs/dev/integration-scheduling.md
+++ b/docs/dev/integration-scheduling.md
@@ -1,0 +1,78 @@
+# Scheduled integration runs (OMN-302)
+
+`npm run test:integration` is the project's only layer-6 (live-bridge) check. **CI cannot run it** — OmniFocus is
+macOS-only, so the GitHub job is `if: false` on `ubuntu-latest` by design. Until OMN-302 nothing else triggered it
+either, so contract changes rotted in the suite silently.
+
+That is not hypothetical. A hand-run on 2026-08-06 — the first in roughly two weeks — returned **7 failures**, from
+three unrelated merges, none of which had swept the suite:
+
+| Source            | Merged     | Undetected for | Outcome |
+| ----------------- | ---------- | -------------- | ------- |
+| OMN-286 (#246)    | 2026-07-24 | 13 days        | 6 stale guard expectations (OMN-300) |
+| OMN-278 (#240)    | 2026-07-24 | 13 days        | 1 stale vocabulary expectation (OMN-301) |
+| OMN-292 (#251)    | 2026-08-05 | caught at review | stale `healthScore` assertion |
+
+The weekly job closes that window to a week. It does not replace running the suite when you change a public contract —
+CLAUDE.md still requires that, and that requirement is exactly what failed three times.
+
+## Layout
+
+Committed under `scripts/ops/` and deployed by a script; the runtime locations are install targets, not sources of
+truth. Edit the canonical files and re-run the installer — never hand-edit a deployed copy. Same shape as the
+diagnose job (see `mcp-failure-diagnosis.md` § Scheduling).
+
+| Committed source                                           | Deployed to                                                  | Role |
+| ---------------------------------------------------------- | ------------------------------------------------------------ | ---- |
+| `scripts/ops/of-mcp-integration`                            | `~/bin/of-mcp-integration`                                    | launchd wrapper: preflight → build → suite → leak check. |
+| `scripts/ops/com.omnifocus-mcp.integration.plist.template`  | `~/Library/LaunchAgents/com.omnifocus-mcp.integration.plist`  | Job definition (paths substituted). |
+| `scripts/ops/install-integration-schedule.sh`               | —                                                             | Installs both, (re)loads the job. |
+
+```bash
+scripts/ops/install-integration-schedule.sh             # install / reload
+scripts/ops/install-integration-schedule.sh --verify    # also run it now (~15 min)
+scripts/ops/install-integration-schedule.sh --uninstall # bootout + remove plist
+```
+
+Runs **Saturday 08:00**, offset from the diagnose job (Sunday 09:00) so the two never contend for OmniFocus.
+
+## What the wrapper does, and why
+
+**It writes to the real OmniFocus database.** The suite creates, mutates, and deletes fixtures in the
+`__MCP_TEST_SANDBOX__` folder and `__TEST__`-prefixed inbox tasks. That is inherent to a live-bridge check.
+
+Three design choices exist because the obvious implementation would have been quietly wrong:
+
+**A wedge is reported as WEDGED, not FAILED.** Two environment blockers make the suite unrunnable through no fault of
+the code: OmniFocus not running, and the AppleEvent/TCC wedge (app up, stops answering events). Either produces a wall
+of red indistinguishable from a regression. The wrapper round-trips one real AppleEvent first, capped by a watchdog
+because a wedged OmniFocus can block forever; failure exits **0** with a WEDGED banner saying the suite never ran. A job
+that cries wolf trains its owner to ignore it.
+
+**The suite's exit code is read directly, never through a pipe.** `npm ... | tail` yields *tail's* status. On 2026-08-06
+that exact mistake made a 7-failure run report exit 0 — the wrapper would have reported green forever.
+
+**Leaks are detected, not auto-deleted.** The suite's cleanup is folder-scoped and has left `__TEST__` inbox tasks
+behind. `npm run test:cleanup` is dry-run by default *because loose substring matching once deleted real user tasks*
+(OMN-46). A scheduled unattended job is the worst possible place to override a safety default adopted after an
+incident, so it reports an inventory and leaves the deletion to a human:
+
+```bash
+npm run test:cleanup -- --apply
+```
+
+## Reading the result
+
+Durable log: `~/.omnifocus-mcp/integration.log` (launchd's own stdout/stderr: `integration-launchd.log`).
+
+Every run ends with two lines:
+
+```
+STATUS: PASS (suite exit 0)          # or FAILED — suite exit N / WEDGED — …
+LEAK: none detected                  # or LEAK: test fixtures remain …
+```
+
+`--verify` distinguishes the three outcomes: exit 0 (job ran, suite passed), exit 1 (job ran, suite failed), exit 3
+(**inconclusive** — OmniFocus was unreachable, so the suite never ran; the job itself is fine). It also checks the run
+log's mtime *before* trusting the exit code, because launchd's "last exit code" persists from the previous run — a
+stale 0 would otherwise read as success for a job that never executed.

--- a/docs/dev/integration-scheduling.md
+++ b/docs/dev/integration-scheduling.md
@@ -73,6 +73,15 @@ LEAK: none detected                  # or LEAK: test fixtures remain …
 ```
 
 `--verify` distinguishes the three outcomes: exit 0 (job ran, suite passed), exit 1 (job ran, suite failed), exit 3
-(**inconclusive** — OmniFocus was unreachable, so the suite never ran; the job itself is fine). It also checks the run
-log's mtime _before_ trusting the exit code, because launchd's "last exit code" persists from the previous run — a stale
-0 would otherwise read as success for a job that never executed.
+(**inconclusive** — OmniFocus was unreachable, so the suite never ran; the job itself is fine).
+
+How it avoids reading a previous run's result, since launchd's "last exit code" persists between runs: it records the
+run log's **line count** before `kickstart`, then waits for a `STATUS:` line to appear _beyond that mark_. The wrapper
+writes exactly one `STATUS:` line, at the very end of a run, so that is this run's completion signal by construction —
+and anything written earlier is unreadable, because nothing before the mark is examined. Keying on the spawned pid
+instead would only narrow the race, never close it: `kickstart` returns when the spawn is accepted, so the pid may not
+be registered yet.
+
+Once the marker appears the wrapper is still finishing (it writes `LEAK:` and then exits), so `--verify` waits for the
+job to leave launchd's running set before reading the exit code. The verdict comes from the `STATUS:` line the wrapper
+wrote — it is the authority — with the exit code as corroboration; a disagreement between the two fails verification.

--- a/docs/dev/integration-scheduling.md
+++ b/docs/dev/integration-scheduling.md
@@ -7,11 +7,11 @@ either, so contract changes rotted in the suite silently.
 That is not hypothetical. A hand-run on 2026-08-06 — the first in roughly two weeks — returned **7 failures**, from
 three unrelated merges, none of which had swept the suite:
 
-| Source            | Merged     | Undetected for | Outcome |
-| ----------------- | ---------- | -------------- | ------- |
-| OMN-286 (#246)    | 2026-07-24 | 13 days        | 6 stale guard expectations (OMN-300) |
-| OMN-278 (#240)    | 2026-07-24 | 13 days        | 1 stale vocabulary expectation (OMN-301) |
-| OMN-292 (#251)    | 2026-08-05 | caught at review | stale `healthScore` assertion |
+| Source         | Merged     | Undetected for   | Outcome                                  |
+| -------------- | ---------- | ---------------- | ---------------------------------------- |
+| OMN-286 (#246) | 2026-07-24 | 13 days          | 6 stale guard expectations (OMN-300)     |
+| OMN-278 (#240) | 2026-07-24 | 13 days          | 1 stale vocabulary expectation (OMN-301) |
+| OMN-292 (#251) | 2026-08-05 | caught at review | stale `healthScore` assertion            |
 
 The weekly job closes that window to a week. It does not replace running the suite when you change a public contract —
 CLAUDE.md still requires that, and that requirement is exactly what failed three times.
@@ -19,14 +19,14 @@ CLAUDE.md still requires that, and that requirement is exactly what failed three
 ## Layout
 
 Committed under `scripts/ops/` and deployed by a script; the runtime locations are install targets, not sources of
-truth. Edit the canonical files and re-run the installer — never hand-edit a deployed copy. Same shape as the
-diagnose job (see `mcp-failure-diagnosis.md` § Scheduling).
+truth. Edit the canonical files and re-run the installer — never hand-edit a deployed copy. Same shape as the diagnose
+job (see `mcp-failure-diagnosis.md` § Scheduling).
 
-| Committed source                                           | Deployed to                                                  | Role |
-| ---------------------------------------------------------- | ------------------------------------------------------------ | ---- |
-| `scripts/ops/of-mcp-integration`                            | `~/bin/of-mcp-integration`                                    | launchd wrapper: preflight → build → suite → leak check. |
-| `scripts/ops/com.omnifocus-mcp.integration.plist.template`  | `~/Library/LaunchAgents/com.omnifocus-mcp.integration.plist`  | Job definition (paths substituted). |
-| `scripts/ops/install-integration-schedule.sh`               | —                                                             | Installs both, (re)loads the job. |
+| Committed source                                           | Deployed to                                                  | Role                                                     |
+| ---------------------------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| `scripts/ops/of-mcp-integration`                           | `~/bin/of-mcp-integration`                                   | launchd wrapper: preflight → build → suite → leak check. |
+| `scripts/ops/com.omnifocus-mcp.integration.plist.template` | `~/Library/LaunchAgents/com.omnifocus-mcp.integration.plist` | Job definition (paths substituted).                      |
+| `scripts/ops/install-integration-schedule.sh`              | —                                                            | Installs both, (re)loads the job.                        |
 
 ```bash
 scripts/ops/install-integration-schedule.sh             # install / reload
@@ -49,13 +49,13 @@ of red indistinguishable from a regression. The wrapper round-trips one real App
 because a wedged OmniFocus can block forever; failure exits **0** with a WEDGED banner saying the suite never ran. A job
 that cries wolf trains its owner to ignore it.
 
-**The suite's exit code is read directly, never through a pipe.** `npm ... | tail` yields *tail's* status. On 2026-08-06
+**The suite's exit code is read directly, never through a pipe.** `npm ... | tail` yields _tail's_ status. On 2026-08-06
 that exact mistake made a 7-failure run report exit 0 — the wrapper would have reported green forever.
 
 **Leaks are detected, not auto-deleted.** The suite's cleanup is folder-scoped and has left `__TEST__` inbox tasks
-behind. `npm run test:cleanup` is dry-run by default *because loose substring matching once deleted real user tasks*
-(OMN-46). A scheduled unattended job is the worst possible place to override a safety default adopted after an
-incident, so it reports an inventory and leaves the deletion to a human:
+behind. `npm run test:cleanup` is dry-run by default _because loose substring matching once deleted real user tasks_
+(OMN-46). A scheduled unattended job is the worst possible place to override a safety default adopted after an incident,
+so it reports an inventory and leaves the deletion to a human:
 
 ```bash
 npm run test:cleanup -- --apply
@@ -74,5 +74,5 @@ LEAK: none detected                  # or LEAK: test fixtures remain …
 
 `--verify` distinguishes the three outcomes: exit 0 (job ran, suite passed), exit 1 (job ran, suite failed), exit 3
 (**inconclusive** — OmniFocus was unreachable, so the suite never ran; the job itself is fine). It also checks the run
-log's mtime *before* trusting the exit code, because launchd's "last exit code" persists from the previous run — a
-stale 0 would otherwise read as success for a job that never executed.
+log's mtime _before_ trusting the exit code, because launchd's "last exit code" persists from the previous run — a stale
+0 would otherwise read as success for a job that never executed.

--- a/docs/dev/integration-scheduling.md
+++ b/docs/dev/integration-scheduling.md
@@ -52,6 +52,15 @@ that cries wolf trains its owner to ignore it.
 **The suite's exit code is read directly, never through a pipe.** `npm ... | tail` yields _tail's_ status. On 2026-08-06
 that exact mistake made a 7-failure run report exit 0 — the wrapper would have reported green forever.
 
+**Every long step is time-bounded, not just the preflight.** OmniFocus can wedge at any moment, not only before the run
+starts. An unbounded wedge mid-suite is this job's worst failure: the wrapper blocks forever, never writes a `STATUS:`
+line, and stays alive under launchd — which will not start a new instance of a `StartCalendarInterval` job while the
+previous one is still running, so **every subsequent Saturday is silently skipped, indefinitely**. That recreates the
+exact blind spot this job exists to close. Build, suite, and cleanup each run under a timeout (`OF_MCP_SUITE_TIMEOUT`,
+default 2700s; `OF_MCP_CLEANUP_TIMEOUT`, default 600s — hang-breakers, not performance budgets). A timeout reports
+`WEDGED`, not `FAILED`, and still attempts the leak scan, since a suite killed mid-flight is _more_ likely to have left
+fixtures behind.
+
 **Leaks are detected, not auto-deleted.** The suite's cleanup is folder-scoped and has left `__TEST__` inbox tasks
 behind. `npm run test:cleanup` is dry-run by default _because loose substring matching once deleted real user tasks_
 (OMN-46). A scheduled unattended job is the worst possible place to override a safety default adopted after an incident,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:watch": "vitest tests/unit",
     "test:pre-commit": "npm run test:unit && npm run test:smoke",
-    "test:pre-push": "npm run typecheck && npm run lint && npm run test:unit",
+    "test:pre-push": "npm run typecheck && npm run format:check && npm run lint && npm run test:unit",
     "test:ci": "npm run test:unit && npm run test:smoke && npm run test:integration",
     "test:quick": "vitest tests/unit --run",
     "test:llm-simulation": "ENABLE_LLM_SIMULATION_TESTS=true vitest tests/integration/llm-assistant-simulation.test.ts --run",

--- a/scripts/ops/com.omnifocus-mcp.integration.plist.template
+++ b/scripts/ops/com.omnifocus-mcp.integration.plist.template
@@ -10,10 +10,18 @@
     <key>Label</key>
     <string>com.omnifocus-mcp.integration</string>
     <!-- launchd's default PATH omits Homebrew → npm not found → exit 127. -->
+    <!-- OF_MCP_REPO_DIR must be passed explicitly: launchd starts the job with a
+         bare environment, so an installer-time override would otherwise be lost
+         and the wrapper would silently fall back to its ~/omnifocus-mcp default
+         — running the weekly suite against a different checkout than the
+         operator configured. (The sibling diagnose plist has this same gap; not
+         touched here, since changing it means reinstalling a working job.) -->
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
       <string>__PATH_VALUE__</string>
+      <key>OF_MCP_REPO_DIR</key>
+      <string>__REPO_DIR__</string>
     </dict>
     <key>ProgramArguments</key>
     <array>

--- a/scripts/ops/com.omnifocus-mcp.integration.plist.template
+++ b/scripts/ops/com.omnifocus-mcp.integration.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated from scripts/ops/com.omnifocus-mcp.integration.plist.template by
+     install-integration-schedule.sh, which substitutes absolute paths and a
+     Homebrew-aware PATH (launchd does NOT expand $HOME or ~). Re-run the
+     installer to update; do not hand-edit the deployed copy. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.omnifocus-mcp.integration</string>
+    <!-- launchd's default PATH omits Homebrew → npm not found → exit 127. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>__PATH_VALUE__</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>__WRAPPER_PATH__</string>
+    </array>
+    <!-- Saturday 08:00 — deliberately offset from the diagnose job (Sunday
+         09:00) so the two never contend for OmniFocus, and early enough on a
+         weekend to be unlikely to collide with a live GTD session. The suite
+         takes ~15 minutes and writes to the real database. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Weekday</key>
+      <integer>6</integer>
+      <key>Hour</key>
+      <integer>8</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__LAUNCHD_LOG__</string>
+    <key>StandardErrorPath</key>
+    <string>__LAUNCHD_LOG__</string>
+  </dict>
+</plist>

--- a/scripts/ops/install-integration-schedule.sh
+++ b/scripts/ops/install-integration-schedule.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# install-integration-schedule.sh — deploy the weekly integration-suite launchd job.
+#
+# Installs the canonical wrapper (scripts/ops/of-mcp-integration) to ~/bin and a
+# launchd plist (generated from the .template) to ~/Library/LaunchAgents, then
+# (re)loads the job. Idempotent: safe to re-run after editing the canonical
+# sources. Sibling of install-diagnose-schedule.sh and deliberately shaped the
+# same way. See tests/integration/README.md § Scheduled runs (OMN-302).
+#
+# Usage:
+#   scripts/ops/install-integration-schedule.sh            # install / reload
+#   scripts/ops/install-integration-schedule.sh --verify   # also kickstart + check
+#   scripts/ops/install-integration-schedule.sh --uninstall # bootout + remove plist
+#
+# Env overrides:
+#   OF_MCP_BIN_DIR   (default ~/bin)             where the wrapper is installed
+#   OF_MCP_REPO_DIR  (default ~/omnifocus-mcp)   prod checkout the job runs against
+#
+# NOTE: --verify runs the FULL suite through launchd (~15 min) and writes to the
+# real OmniFocus database. It is the only way to prove the job actually works —
+# a plist that loads is not a job that runs — but it is not a quick check.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LABEL="com.omnifocus-mcp.integration"
+PLIST_NAME="$LABEL.plist"
+TEMPLATE="$SCRIPT_DIR/$PLIST_NAME.template"
+WRAPPER_SRC="$SCRIPT_DIR/of-mcp-integration"
+
+BIN_DIR="${OF_MCP_BIN_DIR:-$HOME/bin}"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+PLIST_DEST="$LAUNCH_AGENTS/$PLIST_NAME"
+WRAPPER_DEST="$BIN_DIR/of-mcp-integration"
+LAUNCHD_LOG="$HOME/.omnifocus-mcp/integration-launchd.log"
+RUN_LOG="$HOME/.omnifocus-mcp/integration.log"
+GUI="gui/$(id -u)"
+
+uninstall() {
+  echo "Unloading $LABEL ..."
+  launchctl bootout "$GUI/$LABEL" 2>/dev/null || echo "  (was not loaded)"
+  rm -f "$PLIST_DEST" && echo "Removed $PLIST_DEST"
+  echo "Wrapper left in place at $WRAPPER_DEST (delete manually if desired)."
+  exit 0
+}
+
+# Explicit arg dispatch — reject unknowns so a typo (e.g. --verfiy) can't
+# silently skip verification and exit 0 (the silent-success class this guards).
+MODE="install"
+case "${1:-}" in
+  "")          MODE="install" ;;
+  --verify)    MODE="verify" ;;
+  --uninstall) uninstall ;;
+  *) echo "Unknown argument: $1" >&2
+     echo "Usage: $(basename "$0") [--verify | --uninstall]" >&2
+     exit 2 ;;
+esac
+
+# --- Detect Homebrew bin dir(s) so the baked PATH finds npm/node/npx ----------
+# Same order as the wrapper's runtime PATH prepend, so scheduled and manual runs
+# resolve to the same prefix.
+brew_dirs=()
+for d in /opt/homebrew/bin /usr/local/bin; do
+  [ -x "$d/npm" ] && brew_dirs+=("$d")
+done
+if [ ${#brew_dirs[@]} -eq 0 ]; then
+  echo "ERROR: npm not found in /opt/homebrew/bin or /usr/local/bin." >&2
+  echo "       Install Node via Homebrew, or edit the PATH detection above." >&2
+  exit 1
+fi
+PATH_VALUE="$(IFS=:; printf '%s' "${brew_dirs[*]}"):/usr/bin:/bin:/usr/sbin:/sbin"
+
+# --- 1. Install the wrapper ---------------------------------------------------
+mkdir -p "$BIN_DIR"
+install -m 0755 "$WRAPPER_SRC" "$WRAPPER_DEST"
+echo "Installed wrapper → $WRAPPER_DEST"
+
+# --- 2. Generate the plist from the template ----------------------------------
+mkdir -p "$LAUNCH_AGENTS" "$(dirname "$LAUNCHD_LOG")"
+# Substituted values are all $HOME-rooted absolute paths and a PATH string of the
+# same — none can contain '|' (the sed delimiter), '&', or newlines on macOS.
+sed -e "s|__WRAPPER_PATH__|$WRAPPER_DEST|g" \
+    -e "s|__LAUNCHD_LOG__|$LAUNCHD_LOG|g" \
+    -e "s|__PATH_VALUE__|$PATH_VALUE|g" \
+    "$TEMPLATE" > "$PLIST_DEST"
+plutil -lint "$PLIST_DEST" >/dev/null
+echo "Installed plist   → $PLIST_DEST"
+echo "  PATH = $PATH_VALUE"
+
+# --- 3. (Re)load the job ------------------------------------------------------
+# bootout is async; bootstrap can race it. Poll until the old instance is gone,
+# then bootstrap with one retry so a transient hiccup doesn't abort the install.
+launchctl bootout "$GUI/$LABEL" 2>/dev/null || true
+for _ in $(seq 1 10); do
+  launchctl print "$GUI/$LABEL" >/dev/null 2>&1 || break
+  sleep 0.5
+done
+launchctl bootstrap "$GUI" "$PLIST_DEST" || { sleep 1; launchctl bootstrap "$GUI" "$PLIST_DEST"; }
+echo "Loaded job $LABEL (weekly, Saturday 08:00)."
+
+# --- 4. Optional verification -------------------------------------------------
+if [ "$MODE" = "verify" ]; then
+  echo "Verifying via kickstart (runs the FULL suite now through launchd, ~15 min) ..."
+  before_mtime="$(stat -f %m "$RUN_LOG" 2>/dev/null || echo 0)"
+
+  launchctl kickstart -k "$GUI/$LABEL"
+  # kickstart returns once the job is SPAWNED, not when it exits — and launchd's
+  # "last exit code" persists from the PRIOR run until this one ends. Reading it
+  # immediately would latch a stale value (e.g. a stale 0, masking the very 127
+  # PATH bug --verify exists to catch). Wait for the instance to disappear first.
+  # Budget covers build + ~15 min suite + cleanup scan, polled at 5s.
+  pid="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/^[[:space:]]*pid =/{print $NF; exit}')"
+  for _ in $(seq 1 360); do
+    { [ -n "${pid:-}" ] && kill -0 "$pid" 2>/dev/null; } || break
+    sleep 5
+  done
+
+  rc="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/last exit code/{print $NF; exit}')"
+  after_mtime="$(stat -f %m "$RUN_LOG" 2>/dev/null || echo 0)"
+  echo "  last exit code = ${rc:-unknown} (0 = suite passed; 127 = PATH bug)"
+
+  # Corroborate execution BEFORE judging the code. An unchanged run log means
+  # nothing executed, so a 0 here is stale rather than green — check this first
+  # so "exit 0 + didn't run" can never read as success.
+  if [ "$after_mtime" = "$before_mtime" ]; then
+    echo "  VERIFY FAILED — run log unchanged ($RUN_LOG); the job did not execute." >&2
+    exit 1
+  fi
+
+  status_line="$(grep -aE '^STATUS: ' "$RUN_LOG" | tail -1 || true)"
+  leak_line="$(grep -aE '^LEAK: ' "$RUN_LOG" | tail -1 || true)"
+  echo "  ${status_line:-STATUS: (none recorded)}"
+  echo "  ${leak_line:-LEAK: (none recorded)}"
+
+  # A WEDGED run is not a pass and not a failure: the job worked, the
+  # environment didn't. Say so plainly rather than reporting green.
+  case "$status_line" in
+    *WEDGED*)
+      echo "  VERIFY INCONCLUSIVE — OmniFocus was unreachable, so the suite never ran." >&2
+      echo "  The job itself is installed and executed correctly. Re-verify once OmniFocus responds." >&2
+      exit 3 ;;
+  esac
+
+  if [ "${rc:-}" != "0" ]; then
+    echo "  VERIFY FAILED — see $RUN_LOG and $LAUNCHD_LOG" >&2
+    exit 1
+  fi
+  echo "  OK (job executed and the suite passed)."
+fi
+
+echo
+echo "Done. Inspect status:  launchctl list | grep integration"
+echo "Manual run:            launchctl kickstart -p $GUI/$LABEL"
+echo "Durable log:           $RUN_LOG"
+echo "Clean up leaks:        (cd ${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp} && npm run test:cleanup -- --apply)"

--- a/scripts/ops/install-integration-schedule.sh
+++ b/scripts/ops/install-integration-schedule.sh
@@ -126,9 +126,19 @@ if [ "$MODE" = "verify" ]; then
 
   launchctl kickstart -k "$GUI/$LABEL"
 
-  # Budget covers build + ~15 min suite + cleanup scan, polled at 5s.
+  # DERIVE the budget from the wrapper's own timeouts instead of hardcoding one.
+  # A fixed 360x5s = 30 min was shorter than the wrapper's worst case (build 600
+  # + suite 2700 + cleanup 600 = 65 min), so a merely-slow-but-healthy run —
+  # still well inside its own SUITE_TIMEOUT, not hung — was reported as
+  # "VERIFY FAILED: the job did not execute" while it ran on unattended against
+  # the live database. Read the same env vars with the same defaults, sum them,
+  # and add 20% slack; a hardcoded number here silently rots the moment any of
+  # those defaults change.
+  verify_budget=$(( (${OF_MCP_BUILD_TIMEOUT:-600} + ${OF_MCP_SUITE_TIMEOUT:-2700} + ${OF_MCP_CLEANUP_TIMEOUT:-600}) * 12 / 10 ))
+  verify_polls=$(( verify_budget / 5 + 1 ))
+  echo "  waiting up to $((verify_budget / 60)) min for this run's STATUS line ..."
   new_region=""
-  for _ in $(seq 1 360); do
+  for _ in $(seq 1 "$verify_polls"); do
     new_region="$(tail -n "+$((before_lines + 1))" "$RUN_LOG" 2>/dev/null || true)"
     printf '%s' "$new_region" | grep -qaE '^STATUS: ' && break
     new_region=""

--- a/scripts/ops/install-integration-schedule.sh
+++ b/scripts/ops/install-integration-schedule.sh
@@ -28,6 +28,9 @@ TEMPLATE="$SCRIPT_DIR/$PLIST_NAME.template"
 WRAPPER_SRC="$SCRIPT_DIR/of-mcp-integration"
 
 BIN_DIR="${OF_MCP_BIN_DIR:-$HOME/bin}"
+# Resolved here (not just consumed by the wrapper's own default) because it is
+# baked into the plist — see the EnvironmentVariables comment in the template.
+REPO_DIR="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}"
 LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
 PLIST_DEST="$LAUNCH_AGENTS/$PLIST_NAME"
 WRAPPER_DEST="$BIN_DIR/of-mcp-integration"
@@ -81,10 +84,12 @@ mkdir -p "$LAUNCH_AGENTS" "$(dirname "$LAUNCHD_LOG")"
 sed -e "s|__WRAPPER_PATH__|$WRAPPER_DEST|g" \
     -e "s|__LAUNCHD_LOG__|$LAUNCHD_LOG|g" \
     -e "s|__PATH_VALUE__|$PATH_VALUE|g" \
+    -e "s|__REPO_DIR__|$REPO_DIR|g" \
     "$TEMPLATE" > "$PLIST_DEST"
 plutil -lint "$PLIST_DEST" >/dev/null
 echo "Installed plist   → $PLIST_DEST"
 echo "  PATH = $PATH_VALUE"
+echo "  repo = $REPO_DIR"
 
 # --- 3. (Re)load the job ------------------------------------------------------
 # bootout is async; bootstrap can race it. Poll until the old instance is gone,
@@ -100,52 +105,50 @@ echo "Loaded job $LABEL (weekly, Saturday 08:00)."
 # --- 4. Optional verification -------------------------------------------------
 if [ "$MODE" = "verify" ]; then
   echo "Verifying via kickstart (runs the FULL suite now through launchd, ~15 min) ..."
-  before_mtime="$(stat -f %m "$RUN_LOG" 2>/dev/null || echo 0)"
+
+  # WAIT ON THIS RUN'S OWN OUTPUT, not on a pid.
+  #
+  # Every previous approach here keyed off `launchctl print`'s pid, and every one
+  # was only probabilistic: kickstart returns when the spawn is ACCEPTED, so the
+  # pid may not be registered yet; retrying merely narrows that window. Whenever
+  # the pid came back empty, the wait loop broke on iteration 1 and verification
+  # read `last exit code`, `STATUS:` and `LEAK:` seconds after kickstart — all of
+  # which persist from the PREVIOUS run. That reports last week's verdict for a
+  # job still running unsupervised against the live database, and it can report
+  # PASS just as easily as FAIL.
+  #
+  # The wrapper writes exactly one `STATUS:` line, at the very end of a run. So
+  # remember where the log ends now, and wait for a STATUS line to appear BEYOND
+  # that point. That is this run's completion signal by construction — no pid, no
+  # race, and stale content is unreadable because we only ever look past the mark.
+  before_lines="$(wc -l < "$RUN_LOG" 2>/dev/null || echo 0)"
+  before_lines="${before_lines// /}"
 
   launchctl kickstart -k "$GUI/$LABEL"
-  # kickstart returns once the job is SPAWNED, not when it exits — and launchd's
-  # "last exit code" persists from the PRIOR run until this one ends. Reading it
-  # immediately would latch a stale value (e.g. a stale 0, masking the very 127
-  # PATH bug --verify exists to catch). Wait for the instance to disappear first.
-  #
-  # RETRY the pid read. kickstart returns when the spawn request is ACCEPTED, so
-  # the next `launchctl print` can beat launchd to registering the pid. Reading
-  # once and finding it empty would skip the entire wait below on iteration 1,
-  # then compare mtimes against a suite that has not written anything yet — and
-  # report "the job did not execute" while it is in fact running unsupervised
-  # against the live database. A false failure that also hides a real run.
-  pid=""
-  for _ in $(seq 1 20); do
-    pid="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/^[[:space:]]*pid =/{print $NF; exit}')"
-    [ -n "$pid" ] && break
-    sleep 0.5
-  done
-  if [ -z "$pid" ]; then
-    # Either the job finished faster than we could observe it (impossible for a
-    # ~15-min suite, so treat as suspicious) or it never started. Fall through:
-    # the mtime check below is the authority and will catch a non-run.
-    echo "  note: never observed a pid for the spawned job; relying on the run-log check."
-  fi
+
   # Budget covers build + ~15 min suite + cleanup scan, polled at 5s.
+  new_region=""
   for _ in $(seq 1 360); do
-    { [ -n "${pid:-}" ] && kill -0 "$pid" 2>/dev/null; } || break
+    new_region="$(tail -n "+$((before_lines + 1))" "$RUN_LOG" 2>/dev/null || true)"
+    printf '%s' "$new_region" | grep -qaE '^STATUS: ' && break
+    new_region=""
     sleep 5
   done
 
-  rc="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/last exit code/{print $NF; exit}')"
-  after_mtime="$(stat -f %m "$RUN_LOG" 2>/dev/null || echo 0)"
-  echo "  last exit code = ${rc:-unknown} (0 = suite passed; 127 = PATH bug)"
-
-  # Corroborate execution BEFORE judging the code. An unchanged run log means
-  # nothing executed, so a 0 here is stale rather than green — check this first
-  # so "exit 0 + didn't run" can never read as success.
-  if [ "$after_mtime" = "$before_mtime" ]; then
-    echo "  VERIFY FAILED — run log unchanged ($RUN_LOG); the job did not execute." >&2
+  if [ -z "$new_region" ]; then
+    echo "  VERIFY FAILED — no STATUS line appeared in $RUN_LOG within the budget;" >&2
+    echo "  the job either never executed or is still running. Check $LAUNCHD_LOG." >&2
     exit 1
   fi
 
-  status_line="$(grep -aE '^STATUS: ' "$RUN_LOG" | tail -1 || true)"
-  leak_line="$(grep -aE '^LEAK: ' "$RUN_LOG" | tail -1 || true)"
+  # Safe to read now: a STATUS line for THIS run exists, so the job has finished
+  # writing and launchd's exit code refers to it rather than the previous run.
+  rc="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/last exit code/{print $NF; exit}')"
+  echo "  last exit code = ${rc:-unknown} (0 = suite passed; 127 = PATH bug)"
+
+  # Read the verdict ONLY from this run's region of the log.
+  status_line="$(printf '%s' "$new_region" | grep -aE '^STATUS: ' | tail -1 || true)"
+  leak_line="$(printf '%s' "$new_region" | grep -aE '^LEAK: ' | tail -1 || true)"
   echo "  ${status_line:-STATUS: (none recorded)}"
   echo "  ${leak_line:-LEAK: (none recorded)}"
 

--- a/scripts/ops/install-integration-schedule.sh
+++ b/scripts/ops/install-integration-schedule.sh
@@ -5,7 +5,7 @@
 # launchd plist (generated from the .template) to ~/Library/LaunchAgents, then
 # (re)loads the job. Idempotent: safe to re-run after editing the canonical
 # sources. Sibling of install-diagnose-schedule.sh and deliberately shaped the
-# same way. See tests/integration/README.md § Scheduled runs (OMN-302).
+# same way. See docs/dev/integration-scheduling.md.
 #
 # Usage:
 #   scripts/ops/install-integration-schedule.sh            # install / reload
@@ -107,8 +107,26 @@ if [ "$MODE" = "verify" ]; then
   # "last exit code" persists from the PRIOR run until this one ends. Reading it
   # immediately would latch a stale value (e.g. a stale 0, masking the very 127
   # PATH bug --verify exists to catch). Wait for the instance to disappear first.
+  #
+  # RETRY the pid read. kickstart returns when the spawn request is ACCEPTED, so
+  # the next `launchctl print` can beat launchd to registering the pid. Reading
+  # once and finding it empty would skip the entire wait below on iteration 1,
+  # then compare mtimes against a suite that has not written anything yet — and
+  # report "the job did not execute" while it is in fact running unsupervised
+  # against the live database. A false failure that also hides a real run.
+  pid=""
+  for _ in $(seq 1 20); do
+    pid="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/^[[:space:]]*pid =/{print $NF; exit}')"
+    [ -n "$pid" ] && break
+    sleep 0.5
+  done
+  if [ -z "$pid" ]; then
+    # Either the job finished faster than we could observe it (impossible for a
+    # ~15-min suite, so treat as suspicious) or it never started. Fall through:
+    # the mtime check below is the authority and will catch a non-run.
+    echo "  note: never observed a pid for the spawned job; relying on the run-log check."
+  fi
   # Budget covers build + ~15 min suite + cleanup scan, polled at 5s.
-  pid="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/^[[:space:]]*pid =/{print $NF; exit}')"
   for _ in $(seq 1 360); do
     { [ -n "${pid:-}" ] && kill -0 "$pid" 2>/dev/null; } || break
     sleep 5

--- a/scripts/ops/install-integration-schedule.sh
+++ b/scripts/ops/install-integration-schedule.sh
@@ -141,8 +141,20 @@ if [ "$MODE" = "verify" ]; then
     exit 1
   fi
 
-  # Safe to read now: a STATUS line for THIS run exists, so the job has finished
-  # writing and launchd's exit code refers to it rather than the previous run.
+  # A STATUS line exists, but the wrapper is NOT done: it still writes the LEAK:
+  # line and then exits, and launchd only updates "last exit code" once the
+  # process actually terminates. Reading it here would race that exit and see an
+  # empty or previous-run value — reporting VERIFY FAILED for a run that passed.
+  # (Detecting STATUS closed the read-too-early-after-SPAWN half of this race;
+  # this closes the read-too-early-before-TERMINATION half.)
+  #
+  # Wait for the job to leave launchd's running set. `pid =` is present only
+  # while an instance is alive, so its absence is the termination signal.
+  for _ in $(seq 1 60); do
+    launchctl print "$GUI/$LABEL" 2>/dev/null | grep -qE '^[[:space:]]*pid =' || break
+    sleep 1
+  done
+
   rc="$(launchctl print "$GUI/$LABEL" 2>/dev/null | awk '/last exit code/{print $NF; exit}')"
   echo "  last exit code = ${rc:-unknown} (0 = suite passed; 127 = PATH bug)"
 
@@ -161,11 +173,27 @@ if [ "$MODE" = "verify" ]; then
       exit 3 ;;
   esac
 
-  if [ "${rc:-}" != "0" ]; then
-    echo "  VERIFY FAILED — see $RUN_LOG and $LAUNCHD_LOG" >&2
-    exit 1
-  fi
-  echo "  OK (job executed and the suite passed)."
+  # Judge on the STATUS line the wrapper WROTE for this run, not on launchd's
+  # cached exit code. The wrapper is the authority: it computed the verdict and
+  # recorded it in the region we just read. rc is corroboration — and it can
+  # legitimately be unreadable (launchd may not surface it promptly, or at all,
+  # for a job that has already exited), which must not by itself manufacture a
+  # failure for a run whose own STATUS says PASS. The "did it run at all?" case
+  # is already handled above: no STATUS line means we exited 1 before reaching
+  # here, so rc can no longer be a stale value standing in for a run that never
+  # happened.
+  case "$status_line" in
+    *"STATUS: PASS"*)
+      if [ -n "${rc:-}" ] && [ "$rc" != "0" ]; then
+        echo "  VERIFY FAILED — the wrapper logged PASS but launchd reports exit $rc;" >&2
+        echo "  these disagree, so the run is not trustworthy. See $RUN_LOG and $LAUNCHD_LOG" >&2
+        exit 1
+      fi
+      echo "  OK (job executed and the suite passed)." ;;
+    *)
+      echo "  VERIFY FAILED — see $RUN_LOG and $LAUNCHD_LOG" >&2
+      exit 1 ;;
+  esac
 fi
 
 echo

--- a/scripts/ops/of-mcp-integration
+++ b/scripts/ops/of-mcp-integration
@@ -34,11 +34,55 @@ export PATH
 REPO_DIR="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}"
 LOG="${OF_MCP_INTEGRATION_LOG:-$HOME/.omnifocus-mcp/integration.log}"
 PREFLIGHT_TIMEOUT="${OF_MCP_PREFLIGHT_TIMEOUT:-30}"
+# Generous against a ~15-minute suite: this is a hang-breaker, not a perf budget.
+SUITE_TIMEOUT="${OF_MCP_SUITE_TIMEOUT:-2700}"
+CLEANUP_TIMEOUT="${OF_MCP_CLEANUP_TIMEOUT:-600}"
 
 mkdir -p "$(dirname "$LOG")"
 cd "$REPO_DIR" || { echo "of-mcp-integration: repo dir not found: $REPO_DIR" >&2; exit 1; }
 
 log() { echo "$*" >> "$LOG"; }
+
+# EVERY step that talks to OmniFocus must be bounded. The preflight probe was,
+# but the suite and the cleanup scan were not — and OmniFocus can wedge at any
+# moment, not only before the run starts. An unbounded wedge mid-suite is the
+# worst outcome this job has: the wrapper blocks forever, never writes a STATUS
+# line, and stays alive under launchd. launchd will NOT start a new instance of a
+# StartCalendarInterval job while the previous one is still running, so every
+# subsequent Saturday is silently skipped — indefinitely. That recreates the very
+# 13-day blind spot this job exists to close, permanently, until someone notices
+# a stuck process by hand.
+#
+# Returns 124 on timeout, matching GNU timeout, so callers can tell "wedged" from
+# "failed". Uses coreutils timeout when available (--foreground so signals reach
+# the child from a non-interactive shell; -k follows TERM with KILL); otherwise
+# falls back to the same background-watchdog shape the preflight uses.
+TIMEOUT_CMD=""
+for c in timeout gtimeout; do
+  command -v "$c" >/dev/null 2>&1 && { TIMEOUT_CMD="$c"; break; }
+done
+
+run_bounded() {
+  local secs="$1"; shift
+  local rc=0
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" --foreground -k 30s "$secs" "$@" >> "$LOG" 2>&1 || rc=$?
+    return "$rc"
+  fi
+  "$@" >> "$LOG" 2>&1 &
+  local child=$!
+  ( sleep "$secs"; kill -9 "$child" 2>/dev/null ) >/dev/null 2>&1 &
+  local wd=$!
+  disown "$wd" 2>/dev/null || true
+  wait "$child" 2>/dev/null || rc=$?
+  if kill "$wd" 2>/dev/null; then
+    : # watchdog still pending -> the child finished on its own
+  else
+    # Watchdog already fired: SIGKILL surfaces as 137. Report it as a timeout.
+    [ "$rc" -eq 137 ] && rc=124
+  fi
+  return "$rc"
+}
 
 log ""
 log "===== run $(date '+%Y-%m-%d %H:%M:%S %Z') ====="
@@ -97,8 +141,19 @@ fi
 log "preflight: OmniFocus running and answering"
 
 # --- 2. Build (the suite runs against dist/) ----------------------------------
-if ! npm run build >> "$LOG" 2>&1; then
-  log "STATUS: FAILED — build failed; suite not run."
+set +e
+run_bounded "$CLEANUP_TIMEOUT" npm run build
+build_rc=$?
+set -e
+if [ "$build_rc" -ne 0 ]; then
+  # Bounded too: a hung build blocks every future Saturday exactly like a hung
+  # suite does. 124 means it hung rather than failed; say which.
+  if [ "$build_rc" -eq 124 ]; then
+    log "STATUS: WEDGED — build exceeded ${CLEANUP_TIMEOUT}s and was killed; suite not run."
+  else
+    log "STATUS: FAILED — build failed (exit $build_rc); suite not run."
+  fi
+  [ "$build_rc" -eq 124 ] && exit 0
   exit 1
 fi
 
@@ -108,9 +163,30 @@ fi
 # would report success while the suite failed — observed for real on 2026-08-06,
 # where a 7-failure run reported exit 0. Redirect, then read $? directly.
 set +e
-npm run test:integration >> "$LOG" 2>&1
+run_bounded "$SUITE_TIMEOUT" npm run test:integration
 suite_rc=$?
 set -e
+
+if [ "$suite_rc" -eq 124 ]; then
+  # Mid-run wedge: same class as the preflight wedge — the environment failed,
+  # not the code — so exit 0 rather than crying wolf. Still attempt the leak scan
+  # (bounded), because a suite killed mid-flight is MORE likely to have left
+  # fixtures behind, not less.
+  log "STATUS: WEDGED — the suite exceeded ${SUITE_TIMEOUT}s and was killed."
+  log "  Preflight passed, so OmniFocus wedged DURING the run (dialog? sync stall?)."
+  log "  Fixtures were probably left behind — see the LEAK line below."
+  set +e
+  run_bounded "$CLEANUP_TIMEOUT" npm run test:cleanup
+  cleanup_rc=$?
+  set -e
+  case "$cleanup_rc" in
+    0) log "LEAK: none detected" ;;
+    1) log "LEAK: test fixtures remain in OmniFocus — see the inventory above."
+       log "  Clean up with: (cd $REPO_DIR && npm run test:cleanup -- --apply)" ;;
+    *) log "LEAK: UNKNOWN — the cleanup scan failed or timed out (exit $cleanup_rc)." ;;
+  esac
+  exit 0
+fi
 
 # --- 4. Leak check ------------------------------------------------------------
 #
@@ -132,7 +208,7 @@ set -e
 # reported CLEAN. Distinguishing 2 from 0 is the point: "could not determine" is
 # not "nothing there".
 set +e
-npm run test:cleanup >> "$LOG" 2>&1
+run_bounded "$CLEANUP_TIMEOUT" npm run test:cleanup
 cleanup_rc=$?
 set -e
 

--- a/scripts/ops/of-mcp-integration
+++ b/scripts/ops/of-mcp-integration
@@ -100,15 +100,27 @@ set -e
 # tasks, and a scheduled job is the worst possible place to override a safety
 # decision made in response to an incident. Detect and report; a human runs
 # `npm run test:cleanup -- --apply`.
+#
+# Read the EXIT CODE, which scripts/test-cleanup.ts defines for exactly this
+# purpose ("Dry-run exits non-zero if leaks found — makes the scan usable as a
+# CI/teardown gate"):
+#   0 = clean   1 = fixtures found   2 = scan failed (OmniFocus unreachable, …)
+# An earlier version grepped the printed category labels instead. That
+# re-implemented a signal the script already publishes, and did it fragilely:
+# relabelling any category would have silently produced "none detected" forever,
+# and a scan ERROR prints no category lines at all — so a failed scan would have
+# reported CLEAN. Distinguishing 2 from 0 is the point: "could not determine" is
+# not "nothing there".
 set +e
-cleanup_out="$(npm run test:cleanup 2>&1)"
+npm run test:cleanup >> "$LOG" 2>&1
+cleanup_rc=$?
 set -e
-printf '%s\n' "$cleanup_out" >> "$LOG"
 
-leaked="no"
-if printf '%s' "$cleanup_out" | grep -qE '^(Inbox tasks|Orphan tasks|Sandbox projects|Orphan projects|Sandbox folders|Test tags).*: [1-9]'; then
-  leaked="yes"
-fi
+case "$cleanup_rc" in
+  0) leak_state="clean" ;;
+  1) leak_state="leaked" ;;
+  *) leak_state="unknown" ;;
+esac
 
 # --- 5. Verdict ---------------------------------------------------------------
 if [ "$suite_rc" -eq 0 ]; then
@@ -116,11 +128,17 @@ if [ "$suite_rc" -eq 0 ]; then
 else
   log "STATUS: FAILED — suite exit $suite_rc. Grep this log for 'FAIL ' and 'Tests  '."
 fi
-if [ "$leaked" = "yes" ]; then
-  log "LEAK: test fixtures remain in OmniFocus — see the inventory above."
-  log "  Clean up with: (cd $REPO_DIR && npm run test:cleanup -- --apply)"
-else
-  log "LEAK: none detected"
-fi
+case "$leak_state" in
+  leaked)
+    log "LEAK: test fixtures remain in OmniFocus — see the inventory above."
+    log "  Clean up with: (cd $REPO_DIR && npm run test:cleanup -- --apply)" ;;
+  clean)
+    log "LEAK: none detected" ;;
+  *)
+    # Never report "none" here. The scan itself failed, so the honest statement
+    # is that the question is unanswered.
+    log "LEAK: UNKNOWN — the cleanup scan itself failed (exit $cleanup_rc); leak status not determined."
+    log "  Re-check by hand: (cd $REPO_DIR && npm run test:cleanup)" ;;
+esac
 
 exit "$suite_rc"

--- a/scripts/ops/of-mcp-integration
+++ b/scripts/ops/of-mcp-integration
@@ -34,8 +34,13 @@ export PATH
 REPO_DIR="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}"
 LOG="${OF_MCP_INTEGRATION_LOG:-$HOME/.omnifocus-mcp/integration.log}"
 PREFLIGHT_TIMEOUT="${OF_MCP_PREFLIGHT_TIMEOUT:-30}"
-# Generous against a ~15-minute suite: this is a hang-breaker, not a perf budget.
+# Generous against a ~15-minute suite: these are hang-breakers, not perf budgets.
+# Each step gets its OWN knob. The build previously borrowed CLEANUP_TIMEOUT,
+# which meant tuning the leak scan down silently retuned the build — a healthy
+# build over the shortened bound would be killed and the weekly suite would stop
+# running, with nothing actually wedged.
 SUITE_TIMEOUT="${OF_MCP_SUITE_TIMEOUT:-2700}"
+BUILD_TIMEOUT="${OF_MCP_BUILD_TIMEOUT:-600}"
 CLEANUP_TIMEOUT="${OF_MCP_CLEANUP_TIMEOUT:-600}"
 
 mkdir -p "$(dirname "$LOG")"
@@ -54,24 +59,48 @@ log() { echo "$*" >> "$LOG"; }
 # a stuck process by hand.
 #
 # Returns 124 on timeout, matching GNU timeout, so callers can tell "wedged" from
-# "failed". Uses coreutils timeout when available (--foreground so signals reach
-# the child from a non-interactive shell; -k follows TERM with KILL); otherwise
-# falls back to the same background-watchdog shape the preflight uses.
+# "failed".
+#
+# KILLING THE WHOLE PROCESS GROUP IS THE POINT, not just the command we spawned.
+# `npm` forks vitest, which forks node, which may have an osascript outstanding.
+# Killing only the top-level npm leaves those children alive, still mutating the
+# live OmniFocus database, while this wrapper has already logged WEDGED, run the
+# leak scan CONCURRENTLY against a database still being written to (so the
+# inventory is wrong by construction), and exited.
+#
+# coreutils path: deliberately NOT --foreground. Its man page is explicit — "in
+# this mode, children of COMMAND will not be timed out" — so that flag, which an
+# earlier version of this file passed, disables the very group-kill wanted here.
+# Without it, timeout runs the command in its own process group and signals the
+# group. -k follows TERM with KILL for anything ignoring TERM.
+#
+# fallback path: `set -m` puts the child in its own process group (PGID == PID),
+# so `kill -9 -PID` reaches the whole tree; the bare-PID kill is a last resort if
+# the group is already gone.
+# OF_MCP_FORCE_FALLBACK exists so the fallback branch can actually be exercised
+# on a machine that HAS coreutils. Without it the fallback is unreachable here
+# and its process-group kill can only be asserted, never tested — and it is the
+# branch that runs on a stock macOS with no Homebrew coreutils, i.e. the one
+# least likely to be exercised by accident and most likely to leak orphans.
 TIMEOUT_CMD=""
-for c in timeout gtimeout; do
-  command -v "$c" >/dev/null 2>&1 && { TIMEOUT_CMD="$c"; break; }
-done
+if [ -z "${OF_MCP_FORCE_FALLBACK:-}" ]; then
+  for c in timeout gtimeout; do
+    command -v "$c" >/dev/null 2>&1 && { TIMEOUT_CMD="$c"; break; }
+  done
+fi
 
 run_bounded() {
   local secs="$1"; shift
   local rc=0
   if [ -n "$TIMEOUT_CMD" ]; then
-    "$TIMEOUT_CMD" --foreground -k 30s "$secs" "$@" >> "$LOG" 2>&1 || rc=$?
+    "$TIMEOUT_CMD" -k 30s "$secs" "$@" >> "$LOG" 2>&1 || rc=$?
     return "$rc"
   fi
+  set -m
   "$@" >> "$LOG" 2>&1 &
   local child=$!
-  ( sleep "$secs"; kill -9 "$child" 2>/dev/null ) >/dev/null 2>&1 &
+  set +m
+  ( sleep "$secs"; kill -9 -"$child" 2>/dev/null || kill -9 "$child" 2>/dev/null ) >/dev/null 2>&1 &
   local wd=$!
   disown "$wd" 2>/dev/null || true
   wait "$child" 2>/dev/null || rc=$?
@@ -142,14 +171,14 @@ log "preflight: OmniFocus running and answering"
 
 # --- 2. Build (the suite runs against dist/) ----------------------------------
 set +e
-run_bounded "$CLEANUP_TIMEOUT" npm run build
+run_bounded "$BUILD_TIMEOUT" npm run build
 build_rc=$?
 set -e
 if [ "$build_rc" -ne 0 ]; then
   # Bounded too: a hung build blocks every future Saturday exactly like a hung
   # suite does. 124 means it hung rather than failed; say which.
   if [ "$build_rc" -eq 124 ]; then
-    log "STATUS: WEDGED — build exceeded ${CLEANUP_TIMEOUT}s and was killed; suite not run."
+    log "STATUS: WEDGED — build exceeded ${BUILD_TIMEOUT}s and was killed; suite not run."
   else
     log "STATUS: FAILED — build failed (exit $build_rc); suite not run."
   fi

--- a/scripts/ops/of-mcp-integration
+++ b/scripts/ops/of-mcp-integration
@@ -52,9 +52,29 @@ log "repo: $REPO_DIR @ $(git rev-parse --short HEAD 2>/dev/null || echo '?')"
 # wedge (the app is up but stops answering events — a known recurring blocker).
 # Either produces a wall of red that looks exactly like a regression.
 #
-# So: round-trip one real AppleEvent first. Failure here exits 0 with a WEDGED
-# banner — the job did not run, and says so, rather than reporting a fake failure.
-# A hang is capped by a watchdog because a wedged OmniFocus can block forever.
+# Two-step, and the ORDER matters.
+#
+# Step 1 asks System Events whether an OmniFocus process exists. It must NOT be
+# `tell application "OmniFocus" to ...`: AppleScript auto-LAUNCHES the target of
+# a `tell`, so that phrasing cannot detect "not running" — it silently starts the
+# app instead, then the wrapper runs a 15-minute MUTATING suite against a
+# cold-started, possibly still-syncing database, unattended, at 08:00 on a
+# Saturday. The System Events form is verified not to launch: it returns false
+# for a quit app and leaves it quit.
+#
+# Step 2 only then round-trips a real AppleEvent, which is what distinguishes
+# "running and answering" from the TCC/AppleEvent wedge. Watchdogged, because a
+# wedged OmniFocus blocks forever.
+#
+# Either step failing exits 0 with a WEDGED banner naming which blocker it was —
+# the job did not run, and says so, rather than reporting a fake test failure.
+if ! osascript -e 'tell application "System Events" to return (name of processes) contains "OmniFocus"' 2>/dev/null | grep -q '^true$'; then
+  log "STATUS: WEDGED — OmniFocus is not running. The suite was NOT run."
+  log "  Deliberately not started: launching it here would run a mutating suite"
+  log "  against a cold, possibly still-syncing database. Start it and re-run."
+  exit 0
+fi
+
 osascript -e 'tell application "OmniFocus" to get name of default document' >/dev/null 2>&1 &
 probe_pid=$!
 ( sleep "$PREFLIGHT_TIMEOUT"; kill -9 "$probe_pid" 2>/dev/null ) >/dev/null 2>&1 &
@@ -69,12 +89,12 @@ wait "$probe_pid" 2>/dev/null || preflight_rc=$?
 kill "$watchdog_pid" 2>/dev/null || true
 
 if [ "$preflight_rc" -ne 0 ]; then
-  log "STATUS: WEDGED — OmniFocus did not answer an AppleEvent within ${PREFLIGHT_TIMEOUT}s (rc=$preflight_rc)."
+  log "STATUS: WEDGED — OmniFocus is running but did not answer an AppleEvent within ${PREFLIGHT_TIMEOUT}s (rc=$preflight_rc)."
   log "  The suite was NOT run. This is an environment blocker, not a test result."
-  log "  Check: OmniFocus running? a modal dialog open? Automation permission still granted?"
+  log "  Check: a modal dialog open? Automation/TCC permission still granted?"
   exit 0
 fi
-log "preflight: OmniFocus reachable"
+log "preflight: OmniFocus running and answering"
 
 # --- 2. Build (the suite runs against dist/) ----------------------------------
 if ! npm run build >> "$LOG" 2>&1; then

--- a/scripts/ops/of-mcp-integration
+++ b/scripts/ops/of-mcp-integration
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# of-mcp-integration — launchd wrapper for the live integration suite (OMN-302).
+#
+# Canonical source: scripts/ops/of-mcp-integration in the omnifocus-mcp repo.
+# Deploy with scripts/ops/install-integration-schedule.sh, which copies this file
+# to ~/bin and installs the launchd plist. Do NOT hand-edit the deployed copy —
+# edit here and re-run the installer, or the next deploy will clobber your change.
+#
+# WHY THIS EXISTS (OMN-302): `npm run test:integration` is the project's only
+# layer-6 (live-bridge) check, and CI cannot run it — OmniFocus is macOS-only and
+# the GitHub job is `if: false` by design. Nothing else triggered it, so contract
+# changes rotted in it silently: OMN-278 and OMN-286 each shipped a behavior
+# change without sweeping the suite, and both sat undetected for 13 days until a
+# hand-run on 2026-08-06 surfaced 7 failures at once. This job closes that gap to
+# a week.
+#
+# THIS JOB WRITES TO THE REAL OMNIFOCUS DATABASE. The suite creates, mutates, and
+# deletes fixtures inside the __MCP_TEST_SANDBOX__ folder and __TEST__-prefixed
+# inbox tasks. That is inherent to a live-bridge check; it is not a bug.
+set -euo pipefail
+
+# launchd runs with a minimal PATH that omits Homebrew → npm not found → exit 127.
+# Same probe-fixed-dirs approach (and same order) as of-mcp-diagnose, so scheduled
+# and manual runs resolve npm/node to the same prefix.
+brew_dirs=()
+for d in /opt/homebrew/bin /usr/local/bin; do
+  [ -d "$d" ] && brew_dirs+=("$d")
+done
+if [ ${#brew_dirs[@]} -gt 0 ]; then
+  PATH="$(IFS=:; printf '%s' "${brew_dirs[*]}"):$PATH"
+fi
+export PATH
+
+REPO_DIR="${OF_MCP_REPO_DIR:-$HOME/omnifocus-mcp}"
+LOG="${OF_MCP_INTEGRATION_LOG:-$HOME/.omnifocus-mcp/integration.log}"
+PREFLIGHT_TIMEOUT="${OF_MCP_PREFLIGHT_TIMEOUT:-30}"
+
+mkdir -p "$(dirname "$LOG")"
+cd "$REPO_DIR" || { echo "of-mcp-integration: repo dir not found: $REPO_DIR" >&2; exit 1; }
+
+log() { echo "$*" >> "$LOG"; }
+
+log ""
+log "===== run $(date '+%Y-%m-%d %H:%M:%S %Z') ====="
+log "repo: $REPO_DIR @ $(git rev-parse --short HEAD 2>/dev/null || echo '?')"
+
+# --- 1. Pre-flight: is OmniFocus actually reachable? --------------------------
+#
+# A WEDGE IS NOT A TEST FAILURE, and conflating them is how a scheduled job
+# trains its owner to ignore it. Two distinct blockers make the suite unrunnable
+# through no fault of the code: OmniFocus not running, and the AppleEvent/TCC
+# wedge (the app is up but stops answering events — a known recurring blocker).
+# Either produces a wall of red that looks exactly like a regression.
+#
+# So: round-trip one real AppleEvent first. Failure here exits 0 with a WEDGED
+# banner — the job did not run, and says so, rather than reporting a fake failure.
+# A hang is capped by a watchdog because a wedged OmniFocus can block forever.
+osascript -e 'tell application "OmniFocus" to get name of default document' >/dev/null 2>&1 &
+probe_pid=$!
+( sleep "$PREFLIGHT_TIMEOUT"; kill -9 "$probe_pid" 2>/dev/null ) >/dev/null 2>&1 &
+watchdog_pid=$!
+# Drop the watchdog from the job table BEFORE killing it. Without this, bash
+# announces "Terminated: 15" on stderr every healthy run — which lands in the
+# launchd log and reads like an error in a job whose whole point is that its
+# output gets trusted.
+disown "$watchdog_pid" 2>/dev/null || true
+preflight_rc=0
+wait "$probe_pid" 2>/dev/null || preflight_rc=$?
+kill "$watchdog_pid" 2>/dev/null || true
+
+if [ "$preflight_rc" -ne 0 ]; then
+  log "STATUS: WEDGED — OmniFocus did not answer an AppleEvent within ${PREFLIGHT_TIMEOUT}s (rc=$preflight_rc)."
+  log "  The suite was NOT run. This is an environment blocker, not a test result."
+  log "  Check: OmniFocus running? a modal dialog open? Automation permission still granted?"
+  exit 0
+fi
+log "preflight: OmniFocus reachable"
+
+# --- 2. Build (the suite runs against dist/) ----------------------------------
+if ! npm run build >> "$LOG" 2>&1; then
+  log "STATUS: FAILED — build failed; suite not run."
+  exit 1
+fi
+
+# --- 3. Run the suite ---------------------------------------------------------
+#
+# NEVER pipe this. `npm ... | tail` yields tail's exit status, so the wrapper
+# would report success while the suite failed — observed for real on 2026-08-06,
+# where a 7-failure run reported exit 0. Redirect, then read $? directly.
+set +e
+npm run test:integration >> "$LOG" 2>&1
+suite_rc=$?
+set -e
+
+# --- 4. Leak check ------------------------------------------------------------
+#
+# The suite's own cleanup is folder-scoped and has historically left __TEST__
+# inbox tasks behind. test:cleanup is DRY-RUN by default and stays that way here:
+# that default was chosen after loose substring matching once deleted real user
+# tasks, and a scheduled job is the worst possible place to override a safety
+# decision made in response to an incident. Detect and report; a human runs
+# `npm run test:cleanup -- --apply`.
+set +e
+cleanup_out="$(npm run test:cleanup 2>&1)"
+set -e
+printf '%s\n' "$cleanup_out" >> "$LOG"
+
+leaked="no"
+if printf '%s' "$cleanup_out" | grep -qE '^(Inbox tasks|Orphan tasks|Sandbox projects|Orphan projects|Sandbox folders|Test tags).*: [1-9]'; then
+  leaked="yes"
+fi
+
+# --- 5. Verdict ---------------------------------------------------------------
+if [ "$suite_rc" -eq 0 ]; then
+  log "STATUS: PASS (suite exit 0)"
+else
+  log "STATUS: FAILED — suite exit $suite_rc. Grep this log for 'FAIL ' and 'Tests  '."
+fi
+if [ "$leaked" = "yes" ]; then
+  log "LEAK: test fixtures remain in OmniFocus — see the inventory above."
+  log "  Clean up with: (cd $REPO_DIR && npm run test:cleanup -- --apply)"
+else
+  log "LEAK: none detected"
+fi
+
+exit "$suite_rc"


### PR DESCRIPTION
Fixes OMN-302.

`npm run test:integration` is the project's only layer-6 (live-bridge) check, and **CI cannot run it** — OmniFocus is macOS-only, so the GitHub job is `if: false` on `ubuntu-latest` by design. Nothing else triggered it, so contract changes rotted in the suite silently.

Measured, not hypothetical. A hand-run on 2026-08-06 — the first in ~2 weeks — returned **7 failures** from three unrelated merges:

| Source | Merged | Undetected | Outcome |
| --- | --- | --- | --- |
| OMN-286 (#246) | 2026-07-24 | 13 days | 6 stale guard expectations (OMN-300) |
| OMN-278 (#240) | 2026-07-24 | 13 days | 1 stale vocabulary expectation (OMN-301) |
| OMN-292 (#251) | 2026-08-05 | caught at review | stale `healthScore` assertion |

The third is the tell: caught by a reviewer noticing a cross-file gap, which is not a repeatable control. This job closes the window to a week.

## Shape

Mirrors the existing diagnose job — committed template + idempotent installer + wrapper under `scripts/ops/`, deployed copies as install targets rather than sources of truth. Runs **Saturday 08:00**, offset from diagnose (Sunday 09:00) so the two never contend for OmniFocus.

**This job writes to the real OmniFocus database.** Inherent to a live-bridge check; stated in the wrapper header, the plist, and the doc.

## Three places the obvious implementation would have been quietly wrong

**1. A wedge is reported as WEDGED, not FAILED.** OmniFocus not running, or the AppleEvent/TCC wedge (app up, stops answering events), each produce a wall of red indistinguishable from a regression. The wrapper round-trips one real AppleEvent first — watchdogged, because a wedged OmniFocus blocks forever — and on failure exits **0** with a WEDGED banner stating the suite never ran. A job that cries wolf trains its owner to ignore it, which lands us back where we started.

**2. The exit code is read directly, never through a pipe.** `npm ... | tail` yields *tail's* status. That exact mistake made the 2026-08-06 run report exit 0 with 7 failures. A scheduled wrapper repeating it would report green forever — worse than no job at all.

**3. Leaks are detected, not auto-deleted.** `test:cleanup` is dry-run by default *because loose substring matching once deleted real user tasks* (OMN-46). An unattended job is the worst possible place to override a safety default adopted after an incident, so it reports the inventory and leaves `--apply` to a human.

`--verify` distinguishes **three** outcomes, not two: `0` (ran, passed), `1` (ran, failed), `3` (**inconclusive** — OmniFocus unreachable, suite never ran). It checks the run log's mtime *before* trusting the exit code, because launchd's "last exit code" persists from the prior run — a stale `0` would otherwise read as success for a job that never executed.

## Verification

All four wrapper paths exercised against shimmed harnesses:

| Scenario | Result |
| --- | --- |
| Wedged — `osascript` fails | exit 0, `STATUS: WEDGED`, suite skipped |
| Wedged — `osascript` **hangs** | watchdog fires at the cap, rc=137, exit 0 |
| Suite fails + fixtures left behind | exit 1, `STATUS: FAILED`, `LEAK` reported |
| Suite passes + clean inventory | exit 0, `STATUS: PASS`, `LEAK: none` |

Found and fixed en route: bash announced `Terminated: 15` on stderr every healthy run when the watchdog was killed, which would have landed in the launchd log and read as an error in a job whose entire value is that its output gets trusted. Disowned.

Unit suite **185 files / 3947 tests**, lint and typecheck clean.

**Not verified here:** the installer's launchd interaction (`bootstrap`/`kickstart`). That needs a real install — which is what `--verify` is for, and is your call, since it runs the full suite against your live database.

## Vertical Contract Matrix

Ops tooling and docs; no public field or operation, and no `src/` change.

| # | Layer | Status |
|---|---|---|
| 1 | Schema (both) | **N/A** |
| 2 | Normalization | **N/A** |
| 3 | Single-item path | **N/A** |
| 4 | Batch path | **N/A** |
| 5 | Script lowering | **N/A** |
| 6 | Live bridge | **N/A** — this PR *schedules* the layer-6 check; it does not change behaviour under test |
| 7 | Response validation | **N/A** |
| 8 | Cache key | **N/A** |

## After merge

```bash
scripts/ops/install-integration-schedule.sh --verify   # installs + runs it once (~15 min)
```

This clears the structural gap. It does **not** replace running the suite when you change a public contract — CLAUDE.md still requires that, and that requirement is precisely what failed three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaoJtr3bEKwT6nG2C18rKp
