### PR TITLE
fix(OMN-307): delete the unreachable filters.search lowering alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **Internal (no client-visible change): the `filters.search` alias is removed from the AST lowering** (OMN-307) — the
+  AST builder honored `filter.search` as a legacy alias for `filter.text`, but the read schema has never exposed a
+  `filters.search` key, so `{ filters: { search: "..." } }` was rejected at the boundary with
+  `Unrecognized key(s) in object: 'search'` and the lowering branch was unreachable from every MCP client. A layer-5
+  path with no layer-1 door. Deleted rather than exposed: `filters.text` already provides identical name-OR-note
+  matching and is advertised, so wiring `search` through would have added a public field — and the full contract-matrix
+  walk — purely to gain a synonym. `search` survives as a tasks **`mode`** value (a view selector), which is untouched.
+  No `inputSchema` or tool-description change, because the alias was never advertised. Regression cover added in
+  `read-schema.test.ts` pinning that `filters.search` is rejected while `mode: "search"` and `filters.text` still
+  validate; the AST tests that previously asserted alias-equals-text now assert the alias is inert, and the OMN-115
+  `fastSearch` cases were re-pointed at `text` so that fast path stays covered on a reachable code path.
+
 - **BREAKING (analyze response): `task_velocity` drops four fabricated fields and gains four real ones;
   `productivity_stats` surfaces three computed fields it was discarding** (OMN-289) — the response now contains exactly
   what was actually computed: nothing real hidden, nothing fake shipped. **Added to `velocity`:** `averageCreated`,

--- a/src/contracts/ast/builder.ts
+++ b/src/contracts/ast/builder.ts
@@ -135,12 +135,15 @@ export const FILTER_DEFS: readonly FilterDef[] = [
   },
 
   // --- Text search ---
-  // Support both filter.text and filter.search (legacy alias for compatibility)
-  // Per spec (filters.ts:113-115), search checks BOTH name AND note
+  // `text` checks BOTH name AND note.
+  // OMN-307: the legacy `filter.search` alias was removed. The read schema has
+  // never exposed a `filters.search` key (`search` is a tasks *mode*), so the
+  // alias was an unreachable lowering path — accepted here, rejected at the
+  // boundary. `text` is the single spelling; see read-schema.test.ts.
   {
     fields: ['task.name', 'task.note'],
     build: (f) => {
-      const searchTerm = f.text ?? f.search;
+      const searchTerm = f.text;
       if (searchTerm === undefined) return null;
       const operator = f.textOperator === 'MATCHES' ? 'matches' : 'includes';
       const nameMatch = comparison('task.name', operator, searchTerm);

--- a/src/contracts/ast/script-builder.ts
+++ b/src/contracts/ast/script-builder.ts
@@ -1008,8 +1008,8 @@ export function describeFilterForScript(filter: TaskFilter): string {
   if (filter.tags && filter.tags.length > 0) {
     conditions.push(`tags[${filter.tagsOperator || 'AND'}]: ${filter.tags.join(', ')}`);
   }
-  if (filter.text || filter.search) {
-    conditions.push(`text: "${filter.text || filter.search}"`);
+  if (filter.text) {
+    conditions.push(`text: "${filter.text}"`);
   }
   if (filter.name) {
     // OMN-142: name-only filter (distinct from text, which matches notes)

--- a/src/contracts/filters.ts
+++ b/src/contracts/filters.ts
@@ -167,8 +167,11 @@ export interface TaskFilter {
    */
   parentTaskId?: string;
 
-  // --- Search (for name/note search) ---
-  search?: string; // Search term for name/note content
+  // --- Text search ---
+  // OMN-307: the `search` alias was removed. It duplicated `text` (see below)
+  // but had no counterpart in the read schema, so no MCP client could ever set
+  // it. Use `text` for name/note search; `search` survives only as a tasks
+  // `mode` value, which is a view selector rather than a filter.
 
   /**
    * OMN-115: fast search restricts text matching to the task NAME only,

--- a/tests/unit/contracts/ast/builder.test.ts
+++ b/tests/unit/contracts/ast/builder.test.ts
@@ -228,15 +228,26 @@ describe('buildAST', () => {
       });
     });
 
-    it('transforms search alias (legacy) the same as text', () => {
-      const filter: TaskFilter = { search: 'meeting notes' };
+    // OMN-307: the legacy `search` alias is deleted. The schema never exposed a
+    // `filters.search` door, so this lowering branch was unreachable from every
+    // MCP client while still being pinned by tests — a layer-5 path with no
+    // layer-1 entrance. `text` is now the single spelling.
+    it('OMN-307: ignores the removed search alias (produces no text node)', () => {
+      const filter = { search: 'meeting notes' } as unknown as TaskFilter;
+      const ast = buildAST(filter);
+
+      expect(ast).toEqual(buildAST({}));
+    });
+
+    it('OMN-307: a stray search key does not interfere with text', () => {
+      const filter = { text: 'review', search: 'meeting notes' } as unknown as TaskFilter;
       const ast = buildAST(filter);
 
       expect(ast).toEqual({
         type: 'or',
         children: [
-          { type: 'comparison', field: 'task.name', operator: 'includes', value: 'meeting notes' },
-          { type: 'comparison', field: 'task.note', operator: 'includes', value: 'meeting notes' },
+          { type: 'comparison', field: 'task.name', operator: 'includes', value: 'review' },
+          { type: 'comparison', field: 'task.note', operator: 'includes', value: 'review' },
         ],
       });
     });
@@ -265,16 +276,13 @@ describe('buildAST', () => {
       });
     });
 
-    it('OMN-115: fastSearch:true matches name only for the search alias', () => {
-      const filter: TaskFilter = { search: 'meeting notes', fastSearch: true };
+    it('OMN-115: fastSearch:true with no text term produces no node', () => {
+      // Previously asserted via the `search` alias (removed in OMN-307).
+      // fastSearch is a modifier on a text term, not a term itself.
+      const filter: TaskFilter = { fastSearch: true };
       const ast = buildAST(filter);
 
-      expect(ast).toEqual({
-        type: 'comparison',
-        field: 'task.name',
-        operator: 'includes',
-        value: 'meeting notes',
-      });
+      expect(ast).toEqual(buildAST({}));
     });
 
     it('OMN-115: fastSearch:false still matches both name and note', () => {

--- a/tests/unit/contracts/ast/describe-filter-coverage.test.ts
+++ b/tests/unit/contracts/ast/describe-filter-coverage.test.ts
@@ -19,7 +19,8 @@ const KEY_COVERAGE = {
   tagsOperator: 'exempt',
   text: 'described',
   textOperator: 'exempt',
-  search: 'described',
+  // OMN-307: `search` removed — it was a lowering-only alias for `text` with no
+  // key in the read schema, so no client could set it.
   name: 'described',
   nameOperator: 'exempt',
   // dates
@@ -76,7 +77,6 @@ const SAMPLE: Partial<Record<keyof NormalizedTaskFilter, NormalizedTaskFilter>> 
   hasRepetitionRule: { hasRepetitionRule: true } as NormalizedTaskFilter,
   tags: { tags: ['x'] } as NormalizedTaskFilter,
   text: { text: 'foo' } as NormalizedTaskFilter,
-  search: { search: 'foo' } as NormalizedTaskFilter,
   name: { name: 'foo' } as NormalizedTaskFilter,
   dueBefore: { dueBefore: '2026-01-01' } as NormalizedTaskFilter,
   dueAfter: { dueAfter: '2026-01-01' } as NormalizedTaskFilter,

--- a/tests/unit/contracts/ast/filter-coverage.test.ts
+++ b/tests/unit/contracts/ast/filter-coverage.test.ts
@@ -239,21 +239,27 @@ describe('QueryCompiler.transformFilters', () => {
     });
   });
 
-  // OMN-142: name is a name-scoped filter, distinct from text/search which
-  // also match note content.
+  // OMN-142: name is a name-scoped filter, distinct from `text`, which also
+  // matches note content.
+  // OMN-307: these previously asserted `result.search` was unset. The `search`
+  // alias is deleted, so the note-matching field to guard against is now `text`
+  // — that is the assertion carrying OMN-142's intent. The extra cast-based
+  // check pins that the alias does not come back by any route.
   describe('name filter transformation', () => {
-    it('transforms name.contains to name + CONTAINS operator (not search)', () => {
+    it('transforms name.contains to name + CONTAINS operator (not a note-matching filter)', () => {
       const result = compiler.transformFilters({ name: { contains: 'weekly' } });
       expect(result.name).toBe('weekly');
       expect(result.nameOperator).toBe('CONTAINS');
-      expect(result.search).toBeUndefined();
+      expect(result.text).toBeUndefined();
+      expect((result as Record<string, unknown>).search).toBeUndefined();
     });
 
-    it('transforms name.matches to name + MATCHES operator (not search)', () => {
+    it('transforms name.matches to name + MATCHES operator (not a note-matching filter)', () => {
       const result = compiler.transformFilters({ name: { matches: '^Q[1-4]' } });
       expect(result.name).toBe('^Q[1-4]');
       expect(result.nameOperator).toBe('MATCHES');
-      expect(result.search).toBeUndefined();
+      expect(result.text).toBeUndefined();
+      expect((result as Record<string, unknown>).search).toBeUndefined();
     });
   });
 

--- a/tests/unit/contracts/ast/filter-generator.test.ts
+++ b/tests/unit/contracts/ast/filter-generator.test.ts
@@ -43,16 +43,19 @@ describe('generateFilterCode', () => {
       expect(result.predicate).toBe('true');
     });
 
+    // OMN-307: these previously exercised the `search` alias, which the schema
+    // never accepted. Re-pointed at `text` — the spelling clients can actually
+    // reach — so the OMN-115 fast path stays covered on a live code path.
     it('OMN-115: fastSearch emits a name-only predicate (no task.note read)', () => {
-      const filter: TaskFilter = { search: 'review', fastSearch: true };
+      const filter: TaskFilter = { text: 'review', fastSearch: true };
       const result = generateFilterCode(filter);
 
       expect(result.predicate).toContain('task.name');
       expect(result.predicate).not.toContain('task.note');
     });
 
-    it('OMN-115: default search still reads task.note', () => {
-      const filter: TaskFilter = { search: 'review' };
+    it('OMN-115: default text search still reads task.note', () => {
+      const filter: TaskFilter = { text: 'review' };
       const result = generateFilterCode(filter);
 
       expect(result.predicate).toContain('task.name');

--- a/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
+++ b/tests/unit/tools/unified/compilers/QueryCompiler.test.ts
@@ -758,22 +758,28 @@ describe('QueryCompiler', () => {
       });
     });
 
-    // OMN-142: `name` must compile to a name-scoped filter, never the legacy
-    // `search` field — `search` matches note content too, and that over-match
-    // collaterally deleted a real user task on 2026-06-09.
+    // OMN-142: `name` must compile to a name-scoped filter, never a
+    // note-matching one — that over-match collaterally deleted a real user task
+    // on 2026-06-09.
+    // OMN-307: the legacy `search` field this originally guarded is deleted, so
+    // the live note-matching field is `text`; asserting on it is what preserves
+    // OMN-142's intent. The cast-based check additionally pins that `search`
+    // cannot reappear.
     describe('name filter transformation (OMN-142)', () => {
-      it('name.contains compiles to name + CONTAINS, not search', () => {
+      it('name.contains compiles to name + CONTAINS, not a note-matching filter', () => {
         const result = compiler.transformFilters({ name: { contains: 'Quarterly' } });
         expect(result.name).toBe('Quarterly');
         expect(result.nameOperator).toBe('CONTAINS');
-        expect(result.search).toBeUndefined();
+        expect(result.text).toBeUndefined();
+        expect((result as Record<string, unknown>).search).toBeUndefined();
       });
 
       it('name.matches compiles to name + MATCHES (regex no longer degrades to substring)', () => {
         const result = compiler.transformFilters({ name: { matches: 'Review.*' } });
         expect(result.name).toBe('Review.*');
         expect(result.nameOperator).toBe('MATCHES');
-        expect(result.search).toBeUndefined();
+        expect(result.text).toBeUndefined();
+        expect((result as Record<string, unknown>).search).toBeUndefined();
       });
 
       it('name and text filters coexist — neither silently drops the other', () => {

--- a/tests/unit/tools/unified/schemas/read-schema.test.ts
+++ b/tests/unit/tools/unified/schemas/read-schema.test.ts
@@ -748,4 +748,32 @@ describe('ReadSchema', () => {
       }
     });
   });
+
+  describe('OMN-307: filters.search is not a filter key', () => {
+    // `search` is a tasks *mode* ("view selector"), never a filter key. The AST
+    // builder used to honor `filter.search` as a legacy alias for `filter.text`,
+    // but the schema has never exposed a door for it — an unreachable lowering
+    // path. The alias is deleted; `text` is the single spelling. These tests pin
+    // the contract so the alias cannot be reintroduced on one layer only.
+    it('rejects filters.search on a tasks query', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { search: 'meeting notes' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts mode:"search" — the view selector is unaffected', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', mode: 'search', filters: { text: { contains: 'meeting notes' } } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('filters.text remains the supported spelling for name/note search', () => {
+      const result = ReadSchema.safeParse({
+        query: { type: 'tasks', filters: { text: { contains: 'obsidian://open' } } },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Closes the Finding 3 half of OMN-307. (The cross-link-check rewrite, Findings 1–2, is still open on the ticket.)

## Problem

`src/contracts/ast/builder.ts` honored `filter.search` as a legacy alias for `filter.text`:

```js
const searchTerm = f.text ?? f.search;
```

But the read schema has never exposed a `filters.search` key — `search` is a tasks **`mode`** (a view selector), not a filter. So every MCP client got:

```
MCP error -32602: query.filters: Unrecognized key(s) in object: 'search'
```

A layer-5 lowering path with no layer-1 door: unreachable from every client, yet pinned by unit tests that constructed `TaskFilter` objects directly and so bypassed Zod entirely.

This actively misled a session. During the 2026-08-07 `/wrap-up lint` the rejection read as "notes can't be searched server-side", the cross-link rot check was skipped as infeasible, and `NOT CHECKED (no note search)` got written into the lint stamp as a standing constraint. `filters.text` did the job all along.

## Why delete rather than expose

`filters.text` already provides identical name-OR-note matching and **is** advertised. Wiring `search` through the schema would add a public field — and per CLAUDE.md that means the full Vertical Contract Matrix walk plus an `inputSchema` and description change — purely to gain a synonym for something that already works. Deleting removes surface instead of adding it. Consistent with `feedback_impossible_ops_schema_rejection`: resolve a half-existing operation in one direction rather than leaving it straddling layers.

## Changes

| File | Change |
| --- | --- |
| `src/contracts/filters.ts` | `search?: string` removed from `TaskFilter` (propagates to `NormalizedTaskFilter`, which derives from it) |
| `src/contracts/ast/builder.ts` | text-search node reads `f.text` only |
| `src/contracts/ast/script-builder.ts` | filter description drops `\|\| filter.search` |
| `CHANGELOG.md` | entry under Unreleased → Changed |

No internal caller constructed `search` (grepped); the only remaining `.search` hits in `src/` are a `String.prototype.search` call in `OmniFocusAnalyzeTool` and the `mode` enum, both unrelated.

## Vertical Contract Matrix

| # | Layer | Status |
| --- | --- | --- |
| 1 | Schema (both) | **unchanged** — `search` was never a filter key; no `inputSchema` edit, since it was never advertised. New tests pin it. |
| 2 | Normalization | **N/A** — alias was never normalized; no `WRAPPER_HINTS` entry |
| 3 | Single-item path | **N/A** — request-side filter shape only |
| 4 | Batch path | **N/A** — no batch route referenced `filter.search` (grepped) |
| 5 | Script lowering | **CHANGED** — `builder.ts` + `script-builder.ts` |
| 6 | Live bridge | **NOT RUN** — see below |
| 7 | Response validation | **N/A** — request-side only |
| 8 | Cache key | **N/A** — no cache-key builder referenced `filter.search` (grepped) |

**On layer 6, stated plainly rather than marked N/A:** the installed MCP server runs the prod build from `~/omnifocus-mcp`, not this worktree, so no live call could exercise this diff. Risk is minimal — the removed branch was unreachable by construction, and the surviving path (`filters.text`) *was* live-verified against real OmniFocus during OMN-307 triage (`{text:{contains:"obsidian://open"}}` → 284 matches; a control term → 0, proving CONTAINS is a literal substring match). Worth a live spot-check after the next redeploy regardless.

## Tests

- **New** in `read-schema.test.ts`: `filters.search` is rejected; `mode:"search"` still validates; `filters.text` still validates.
- **Changed** in `builder.test.ts`: the two assertions that alias-equals-text now assert the alias is **inert** (a stray `search` key yields the same AST as an empty filter, and does not interfere with a real `text` term).
- **Changed** in `filter-generator.test.ts`: the OMN-115 `fastSearch` cases were re-pointed from `search` to `text`, so that fast path stays covered on a *reachable* code path — it had been asserted only through the dead alias.
- **Changed** in `describe-filter-coverage.test.ts`: `search` dropped from the OMN-172 F10 key-coverage table. This test caught the removal on its own, which is the guard working as designed.

## Gate

`npm run build` ✅ · `npm run lint --max-warnings=0` ✅ · `npm run test:unit` ✅ 185 files / 3950 tests · no stray `console.log` in `src/`

Integration tests not run (17 min, and this diff touches no live-bridge path).

Draft pending Kip's `/code-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCbHmyRGvfxPNdjJD1V4Q5