### PR TITLE
docs(OMN-307): add typecheck:test to the pre-completion gate, and to ci:local

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,14 +26,17 @@ here.)_
 - **Measure before optimizing;** bulk operations are NOT the same as multiple single queries — check how the batch route
   actually lowers before assuming equivalence.
 - **Before declaring a task complete:** `npm run build`, `npm run lint` (`--max-warnings=0` — warnings fail),
-  `npm run format:check`, and `npm run test:unit` pass locally — `format:check` covers `**/*.{ts,js,json,md}`, so it is
-  the ONLY one of these that sees markdown and JSON (`lint` is eslint over `src/` alone); a docs-only change can pass
-  every other check here and still fail CI without it. `npm run ci:local` runs the whole set;
-  `grep -rn 'console\.log' src/` shows no hits beyond the known `--help` printer in `src/utils/cli.ts` (runs and exits
-  before stdio mode) — ESLint's `no-console` is deliberately off here, and a stray `console.log` on a stdio MCP server
-  corrupts JSON-RPC framing for every client (`console.error`/`console.warn` write to stderr and are safe); TODO
-  comments you touched still reflect reality. Features additionally need integration tests before they're considered
-  complete (long-running — see `tests/integration/PERFORMANCE.md`; run in the background, never inside fleet builds).
+  `npm run format:check`, `npm run typecheck:test`, and `npm run test:unit` pass locally — `format:check` covers
+  `**/*.{ts,js,json,md}`, so it is the ONLY one of these that sees markdown and JSON (`lint` is eslint over `src/`
+  alone); a docs-only change can pass every other check here and still fail CI without it. `typecheck:test` is the ONLY
+  one that type-checks `tests/` and `scripts/`: vitest runs through esbuild, which **strips types without checking
+  them**, and the main tsconfig excludes `tests/` — so `test:unit` goes green over test-directory type errors, which
+  then fail CI (OMN-307). `npm run ci:local` runs the whole set; `grep -rn 'console\.log' src/` shows no hits beyond the
+  known `--help` printer in `src/utils/cli.ts` (runs and exits before stdio mode) — ESLint's `no-console` is
+  deliberately off here, and a stray `console.log` on a stdio MCP server corrupts JSON-RPC framing for every client
+  (`console.error`/`console.warn` write to stderr and are safe); TODO comments you touched still reflect reality.
+  Features additionally need integration tests before they're considered complete (long-running — see
+  `tests/integration/PERFORMANCE.md`; run in the background, never inside fleet builds).
 - **Changes spanning >10 files:** STOP and get explicit approval of the blast radius before proceeding.
 
 **Full docs:** [docs/DOCS_MAP.md](docs/DOCS_MAP.md)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -71,10 +71,19 @@ print_step "TypeScript compilation check"
 run_command "npm run build" "TypeScript compilation"
 print_success "TypeScript compilation successful"
 
-# Step 2: Type checking
+# Step 2: Type checking (src)
 print_step "TypeScript type checking"
 npm run typecheck
 print_success "TypeScript type checking passed"
+
+# Step 2b: Type checking (tests + scripts) — OMN-307
+# vitest runs through esbuild, which STRIPS types without checking them, and the
+# main tsconfig excludes tests/. So `npm run test:unit` can be fully green while
+# tests/ has type errors. CI's Quick Validation runs this separately; without it
+# here, "ci:local passed" does not imply CI will pass.
+print_step "TypeScript type checking (tests + scripts)"
+npm run typecheck:test
+print_success "Test/script type checking passed"
 
 # Step 3: Lint check (zero-warnings ceiling — mirrors CI, OMN-212)
 print_step "Lint check (eslint --max-warnings=0)"
@@ -151,7 +160,8 @@ echo "================================="
 echo -e "${BLUE}Summary:${NC}"
 echo "- Code formatting: ✅"
 echo "- TypeScript compilation: ✅"
-echo "- Type checking: ✅"
+echo "- Type checking (src): ✅"
+echo "- Type checking (tests + scripts): ✅"
 echo "- Lint errors: ✅ ($ERROR_COUNT <= 50)"
 echo "- Unit tests: ✅"
 echo "- Integration tests: ⏭️  (skipped in pre-push, run 'npm test' manually)"


### PR DESCRIPTION
Follow-up to #260, which shipped four `TS2339` errors past a fully green local gate. This closes the hole that allowed it.

## The hole

`npm run test:unit` runs vitest through **esbuild, which strips TypeScript types without checking them**, and the main `tsconfig` excludes `tests/`. So no command in CLAUDE.md's pre-completion list type-checks the test directory:

| Gate | `src/` types | `tests/` types |
| --- | --- | --- |
| `npm run build` (`tsc`) | ✅ | ❌ (`tests/` excluded) |
| `npm run lint` | ❌ (eslint, not tsc) | ❌ |
| `npm run format:check` | ❌ | ❌ |
| `npm run test:unit` | ❌ (esbuild strips) | ❌ (esbuild strips) |
| `npm run typecheck:test` | — | ✅ |

CI's Quick Validation runs `typecheck:test` (workflow line 67). Nothing local did.

## Two changes, because documenting the command alone would leave a false claim standing

**1. `CLAUDE.md`** — `npm run typecheck:test` added to the enumerated gate, with the esbuild/tsconfig mechanism stated inline so a future reader can't quietly drop it again as redundant with `build`.

**2. `scripts/ci-local.sh`** — the same step added. This is the more important half: CLAUDE.md claims `npm run ci:local` "runs the whole set", but the script mirrored CI's `typecheck` (line 58) while skipping its `typecheck:test` (line 67). **"ci:local passed" did not imply CI would pass.** The new step is placed after the existing build step, because `typecheck:test` resolves imports against `dist/` — running it on a clean tree produces `TS2307 Cannot find module '../../dist/...'` rather than a useful signal.

## Verification — measured, not inspected

A probe test referencing a nonexistent field on `TaskFilter` (the same error class that failed #260):

| Command | Result |
| --- | --- |
| `npx vitest run …/zz-probe.test.ts` | **1 passed** — type error completely invisible |
| `npm run typecheck:test` | **`error TS2339: Property 'thisFieldDoesNotExist' does not exist on type 'TaskFilter'`** |

Probe deleted after the check; `typecheck:test` clean on the final tree.

## Gate

`build` ✅ · `format:check` ✅ · `lint --max-warnings=0` ✅ · `typecheck` ✅ · `typecheck:test` ✅ · `test:unit` ✅ 185 files / 3947 tests · CLAUDE.md path-rot guard (`tests/unit/docs/claude-md-paths.test.ts`) ✅ 8 tests

Note `format:check` flagged my CLAUDE.md edit on the first pass — the exact docs-only-change trap that same paragraph warns about. Fixed before commit.

## Scope

Docs + local-CI script only; no `src/` change. Deliberately kept off #260 so that PR's green review state stays undisturbed and a docs change doesn't ride along with a code change.

Draft pending Kip's `/code-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCbHmyRGvfxPNdjJD1V4Q5